### PR TITLE
CDH Improvements

### DIFF
--- a/src/NzbDrone.Api/Queue/QueueResource.cs
+++ b/src/NzbDrone.Api/Queue/QueueResource.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using NzbDrone.Api.REST;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Api.Series;
 using NzbDrone.Api.Episodes;
@@ -17,6 +19,7 @@ namespace NzbDrone.Api.Queue
         public TimeSpan? Timeleft { get; set; }
         public DateTime? EstimatedCompletionTime { get; set; }
         public String Status { get; set; }
-        public String ErrorMessage { get; set; }
+        public String TrackedDownloadStatus { get; set; }
+        public List<TrackedDownloadStatusMessage> StatusMessages { get; set; }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/NotInQueueSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/NotInQueueSpecificationFixture.cs
@@ -69,10 +69,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 queue.Add(new TrackedDownload
                 {
                     State = state,
-                    DownloadItem = new DownloadClientItem
-                        {
-                            RemoteEpisode = remoteEpisode
-                        }
+                    RemoteEpisode = remoteEpisode
                 });
             }
 

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using FluentAssertions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Parser;
@@ -30,7 +31,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
                 .Returns(30);
 
             Mocker.GetMock<IParsingService>()
-                .Setup(s => s.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), null))
+                .Setup(s => s.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), (SearchCriteriaBase)null))
                 .Returns(() => CreateRemoteEpisode());
 
             Mocker.GetMock<IHttpClient>()
@@ -64,11 +65,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
         {
             downloadClientItem.DownloadClient.Should().Be(Subject.Definition.Name);
             downloadClientItem.DownloadClientId.Should().NotBeNullOrEmpty();
-
             downloadClientItem.Title.Should().NotBeNullOrEmpty();
-
-            downloadClientItem.RemoteEpisode.Should().NotBeNull();
-
         }
 
         protected void VerifyQueued(DownloadClientItem downloadClientItem)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotInQueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotInQueueSpecification.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         {
             var queue = _downloadTrackingService.GetQueuedDownloads()
                             .Where(v => v.State == TrackedDownloadState.Downloading)
-                            .Select(q => q.DownloadItem.RemoteEpisode).ToList();
+                            .Select(q => q.RemoteEpisode).ToList();
 
             if (IsInQueue(subject, queue))
             {

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -201,9 +201,6 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
             {
                 if (downloadClientItem.Category == Settings.TvCategory)
                 {
-                    downloadClientItem.RemoteEpisode = GetRemoteEpisode(downloadClientItem.Title);
-                    if (downloadClientItem.RemoteEpisode == null) continue;
-
                     yield return downloadClientItem;
                 }
             }

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -103,9 +103,6 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
                     historyItem.Status = DownloadItemStatus.Completed;
                 }
 
-                historyItem.RemoteEpisode = GetRemoteEpisode(historyItem.Title);
-                if (historyItem.RemoteEpisode == null) continue;
-
                 yield return historyItem;
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -188,9 +188,6 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
             {
                 if (downloadClientItem.Category == Settings.TvCategory)
                 {
-                    downloadClientItem.RemoteEpisode = GetRemoteEpisode(downloadClientItem.Title);
-                    if (downloadClientItem.RemoteEpisode == null) continue;
-
                     yield return downloadClientItem;
                 }
             }

--- a/src/NzbDrone.Core/Download/Clients/UsenetBlackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/UsenetBlackhole/UsenetBlackhole.cs
@@ -90,9 +90,6 @@ namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
                     historyItem.RemainingTime = TimeSpan.Zero;
                 }
 
-                historyItem.RemoteEpisode = GetRemoteEpisode(historyItem.Title);
-                if (historyItem.RemoteEpisode == null) continue;
-
                 yield return historyItem;
             }
 
@@ -120,9 +117,6 @@ namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
                     historyItem.Status = DownloadItemStatus.Completed;
                     historyItem.RemainingTime = TimeSpan.Zero;
                 }
-
-                historyItem.RemoteEpisode = GetRemoteEpisode(historyItem.Title);
-                if (historyItem.RemoteEpisode == null) continue;
 
                 yield return historyItem;
             }

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 using NzbDrone.Common;
 using NzbDrone.Common.Disk;
