### PR TITLE
Minor code cleanup

### DIFF
--- a/NzbDrone.Api/Exceptions/InvalidApiKeyException.cs
+++ b/NzbDrone.Api/Exceptions/InvalidApiKeyException.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace NzbDrone.Api.Exceptions
 {
+    [Serializable]
     public class InvalidApiKeyException : Exception
     {
         public InvalidApiKeyException()

--- a/NzbDrone.Api/Filters/ValidApiRequestAttribute.cs
+++ b/NzbDrone.Api/Filters/ValidApiRequestAttribute.cs
@@ -10,7 +10,7 @@ using ServiceStack.ServiceInterface;
 
 namespace NzbDrone.Api.Filters
 {
-    public class ValidApiRequestAttribute : Attribute, IHasRequestFilter
+    public sealed class ValidApiRequestAttribute : Attribute, IHasRequestFilter
     {
         public ApplyTo ApplyTo { get; set; }
         public int Priority { get; set; }

--- a/NzbDrone.Core/Model/Notification/ProgressNotification.cs
+++ b/NzbDrone.Core/Model/Notification/ProgressNotification.cs
@@ -83,13 +83,26 @@ namespace NzbDrone.Core.Model.Notification
 
         #region IDisposable Members
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
-            if (Status == ProgressNotificationStatus.InProgress)
-            {
-                Logger.Warn("Background task '{0}' was unexpectedly abandoned.", Title);
-                Status = ProgressNotificationStatus.Failed;
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+         protected virtual void Dispose(bool disposing)
+        {
+             if(disposing)
+             {
+                 if(Status == ProgressNotificationStatus.InProgress)
+                 {
+                     Logger.Warn("Background task '{0}' was unexpectedly abandoned.", Title);
+                     Status = ProgressNotificationStatus.Failed;
+                 }
+             }
         }
 
         #endregion

--- a/NzbDrone/Providers/MonitoringProvider.cs
+++ b/NzbDrone/Providers/MonitoringProvider.cs
@@ -9,7 +9,7 @@ using NzbDrone.Common.Model;
 
 namespace NzbDrone.Providers
 {
-    public class MonitoringProvider
+    public class MonitoringProvider : IDisposable
     {
         private static readonly Logger logger = LogManager.GetLogger("Host.MonitoringProvider");
 
@@ -117,6 +117,25 @@ namespace NzbDrone.Providers
 
            
             logger.FatalException("EPIC FAIL: " + excepion.Message, excepion);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_pingTimer != null) _pingTimer.Dispose();
+                if (_processPriorityCheckTimer != null) _processPriorityCheckTimer.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
- Implemented IDisposable for MonitoringProvider
- CA1813: Avoid unsealed attributes
- CA2237: Mark ISerializable types with SerializableAttribute
- CA1816: Call GC.SuppressFinalize correctly
