### PR TITLE
Adds leading 0 for single digit Anime searches

### DIFF
--- a/src/NzbDrone.Core/Indexers/Fanzub/Fanzub.cs
+++ b/src/NzbDrone.Core/Indexers/Fanzub/Fanzub.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Indexers.Fanzub
 
         public override IEnumerable<string> GetAnimeEpisodeSearchUrls(string seriesTitle, int tvRageId, int absoluteEpisodeNumber)
         {
-            return RecentFeed.Select(url => String.Format("{0}&q={1}%20{2}", url, seriesTitle, absoluteEpisodeNumber));
+            return RecentFeed.Select(url => String.Format("{0}&q={1}%20{2:00}", url, seriesTitle, absoluteEpisodeNumber));
         }
 
         public override IEnumerable<string> GetSearchUrls(string query, int offset)

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Indexers.Newznab
              * For now: just search based on name and abs episode number
              */
 
-            return RecentFeed.Select(url => String.Format("{0}&limit=100&q={1}+{2}", url.Replace("t=tvsearch", "t=search"), NewsnabifyTitle(seriesTitle), absoluteEpisodeNumber));
+            return RecentFeed.Select(url => String.Format("{0}&limit=100&q={1}+{2:00}", url.Replace("t=tvsearch", "t=search"), NewsnabifyTitle(seriesTitle), absoluteEpisodeNumber));
         }
 
         public override IEnumerable<string> GetSeasonSearchUrls(string seriesTitle, int tvRageId, int seasonNumber, int offset)


### PR DESCRIPTION
When requesting an episode of Anime with a single digit episode number,
the results would get cluttered with episodes that weren't requested.
Nzbdrone correctly ignored those episodes, but sometimes more than 100 of
those results would appear which would keep requested episodes from showing
up in search results. This change makes it so that at least 2 digits are
used in the query string when searching for Anime episodes. Besides being
a closer match to what the scene actually releases, it also cuts down on the
clutter from non-requested episodes containing the requested episode number
in the hash/resolution.