@@ -21,7 +20,6 @@ namespace NzbDrone.Core.Download
     {
         protected readonly IConfigService _configService;
         protected readonly IDiskProvider _diskProvider;
-        protected readonly IParsingService _parsingService;
         protected readonly IRemotePathMappingService _remotePathMappingService;
         protected readonly Logger _logger;
 
@@ -55,7 +53,6 @@ namespace NzbDrone.Core.Download
         {
             _configService = configService;
             _diskProvider = diskProvider;
-            _parsingService = parsingService;
             _remotePathMappingService = remotePathMappingService;
             _logger = logger;
         }
@@ -75,17 +72,6 @@ namespace NzbDrone.Core.Download
         public abstract void RemoveItem(string id);
         public abstract String RetryDownload(string id);
         public abstract DownloadClientStatus GetStatus();
-
-        protected RemoteEpisode GetRemoteEpisode(String title)
-        {
-            var parsedEpisodeInfo = Parser.Parser.ParseTitle(title);
-            if (parsedEpisodeInfo == null) return null;
-
-            var remoteEpisode = _parsingService.Map(parsedEpisodeInfo, 0);
-            if (remoteEpisode.Series == null) return null;
-
-            return remoteEpisode;
-        }
 
         public ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -1,5 +1,4 @@
-﻿using NzbDrone.Core.Parser.Model;
-using System;
+﻿using System;
 
 namespace NzbDrone.Core.Download
 {
@@ -21,7 +20,5 @@ namespace NzbDrone.Core.Download
         public DownloadItemStatus Status { get; set; }
         public Boolean IsEncrypted { get; set; }
         public Boolean IsReadOnly { get; set; }
-
-        public RemoteEpisode RemoteEpisode { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadItemStatus.cs
+++ b/src/NzbDrone.Core/Download/DownloadItemStatus.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace NzbDrone.Core.Download
+﻿namespace NzbDrone.Core.Download
 {
     public enum DownloadItemStatus
     {

--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NzbDrone.Common;
-using NzbDrone.Common.Cache;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.History;
-using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Download
@@ -68,7 +66,7 @@ namespace NzbDrone.Core.Download
 
                 if (!grabbedItems.Any())
                 {
-                    UpdateStatusMessage(trackedDownload, LogLevel.Debug, "Download was not grabbed by drone, ignoring download");
+                    UpdateStatusMessage(trackedDownload, LogLevel.Warn, "Download was not grabbed by drone, ignoring download");
                     return;
                 }
 
@@ -92,7 +90,7 @@ namespace NzbDrone.Core.Download
 
                 if (!grabbedItems.Any())
                 {
-                    UpdateStatusMessage(trackedDownload, LogLevel.Debug, "Download wasn't grabbed by drone or not in a category, ignoring download.");
+                    UpdateStatusMessage(trackedDownload, LogLevel.Warn, "Download wasn't grabbed by drone or not in a category, ignoring download.");
                     return;
                 }
 
@@ -244,8 +242,12 @@ namespace NzbDrone.Core.Download
 
             if (trackedDownload.StatusMessage != statusMessage)
             {
-                trackedDownload.HasError = logLevel >= LogLevel.Warn;
+                trackedDownload.SetStatusLevel(logLevel);
                 trackedDownload.StatusMessage = statusMessage;
+                trackedDownload.StatusMessages = new List<TrackedDownloadStatusMessage>
+                                                 {
+                                                     new TrackedDownloadStatusMessage(trackedDownload.DownloadItem.Title, statusMessage)
+                                                 };
                 _logger.Log(logLevel, logMessage);
             }
             else

--- a/src/NzbDrone.Core/Download/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownload.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using NLog;
+using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Download
 {
@@ -9,12 +11,33 @@ namespace NzbDrone.Core.Download
         public Int32 DownloadClient { get; set; }
         public DownloadClientItem DownloadItem { get; set; }
         public TrackedDownloadState State { get; set; }
+        public TrackedDownloadStatus Status { get; set; }
         public DateTime StartedTracking { get; set; }
         public DateTime LastRetry { get; set; }
         public Int32 RetryCount { get; set; }
-        public Boolean HasError { get; set; }
         public String StatusMessage { get; set; }
-        public List<String> StatusMessages { get; set; }
+        public RemoteEpisode RemoteEpisode { get; set; }
+        public List<TrackedDownloadStatusMessage> StatusMessages { get; set; }
+
+        public TrackedDownload()
+        {
+            StatusMessages = new List<TrackedDownloadStatusMessage>();
+        }
+
+        public void SetStatusLevel(LogLevel logLevel)
+        {
+            if (logLevel == LogLevel.Warn)
+            {
+                Status = TrackedDownloadStatus.Warning;
+            }
+
+            if (logLevel >= LogLevel.Error)
+            {
+                Status = TrackedDownloadStatus.Error;
+            }
+
+            else Status = TrackedDownloadStatus.Ok;
+        }
     }
 
     public enum TrackedDownloadState
@@ -24,5 +47,12 @@ namespace NzbDrone.Core.Download
         Imported,
         DownloadFailed,
         Removed
+    }
+
+    public enum TrackedDownloadStatus
+    {
+        Ok,
+        Warning,
+        Error
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloadStatusMessage.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloadStatusMessage.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Download
+{
+    public class TrackedDownloadStatusMessage
+    {
+        public String Title { get; set; }
+        public List<String> Messages { get; set; }
+
+        public TrackedDownloadStatusMessage(String title, List<String> messages)
+        {
+            Title = title;
+            Messages = messages;
+        }
+
+        public TrackedDownloadStatusMessage(String title, String message)
+        {
+            Title = title;
+            Messages = new List<String>{ message };
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Download\Clients\UsenetBlackhole\UsenetBlackhole.cs" />
     <Compile Include="Download\Clients\UsenetBlackhole\UsenetBlackholeSettings.cs" />
     <Compile Include="Download\CompletedDownloadService.cs" />
+    <Compile Include="Download\TrackedDownloadStatusMessage.cs" />
     <Compile Include="Download\UsenetClientBase.cs" />
     <Compile Include="Download\DownloadClientBase.cs" />
     <Compile Include="Download\DownloadClientDefinition.cs" />

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -16,7 +16,8 @@ namespace NzbDrone.Core.Parser
     {
         LocalEpisode GetLocalEpisode(string filename, Series series, bool sceneSource);
         Series GetSeries(string title);
-        RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvRageId, SearchCriteriaBase searchCriteria = null);
+        RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 tvRageId, SearchCriteriaBase searchCriteria = null);
+        RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 seriesId, IEnumerable<Int32> episodeIds);
         List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series series, bool sceneSource, SearchCriteriaBase searchCriteria = null);
         ParsedEpisodeInfo ParseSpecialEpisodeTitle(string title, int tvRageId, SearchCriteriaBase searchCriteria = null);
         ParsedEpisodeInfo ParseSpecialEpisodeTitle(string title, Series series);
@@ -99,7 +100,7 @@ namespace NzbDrone.Core.Parser
             return series;
         }
 
-        public RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvRageId, SearchCriteriaBase searchCriteria = null)
+        public RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 tvRageId, SearchCriteriaBase searchCriteria = null)
         {
             var remoteEpisode = new RemoteEpisode
                 {
@@ -116,6 +117,18 @@ namespace NzbDrone.Core.Parser
 
             remoteEpisode.Series = series;
             remoteEpisode.Episodes = GetEpisodes(parsedEpisodeInfo, series, true, searchCriteria);
+
+            return remoteEpisode;
+        }
+
+        public RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 seriesId, IEnumerable<Int32> episodeIds)
+        {
+            var remoteEpisode = new RemoteEpisode
+            {
+                ParsedEpisodeInfo = parsedEpisodeInfo,
+                Series = _seriesService.GetSeries(seriesId),
+                Episodes = _episodeService.GetEpisodes(episodeIds)
+            };
 
             return remoteEpisode;
         }

--- a/src/NzbDrone.Core/Queue/Queue.cs
+++ b/src/NzbDrone.Core/Queue/Queue.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Parser.Model;
@@ -17,7 +19,8 @@ namespace NzbDrone.Core.Queue
         public TimeSpan? Timeleft { get; set; }
         public DateTime? EstimatedCompletionTime { get; set; }
         public String Status { get; set; }
-        public String ErrorMessage { get; set; }
+        public String TrackedDownloadStatus { get; set; }
+        public List<TrackedDownloadStatusMessage> StatusMessages { get; set; }
         public RemoteEpisode RemoteEpisode { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -28,32 +28,29 @@ namespace NzbDrone.Core.Queue
             return MapQueue(queueItems);
         }
 
-        private List<Queue> MapQueue(IEnumerable<TrackedDownload> queueItems)
+        private List<Queue> MapQueue(IEnumerable<TrackedDownload> trackedDownloads)
         {
             var queued = new List<Queue>();
 
-            foreach (var queueItem in queueItems)
+            foreach (var trackedDownload in trackedDownloads)
             {
-                foreach (var episode in queueItem.DownloadItem.RemoteEpisode.Episodes)
+                foreach (var episode in trackedDownload.RemoteEpisode.Episodes)
                 {
                     var queue = new Queue
                                 {
-                                    Id = episode.Id ^ (queueItem.DownloadItem.DownloadClientId.GetHashCode().GetHashCode() << 16),
-                                    Series = queueItem.DownloadItem.RemoteEpisode.Series,
+                                    Id = episode.Id ^ (trackedDownload.DownloadItem.DownloadClientId.GetHashCode().GetHashCode() << 16),
+                                    Series = trackedDownload.RemoteEpisode.Series,
                                     Episode = episode,
-                                    Quality = queueItem.DownloadItem.RemoteEpisode.ParsedEpisodeInfo.Quality,
-                                    Title = queueItem.DownloadItem.Title,
-                                    Size = queueItem.DownloadItem.TotalSize,
-                                    Sizeleft = queueItem.DownloadItem.RemainingSize,
-                                    Timeleft = queueItem.DownloadItem.RemainingTime,
-                                    Status = queueItem.DownloadItem.Status.ToString(),
-                                    RemoteEpisode = queueItem.DownloadItem.RemoteEpisode
+                                    Quality = trackedDownload.RemoteEpisode.ParsedEpisodeInfo.Quality,
+                                    Title = trackedDownload.DownloadItem.Title,
+                                    Size = trackedDownload.DownloadItem.TotalSize,
+                                    Sizeleft = trackedDownload.DownloadItem.RemainingSize,
+                                    Timeleft = trackedDownload.DownloadItem.RemainingTime,
+                                    Status = trackedDownload.DownloadItem.Status.ToString(),
+                                    RemoteEpisode = trackedDownload.RemoteEpisode,
+                                    TrackedDownloadStatus = trackedDownload.Status.ToString(),
+                                    StatusMessages = trackedDownload.StatusMessages
                                 };
-
-                    if (queueItem.HasError)
-                    {
-                        queue.ErrorMessage = queueItem.StatusMessage;
-                    }
 
                     if (queue.Timeleft.HasValue)
                     {

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.Tv
     public interface IEpisodeService
     {
         Episode GetEpisode(int id);
+        List<Episode> GetEpisodes(IEnumerable<Int32> ids);
         Episode FindEpisode(int seriesId, int seasonNumber, int episodeNumber);
         Episode FindEpisode(int seriesId, int absoluteEpisodeNumber);
         Episode FindEpisodeByName(int seriesId, int seasonNumber, string episodeTitle);
@@ -37,9 +38,9 @@ namespace NzbDrone.Core.Tv
     }
 
     public class EpisodeService : IEpisodeService,
-        IHandle<EpisodeFileDeletedEvent>,
-        IHandle<EpisodeFileAddedEvent>,
-        IHandleAsync<SeriesDeletedEvent>
+                                  IHandle<EpisodeFileDeletedEvent>,
+                                  IHandle<EpisodeFileAddedEvent>,
+                                  IHandleAsync<SeriesDeletedEvent>
     {
         private readonly IEpisodeRepository _episodeRepository;
         private readonly IConfigService _configService;
@@ -55,6 +56,11 @@ namespace NzbDrone.Core.Tv
         public Episode GetEpisode(int id)
         {
             return _episodeRepository.Get(id);
+        }
+
+        public List<Episode> GetEpisodes(IEnumerable<int> ids)
+        {
+            return _episodeRepository.Get(ids).ToList();
         }
 
         public Episode FindEpisode(int seriesId, int seasonNumber, int episodeNumber)

--- a/src/UI/Content/icons.less
+++ b/src/UI/Content/icons.less
@@ -204,3 +204,7 @@
 .icon-nd-deleted:before {
   .icon(@trash);
 }
+
+.icon-nd-warning:before {
+  color: @brand-warning;
+}

--- a/src/UI/History/Queue/QueueStatusCell.js
+++ b/src/UI/History/Queue/QueueStatusCell.js
@@ -2,20 +2,26 @@
 
 define(
     [
+        'marionette',
         'Cells/NzbDroneCell'
-    ], function (NzbDroneCell) {
+    ], function (Marionette, NzbDroneCell) {
         return NzbDroneCell.extend({
 
-            className: 'queue-status-cell',
+            className : 'queue-status-cell',
+            template  : 'History/Queue/QueueStatusCellTemplate',
 
             render: function () {
                 this.$el.empty();
 
                 if (this.cellValue) {
                     var status = this.cellValue.get('status').toLowerCase();
-                    var errorMessage = (this.cellValue.get('errorMessage') || '');
+                    var trackedDownloadStatus = this.cellValue.get('trackedDownloadStatus').toLowerCase();
+                    var hasError = this.cellValue.get('hasError') || false;
+                    var hasWarning = this.cellValue.get('hasWarning') || false;
                     var icon = 'icon-nd-downloading';
                     var title = 'Downloading';
+                    var itemTitle = this.cellValue.get('title');
+                    var content = itemTitle;
 
                     if (status === 'paused') {
                         icon = 'icon-pause';
@@ -39,7 +45,7 @@ define(
 
                     if (status === 'failed') {
                         icon = 'icon-nd-download-failed';
-                        title = 'Download failed: check download client for more details';
+                        title = 'Download failed';
                     }
 
                     if (status === 'warning') {
@@ -47,29 +53,37 @@ define(
                         title = 'Download warning: check download client for more details';
                     }
 
-                    if (errorMessage !== '') {
+                    if (trackedDownloadStatus === 'warning') {
+                        icon += ' icon-nd-warning';
+//                        title = 'Download failed';
+
+                        this.templateFunction = Marionette.TemplateCache.get(this.template);
+                        content = this.templateFunction(this.cellValue.toJSON());
+                    }
+
+                    if (trackedDownloadStatus === 'error') {
                         if (status === 'completed') {
                             icon = 'icon-nd-import-failed';
-                            title = 'Import failed';
+                            title = 'Import failed: ' + itemTitle;
                         }
                         else {
                             icon = 'icon-nd-download-failed';
                             title = 'Download failed';
                         }
-                        this.$el.html('<i class="{0}"></i>'.format(icon));
-                        
-                        this.$el.popover({
-                            content  : errorMessage.replace(new RegExp('\r\n', 'g'), '<br/>'),
-                            html     : true,
-                            trigger  : 'hover',
-                            title    : title,
-                            placement: 'right',
-                            container: this.$el
-                        });
+
+                        this.templateFunction = Marionette.TemplateCache.get(this.template);
+                        content = this.templateFunction(this.cellValue.toJSON());
                     }
-                    else {
-                        this.$el.html('<i class="{0}" title="{1}"></i>'.format(icon, title));
-                    }
+
+                    this.$el.html('<i class="{0}"></i>'.format(icon));
+                    this.$el.popover({
+                        content  : content,
+                        html     : true,
+                        trigger  : 'hover',
+                        title    : title,
+                        placement: 'right',
+                        container: this.$el
+                    });
                 }
 
                 return this;

--- a/src/UI/History/Queue/QueueStatusCellTemplate.hbs
+++ b/src/UI/History/Queue/QueueStatusCellTemplate.hbs
@@ -1,0 +1,8 @@
+﻿{{#each statusMessages}}
+    {{title}}
+    <ul>
+        {{#each messages}}
+            <li>{{this}}</li>
+        {{/each}}
+    </ul>
+{{/each}}


### PR DESCRIPTION
@kayone @Taloth 

CDH currently doesn't offer any advantages over Drone Factory in regards to parsing, it doesn't take advantage of the fact that we knew the series and episode(s) when it was grabbed. This PR will fix that. It will let us properly handle releases in queue that don't have a matching series title and when importing.

I'm also going to take a look at: https://trello.com/c/wU6kd6i6/778-hashed-files-inside-a-hashed-folder because this and releases where the episode inside the rar-set don't match the release can be solved by using the release name when it makes sense.

I see this contradicts @Taloth's response on the forums, but right now it is completely broken, we grab it, but don't track it through the queue and never try to post process it because we have no clue what it is. If we want to skip the import and offer the user the option to import it with some intervention, that would be cool, but as-is its worse than importing a few of the wrong episodes I think.
