### PR TITLE
1080p samples can sometimes be falsely imported

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
@@ -49,11 +49,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                 return true;
             }
 
-            if (localEpisode.Size > SampleSizeLimit)
-            {
-                return true;
-            }
-
             var runTime = _videoFileInfoReader.GetRunTime(localEpisode.Path);
 
             if (runTime.TotalMinutes.Equals(0))
@@ -66,6 +61,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             {
                 _logger.Trace("[{0}] appears to be a sample. Size: {1} Runtime: {2}", localEpisode.Path, localEpisode.Size, runTime);
                 return false;
+            }
+
+            if (localEpisode.Size > SampleSizeLimit)
+            {
+                return true;
             }
 
             return true;


### PR DESCRIPTION
1 minute 1080p samples can sometimes be over 70mb, this will cause the main episode file to be deleted and attempted to be replaced with the sample. We should check the file size last, after all other checks.
