### PR TITLE
Season Search now correctly uses scene numbering

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -239,11 +239,16 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                         Episodes = episodes.Where(v => v.SceneEpisodeNumber == p.EpisodeNumbers.First()).ToList()
                     });
 
-            Mocker.SetConstant<IEnumerable<IDecisionEngineSpecification>>(new List<IDecisionEngineSpecification>());
+            Mocker.SetConstant<IEnumerable<IDecisionEngineSpecification>>(new List<IDecisionEngineSpecification>
+            {
+                Mocker.Resolve<NzbDrone.Core.DecisionEngine.Specifications.Search.EpisodeRequestedSpecification>()
+            });
 
             var decisions = Subject.GetSearchDecision(reports, criteria);
 
-            Assert.AreEqual(1, decisions.Count);
+            var approvedDecisions = decisions.Where(v => v.Approved).ToList();
+
+            approvedDecisions.Count.Should().Be(1);
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -97,17 +97,6 @@ namespace NzbDrone.Core.DecisionEngine
 
                 if (decision != null)
                 {
-                    if (searchCriteria != null)
-                    {
-                        var criteriaEpisodes = searchCriteria.Episodes.Select(v => v.Id).ToList();
-                        var remoteEpisodes = decision.RemoteEpisode.Episodes.Select(v => v.Id).ToList();
-                        if (!criteriaEpisodes.Intersect(remoteEpisodes).Any())
-                        {
-                            _logger.Debug("Release rejected since the episode wasn't requested: {0}", decision.RemoteEpisode.ParsedEpisodeInfo);
-                            continue;
-                        }
-                    }
-
                     if (decision.Rejections.Any())
                     {
                         _logger.Debug("Release rejected for the following reasons: {0}", String.Join(", ", decision.Rejections));

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using NLog;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Parser.Model;
+
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.Search
+{
+    public class EpisodeRequestedSpecification : IDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public EpisodeRequestedSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public string RejectionReason
+        {
+            get
+            {
+                return "Episode wasn't requested";
+            }
+        }
+
+        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        {
+            if (searchCriteria == null)
+            {
+                return true;
+            }
+            var criteriaEpisodes = searchCriteria.Episodes.Select(v => v.Id).ToList();
+            var remoteEpisodes = remoteEpisode.Episodes.Select(v => v.Id).ToList();
+            if (!criteriaEpisodes.Intersect(remoteEpisodes).Any())
+            {
+                _logger.Debug("Release rejected since the episode wasn't requested: {0}", remoteEpisode.ParsedEpisodeInfo);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -217,6 +217,7 @@
     <Compile Include="DecisionEngine\Specifications\NotRestrictedReleaseSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\NotSampleSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\ProperSpecification.cs" />
+    <Compile Include="DecisionEngine\Specifications\Search\EpisodeRequestedSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\SeriesSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\SeasonMatchSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\DailyEpisodeMatchSpecification.cs" />


### PR DESCRIPTION
SeasonSearch now groups the episodes by SceneSeasonNumber.
Then, per group, it decides whether to search for season or single episode.
This is to prevent full season searched for the odd cases that an single episode from one season is included in another season.

Once the search is complete, reports that weren't originally searched for are ignored. This makes sure it only processes the season the user requested.

Code was developed test-driven.
