### PR TITLE
Solved 587-failed-download-history-not-working

### DIFF
--- a/src/NzbDrone.Common/DictionaryExtensions.cs
+++ b/src/NzbDrone.Common/DictionaryExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Common
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue = default(TValue))
+        {
+            TValue value;
+            return dictionary.TryGetValue(key, out value) ? value : defaultValue;
+        }
+    }
+}

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Composition\IContainer.cs" />
     <Compile Include="Composition\ContainerBuilderBase.cs" />
     <Compile Include="DateTimeExtensions.cs" />
+    <Compile Include="DictionaryExtensions.cs" />
     <Compile Include="Disk\DiskProviderBase.cs" />
     <Compile Include="EnsureThat\Ensure.cs" />
     <Compile Include="EnsureThat\EnsureBoolExtensions.cs" />

--- a/src/NzbDrone.Core.Test/Download/FailedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/FailedDownloadServiceFixture.cs
@@ -132,6 +132,54 @@ namespace NzbDrone.Core.Test.Download
         }
 
         [Test]
+        public void should_not_process_if_grabbed_history_contains_null_downloadclient_id()
+        {
+            GivenFailedDownloadClientHistory();
+
+            var historyGrabbed = Builder<History.History>.CreateListOfSize(1)
+                                                  .Build()
+                                                  .ToList();
+
+            historyGrabbed.First().Data.Add("downloadClient", "SabnzbdClient");
+            historyGrabbed.First().Data.Add("downloadClientId", null);
+
+            GivenGrabbedHistory(historyGrabbed);
+            GivenNoFailedHistory();
+
+            Subject.Execute(new CheckForFailedDownloadCommand());
+
+            VerifyNoFailedDownloads();
+        }
+
+        [Test]
+        public void should_process_if_failed_history_contains_null_downloadclient_id()
+        {
+            GivenFailedDownloadClientHistory();
+
+            var historyGrabbed = Builder<History.History>.CreateListOfSize(1)
+                                                  .Build()
+                                                  .ToList();
+
+            historyGrabbed.First().Data.Add("downloadClient", "SabnzbdClient");
+            historyGrabbed.First().Data.Add("downloadClientId", _failed.First().Id);
+
+            GivenGrabbedHistory(historyGrabbed);
+
+            var historyFailed = Builder<History.History>.CreateListOfSize(1)
+                                                  .Build()
+                                                  .ToList();
+
+            historyFailed.First().Data.Add("downloadClient", "SabnzbdClient");
+            historyFailed.First().Data.Add("downloadClientId", null);
+            
+            GivenFailedHistory(historyFailed);
+
+            Subject.Execute(new CheckForFailedDownloadCommand());
+
+            VerifyFailedDownloads();
+        }
+
+        [Test]
         public void should_not_process_if_already_added_to_history_as_failed()
         {
             GivenFailedDownloadClientHistory();


### PR DESCRIPTION
Some history items had null as downloadClientId on which FailedDownloadService crashed on that.
This PR is to prevent those crashes.
Note that for all Blackhole/nzbget grabs history items have null as downloadClientId.

But the original complaint was for history downloadFailed events (with null) which had matching grabbed events (with valid id). This hasn't been checked by a dev though.
As far as I can see in the code that can't happen: An existing grabbed.downloadClientId is always copied to the downloadFailed event. Unfortunately this means the 'cause' can't be solved.
