### PR TITLE
Download decision rejection reasons are no longer static messages

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultSingle.Series = series;
             parseResultSingle.Release.Size = sizeInMegaBytes.Megabytes();
 
-            Subject.IsSatisfiedBy(parseResultSingle, null).Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(parseResultSingle, null).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 500, true)]
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultSingle.Series = series;
             parseResultSingle.Release.Size = sizeInMegaBytes.Megabytes();
 
-            Subject.IsSatisfiedBy(parseResultSingle, null).Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(parseResultSingle, null).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 50 * 2, false)]
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultMulti.Series = series;
             parseResultMulti.Release.Size = sizeInMegaBytes.Megabytes();
 
-            Subject.IsSatisfiedBy(parseResultMulti, null).Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(parseResultMulti, null).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 50 * 6, false)]
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultMultiSet.Series = series;
             parseResultMultiSet.Release.Size = sizeInMegaBytes.Megabytes();
 
-            Subject.IsSatisfiedBy(parseResultMultiSet, null).Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(parseResultMultiSet, null).Accepted.Should().Be(expectedResult);
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultSingle.Release.Size = 18457280000;
             qualityType.MaxSize = 0;
 
-            Subject.IsSatisfiedBy(parseResultSingle, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResultSingle, null).Accepted.Should().BeTrue();
         }
         
         [Test]
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             parseResultSingle.Release.Size = 36857280000;
             qualityType.MaxSize = 0;
 
-            Subject.IsSatisfiedBy(parseResultSingle, null).Should().BeTrue();;
+            Subject.IsSatisfiedBy(parseResultSingle, null).Accepted.Should().BeTrue(); ;
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             qualityType.MaxSize = 10;
 
-            Subject.IsSatisfiedBy(parseResultSingle, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -185,18 +185,18 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                     ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = new QualityModel(Quality.RAWHD) },
                 };
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
         }
 
         [Test]
-        public void should_always_return_false_if_unknown()
+        public void should_return_true_if_unknown()
         {
             var parseResult = new RemoteEpisode
             {
                 ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = new QualityModel(Quality.Unknown) },
             };
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
 
             Mocker.GetMock<IQualityDefinitionService>().Verify(c => c.Get(It.IsAny<Quality>()), Times.Never());
         }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AnimeVersionUpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AnimeVersionUpgradeSpecificationFixture.cs
