### PR TITLE
Fix extern import

### DIFF
--- a/src/NzbDrone.Api/Queue/QueueActionModule.cs
+++ b/src/NzbDrone.Api/Queue/QueueActionModule.cs
@@ -102,7 +102,7 @@ namespace NzbDrone.Api.Queue
                 throw new NotFoundException();
             }
 
-            var trackedDownload = _trackedDownloadService.Find(queueItem.TrackingId);
+            var trackedDownload = _trackedDownloadService.Find(queueItem.DownloadId);
 
             if (trackedDownload == null)
             {

--- a/src/NzbDrone.Api/Queue/QueueResource.cs
+++ b/src/NzbDrone.Api/Queue/QueueResource.cs
@@ -21,6 +21,6 @@ namespace NzbDrone.Api.Queue
         public String Status { get; set; }
         public String TrackedDownloadStatus { get; set; }
         public List<TrackedDownloadStatusMessage> StatusMessages { get; set; }
-        public String TrackingId { get; set; }
+        public String DownloadId { get; set; }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesCommandServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesCommandServiceFixture.cs
@@ -6,10 +6,13 @@ using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Commands;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MediaFiles
@@ -18,6 +21,9 @@ namespace NzbDrone.Core.Test.MediaFiles
     public class DownloadedEpisodesCommandServiceFixture : CoreTest<DownloadedEpisodesCommandService>
     {
         private string _droneFactory = "c:\\drop\\".AsOsAgnostic();
+        private string _downloadFolder = "c:\\drop_other\\Show.S01E01\\".AsOsAgnostic();
+
+        private TrackedDownload _trackedDownload;
 
         [SetUp]
         public void Setup()
@@ -31,6 +37,33 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<IDownloadedEpisodesImportService>()
                 .Setup(v => v.ProcessRootFolder(It.IsAny<DirectoryInfo>()))
                 .Returns(new List<ImportResult>());
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>()
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>());
+
+            var downloadItem = Builder<DownloadClientItem>.CreateNew()
+                .With(v => v.DownloadId = "sab1")
+                .With(v => v.Status = DownloadItemStatus.Downloading)
+                .Build();
+
+            var remoteEpisode = Builder<RemoteEpisode>.CreateNew()
+                .With(v => v.Series = new Series())
+                .Build();
+
+            _trackedDownload = new TrackedDownload
+                    {
+                        DownloadItem = downloadItem,
+                        RemoteEpisode = remoteEpisode,
+                        State = TrackedDownloadStage.Downloading
+                    };
+        }
+
+        private void GivenValidQueueItem()
+        {
+            Mocker.GetMock<ITrackedDownloadService>()
+                  .Setup(s => s.Find("sab1"))
+                  .Returns(_trackedDownload);
         }
 
         [Test]
@@ -51,6 +84,42 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessRootFolder(It.IsAny<DirectoryInfo>()), Times.Never());
 
             ExceptionVerification.ExpectedWarns(1);
-        }       
+        }
+
+        [Test]
+        public void should_ignore_downloadclientid_if_path_is_not_specified()
+        {
+            Subject.Execute(new DownloadedEpisodesScanCommand() { DownloadClientId = "sab1" });
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessRootFolder(It.IsAny<DirectoryInfo>()), Times.Once());
+        }
+
+        [Test]
+        public void should_process_folder_if_downloadclientid_is_not_specified()
+        {
+            Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder });
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), null, null), Times.Once());
+        }
+
+        [Test]
+        public void should_process_folder_with_downloadclientitem_if_available()
+        {
+            GivenValidQueueItem();
+
+            Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder, DownloadClientId = "sab1" });
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem), Times.Once());
+        }
+
+        [Test]
+        public void should_process_folder_without_downloadclientitem_if_not_available()
+        {
+            Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder, DownloadClientId = "sab1" });
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, null, null), Times.Once());
+
+            ExceptionVerification.ExpectedWarns(1);
+        }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -6,7 +6,6 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 {
     public class TrackedDownload
     {
-        public String TrackingId { get; set; }
         public Int32 DownloadClient { get; set; }
         public DownloadClientItem DownloadItem { get; set; }
         public TrackedDownloadStage State { get; set; }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -32,9 +32,9 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             _logger = logger;
         }
 
-        public TrackedDownload Find(string trackingId)
+        public TrackedDownload Find(string downloadId)
         {
-            return _cache.Find(trackingId);
+            return _cache.Find(downloadId);
         }
 
         public TrackedDownload TrackDownload(DownloadClientDefinition downloadClient, DownloadClientItem downloadItem)
@@ -49,7 +49,6 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
             var trackedDownload = new TrackedDownload
             {
-                TrackingId = downloadClient.Id + "-" + downloadItem.DownloadId,
                 DownloadClient = downloadClient.Id,
                 DownloadItem = downloadItem,
                 Protocol = downloadClient.Protocol
@@ -89,7 +88,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 trackedDownload.State = GetStateFromHistory(historyItem.EventType);
             }
 
-            _cache.Set(trackedDownload.TrackingId, trackedDownload);
+            _cache.Set(trackedDownload.DownloadItem.DownloadId, trackedDownload);
 
             return trackedDownload;
         }

--- a/src/NzbDrone.Core/MediaFiles/Commands/DownloadedEpisodesScanCommand.cs
+++ b/src/NzbDrone.Core/MediaFiles/Commands/DownloadedEpisodesScanCommand.cs
@@ -14,5 +14,9 @@ namespace NzbDrone.Core.MediaFiles.Commands
         }
 
         public Boolean SendUpdates { get; set; }
+
+        // Properties used by third-party apps, do not modify.
+        public String Path { get; set; }
+        public String DownloadClientId { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Queue/Queue.cs
+++ b/src/NzbDrone.Core/Queue/Queue.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Queue
         public String Status { get; set; }
         public String TrackedDownloadStatus { get; set; }
         public List<TrackedDownloadStatusMessage> StatusMessages { get; set; }
-        public String TrackingId { get; set; }
+        public String DownloadId { get; set; }
         public RemoteEpisode RemoteEpisode { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Queue
                     TrackedDownloadStatus = trackedDownload.Status.ToString(),
                     StatusMessages = trackedDownload.StatusMessages.ToList(),
                     RemoteEpisode = trackedDownload.RemoteEpisode,
-                    TrackingId = trackedDownload.TrackingId
+                    DownloadId = trackedDownload.DownloadItem.DownloadId
                 };
 
                 if (queue.Timeleft.HasValue)


### PR DESCRIPTION
@markus101 @kayone Haven't yet tested it in intergrated environment so it can't be merged but all tests pass.

I also changed the trackedDownloadService again from TrackingId to DownloadId hopefully not overlooking a  ```Find``` call. Using the TrackingId was to make items, but in the db the DownloadId has to be unique anyway to be effective so it was giving more headaches than it solved.

I basically took the old implementation and refactored it to ```ProcessPath```.