### PR TITLE
Fixed: Repaired Cutoff Unmet UI and added Cutoff Unmet status badge to H...

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarModule.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Api.Episodes;
 using NzbDrone.Api.Extensions;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
@@ -11,17 +12,11 @@ namespace NzbDrone.Api.Calendar
 {
     public class CalendarModule : EpisodeModuleWithSignalR
     {
-        private readonly IEpisodeService _episodeService;
-        private readonly SeriesRepository _seriesRepository;
-
-        public CalendarModule(IBroadcastSignalRMessage signalRBroadcaster,
-                              IEpisodeService episodeService,
-                              SeriesRepository seriesRepository)
-            : base(episodeService, signalRBroadcaster, "calendar")
+        public CalendarModule(IEpisodeService episodeService,
+                              IQualityUpgradableSpecification qualityUpgradableSpecification,
+                              IBroadcastSignalRMessage signalRBroadcaster)
+            : base(episodeService, qualityUpgradableSpecification, signalRBroadcaster, "calendar")
         {
-            _episodeService = episodeService;
-            _seriesRepository = seriesRepository;
-
             GetResourceAll = GetCalendar;
         }
 
@@ -36,8 +31,7 @@ namespace NzbDrone.Api.Calendar
             if (queryStart.HasValue) start = DateTime.Parse(queryStart.Value);
             if (queryEnd.HasValue) end = DateTime.Parse(queryEnd.Value);
 
-            var resources = ToListResource(() => _episodeService.EpisodesBetweenDates(start, end))
-                .LoadSubtype(e => e.SeriesId, _seriesRepository);
+            var resources = ToListResource(() => _episodeService.EpisodesBetweenDates(start, end));
 
             return resources.OrderBy(e => e.AirDateUtc).ToList();
         }

--- a/src/NzbDrone.Api/History/HistoryModule.cs
+++ b/src/NzbDrone.Api/History/HistoryModule.cs
@@ -2,6 +2,7 @@
 using Nancy;
 using NzbDrone.Api.Extensions;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.History;
 
@@ -10,15 +11,33 @@ namespace NzbDrone.Api.History
     public class HistoryModule : NzbDroneRestModule<HistoryResource>
     {
         private readonly IHistoryService _historyService;
+        private readonly IQualityUpgradableSpecification _qualityUpgradableSpecification;
         private readonly IDownloadTrackingService _downloadTrackingService;
 
-        public HistoryModule(IHistoryService historyService, IDownloadTrackingService downloadTrackingService)
+        public HistoryModule(IHistoryService historyService,
+                             IQualityUpgradableSpecification qualityUpgradableSpecification,
+                             IDownloadTrackingService downloadTrackingService)
         {
             _historyService = historyService;
+            _qualityUpgradableSpecification = qualityUpgradableSpecification;
             _downloadTrackingService = downloadTrackingService;
             GetResourcePaged = GetHistory;
 
             Post["/failed"] = x => MarkAsFailed();
+        }
+
+        protected override HistoryResource ToResource<TModel>(TModel model)
+        {
+            var resource = base.ToResource<TModel>(model);
+
+            var history = model as NzbDrone.Core.History.History;
+
+            if (history != null && history.Series != null)
+            {
+                resource.QualityCutoffNotMet = _qualityUpgradableSpecification.CutoffNotMet(history.Series.Profile.Value, history.Quality);
+            }
+
+            return resource;
         }
 
         private PagingResource<HistoryResource> GetHistory(PagingResource<HistoryResource> pagingResource)

--- a/src/NzbDrone.Api/History/HistoryResource.cs
+++ b/src/NzbDrone.Api/History/HistoryResource.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Api.History
         public int SeriesId { get; set; }
         public string SourceTitle { get; set; }
         public QualityModel Quality { get; set; }
+        public Boolean QualityCutoffNotMet { get; set; }
         public DateTime Date { get; set; }
         public string Indexer { get; set; }
         public string NzbInfoUrl { get; set; }

--- a/src/NzbDrone.Api/NzbDroneRestModule.cs
+++ b/src/NzbDrone.Api/NzbDroneRestModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using NzbDrone.Api.REST;
 using NzbDrone.Api.Validation;
@@ -34,7 +35,17 @@ namespace NzbDrone.Api
         protected List<TResource> ToListResource<TModel>(Func<IEnumerable<TModel>> function) where TModel : class
         {
             var modelList = function();
-            return modelList.InjectTo<List<TResource>>();
+            return ToListResource(modelList);
+        }
+
+        protected virtual List<TResource> ToListResource<TModel>(IEnumerable<TModel> modelList) where TModel : class
+        {
+            return modelList.Select(ToResource).ToList();
+        }
+
+        protected virtual TResource ToResource<TModel>(TModel model) where TModel : class
+        {
+            return model.InjectTo<TResource>();
         }
 
         protected PagingResource<TResource> ApplyToPage<TModel>(Func<PagingSpec<TModel>, PagingSpec<TModel>> function, PagingSpec<TModel> pagingSpec) where TModel : ModelBase, new()
@@ -48,7 +59,7 @@ namespace NzbDrone.Api
                            SortDirection = pagingSpec.SortDirection,
                            SortKey = pagingSpec.SortKey,
                            TotalRecords = pagingSpec.TotalRecords,
-                           Records = pagingSpec.Records.InjectTo<List<TResource>>()
+                           Records = ToListResource(pagingSpec.Records)
                        };
         }
     }

