### PR TITLE
Clarifying error message

### DIFF
--- a/src/NzbDrone.Mono/DiskProvider.cs
+++ b/src/NzbDrone.Mono/DiskProvider.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Mono
             {
                 var error = Stdlib.GetLastError();
 
-                throw new LinuxPermissionsException("Error setting file owner: " + error);
+                throw new LinuxPermissionsException("Error setting file owner and/or group: " + error);
             }
         }
 


### PR DESCRIPTION
This error will be triggered if either setting the group or the user is the problem.  Fixing the wording after being led astray tracking down issue that was group, not user, related.