@@ -63,21 +63,21 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.Episodes.First().EpisodeFileId = 0;
 
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_true_if_series_is_not_anime()
         {
             GivenStandardSeries();
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_true_if_is_not_a_version_upgrade_for_existing_file()
         {
             GivenNoVersionUpgrade();
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -85,27 +85,27 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _episodeFile.ReleaseGroup = _remoteEpisode.ParsedEpisodeInfo.ReleaseGroup;
 
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_false_when_existing_file_doesnt_have_a_release_group()
         {
             _episodeFile.ReleaseGroup = String.Empty;
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_should_be_false_when_release_doesnt_have_a_release_group()
         {
             _remoteEpisode.ParsedEpisodeInfo.ReleaseGroup = String.Empty;
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_false_when_release_group_does_not_match()
         {
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -39,24 +39,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _fail2 = new Mock<IDecisionEngineSpecification>();
             _fail3 = new Mock<IDecisionEngineSpecification>();
 
-            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(true);
-            _pass1.Setup(c => c.RejectionReason).Returns("_pass1");
-
-            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(true);
-            _pass2.Setup(c => c.RejectionReason).Returns("_pass2");
-
-            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(true);
-            _pass3.Setup(c => c.RejectionReason).Returns("_pass3");
-
-
-            _fail1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(false);
-            _fail1.Setup(c => c.RejectionReason).Returns("_fail1");
-
-            _fail2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(false);
-            _fail2.Setup(c => c.RejectionReason).Returns("_fail2");
-
-            _fail3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(false);
-            _fail3.Setup(c => c.RejectionReason).Returns("_fail3");
+            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
+            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
+            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
+            
+            _fail1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail1"));
+            _fail2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail2"));
+            _fail3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail3"));
 
             _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "The.Office.S03E115.DVDRip.XviD-OSiTV" } };
             _remoteEpisode = new RemoteEpisode { Series = new Series() };

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/HistorySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/HistorySpecificationFixture.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_be_upgradable_if_only_episode_is_upgradable()
         {
             WithFirstReportUpgradable();
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -107,27 +107,27 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithFirstReportUpgradable();
             WithSecondReportUpgradable();
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_not_be_upgradable_if_both_episodes_are_not_upgradable()
         {
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_first_episodes_is_upgradable()
         {
             WithFirstReportUpgradable();
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_second_episodes_is_upgradable()
         {
             WithSecondReportUpgradable();
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -139,13 +139,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Mocker.GetMock<IHistoryService>().Setup(c => c.GetBestQualityInHistory(It.IsAny<Profile>(), 1)).Returns(_upgradableQuality);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_true_if_it_is_a_search()
         {
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new SeasonSearchCriteria()).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -153,7 +153,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenSabnzbdDownloadClient();
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenSabnzbdDownloadClient();
             GivenMostRecentForEpisode(HistoryEventType.Grabbed);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenSabnzbdDownloadClient();
             GivenMostRecentForEpisode(HistoryEventType.DownloadFailed);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenSabnzbdDownloadClient();
             GivenMostRecentForEpisode(HistoryEventType.DownloadFolderImported);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/LanguageSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/LanguageSpecificationFixture.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithEnglishRelease();
 
-            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithGermanRelease();
 
-            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Mocker.Resolve<LanguageSpecification>().IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MonitoredEpisodeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MonitoredEpisodeSpecificationFixture.cs
@@ -64,22 +64,22 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void setup_should_return_monitored_episode_should_return_true()
         {
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void not_monitored_series_should_be_skipped()
         {
             _fakeSeries.Monitored = false;
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void only_episode_not_monitored_should_return_false()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -87,28 +87,28 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithFirstEpisodeUnmonitored();
             WithSecondEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void only_first_episode_not_monitored_should_return_monitored()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void only_second_episode_not_monitored_should_return_monitored()
         {
             WithSecondEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_it_is_a_search()
         {
             _fakeSeries.Monitored = false;
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new SeasonSearchCriteria()).Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/NotInQueueSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/NotInQueueSpecificationFixture.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_true_when_queue_is_empty()
         {
             GivenEmptyQueue();
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                        .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode }, TrackedDownloadState.DownloadFailed);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -190,7 +190,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Episodes.Add(_otherEpisode);
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -226,7 +226,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Episodes.Add(_otherEpisode);
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             _remoteEpisode.Episodes.Add(_otherEpisode);
             GivenQueue(remoteEpisodes);
-            Subject.IsSatisfiedBy(_remoteEpisode, null ).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/NotRestrictedReleaseSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/NotRestrictedReleaseSpecificationFixture.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_be_true_when_restrictions_are_empty()
         {
-            Subject.IsSatisfiedBy(_parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResult, null).Accepted.Should().BeTrue();
         }
 
         [TestCase("KYR")]
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_be_false_when_nzb_contains_a_restricted_term(string restrictions)
         {
             Mocker.GetMock<IConfigService>().SetupGet(c => c.ReleaseRestrictions).Returns(restrictions);
-            Subject.IsSatisfiedBy(_parseResult, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResult, null).Accepted.Should().BeFalse();
         }
 
         [TestCase("NotReal")]
@@ -47,14 +47,14 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_be_true_when_nzb_does_not_contain_a_restricted_term(string restrictions)
         {
             Mocker.GetMock<IConfigService>().SetupGet(c => c.ReleaseRestrictions).Returns(restrictions);
-            Subject.IsSatisfiedBy(_parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResult, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_not_try_to_find_empty_string_as_a_match()
         {
             Mocker.GetMock<IConfigService>().SetupGet(c => c.ReleaseRestrictions).Returns("test\n");
-            Subject.IsSatisfiedBy(_parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResult, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/QualityAllowedByProfileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/QualityAllowedByProfileSpecificationFixture.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             remoteEpisode.ParsedEpisodeInfo.Quality.Quality = qualityType;
             remoteEpisode.Series.Profile.Value.Items = Qualities.QualityFixture.GetDefaultQualities(Quality.DVD, Quality.HDTV720p, Quality.Bluray1080p);
 
-            Subject.IsSatisfiedBy(remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test, TestCaseSource("DeniedTestCases")]
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             remoteEpisode.ParsedEpisodeInfo.Quality.Quality = qualityType;
             remoteEpisode.Series.Profile.Value.Items = Qualities.QualityFixture.GetDefaultQualities(Quality.DVD, Quality.HDTV720p, Quality.Bluray1080p);
 
-            Subject.IsSatisfiedBy(remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(remoteEpisode, null).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RetentionSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RetentionSpecificationFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(0);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(1000);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(100);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(10);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(0);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(parseResult, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(parseResult, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         [Test]
         public void should_be_true_when_search()
         {
-            Subject.IsSatisfiedBy(new RemoteEpisode(), new SingleEpisodeSearchCriteria()).Should().BeTrue();
+            Subject.IsSatisfiedBy(new RemoteEpisode(), new SingleEpisodeSearchCriteria()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             _profile.GrabDelay = 0;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             _remoteEpisode.ParsedEpisodeInfo.Quality = new QualityModel(Quality.Bluray720p);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             
             _profile.GrabDelay = 1;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _profile.GrabDelay = 12;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
                   .Setup(s => s.GetPendingRemoteEpisodes(It.IsAny<Int32>()))
                   .Returns(new List<RemoteEpisode>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
                   .Setup(s => s.GetPendingRemoteEpisodes(It.IsAny<Int32>()))
                   .Returns(new List<RemoteEpisode> { _remoteEpisode.JsonClone() });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
                   .Setup(s => s.GetPendingRemoteEpisodes(It.IsAny<Int32>()))
                   .Returns(new List<RemoteEpisode> { pendingRemoteEpisode });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -271,7 +271,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
                   .Setup(s => s.GetPendingRemoteEpisodes(It.IsAny<Int32>()))
                   .Returns(new List<RemoteEpisode> { pendingRemoteEpisode1, pendingRemoteEpisode2 });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/ProperSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/ProperSpecificationFixture.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _secondFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _secondFile.Quality.Quality = Quality.DVD;
 
             _secondFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             WithFirstFileUpgradable();
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             WithFirstFileUpgradable();
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria()).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today;
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -132,7 +132,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today;
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeriesSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeriesSpecificationFixture.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             _searchCriteria.Series = _series2;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             _searchCriteria.Series = _series1;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_true_if_episode_has_no_existing_file()
         {
             _parseResultSingle.Episodes.ForEach(c => c.EpisodeFileId = 0);
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -79,14 +79,14 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _parseResultSingle.Episodes = new List<Episode>();
 
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_upgradable_if_only_episode_is_upgradable()
         {
             WithFirstFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -94,27 +94,27 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithFirstFileUpgradable();
             WithSecondFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_not_upgradable_if_both_episodes_are_not_upgradable()
         {
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_first_episodes_is_upgradable()
         {
             WithFirstFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_second_episodes_is_upgradable()
         {
             WithSecondFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _firstFile.Quality = new QualityModel(Quality.WEBDL1080p);
             _parseResultSingle.ParsedEpisodeInfo.Quality = new QualityModel(Quality.WEBDL1080p);
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Decision.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Decision.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace NzbDrone.Core.DecisionEngine
+{
+    public class Decision
+    {
+        public Boolean Accepted { get; private set; }
+        public String Reason { get; private set; }
+
+        public static Decision Accept()
+        {
+            return new Decision
+            {
+                Accepted = true
+            };
+        }
+
+        public static Decision Reject(String reason, params object[] args)
+        {
+            return Reject(String.Format(reason, args));
+        }
+
+        public static Decision Reject(String reason)
+        {
+            return new Decision
+            {
+                Accepted = false,
+                Reason = reason
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/IDecisionEngineSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/IDecisionEngineSpecification.cs
@@ -1,13 +1,12 @@
-using System;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine
 {
-    public interface IDecisionEngineSpecification : IRejectWithReason
+    public interface IDecisionEngineSpecification
     {
         RejectionType Type { get; }
-        
-        Boolean IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria);
+
+        Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria);
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -22,14 +22,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public String RejectionReason
-        {
-            get { return "File size too big or small"; }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public  bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             _logger.Debug("Beginning size check for: {0}", subject);
 
@@ -38,13 +33,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (quality == Quality.RAWHD)
             {
                 _logger.Debug("Raw-HD release found, skipping size check.");
-                return true;
+                return Decision.Accept();
             }
 
             if (quality == Quality.Unknown)
             {
                 _logger.Debug("Unknown quality. skipping size check.");
-                return false;
+                return Decision.Accept();
             }
 
             var qualityDefinition = _qualityDefinitionService.Get(quality);
@@ -57,7 +52,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (subject.Release.Size < minSize)
             {
                 _logger.Debug("Item: {0}, Size: {1} is smaller than minimum allowed size ({2}), rejecting.", subject, subject.Release.Size, minSize);
-                return false;
+                return Decision.Reject("{0} is smaller than minimum allowed: {1}", subject.Release.Size, minSize);
             }
             if (qualityDefinition.MaxSize == 0)
             {
@@ -97,11 +92,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 if (subject.Release.Size > maxSize)
                 {
                     _logger.Debug("Item: {0}, Size: {1} is greater than maximum allowed size ({2}), rejecting.", subject, subject.Release.Size, maxSize);
-                    return false;
+                    return Decision.Reject("{0} is larger than maximum allowed: {1}", subject.Release.Size, maxSize);
                 }
             }
+
             _logger.Debug("Item: {0}, meets size constraints.", subject);
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/BlacklistSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/BlacklistSpecification.cs
@@ -19,31 +19,23 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Release is blacklisted";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (!_configService.EnableFailedDownloadHandling)
             {
                 _logger.Debug("Failed Download Handling is not enabled");
-                return true;
+                return Decision.Accept();
             }
 
             if (_blacklistService.Blacklisted(subject.Series.Id, subject.Release.Title, subject.Release.PublishDate))
             {
                 _logger.Debug("{0} is blacklisted, rejecting.", subject.Release.Title);
-                return false;
+                return Decision.Reject("Release is blacklisted");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/CutoffSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/CutoffSpecification.cs
@@ -16,17 +16,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Cutoff has already been met";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             foreach (var file in subject.Episodes.Where(c => c.EpisodeFileId != 0).Select(c => c.EpisodeFile.Value))
             {
@@ -36,11 +28,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 if (!_qualityUpgradableSpecification.CutoffNotMet(subject.Series.Profile, file.Quality, subject.ParsedEpisodeInfo.Quality))
                 {
                     _logger.Debug("Cutoff already met, rejecting.");
-                    return false;
+                    return Decision.Reject("Existing file meets cutoff: {0}", subject.Series.Profile);
                 }
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
@@ -13,17 +13,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Language is not wanted";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             var wantedLanguage = subject.Series.Profile.Value.Language;
             
@@ -32,10 +24,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (subject.ParsedEpisodeInfo.Language != wantedLanguage)
             {
                 _logger.Debug("Report Language: {0} rejected because it is not wanted, wanted {1}", subject.ParsedEpisodeInfo.Language, wantedLanguage);
-                return false;
+                return Decision.Reject("{0} is wanted, but found {1}", wantedLanguage, subject.ParsedEpisodeInfo.Language);
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotInQueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotInQueueSpecification.cs
@@ -19,17 +19,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Already in download queue.";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             var queue = _downloadTrackingService.GetQueuedDownloads()
                             .Where(v => v.State == TrackedDownloadState.Downloading)
@@ -38,10 +30,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (IsInQueue(subject, queue))
             {
                 _logger.Debug("Already in queue, rejecting.");
-                return false;
+                return Decision.Reject("Already in download queue");
             }
 
-            return true;
+            return Decision.Accept();
         }
 
         private bool IsInQueue(RemoteEpisode newEpisode, IEnumerable<RemoteEpisode> queue)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotRestrictedReleaseSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotRestrictedReleaseSpecification.cs
@@ -17,17 +17,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Contains restricted term.";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             _logger.Debug("Checking if release contains any restricted terms: {0}", subject);
 
@@ -36,7 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (String.IsNullOrWhiteSpace(restrictionsString))
             {
                 _logger.Debug("No restrictions configured, allowing: {0}", subject);
-                return true;
+                return Decision.Accept();
             }
 
             var restrictions = restrictionsString.Split(new []{ '\n' }, StringSplitOptions.RemoveEmptyEntries);
@@ -46,12 +38,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 if (subject.Release.Title.ToLowerInvariant().Contains(restriction.ToLowerInvariant()))
                 {
                     _logger.Debug("{0} is restricted: {1}", subject, restriction);
-                    return false;
+                    return Decision.Reject("Contains restricted term: {0}", restriction);
                 }
             }
 
             _logger.Debug("No restrictions apply, allowing: {0}", subject);
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
@@ -8,7 +8,6 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
     {
         private readonly Logger _logger;
 
-        public string RejectionReason { get { return "Sample"; } }
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
         public NotSampleSpecification(Logger logger)
@@ -16,15 +15,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (subject.Release.Title.ToLower().Contains("sample") && subject.Release.Size < 70.Megabytes())
             {
                 _logger.Debug("Sample release, rejecting.");
-                return false;
+                return Decision.Reject("Sample");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
@@ -13,26 +13,18 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Quality rejected by series profile";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             _logger.Debug("Checking if report meets quality requirements. {0}", subject.ParsedEpisodeInfo.Quality);
             if (!subject.Series.Profile.Value.Items.Exists(v => v.Allowed && v.Quality == subject.ParsedEpisodeInfo.Quality.Quality))
             {
                 _logger.Debug("Quality {0} rejected by Series' quality profile", subject.ParsedEpisodeInfo.Quality);
-                return false;
+                return Decision.Reject("{0} quality not wanted in profile");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
@@ -16,18 +16,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-
-        public string RejectionReason
-        {
-            get
-            {
-                return "Report past retention limit.";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             var age = subject.Release.Age;
             var retention = _configService.Retention;
@@ -36,10 +27,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (retention > 0 && age > retention)
             {
                 _logger.Debug("Report age: {0} rejected by user's retention limit", age);
-                return false;
+                return Decision.Reject("Older than configured retention");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RetrySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RetrySpecification.cs
@@ -22,22 +22,14 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Release has been retried too many times";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (!_configService.EnableFailedDownloadHandling)
             {
                 _logger.Debug("Failed Download Handling is not enabled");
-                return true;
+                return Decision.Accept();
             }
 
             var history = _historyService.FindBySourceTitle(subject.Release.Title);
@@ -47,10 +39,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                                    _configService.BlacklistRetryLimit)
             {
                 _logger.Debug("Release has been attempted more times than allowed, rejecting");
-                return false;
+                return Decision.Reject("Retried too many times");
             }
 
-            return true;
+            return Decision.Accept();
         }
 
         private bool HasSamePublishedDate(History.History item, DateTime publishedDate)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -26,22 +26,14 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Existing file in history is of equal or higher quality";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria != null)
             {
                 _logger.Debug("Skipping history check during search");
-                return true;
+                return Decision.Accept();
             }
 
             var downloadClients = _downloadClientProvider.GetDownloadClients();
@@ -57,10 +49,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     if (mostRecent != null && mostRecent.EventType == HistoryEventType.Grabbed)
                     {
                         _logger.Debug("Latest history item is downloading, rejecting.");
-                        return false;
+                        return Decision.Reject("Latest history item is still downloading");
                     }
                 }
-                return true;
+                return Decision.Accept();
             }
 
             foreach (var episode in subject.Episodes)
@@ -69,12 +61,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 if (bestQualityInHistory != null)
                 {
                     _logger.Debug("Comparing history quality with report. History is {0}", bestQualityInHistory);
+
                     if (!_qualityUpgradableSpecification.IsUpgradable(subject.Series.Profile, bestQualityInHistory, subject.ParsedEpisodeInfo.Quality))
-                        return false;
+                    {
+                        return Decision.Reject("Existing file in history is of equal or higher quality: {0}", bestQualityInHistory);
+                    }
                 }
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
@@ -14,38 +14,30 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Series or Episode is not monitored";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria != null)
             {
                 _logger.Debug("Skipping monitored check during search");
-                return true;
+                return Decision.Accept();
             }
 
             if (!subject.Series.Monitored)
             {
                 _logger.Debug("{0} is present in the DB but not tracked. skipping.", subject.Series);
-                return false;
+                return Decision.Reject("Series is not monitored");
             }
 
             //return monitored if any of the episodes are monitored
             if (subject.Episodes.Any(episode => episode.Monitored))
             {
-                return true;
+                return Decision.Accept();
             }
 
             _logger.Debug("No episodes are monitored. skipping.");
-            return false;
+            return Decision.Reject("Episode is not monitored");
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
@@ -20,21 +20,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Proper for old episode";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria != null)
             {
-                return true;
+                return Decision.Accept();
             }
 
             foreach (var file in subject.Episodes.Where(c => c.EpisodeFileId != 0).Select(c => c.EpisodeFile.Value))
@@ -44,18 +36,18 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     if (file.DateAdded < DateTime.Today.AddDays(-7))
                     {
                         _logger.Debug("Proper for old file, rejecting: {0}", subject);
-                        return false;
+                        return Decision.Reject("Proper for old file");
                     }
 
                     if (!_configService.AutoDownloadPropers)
                     {
                         _logger.Debug("Auto downloading of propers is disabled");
-                        return false;
+                        return Decision.Reject("Proper downloading is disabled");
                     }
                 }
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/DailyEpisodeMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/DailyEpisodeMatchSpecification.cs
@@ -16,36 +16,28 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _episodeService = episodeService;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Episode doesn't match";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria == null)
             {
-                return true;
+                return Decision.Accept();
             }
 
             var dailySearchSpec = searchCriteria as DailyEpisodeSearchCriteria;
 
-            if (dailySearchSpec == null) return true;
+            if (dailySearchSpec == null) return Decision.Accept();
 
             var episode = _episodeService.GetEpisode(dailySearchSpec.Series.Id, dailySearchSpec.AirDate.ToString(Episode.AIR_DATE_FORMAT));
 
             if (!remoteEpisode.ParsedEpisodeInfo.IsDaily || remoteEpisode.ParsedEpisodeInfo.AirDate != episode.AirDate)
             {
                 _logger.Debug("Episode AirDate does not match searched episode number, skipping.");
-                return false;
+                return Decision.Reject("Episode does not match");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
@@ -15,31 +15,25 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Episode wasn't requested";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria == null)
             {
-                return true;
+                return Decision.Accept();
             }
+
             var criteriaEpisodes = searchCriteria.Episodes.Select(v => v.Id).ToList();
             var remoteEpisodes = remoteEpisode.Episodes.Select(v => v.Id).ToList();
+
             if (!criteriaEpisodes.Intersect(remoteEpisodes).Any())
             {
                 _logger.Debug("Release rejected since the episode wasn't requested: {0}", remoteEpisode.ParsedEpisodeInfo);
-                return false;
+                return Decision.Reject("Episode wasn't requested");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
@@ -13,33 +13,25 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Episode doesn't match";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria == null)
             {
-                return true;
+                return Decision.Accept();
             }
 
             var singleEpisodeSpec = searchCriteria as SeasonSearchCriteria;
-            if (singleEpisodeSpec == null) return true;
+            if (singleEpisodeSpec == null) return Decision.Accept();
 
             if (singleEpisodeSpec.SeasonNumber != remoteEpisode.ParsedEpisodeInfo.SeasonNumber)
             {
                 _logger.Debug("Season number does not match searched season number, skipping.");
-                return false;
+                return Decision.Reject("Wrong season");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
@@ -13,21 +13,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Wrong series";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria == null)
             {
-                return true;
+                return Decision.Accept();
             }
 
             _logger.Debug("Checking if series matches searched series");
@@ -35,10 +27,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             if (remoteEpisode.Series.Id != searchCriteria.Series.Id)
             {
                 _logger.Debug("Series {0} does not match {1}", remoteEpisode.Series, searchCriteria.Series);
-                return false;
+                return Decision.Reject("Wrong series");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
@@ -14,39 +14,31 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Episode doesn't match";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public bool IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
         {
             if (searchCriteria == null)
             {
-                return true;
+                return Decision.Accept();
             }
 
             var singleEpisodeSpec = searchCriteria as SingleEpisodeSearchCriteria;
-            if (singleEpisodeSpec == null) return true;
+            if (singleEpisodeSpec == null) return Decision.Accept();
 
             if (singleEpisodeSpec.SeasonNumber != remoteEpisode.ParsedEpisodeInfo.SeasonNumber)
             {
                 _logger.Debug("Season number does not match searched season number, skipping.");
-                return false;
+                return Decision.Reject("Wrong season");
             }
 
             if (!remoteEpisode.ParsedEpisodeInfo.EpisodeNumbers.Contains(singleEpisodeSpec.EpisodeNumber))
             {
                 _logger.Debug("Episode number does not match searched episode number, skipping.");
-                return false;
+                return Decision.Reject("Wrong episode");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -16,17 +16,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason
-        {
-            get
-            {
-                return "Existing file on disk is of equal or higher quality";
-            }
-        }
-
         public RejectionType Type { get { return RejectionType.Permanent; } }
 
-        public virtual bool IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             foreach (var file in subject.Episodes.Where(c => c.EpisodeFileId != 0).Select(c => c.EpisodeFile.Value))
             {
@@ -34,11 +26,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 if (!_qualityUpgradableSpecification.IsUpgradable(subject.Series.Profile, file.Quality, subject.ParsedEpisodeInfo.Quality))
                 {
-                    return false;
+                    return Decision.Reject("Existing file on disk is of equal or higher quality: {0}", file.Quality);
                 }
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Datastore\PagingSpec.cs" />
     <Compile Include="Datastore\ResultSet.cs" />
     <Compile Include="Datastore\TableMapping.cs" />
+    <Compile Include="DecisionEngine\Decision.cs" />
     <Compile Include="DecisionEngine\DownloadDecision.cs" />
     <Compile Include="DecisionEngine\DownloadDecisionMaker.cs" />
     <Compile Include="DecisionEngine\DownloadDecisionPriorizationService.cs" />


### PR DESCRIPTION
@kayone @Taloth 

A couple people have asked about it (and will help with rejected for size related reasons), but the biggest driver for this is to deal with required/preferred/ignored so we can show the required/ignored term in the UI during a manual search, without this it would be a source of confusion.
