### PR TITLE
New: Show episode file file deletions in history and episode activity

### DIFF
--- a/src/NzbDrone.Api/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/NzbDrone.Api/EpisodeFiles/EpisodeFileModule.cs
@@ -79,8 +79,8 @@ namespace NzbDrone.Api.EpisodeFiles
             var fullPath = Path.Combine(series.Path, episodeFile.RelativePath);
 
             _logger.Info("Deleting episode file: {0}", fullPath);
-            _recycleBinProvider.DeleteFile(fullPath);
-            _mediaFileService.Delete(episodeFile);
+//            _recycleBinProvider.DeleteFile(fullPath);
+            _mediaFileService.Delete(episodeFile, DeleteMediaFileReason.Manual);
         }
 
         private EpisodeFileResource MapToResource(Core.Tv.Series series, EpisodeFile episodeFile)

--- a/src/NzbDrone.Api/Series/SeriesModule.cs
+++ b/src/NzbDrone.Api/Series/SeriesModule.cs
@@ -5,6 +5,7 @@ using FluentValidation;
 using NzbDrone.Common;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
@@ -188,7 +189,7 @@ namespace NzbDrone.Api.Series
 
         public void Handle(EpisodeFileDeletedEvent message)
         {
-            if (message.ForUpgrade) return;
+            if (message.Reason == DeleteMediaFileReason.Upgrade) return;
 
             BroadcastResourceChange(ModelAction.Updated, message.EpisodeFile.SeriesId);
         }

--- a/src/NzbDrone.Core.Test/Datastore/DatabaseRelationshipFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/DatabaseRelationshipFixture.cs
@@ -93,7 +93,9 @@ namespace NzbDrone.Core.Test.Datastore
                 options => options
                     .IncludingAllRuntimeProperties()
                     .Excluding(c => c.DateAdded)
-                    .Excluding(c => c.Path));
+                    .Excluding(c => c.Path)
+                    .Excluding(c => c.Series)
+                    .Excluding(c => c.Episodes));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaFileTableCleanupServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaFileTableCleanupServiceFixture.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new CleanMediaFileDb(0));
 
-            Mocker.GetMock<IMediaFileService>().Verify(c => c.Delete(It.Is<EpisodeFile>(e => e.RelativePath == DELETED_PATH), false), Times.Exactly(2));
+            Mocker.GetMock<IMediaFileService>().Verify(c => c.Delete(It.Is<EpisodeFile>(e => e.RelativePath == DELETED_PATH), DeleteMediaFileReason.RemovedFromDisk), Times.Exactly(2));
         }
 
         [Test]
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new CleanMediaFileDb(0));
 
-            Mocker.GetMock<IMediaFileService>().Verify(c => c.Delete(It.IsAny<EpisodeFile>(), false), Times.Exactly(10));
+            Mocker.GetMock<IMediaFileService>().Verify(c => c.Delete(It.IsAny<EpisodeFile>(), DeleteMediaFileReason.NoLinkedEpisodes), Times.Exactly(10));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode);
 
-            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(It.IsAny<EpisodeFile>(), true), Times.Once());
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(It.IsAny<EpisodeFile>(), DeleteMediaFileReason.Upgrade), Times.Once());
         }
 
         [Test]
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode);
 
-            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localEpisode.Episodes.Single().EpisodeFile.Value, true), Times.Once());
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localEpisode.Episodes.Single().EpisodeFile.Value, DeleteMediaFileReason.Upgrade), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeProviderTests/HandleEpisodeFileDeletedFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeProviderTests/HandleEpisodeFileDeletedFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeProviderTests
         {
             GivenSingleEpisodeFile();
 
-            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, false));
+            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.RemovedFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
                 .Verify(v => v.Update(It.Is<Episode>(e => e.EpisodeFileId == 0)), Times.Once());
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeProviderTests
         {
             GivenMultiEpisodeFile();
 
-            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, false));
+            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.RemovedFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
                 .Verify(v => v.Update(It.Is<Episode>(e => e.EpisodeFileId == 0)), Times.Exactly(2));
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeProviderTests
                   .SetupGet(s => s.AutoUnmonitorPreviouslyDownloadedEpisodes)
                   .Returns(true);
 
