### PR TITLE
Added support to the api mediacover endpoint to resize the image

### DIFF
--- a/src/NzbDrone.Api/Frontend/Mappers/MediaCoverMapper.cs
+++ b/src/NzbDrone.Api/Frontend/Mappers/MediaCoverMapper.cs
@@ -1,4 +1,6 @@
 using System.IO;
+using System.Text.RegularExpressions;
+using Nancy;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
@@ -8,6 +10,8 @@ namespace NzbDrone.Api.Frontend.Mappers
 {
     public class MediaCoverMapper : StaticResourceMapperBase
     {
+        private static readonly Regex RegexResizedImage = new Regex(@"-\d+\.jpg($|\?)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private readonly IAppFolderInfo _appFolderInfo;
 
         public MediaCoverMapper(IAppFolderInfo appFolderInfo, IDiskProvider diskProvider, Logger logger)
@@ -22,6 +26,24 @@ namespace NzbDrone.Api.Frontend.Mappers
             path = path.Trim(Path.DirectorySeparatorChar);
 
             return Path.Combine(_appFolderInfo.GetAppDataPath(), path);
+        }
+
+        public override Response GetResponse(string resourceUrl)
+        {
+            var result =  base.GetResponse(resourceUrl);
+
+            // Return the full sized image if someone requests a non-existing resized one.
+            // TODO: This code can be removed later once everyone had the update for a while.
+            if (result is NotFoundResponse)
+            {
+                var baseResourceUrl = RegexResizedImage.Replace(resourceUrl, ".jpg$1");
+                if (baseResourceUrl != resourceUrl)
+                {
+                    result = base.GetResponse(baseResourceUrl);
+                }
+            }
+
+            return result;
         }
 
         public override bool CanHandle(string resourceUrl)

--- a/src/NzbDrone.Common/Crypto/HashProvider.cs
+++ b/src/NzbDrone.Common/Crypto/HashProvider.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Common.Crypto
         {
             using (var md5 = MD5.Create())
             {
-                using (var stream = _diskProvider.StreamFile(path))
+                using (var stream = _diskProvider.OpenReadStream(path))
                 {
                     return md5.ComputeHash(stream);
                 }

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -421,7 +421,7 @@ namespace NzbDrone.Common.Disk
             return driveInfo.VolumeLabel;
         }
 
-        public FileStream StreamFile(string path)
+        public FileStream OpenReadStream(string path)
         {
             if (!FileExists(path))
             {
@@ -429,6 +429,11 @@ namespace NzbDrone.Common.Disk
             }
 
             return new FileStream(path, FileMode.Open, FileAccess.Read);
+        }
+
+        public FileStream OpenWriteStream(string path)
+        {
+            return new FileStream(path, FileMode.Create);
         }
 
         public List<DriveInfo> GetDrives()

--- a/src/NzbDrone.Common/Disk/IDiskProvider.cs
+++ b/src/NzbDrone.Common/Disk/IDiskProvider.cs
@@ -45,7 +45,8 @@ namespace NzbDrone.Common.Disk
         void EmptyFolder(string path);
         string[] GetFixedDrives();
         string GetVolumeLabel(string path);
-        FileStream StreamFile(string path);
+        FileStream OpenReadStream(string path);
+        FileStream OpenWriteStream(string path);
         List<DriveInfo> GetDrives();
         List<DirectoryInfo> GetDirectoryInfos(string path);
         List<FileInfo> GetFileInfos(string path);

--- a/src/NzbDrone.Common/Extensions/StreamExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StreamExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace NzbDrone.Common.Extensions
 {

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DeleteBadMediaCovers.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DeleteBadMediaCovers.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             Subject.Clean();
 
-            Mocker.GetMock<IDiskProvider>().Verify(c => c.StreamFile(It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenReadStream(It.IsAny<string>()), Times.Never());
 
         }
 
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             Subject.Clean();
 
-            Mocker.GetMock<IDiskProvider>().Verify(c => c.StreamFile(It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenReadStream(It.IsAny<string>()), Times.Never());
         }
 
 
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             _metaData.First().Type = MetadataType.SeriesImage;
 
             Mocker.GetMock<IDiskProvider>()
-                .Setup(c => c.StreamFile(imagePath))
+                .Setup(c => c.OpenReadStream(imagePath))
                 .Returns(new FileStream("Files\\html_image.jpg".AsOsAgnostic(), FileMode.Open, FileAccess.Read));
 
 
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             _metaData.First().RelativePath = "Season\\image.jpg".AsOsAgnostic();
 
             Mocker.GetMock<IDiskProvider>()
-                .Setup(c => c.StreamFile(imagePath))
+                .Setup(c => c.OpenReadStream(imagePath))
                               .Returns(new FileStream("Files\\emptyfile.txt".AsOsAgnostic(), FileMode.Open, FileAccess.Read));
 
 
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             _metaData.First().RelativePath = "Season\\image.jpg".AsOsAgnostic();
 
             Mocker.GetMock<IDiskProvider>()
-                .Setup(c => c.StreamFile(imagePath))
+                .Setup(c => c.OpenReadStream(imagePath))
                               .Returns(new FileStream("Files\\Queue.txt".AsOsAgnostic(), FileMode.Open, FileAccess.Read));
 
 

--- a/src/NzbDrone.Core.Test/MediaCoverTests/ImageResizerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/ImageResizerFixture.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Crypto;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MediaCoverTests
+{
+    [TestFixture]
+    public class ImageResizerFixture : CoreTest<ImageResizer>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.OpenReadStream(It.IsAny<string>()))
+                  .Returns<string>(s => new FileStream(s, FileMode.Open));
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.OpenWriteStream(It.IsAny<string>()))
+                  .Returns<string>(s => new FileStream(s, FileMode.Create));
+        }
+
+        [Test]
+        public void should_resize_image()
+        {
+            var mainFile = Path.Combine(TempFolder, "logo.png");
+            var resizedFile = Path.Combine(TempFolder, "logo-170.png");
+
+            File.Copy(@"Files/1024.png", mainFile);
+
+            Subject.Resize(mainFile, resizedFile, 170);
+
+            var fileInfo = new FileInfo(resizedFile);
+            fileInfo.Exists.Should().BeTrue();
+            fileInfo.Length.Should().BeInRange(1000, 30000);
+
+            var image = System.Drawing.Image.FromFile(resizedFile);
+            image.Height.Should().Be(170);
+            image.Width.Should().Be(170);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -7,17 +9,25 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Test.Framework;
-using System.Linq;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.Tv.Events;
 
 namespace NzbDrone.Core.Test.MediaCoverTests
 {
     [TestFixture]
     public class MediaCoverServiceFixture : CoreTest<MediaCoverService>
     {
+        Series _series;
+
         [SetUp]
         public void Setup()
         {
             Mocker.SetConstant<IAppFolderInfo>(new AppFolderInfo(Mocker.Resolve<IStartupContext>()));
+
+            _series = Builder<Series>.CreateNew()
+                .With(v => v.Id = 2)
+                .With(v => v.Images = new List<MediaCover.MediaCover> { new MediaCover.MediaCover(MediaCoverTypes.Poster, "") })
+                .Build();
         }
 
         [Test]
@@ -55,5 +65,55 @@ namespace NzbDrone.Core.Test.MediaCoverTests
             covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg");
         }
 
+        [Test]
+        public void should_resize_covers_if_main_downloaded()
+        {
+            Mocker.GetMock<ICoverExistsSpecification>()
+                  .Setup(v => v.AlreadyExists(It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(false);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(It.IsAny<string>()))
+                  .Returns(true);
+
+            Subject.HandleAsync(new SeriesUpdatedEvent(_series));
+
+            Mocker.GetMock<IImageResizer>()
+                  .Verify(v => v.Resize(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void should_resize_covers_if_missing()
+        {
+            Mocker.GetMock<ICoverExistsSpecification>()
+                  .Setup(v => v.AlreadyExists(It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(true);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(It.IsAny<string>()))
+                  .Returns(false);
+
+            Subject.HandleAsync(new SeriesUpdatedEvent(_series));
+
+            Mocker.GetMock<IImageResizer>()
+                  .Verify(v => v.Resize(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void should_not_resize_covers_if_exists()
+        {
+            Mocker.GetMock<ICoverExistsSpecification>()
+                  .Setup(v => v.AlreadyExists(It.IsAny<string>(), It.IsAny<string>()))
+                  .Returns(true);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(It.IsAny<string>()))
+                  .Returns(true);
+
+            Subject.HandleAsync(new SeriesUpdatedEvent(_series));
+
+            Mocker.GetMock<IImageResizer>()
+                  .Verify(v => v.Resize(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()), Times.Never());
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -74,6 +74,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
@@ -215,6 +216,7 @@
     <Compile Include="JobTests\JobRepositoryFixture.cs" />
     <Compile Include="JobTests\TestJobs.cs" />
     <Compile Include="MediaCoverTests\CoverExistsSpecificationFixture.cs" />
+    <Compile Include="MediaCoverTests\ImageResizerFixture.cs" />
     <Compile Include="MediaCoverTests\MediaCoverServiceFixture.cs" />
     <Compile Include="MediaFiles\DiskScanServiceTests\ScanFixture.cs" />
     <Compile Include="MediaFiles\DownloadedEpisodesCommandServiceFixture.cs" />
@@ -348,6 +350,10 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\..\Logo\1024.png">
+      <Link>Files\1024.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\Libraries\Sqlite\sqlite3.dll">
       <Link>sqlite3.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/DeleteBadMediaCovers.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/DeleteBadMediaCovers.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Housekeeping.Housekeepers
         {
             var buffer = new byte[10];
 
-            using (var imageStream = _diskProvider.StreamFile(path))
+            using (var imageStream = _diskProvider.OpenReadStream(path))
             {
                 if (imageStream.Length < buffer.Length) return false;
                 imageStream.Read(buffer, 0, buffer.Length);

--- a/src/NzbDrone.Core/MediaCover/ImageResizer.cs
+++ b/src/NzbDrone.Core/MediaCover/ImageResizer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ImageResizer;
+using NzbDrone.Common.Disk;
+
+namespace NzbDrone.Core.MediaCover
+{
+    public interface IImageResizer
+    {
+        void Resize(string source, string destination, int height);
+    }
+
+    public class ImageResizer : IImageResizer
+    {
+        private readonly IDiskProvider _diskProvider;
+
+        public ImageResizer(IDiskProvider diskProvider)
+        {
+            _diskProvider = diskProvider;
+        }
+
+        public void Resize(string source, string destination, int height)
+        {
+            using (var sourceStream = _diskProvider.OpenReadStream(source))
+            {
+                using (var outputStream = _diskProvider.OpenWriteStream(destination))
+                {
+                    var settings = new Instructions();
+                    settings.Height = height;
+
+                    var job = new ImageJob(sourceStream, outputStream, settings);
+
+                    ImageBuilder.Current.Build(job);
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -72,6 +72,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libraries\Growl.CoreLibrary.dll</HintPath>
     </Reference>
+    <Reference Include="ImageResizer, Version=3.4.3.103, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\ImageResizer.3.4.3\lib\ImageResizer.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
@@ -522,6 +526,7 @@
     <Compile Include="Lifecycle\LifecycleService.cs" />
     <Compile Include="MediaCover\CoverAlreadyExistsSpecification.cs" />
     <Compile Include="MediaCover\MediaCover.cs" />
+    <Compile Include="MediaCover\ImageResizer.cs" />
     <Compile Include="MediaCover\MediaCoverService.cs" />
     <Compile Include="MediaCover\MediaCoversUpdatedEvent.cs" />
     <Compile Include="MediaFiles\Commands\BackendCommandAttribute.cs" />

--- a/src/NzbDrone.Core/Update/UpdateVerification.cs
+++ b/src/NzbDrone.Core/Update/UpdateVerification.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Update
 
         public Boolean Verify(UpdatePackage updatePackage, String packagePath)
         {
-            using (var fileStream = _diskProvider.StreamFile(packagePath))
+            using (var fileStream = _diskProvider.OpenReadStream(packagePath))
             {
                 var hash = fileStream.SHA256Hash();
 

--- a/src/NzbDrone.Core/packages.config
+++ b/src/NzbDrone.Core/packages.config
@@ -3,6 +3,7 @@
   <package id="FluentMigrator" version="1.3.1.0" targetFramework="net40" />
   <package id="FluentMigrator.Runner" version="1.3.1.0" targetFramework="net40" />
   <package id="FluentValidation" version="5.5.0.0" targetFramework="net40" />
+  <package id="ImageResizer" version="3.4.3" targetFramework="net40" />
   <package id="MediaInfoNet" version="0.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net40" />
   <package id="NLog" version="2.1.0" targetFramework="net40" />

--- a/src/NzbDrone.sln
+++ b/src/NzbDrone.sln
@@ -34,10 +34,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceUninstall", "ServiceHelpers\ServiceUninstall\ServiceUninstall.csproj", "{700D0B95-95CD-43F3-B6C9-FAA0FC1358D4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NzbDrone.Core", "NzbDrone.Core\NzbDrone.Core.csproj", "{FF5EE3B6-913B-47CE-9CEB-11C51B4E1205}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0CC493D7-0A9F-4199-9615-0A977945D716} = {0CC493D7-0A9F-4199-9615-0A977945D716}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NzbDrone.Update", "NzbDrone.Update\NzbDrone.Update.csproj", "{4CCC53CD-8D5E-4CC4-97D2-5C9312AC2BD7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NzbDrone.Common", "NzbDrone.Common\NzbDrone.Common.csproj", "{F2BE0FDF-6E47-4827-A420-DD4EF82407F8}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9DC31DE3-79FF-47A8-96B4-6BA18F6BB1CB} = {9DC31DE3-79FF-47A8-96B4-6BA18F6BB1CB}
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1E6B3CBE-1578-41C1-9BF9-78D818740BE9}"
 	ProjectSection(SolutionItems) = preProject
@@ -81,6 +87,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogentriesCore", "LogentriesCore\LogentriesCore.csproj", "{90D6E9FC-7B88-4E1B-B018-8FA742274558}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogentriesNLog", "LogentriesNLog\LogentriesNLog.csproj", "{9DC31DE3-79FF-47A8-96B4-6BA18F6BB1CB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{90D6E9FC-7B88-4E1B-B018-8FA742274558} = {90D6E9FC-7B88-4E1B-B018-8FA742274558}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TVDBSharp", "TVDBSharp\TVDBSharp.csproj", "{0CC493D7-0A9F-4199-9615-0A977945D716}"
 EndProject

--- a/src/UI/Handlebars/Helpers/Html.js
+++ b/src/UI/Handlebars/Helpers/Html.js
@@ -17,8 +17,16 @@ define(
             img.onerror = null;
         };
 
-        Handlebars.registerHelper('defaultImg', function () {
-            return new Handlebars.SafeString('onerror=window.NzbDrone.imageError(this)');
+        Handlebars.registerHelper('defaultImg', function (src, size) {
+            if (!src) {
+                return new Handlebars.SafeString('onerror="window.NzbDrone.imageError(this);"');
+            }
+
+            if (size) {
+                src = src.replace(/\.jpg($|\?)/g, '-' + size + '.jpg$1');
+            }
+
+            return new Handlebars.SafeString('src="{0}" onerror="window.NzbDrone.imageError(this);"'.format(src));
         });
 
         Handlebars.registerHelper('UrlBase', function () {

--- a/src/UI/Handlebars/Helpers/Series.js
+++ b/src/UI/Handlebars/Helpers/Series.js
@@ -11,7 +11,7 @@ define(
             var poster = _.where(this.images, {coverType: 'poster'});
 
             if (poster[0]) {
-                return new Handlebars.SafeString('<img class="series-poster" src="{0}" {1}>'.format(poster[0].url, Handlebars.helpers.defaultImg.call()));
+                return new Handlebars.SafeString('<img class="series-poster" {0}>'.format(Handlebars.helpers.defaultImg.call(null, poster[0].url, 250)));
             }
 
             return new Handlebars.SafeString('<img class="series-poster placeholder-image" src="{0}">'.format(placeholder));


### PR DESCRIPTION
Didn't do caching, but the thirdparty app should do that anyway. Using the ImageResizer library to do the heavy lifting.

You can specify ```&width=``` and/or ```&height=``` if you do both it you can additionally specify ```&mode=Max|Pad|Crop|Carve|Stretch``` (defaults to Crop).
I would recommend Max or Crop, which preserve aspect ratio.