--- a/src/NzbDrone.Api/Wanted/CutoffModule.cs
+++ b/src/NzbDrone.Api/Wanted/CutoffModule.cs
@@ -2,6 +2,7 @@
 using NzbDrone.Api.Episodes;
 using NzbDrone.Api.Extensions;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
 
@@ -10,13 +11,14 @@ namespace NzbDrone.Api.Wanted
     public class CutoffModule : EpisodeModuleWithSignalR
     {
         private readonly IEpisodeCutoffService _episodeCutoffService;
-        private readonly ISeriesRepository _seriesRepository;
 
-        public CutoffModule(IEpisodeService episodeService, IEpisodeCutoffService episodeCutoffService, ISeriesRepository seriesRepository, IBroadcastSignalRMessage signalRBroadcaster)
-            : base(episodeService, signalRBroadcaster, "wanted/cutoff")
+        public CutoffModule(IEpisodeCutoffService episodeCutoffService,
+                            IEpisodeService episodeService,
+                            IQualityUpgradableSpecification qualityUpgradableSpecification,
+                            IBroadcastSignalRMessage signalRBroadcaster)
+            : base(episodeService, qualityUpgradableSpecification, signalRBroadcaster, "wanted/cutoff")
         {
             _episodeCutoffService = episodeCutoffService;
-            _seriesRepository = seriesRepository;
             GetResourcePaged = GetCutoffUnmetEpisodes;
         }
 
@@ -40,8 +42,6 @@ namespace NzbDrone.Api.Wanted
             }
 
             PagingResource<EpisodeResource> resource = ApplyToPage(_episodeCutoffService.EpisodesWhereCutoffUnmet, pagingSpec);
-
-            resource.Records = resource.Records.LoadSubtype(e => e.SeriesId, _seriesRepository).ToList();
 
             return resource;
         }

--- a/src/NzbDrone.Api/Wanted/MissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/MissingModule.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NzbDrone.Api.Episodes;
 using NzbDrone.Api.Extensions;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
@@ -11,14 +12,11 @@ namespace NzbDrone.Api.Wanted
 {
     public class MissingModule : EpisodeModuleWithSignalR
     {
-        private readonly IEpisodeService _episodeService;
-        private readonly ISeriesRepository _seriesRepository;
-
-        public MissingModule(IEpisodeService episodeService, ISeriesRepository seriesRepository, IBroadcastSignalRMessage signalRBroadcaster)
-            : base(episodeService, signalRBroadcaster, "wanted/missing")
+        public MissingModule(IEpisodeService episodeService,
+                             IQualityUpgradableSpecification qualityUpgradableSpecification,
+                             IBroadcastSignalRMessage signalRBroadcaster)
+            : base(episodeService, qualityUpgradableSpecification, signalRBroadcaster, "wanted/missing")
         {
-            _episodeService = episodeService;
-            _seriesRepository = seriesRepository;
             GetResourcePaged = GetMissingEpisodes;
         }
 
@@ -42,8 +40,6 @@ namespace NzbDrone.Api.Wanted
             }
 
             PagingResource<EpisodeResource> resource = ApplyToPage(v => _episodeService.EpisodesWithoutFiles(v), pagingSpec);
-
-            resource.Records = resource.Records.LoadSubtype(e => e.SeriesId, _seriesRepository).ToList();
 
             return resource;
         }

