### PR TITLE
Download Warning instead of Failure

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
@@ -210,6 +210,33 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbgetTests
         }
 
         [Test]
+        public void should_report_health_deletestatus_as_failed()
+        {
+            _completed.DeleteStatus = "HEALTH";
+
+            GivenQueue(null);
+            GivenHistory(_completed);
+
+            var result = Subject.GetItems().Single();
+
+            result.Status.Should().Be(DownloadItemStatus.Failed);
+        }
+
+        [Test]
+        public void should_report_script_error_as_warning()
+        {
+            _completed.ScriptStatus = "FAILED";
+
+            GivenQueue(null);
+            GivenHistory(_completed);
+
+            var items = Subject.GetItems();
+
+            items.First().Status.Should().Be(DownloadItemStatus.Warning);
+        }
+
+
+        [Test]
         public void Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
@@ -260,6 +260,20 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
         }
 
         [Test]
+        public void should_report_diskspace_unpack_error_as_warning()
+        {
+            _completed.Items.First().FailMessage = "Unpacking failed, write error or disk is full?";
+            _completed.Items.First().Status = SabnzbdDownloadStatus.Failed;
+
+            GivenQueue(null);
+            GivenHistory(_completed);
+
+            var items = Subject.GetItems();
+
+            items.First().Status.Should().Be(DownloadItemStatus.Warning);
+        }
+
+        [Test]
         public void Download_should_use_sabRecentTvPriority_when_recentEpisode_is_true()
         {
             Mocker.GetMock<ISabnzbdProxy>()

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -159,9 +159,18 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
                 }
 
                 if (!successStatus.Contains(item.ParStatus) ||
-                         !successStatus.Contains(item.UnpackStatus) ||
-                         !successStatus.Contains(item.MoveStatus) ||
-                         !successStatus.Contains(item.ScriptStatus))
+                    !successStatus.Contains(item.UnpackStatus) ||
+                    !successStatus.Contains(item.MoveStatus))
+                {
+                    historyItem.Status = DownloadItemStatus.Failed;
+                }
+
+                if (!successStatus.Contains(item.ScriptStatus))
+                {
+                    historyItem.Status = DownloadItemStatus.Warning;
+                }
+
+                if (!successStatus.Contains(item.DeleteStatus))
                 {
                     historyItem.Status = DownloadItemStatus.Failed;
                 }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -138,7 +138,15 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
                 if (sabHistoryItem.Status == SabnzbdDownloadStatus.Failed)
                 {
-                    historyItem.Status = DownloadItemStatus.Failed;
+                    if (sabHistoryItem.FailMessage.IsNotNullOrWhiteSpace() && 
+                        sabHistoryItem.FailMessage.Equals("Unpacking failed, write error or disk is full?", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        historyItem.Status = DownloadItemStatus.Warning;
+                    }
+                    else
+                    {
+                        historyItem.Status = DownloadItemStatus.Failed;
+                    }
                 }
                 else if (sabHistoryItem.Status == SabnzbdDownloadStatus.Completed)
                 {

--- a/src/NzbDrone.Core/Download/DownloadItemStatus.cs
+++ b/src/NzbDrone.Core/Download/DownloadItemStatus.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Download
         Paused = 1,
         Downloading = 2,
         Completed = 3,
-        Failed = 4
+        Failed = 4,
+        Warning = 5
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadTrackingService.cs
+++ b/src/NzbDrone.Core/Download/DownloadTrackingService.cs
@@ -107,6 +107,7 @@ namespace NzbDrone.Core.Download
                         v.DownloadItem.Status == DownloadItemStatus.Queued ||
                         v.DownloadItem.Status == DownloadItemStatus.Paused ||
                         v.DownloadItem.Status == DownloadItemStatus.Downloading ||
+                        v.DownloadItem.Status == DownloadItemStatus.Warning ||
                         v.DownloadItem.Status == DownloadItemStatus.Failed && enabledFailedDownloadHandling ||
                         v.DownloadItem.Status == DownloadItemStatus.Completed && enabledCompletedDownloadHandling)
                     .ToArray();

--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -105,15 +105,6 @@ namespace NzbDrone.Core.Download
                 }
                 else
                 {
-                    //TODO: Make this more configurable (ignore failure reasons) to support changes and other failures that should be ignored
-                    if (!trackedDownload.DownloadItem.Message.IsNullOrWhiteSpace() &&
-                        trackedDownload.DownloadItem.Message.Equals("Unpacking failed, write error or disk is full?",
-                            StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        UpdateStatusMessage(trackedDownload, LogLevel.Error, "Download failed due to lack of disk space, not blacklisting.");
-                        return;
-                    }
-
                     if (FailedDownloadForRecentRelease(downloadClient, trackedDownload, grabbedItems))
                     {
                         _logger.Debug("[{0}] Recent release Failed, do not blacklist.", trackedDownload.DownloadItem.Title);

--- a/src/UI/Calendar/CalendarView.js
+++ b/src/UI/Calendar/CalendarView.js
@@ -80,6 +80,10 @@ define(
                         this._addStatusIcon(element, 'icon-nd-download-failed', 'Download failed: check download client for more details');
                     }
 
+                    else if (status === 'warning') {
+                        this._addStatusIcon(element, 'icon-nd-download-warning', 'Download warning: check download client for more details');
+                    }
+
                     else {
                         this.$(element).find('.fc-event-time')
                             .after('<span class="chart pull-right" data-percent="{0}"></span>'.format(progress));

--- a/src/UI/Content/icons.less
+++ b/src/UI/Content/icons.less
@@ -173,6 +173,11 @@
   color: @brand-danger;
 }
 
+.icon-nd-download-warning:before {
+  .icon(@cloud-download);
+  color: @brand-warning;
+}
+
 .icon-nd-shutdown:before {
   .icon(@off);
   color: @brand-danger;

--- a/src/UI/History/Queue/QueueStatusCell.js
+++ b/src/UI/History/Queue/QueueStatusCell.js
@@ -42,6 +42,11 @@ define(
                         title = 'Download failed: check download client for more details';
                     }
 
+                    if (status === 'warning') {
+                        icon = 'icon-nd-download-warning';
+                        title = 'Download warning: check download client for more details';
+                    }
+
                     if (errorMessage !== '') {
                         if (status === 'completed') {
                             icon = 'icon-nd-import-failed';


### PR DESCRIPTION
Fixed Nzbget history item with a DeleteStatus==HEALTH. Should now be recognized as failure.
Changed NzbGet ScriptStatus error as 'Warning' (new DownloadItemStatus)
Also moved the Sabnzbd unpack failure due to free-space and reported as the same 'Warning'.

This warning shows up on the Queue UI.
