### PR TITLE
Fixed: Moved main database cleanup to daily housekeeping process

### DIFF
--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -78,12 +78,6 @@ namespace NzbDrone.Core.Datastore
                     return dataMapper;
                 });
 
-
-            if (migrationType == MigrationType.Main)
-            {
-                db.Vacuum();
-            }
-
             return db;
         }
     }


### PR DESCRIPTION
To prevent windows service startup failures the db vacuum must be performed during housekeeping instead of startup.
