### PR TITLE
fix SetFolderWriteTime: Season Folder not being updated

### DIFF
--- a/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.MediaFiles
 
             if (series.SeasonFolder)
             {
-                var seasonFolder = Path.GetDirectoryName(episodeFile.Path);
+                var seasonFolder = Path.GetDirectoryName(destinationFilename);
 
                 _logger.Trace("Setting last write time on season folder: {0}", seasonFolder);
                 _diskProvider.SetFolderWriteTime(seasonFolder, episodeFile.DateAdded);


### PR DESCRIPTION
@markus101

Thanks for merging in my changes.
However, it's not setting the write time on the season folder.

My understanding is that `episodeFile.Path` contains the path to the original location of the file.
By the time SetFolderWriteTime is called for the season folder, I don't see where `episodeFile.Path` gets updated.
So I think it would be more appropriate to get the seasonFolder from `destinationFileName`