-            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, false));
+            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.RemovedFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
                 .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == false)), Times.Once());
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeProviderTests
                   .SetupGet(s => s.AutoUnmonitorPreviouslyDownloadedEpisodes)
                   .Returns(false);
 
-            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, false));
+            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.Upgrade));
 
             Mocker.GetMock<IEpisodeRepository>()
                 .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == true)), Times.Once());
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeProviderTests
                   .SetupGet(s => s.AutoUnmonitorPreviouslyDownloadedEpisodes)
                   .Returns(true);
 
-            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, true));
+            Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.Upgrade));
 
             Mocker.GetMock<IEpisodeRepository>()
                 .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == true)), Times.Once());

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -64,7 +64,11 @@ namespace NzbDrone.Core.Datastore
 
             Mapper.Entity<EpisodeFile>().RegisterModel("EpisodeFiles")
                   .Ignore(f => f.Path)
-                  .Relationships.AutoMapICollectionOrComplexProperties();
+                  .Relationships.AutoMapICollectionOrComplexProperties()
+                  .For("Episodes")
+                  .LazyLoad(condition: parent => parent.Id > 0, 
+                            query: (db, parent) => db.Query<Episode>().Where(c => c.EpisodeFileId == parent.Id).ToList())
+                  .HasOne(file => file.Series, file => file.SeriesId);
 
             Mapper.Entity<Episode>().RegisterModel("Episodes")
                   .Ignore(e => e.SeriesTitle)

--- a/src/NzbDrone.Core/History/History.cs
+++ b/src/NzbDrone.Core/History/History.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Core.History
         Grabbed = 1,
         SeriesFolderImported = 2,
         DownloadFolderImported = 3,