--- a/src/UI/Cells/QualityCellTemplate.html
+++ b/src/UI/Cells/QualityCellTemplate.html
@@ -1,5 +1,5 @@
 ﻿{{#if proper}}
     <span class="badge badge-info" title="PROPER">{{quality.name}}</span>
 {{else}}
-    <span class="badge badge-inverse">{{quality.name}}</span>
+    <span class="badge">{{quality.name}}</span>
 {{/if}}

--- a/src/UI/Cells/cells.less
+++ b/src/UI/Cells/cells.less
@@ -78,7 +78,7 @@
   }
 }
 
-td.episode-status-cell, td.quality-cell {
+td.episode-status-cell, td.quality-cell, td.history-quality-cell {
   text-align: center;
   width: 80px;
 

--- a/src/UI/History/Table/HistoryQualityCell.js
+++ b/src/UI/History/Table/HistoryQualityCell.js
@@ -1,0 +1,31 @@
+'use strict';
+define(
+    [
+        'Cells/NzbDroneCell'
+    ], function (NzbDroneCell) {
+        return NzbDroneCell.extend({
+
+            className: 'history-quality-cell',
+
+            render: function () {
+
+                var title = '';
+                var quality = this.model.get('quality');
+
+                if (quality.proper) {
+                    title = 'PROPER';
+                }
+
+                if (this.model.get('qualityCutoffNotMet')) {
+                    this.$el.html('<span class="badge badge-inverse" title="{0}">{1}</span>'.format(title, quality.quality.name));
+                }
+                else {
+                    this.$el.html('<span class="badge" title="{0}">{1}</span>'.format(title, quality.quality.name));
+                }
+
+                return this;
+            }
+
+
+        });
+    });

--- a/src/UI/History/Table/HistoryTableLayout.js
+++ b/src/UI/History/Table/HistoryTableLayout.js
@@ -8,7 +8,7 @@ define(
         'Cells/SeriesTitleCell',
         'Cells/EpisodeNumberCell',
         'Cells/EpisodeTitleCell',
-        'Cells/QualityCell',
+        'History/Table/HistoryQualityCell',
         'Cells/RelativeDateCell',
         'History/Table/HistoryDetailsCell',
         'Shared/Grid/Pager',
@@ -21,7 +21,7 @@ define(
                  SeriesTitleCell,
                  EpisodeNumberCell,
                  EpisodeTitleCell,
-                 QualityCell,
+                 HistoryQualityCell,
                  RelativeDateCell,
                  HistoryDetailsCell,
                  GridPager,
@@ -62,9 +62,9 @@ define(
                         sortable  : false
                     },
                     {
-                        name      : 'quality',
+                        name      : 'this',
                         label     : 'Quality',
-                        cell      : QualityCell,
+                        cell      : HistoryQualityCell,
                         sortable  : false
                     },
                     {


### PR DESCRIPTION
@markus101 In my Cutoff Unmet badge changes I apparently broke Wanted->Cutoff Unmet.
This is because I changed EpisodeResource property EpisodeFile to a Resource. InjectTo can't handle that leaving the property null.
I also noticed the History view not showing that status either, so change the UI a bit there.

Personally I think we can improve the Model to Resource conversions by allowing the Module to register a converter, instead of defaulting to ToListResource with InjectTo<List<TResource>>. That way we can populate additional properties in a logical manner.

I've also removed the LoadSubtype calls, the Series properties already get populated via a Join in the Repository.
