### PR TITLE
Updated transaction locks to be defered.

### DIFF
--- a/src/Marr.Data/DataMapper.cs
+++ b/src/Marr.Data/DataMapper.cs
@@ -894,10 +894,10 @@ namespace Marr.Data
             ClosingConnection = null;
         }
 
-        public void BeginTransaction()
+        public void BeginTransaction(IsolationLevel isolationLevel)
         {
             OpenConnection();
-            DbTransaction trans = Command.Connection.BeginTransaction();
+            DbTransaction trans = Command.Connection.BeginTransaction(isolationLevel);
             Command.Transaction = trans;
         }
 

--- a/src/Marr.Data/IDataMapper.cs
+++ b/src/Marr.Data/IDataMapper.cs
@@ -90,7 +90,7 @@ namespace Marr.Data
 
         #region - Connections / Transactions -
 
-        void BeginTransaction();
+        void BeginTransaction(IsolationLevel isolationLevel);
         void RollBack();
         void Commit();
         event EventHandler OpeningConnection;

--- a/src/Marr.Data/UnitOfWork.cs
+++ b/src/Marr.Data/UnitOfWork.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Runtime.Serialization;
 
 namespace Marr.Data
@@ -54,12 +55,12 @@ namespace Marr.Data
             }
         }
 
-        public void BeginTransaction()
+        public void BeginTransaction(IsolationLevel isolationLevel)
         {
             // Only allow one transaction to begin
             if (_transactionCount < 1)
             {
-                DB.BeginTransaction();
+                DB.BeginTransaction(isolationLevel);
             }
 
             _transactionCount++;

--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -108,7 +109,7 @@ namespace NzbDrone.Core.Backup
 
             using (var unitOfWork = new UnitOfWork(() => _maindDb.GetDataMapper()))
             {
-                unitOfWork.BeginTransaction();
+                unitOfWork.BeginTransaction(IsolationLevel.Serializable);
 
                 var databaseFile = _appFolderInfo.GetNzbDroneDatabase();
                 var tempDatabaseFile = Path.Combine(_backupTempFolder, Path.GetFileName(databaseFile));

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
 using Marr.Data;
@@ -145,7 +146,7 @@ namespace NzbDrone.Core.Datastore
         {
             using (var unitOfWork = new UnitOfWork(() => DataMapper))
             {
-                unitOfWork.BeginTransaction();
+                unitOfWork.BeginTransaction(IsolationLevel.ReadCommitted);
 
                 foreach (var model in models)
                 {
@@ -160,7 +161,7 @@ namespace NzbDrone.Core.Datastore
         {
             using (var unitOfWork = new UnitOfWork(() => DataMapper))
             {
-                unitOfWork.BeginTransaction();
+                unitOfWork.BeginTransaction(IsolationLevel.ReadCommitted);
 
                 foreach (var model in models)
                 {
@@ -203,7 +204,7 @@ namespace NzbDrone.Core.Datastore
         {
             using (var unitOfWork = new UnitOfWork(() => DataMapper))
             {
-                unitOfWork.BeginTransaction();
+                unitOfWork.BeginTransaction(IsolationLevel.ReadCommitted);
 
                 foreach (var id in ids)
                 {

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors.SQLite;
@@ -21,6 +22,8 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
         public void MigrateToLatest(string connectionString, MigrationType migrationType)
         {
+            var sw = Stopwatch.StartNew();
+
             _announcer.Heading("Migrating " + connectionString);
 
             var assembly = Assembly.GetExecutingAssembly();
@@ -39,6 +42,10 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             var processor = factory.Create(connectionString, _announcer, options);
             var runner = new MigrationRunner(assembly, migrationContext, processor);
             runner.MigrateUp(true);
+
+            sw.Stop();
+
+           _announcer.ElapsedTime(sw.Elapsed);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationDbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationDbFactory.cs
@@ -1,0 +1,14 @@
+﻿using System.Data.Common;
+using System.Data.SQLite;
+using FluentMigrator.Runner.Processors;
+
+namespace NzbDrone.Core.Datastore.Migration.Framework
+{
+    public class MigrationDbFactory : DbFactoryBase
+    {
+        protected override DbProviderFactory CreateFactory()
+        {
+            return SQLiteFactory.Instance;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationLogger.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationLogger.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
         public void ElapsedTime(TimeSpan timeSpan)
         {
+            _logger.Debug("Took: {0}", timeSpan);
         }
 
         public void Error(string message)

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSqliteProcessorFactory.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSqliteProcessorFactory.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
     {
         public override IMigrationProcessor Create(String connectionString, IAnnouncer announcer, IMigrationProcessorOptions options)
         {
-            var factory = new SqliteDbFactory();
+            var factory = new MigrationDbFactory();
             var connection = factory.CreateConnection(connectionString);
             var generator = new SqliteGenerator() { compatabilityMode = CompatabilityMode.STRICT };
             return new NzbDroneSqliteProcessor(connection, generator, announcer, options, factory);

--- a/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
+++ b/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
@@ -22,7 +22,8 @@ namespace NzbDrone.Core.Instrumentation
 
         public DatabaseTarget(IConnectionStringFactory connectionStringFactory)
         {
-            _connection = new SQLiteConnection(connectionStringFactory.LogDbConnectionString).OpenAndReturn();
+            _connection = new SQLiteConnection(connectionStringFactory.LogDbConnectionString);
+            _connection.Open();
         }
 
         public void Register()

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Datastore\Migration\067_add_added_to_series.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
+    <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationExtension.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationLogger.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationOptions.cs" />


### PR DESCRIPTION
This adds  `IsolationLevel` as a parameter when starting a transaction, by default SQLite tries to obtain a very restrictive write lock (`IsolationLevel.Serializable`). this change switchies most of our locks to more friendly `IsolationLevel.ReadCommitted` isolation level.
##### READ COMMITTED

Specifies that shared locks are held while the data is being read to avoid dirty reads, but the data can be changed before the end of the transaction, resulting in nonrepeatable reads or phantom data. This option is the SQL Server default.
##### SERIALIZABLE

Places a range lock on the data set, preventing other users from updating or inserting rows into the data set until the transaction is complete. This is the most restrictive of the four isolation levels. Because concurrency is lower, use this option only when necessary. This option has the same effect as setting HOLDLOCK on all tables in all SELECT statements in a transaction.