-        DownloadFailed = 4
+        DownloadFailed = 4,
+        EpisodeFileDeleted = 5
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
+++ b/src/NzbDrone.Core/MediaFiles/DeleteMediaFileReason.cs
@@ -1,0 +1,10 @@
+﻿namespace NzbDrone.Core.MediaFiles
+{
+    public enum DeleteMediaFileReason
+    {
+        RemovedFromDisk,
+        Manual,
+        Upgrade,
+        NoLinkedEpisodes
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFile.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Marr.Data;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
@@ -18,7 +20,8 @@ namespace NzbDrone.Core.MediaFiles
         public String ReleaseGroup { get; set; }
         public QualityModel Quality { get; set; }
         public MediaInfoModel MediaInfo { get; set; }
-        public LazyList<Episode> Episodes { get; set; }
+        public LazyLoaded<List<Episode>> Episodes { get; set; }
+        public LazyLoaded<Series> Series { get; set; }
 
         public override String ToString()
         {

--- a/src/NzbDrone.Core/MediaFiles/Events/EpisodeFileDeletedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/EpisodeFileDeletedEvent.cs
@@ -1,17 +1,16 @@
-﻿using System;
-using NzbDrone.Common.Messaging;
+﻿using NzbDrone.Common.Messaging;
 
 namespace NzbDrone.Core.MediaFiles.Events
 {
     public class EpisodeFileDeletedEvent : IEvent
     {
         public EpisodeFile EpisodeFile { get; private set; }
-        public Boolean ForUpgrade { get; private set; }
+        public DeleteMediaFileReason Reason { get; private set; }
 
-        public EpisodeFileDeletedEvent(EpisodeFile episodeFile, Boolean forUpgrade)
+        public EpisodeFileDeletedEvent(EpisodeFile episodeFile, DeleteMediaFileReason reason)
         {
             EpisodeFile = episodeFile;
-            ForUpgrade = forUpgrade;
+            Reason = reason;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
@@ -47,14 +47,14 @@ namespace NzbDrone.Core.MediaFiles
                     if (!_diskProvider.FileExists(episodeFilePath))
                     {
                         _logger.Debug("File [{0}] no longer exists on disk, removing from db", episodeFilePath);
-                        _mediaFileService.Delete(episodeFile);
+                        _mediaFileService.Delete(episodeFile, DeleteMediaFileReason.RemovedFromDisk);
                         continue;
                     }
 
                     if (!episodes.Any(e => e.EpisodeFileId == episodeFile.Id))
                     {
                         _logger.Debug("File [{0}] is not assigned to any episodes, removing from db", episodeFilePath);
-                        _mediaFileService.Delete(episodeFile);
+                        _mediaFileService.Delete(episodeFile, DeleteMediaFileReason.NoLinkedEpisodes);
                         continue;
                     }
 

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
 
                 moveFileResult.OldFiles.Add(file);
-                _mediaFileService.Delete(file, true);
+                _mediaFileService.Delete(file, DeleteMediaFileReason.Upgrade);
             }
 
             if (copyOnly)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -459,6 +459,7 @@
     <Compile Include="MediaFiles\Commands\RenameFilesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameSeriesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RescanSeriesCommand.cs" />
+    <Compile Include="MediaFiles\DeleteMediaFileReason.cs" />
     <Compile Include="MediaFiles\DiskScanService.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NLog;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Tv.Events;
@@ -185,7 +186,7 @@ namespace NzbDrone.Core.Tv
                 _logger.Debug("Detaching episode {0} from file.", episode.Id);
                 episode.EpisodeFileId = 0;
 
-                if (!message.ForUpgrade && _configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
+                if (message.Reason != DeleteMediaFileReason.Upgrade && _configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
                 {
                     episode.Monitored = false;
                 }

--- a/src/UI/Cells/EventTypeCell.js
+++ b/src/UI/Cells/EventTypeCell.js
@@ -33,6 +33,10 @@ define(
                             icon = 'icon-nd-download-failed';
                             toolTip = 'Episode download failed';
                             break;
+                        case 'episodeFileDeleted':
+                            icon = 'icon-nd-deleted';
+                            toolTip = 'Episode file deleted';
+                            break;
                         default :
                             icon = 'icon-question';
                             toolTip = 'unknown event';

--- a/src/UI/Content/icons.less
+++ b/src/UI/Content/icons.less
@@ -191,3 +191,7 @@
   .icon(@exclamation-sign);
   color : @brand-danger;
 }
+
+.icon-nd-deleted:before {
+  .icon(@trash);
+}

--- a/src/UI/History/Details/HistoryDetailsLayoutTemplate.hbs
+++ b/src/UI/History/Details/HistoryDetailsLayoutTemplate.hbs
@@ -7,6 +7,7 @@
                 {{#if_eq eventType compare="grabbed"}}Grabbed{{/if_eq}}
                 {{#if_eq eventType compare="downloadFailed"}}Download Failed{{/if_eq}}
                 {{#if_eq eventType compare="downloadFolderImported"}}Episode Imported{{/if_eq}}
+                {{#if_eq eventType compare="episodeFileDeleted"}}Episode File Deleted{{/if_eq}}
             </h3>
 
         </div>

--- a/src/UI/History/Details/HistoryDetailsViewTemplate.hbs
+++ b/src/UI/History/Details/HistoryDetailsViewTemplate.hbs
@@ -36,6 +36,7 @@
     {{/with}}
 </dl>
 {{/if_eq}}
+
 {{#if_eq eventType compare="downloadFailed"}}
 <dl class="dl-horizontal">
 
@@ -48,6 +49,7 @@
     {{/with}}
 </dl>
 {{/if_eq}}
+
 {{#if_eq eventType compare="downloadFolderImported"}}
 <dl class="dl-horizontal">
 
@@ -66,6 +68,31 @@
     <dt>Imported To:</dt>
     <dd>{{importedPath}}</dd>
     {{/if}}
+    {{/with}}
+</dl>
+{{/if_eq}}
+
+{{#if_eq eventType compare="episodeFileDeleted"}}
+<dl class="dl-horizontal">
+
+    <dt>Path:</dt>
+    <dd>{{sourceTitle}}</dd>
+
+    {{#with data}}
+    <dt>Reason:</dt>
+    <dd>
+        {{#if_eq reason compare="Manual"}}
+            File was deleted by via UI
+        {{/if_eq}}
+
+        {{#if_eq reason compare="RemovedFromDisk"}}
+            File was deleted directly from disk
+        {{/if_eq}}
+
+        {{#if_eq reason compare="Upgrade"}}
+            File was deleted to imported an upgrade
+        {{/if_eq}}
+    </dd>
     {{/with}}
 </dl>
 {{/if_eq}}


### PR DESCRIPTION
This will show deletions (for upgrades, deleted from disk or deleted by the user), in history and activity for the episode. The main idea was to show upgrades, so we know for certain why a file was deleted (because it can be a bit of a guessing game w/o logs) and people lie (get things mixed up).
