### PR TITLE
Move grid below show/hide button so that the button does not move when t...

### DIFF
--- a/src/UI/Series/Details/SeasonLayoutTemplate.html
+++ b/src/UI/Series/Details/SeasonLayoutTemplate.html
@@ -31,7 +31,6 @@
             </div>
         </span>
     </h2>
-    <div class="x-episode-grid table-responsive"></div>
     <div class="show-hide-episodes x-show-hide-episodes">
         <h4>
             {{#if showingEpisodes}}
@@ -43,4 +42,5 @@
             {{/if}}
         </h4>
     </div>
+    <div class="x-episode-grid table-responsive"></div>
 </div>


### PR DESCRIPTION
...he grid is shown. The reason for this change is when you click the button to show the episodes, the button moves to the bottom, which requires a scroll down to then hide the episode list. This is incredibly frustrating when you just want to take a quick look at the episode list.
