### PR TITLE
Import using folder name

### DIFF
--- a/src/NzbDrone.Common/Extensions/ObjectExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/ObjectExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using NzbDrone.Common.Serializer;
 
-namespace NzbDrone.Test.Common
+namespace NzbDrone.Common.Extensions
 {
     public static class ObjectExtensions
     {

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Crypto\HashConverter.cs" />
     <Compile Include="Extensions\Int64Extensions.cs" />
+    <Compile Include="Extensions\ObjectExtensions.cs" />
     <Compile Include="Extensions\StreamExtensions.cs" />
     <Compile Include="Extensions\XmlExtentions.cs" />
     <Compile Include="HashUtil.cs" />

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
@@ -5,6 +5,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
@@ -153,8 +154,13 @@ namespace NzbDrone.Core.Test.Download
                   .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
-                               new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}, "Rejected!"),"Test Failure"),
-                               new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E02.mkv"}, "Rejected!"),"Test Failure")
+                               new ImportResult(
+                                   new ImportDecision(
+                                       new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}, new Rejection("Rejected!")), "Test Failure"),
+                               
+                                new ImportResult(
+                                   new ImportDecision(
+                                       new LocalEpisode {Path = @"C:\TestPath\Droned.S01E02.mkv"},new Rejection("Rejected!")), "Test Failure")
                            });
 
             Subject.Process(_trackedDownload);

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/AddFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/AddFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using Marr.Data;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download.Pending;
 using NzbDrone.Core.Parser;
@@ -12,7 +13,6 @@ using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
 {

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveGrabbedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveGrabbedFixture.cs
@@ -4,17 +4,16 @@ using FizzWare.NBuilder;
 using Marr.Data;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Pending;
-using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
 {

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveRejectedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveRejectedFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using Marr.Data;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Pending;
@@ -14,7 +15,6 @@ using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
 {

--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
             Subject.Scan(_series);
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series, false, (QualityModel)null), Times.Once());
+                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series), Times.Once());
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
             Subject.Scan(_series);
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series, false, (QualityModel)null), Times.Once());
+                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series), Times.Once());
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
             Subject.Scan(_series);
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 4), _series, false, (QualityModel)null), Times.Once());
+                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 4), _series), Times.Once());
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
             Subject.Scan(_series);
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series, false, (QualityModel)null), Times.Once());
+                  .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
 
             Mocker.GetMock<IMakeImportDecision>()
-                .Verify(c => c.GetImportDecisions(It.IsAny<List<string>>(), It.IsAny<Series>(), It.IsAny<bool>(), It.IsAny<QualityModel>()),
+                .Verify(c => c.GetImportDecisions(It.IsAny<List<string>>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()),
                     Times.Never());
 
             VerifyNoImport();
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             imported.Add(new ImportDecision(localEpisode));
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), true, null))
+                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), null, true))
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
@@ -155,14 +155,14 @@ namespace NzbDrone.Core.Test.MediaFiles
             imported.Add(new ImportDecision(localEpisode));
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), true, null))
+                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), null, true))
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
                   .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
                   .Returns(imported.Select(i => new ImportResult(i)).ToList());
 
-            Mocker.GetMock<ISampleService>()
+            Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
                       It.IsAny<QualityModel>(),
                       It.IsAny<String>(),
@@ -224,14 +224,14 @@ namespace NzbDrone.Core.Test.MediaFiles
             imported.Add(new ImportDecision(localEpisode));
 
             Mocker.GetMock<IMakeImportDecision>()
-                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), true, null))
+                  .Setup(s => s.GetImportDecisions(It.IsAny<List<String>>(), It.IsAny<Series>(), null, true))
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
                   .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
                   .Returns(imported.Select(i => new ImportResult(i)).ToList());
 
-            Mocker.GetMock<ISampleService>()
+            Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
                       It.IsAny<QualityModel>(),
                       It.IsAny<String>(),

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/SampleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/SampleServiceFixture.cs
@@ -14,7 +14,7 @@ using NzbDrone.Core.Tv;
 namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
 {
     [TestFixture]
-    public class SampleServiceFixture : CoreTest<SampleService>
+    public class SampleServiceFixture : CoreTest<DetectSample>
     {
         private Series _series;
         private LocalEpisode _localEpisode;

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(80.Megabytes());
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
             ExceptionVerification.ExpectedWarns(1);
         }
 
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(150.Megabytes());
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
             ExceptionVerification.ExpectedWarns(1);
         }
 
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(1.Gigabytes());
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(1.Gigabytes());
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
 
             Mocker.GetMock<IDiskProvider>()
                 .Verify(v => v.GetAvailableSpace(_rootFolder), Times.Once());
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(null);
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                   .Setup(s => s.GetAvailableSpace(It.IsAny<String>()))
                   .Throws(new TestException());
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
             ExceptionVerification.ExpectedErrors(1);
         }
 
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         {
             _localEpisode.ExistingFile = true;
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
 
             Mocker.GetMock<IDiskProvider>()
                   .Verify(s => s.GetAvailableSpace(It.IsAny<String>()), Times.Never());
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                   .Setup(s => s.GetAvailableSpace(It.IsAny<String>()))
                   .Returns(freeSpace);
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                   .Setup(s => s.SkipFreeSpaceCheckWhenImporting)
                   .Returns(true);
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FullSeasonSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FullSeasonSpecificationFixture.cs
@@ -34,13 +34,13 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         {
             _localEpisode.ParsedEpisodeInfo.FullSeason = true;
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_true_when_file_does_not_contain_the_full_season()
         {
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecificationFixture.cs
@@ -1,0 +1,84 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Specifications;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
+{
+    [TestFixture]
+    public class MatchesFolderSpecificationFixture : CoreTest<MatchesFolderSpecification>
+    {
+        private LocalEpisode _localEpisode;
+
+        [SetUp]
+        public void Setup()
+        {
+            _localEpisode = Builder<LocalEpisode>.CreateNew()
+                                                 .With(l => l.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E05.mkv".AsOsAgnostic())
+                                                 .With(l => l.ParsedEpisodeInfo =
+                                                     Builder<ParsedEpisodeInfo>.CreateNew()
+                                                                               .With(p => p.EpisodeNumbers = new[] {5})
+                                                                               .With(p => p.FullSeason = false)
+                                                                               .Build())
+                                                 .Build();
+        }
+
+        [Test]
+        public void should_be_accepted_for_existing_file()
+        {
+            _localEpisode.ExistingFile = true;
+
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_folder_name_is_not_parseable()
+        {
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title\S01E01.mkv".AsOsAgnostic();
+
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_should_be_accepted_for_full_season()
+        {
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title.S01\S01E01.mkv".AsOsAgnostic();
+
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_and_folder_have_the_same_episode()
+        {
+            _localEpisode.ParsedEpisodeInfo.EpisodeNumbers = new[] { 1 };
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E01.mkv".AsOsAgnostic();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_be_accepted_if_file_is_one_episode_in_folder()
+        {
+            _localEpisode.ParsedEpisodeInfo.EpisodeNumbers = new[] { 1 };
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title.S01E01E02.720p.HDTV-Sonarr\S01E01.mkv".AsOsAgnostic();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();            
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_and_folder_do_not_have_same_episode()
+        {
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-Sonarr\S01E05.mkv".AsOsAgnostic();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();            
+        }
+
+        [Test]
+        public void should_be_rejected_if_file_and_folder_do_not_have_same_episodes()
+        {
+            _localEpisode.ParsedEpisodeInfo.EpisodeNumbers = new[] { 5, 6 };
+            _localEpisode.Path = @"C:\Test\Unsorted\Series.Title.S01E01E02.720p.HDTV-Sonarr\S01E05E06.mkv".AsOsAgnostic();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotSampleSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotSampleSpecificationFixture.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         public void should_return_true_for_existing_file()
         {
             _localEpisode.ExistingFile = true;
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotUnpackingSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotUnpackingSpecificationFixture.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         [Test]
         public void should_return_true_if_not_in_working_folder()
         {
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenInWorkingFolder();
             GivenLastWriteTimeUtc(DateTime.UtcNow.AddHours(-1));
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenInWorkingFolder();
             GivenLastWriteTimeUtc(DateTime.UtcNow);
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
             GivenInWorkingFolder();
             GivenLastWriteTimeUtc(DateTime.UtcNow.AddDays(-5));
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/UpgradeSpecificationFixture.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeTrue();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
                                                      .Build()
                                                      .ToList();
 
-            Subject.IsSatisfiedBy(_localEpisode).Should().BeFalse();
+            Subject.IsSatisfiedBy(_localEpisode).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
@@ -6,6 +6,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
@@ -44,9 +45,9 @@ namespace NzbDrone.Core.Test.MediaFiles
 
 
 
-            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), "Rejected!"));
-            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), "Rejected!"));
-            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), "Rejected!"));
+            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), new Rejection("Rejected!")));
+            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), new Rejection("Rejected!")));
+            _rejectedDecisions.Add(new ImportDecision(new LocalEpisode(), new Rejection("Rejected!")));
 
             foreach (var episode in episodes)
             {

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -227,6 +227,7 @@
     <Compile Include="MediaFiles\EpisodeImport\SampleServiceFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FreeSpaceSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FullSeasonSpecificationFixture.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Specifications\MatchesFolderSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotSampleSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotUnpackingSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\UpgradeSpecificationFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/CrapParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/CrapParserFixture.cs
@@ -29,6 +29,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("08bbc153931ce3ca5fcafe1b92d3297285feb061.mkv")]
         [TestCase("185d86a343e39f3341e35c4dad3ff159")]
         [TestCase("ah63jka93jf0jh26ahjas961.mkv")]
+        [TestCase("qrdSD3rYzWb7cPdVIGSn4E7")]
         public void should_not_parse_crap(string title)
         {
             Parser.Parser.ParseTitle(title).Should().BeNull();
@@ -81,6 +82,12 @@ namespace NzbDrone.Core.Test.ParserTests
             }
 
             success.Should().Be(repetitions);
+        }
+
+        [TestCase("thebiggestloser1618finale")]
+        public void should_not_parse_file_name_without_proper_spacing(string fileName)
+        {
+            Parser.Parser.ParseTitle(fileName).Should().BeNull();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
@@ -5,10 +5,10 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Test.Framework;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.TvTests
 {

--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -4,11 +4,11 @@ using System.Linq;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Tv.Commands;
-using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.TvTests
 {

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.MediaFiles
             _logger.Trace("Finished getting episode files for: {0} [{1}]", series, videoFilesStopwatch.Elapsed);
 
             var decisionsStopwatch = Stopwatch.StartNew();
-            var decisions = _importDecisionMaker.GetImportDecisions(mediaFileList, series, false);
+            var decisions = _importDecisionMaker.GetImportDecisions(mediaFileList, series);
             decisionsStopwatch.Stop();
             _logger.Trace("Import decisions complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -8,19 +8,19 @@ using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
-    public interface ISampleService
+    public interface IDetectSample
     {
         bool IsSample(Series series, QualityModel quality, string path, long size, int seasonNumber);
     }
 
-    public class SampleService : ISampleService
+    public class DetectSample : IDetectSample
     {
         private readonly IVideoFileInfoReader _videoFileInfoReader;
         private readonly Logger _logger;
 
         private static List<Quality> _largeSampleSizeQualities = new List<Quality> { Quality.HDTV1080p, Quality.WEBDL1080p, Quality.Bluray1080p };
 
-        public SampleService(IVideoFileInfoReader videoFileInfoReader, Logger logger)
+        public DetectSample(IVideoFileInfoReader videoFileInfoReader, Logger logger)
         {
             _videoFileInfoReader = videoFileInfoReader;
             _logger = logger;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/IImportDecisionEngineSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/IImportDecisionEngineSpecification.cs
@@ -3,8 +3,8 @@ using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
-    public interface IImportDecisionEngineSpecification : IRejectWithReason
+    public interface IImportDecisionEngineSpecification
     {
-        bool IsSatisfiedBy(LocalEpisode localEpisode);
+        Decision IsSatisfiedBy(LocalEpisode localEpisode);
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
             //Adding all the rejected decisions
             importResults.AddRange(decisions.Where(c => !c.Approved)
-                                            .Select(d => new ImportResult(d, d.Rejections.ToArray())));
+                                            .Select(d => new ImportResult(d, d.Rejections.Select(r => r.Reason).ToArray())));
 
             return importResults;
         }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecision.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecision.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
     public class ImportDecision
     {
         public LocalEpisode LocalEpisode { get; private set; }
-        public IEnumerable<string> Rejections { get; private set; }
+        public IEnumerable<Rejection> Rejections { get; private set; }
 
         public bool Approved
         {
@@ -18,7 +19,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             }
         }
 
-        public ImportDecision(LocalEpisode localEpisode, params string[] rejections)
+        public ImportDecision(LocalEpisode localEpisode, params Rejection[] rejections)
         {
             LocalEpisode = localEpisode;
             Rejections = rejections.ToList();

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportResult.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportResult.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.EnsureThat;
 
@@ -8,7 +7,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
     public class ImportResult
     {
         public ImportDecision ImportDecision { get; private set; }
-        public List<String> Errors { get; private set; }
+        public List<string> Errors { get; private set; }
 
         public ImportResultType Result
         {
@@ -28,7 +27,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             }
         }
 
-        public ImportResult(ImportDecision importDecision, params String[] errors)
+        public ImportResult(ImportDecision importDecision, params string[] errors)
         {
             Ensure.That(importDecision, () => importDecision).IsNotNull();
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
@@ -3,6 +3,7 @@ using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
@@ -20,14 +21,12 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason { get { return "Not enough free space"; } }
-
-        public bool IsSatisfiedBy(LocalEpisode localEpisode)
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
         {
             if (_configService.SkipFreeSpaceCheckWhenImporting)
             {
                 _logger.Debug("Skipping free space check when importing");
-                return true;
+                return Decision.Accept();
             }
 
             try
@@ -35,7 +34,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                 if (localEpisode.ExistingFile)
                 {
                     _logger.Debug("Skipping free space check for existing episode");
-                    return true;
+                    return Decision.Accept();
                 }
 
                 var path = Directory.GetParent(localEpisode.Series.Path);
@@ -44,13 +43,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                 if (!freeSpace.HasValue)
                 {
                     _logger.Debug("Free space check returned an invalid result for: {0}", path);
-                    return true;
+                    return Decision.Accept();
                 }
 
                 if (freeSpace < localEpisode.Size + 100.Megabytes())
                 {
                     _logger.Warn("Not enough free space ({0}) to import: {1} ({2})", freeSpace, localEpisode, localEpisode.Size);
-                    return false;
+                    return Decision.Reject("Not enough free space");
                 }
             }
             catch (DirectoryNotFoundException ex)
@@ -62,7 +61,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                 _logger.ErrorException("Unable to check free disk space while importing: " + localEpisode.Path, ex);
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FullSeasonSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FullSeasonSpecification.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
@@ -12,17 +13,15 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason { get { return "Full season file"; } }
-
-        public bool IsSatisfiedBy(LocalEpisode localEpisode)
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
         {
             if (localEpisode.ParsedEpisodeInfo.FullSeason)
             {
                 _logger.Debug("Single episode file detected as containing all episodes in the season");
-                return false;
+                return Decision.Reject("Single episode file contains all episodes in seasons");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecification.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NLog;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
+{
+    public class MatchesFolderSpecification : IImportDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public MatchesFolderSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
+        {
+            if (localEpisode.ExistingFile)
+            {
+                return Decision.Accept();
+            }
+
+            var folderInfo = Parser.Parser.ParseTitle(new FileInfo(localEpisode.Path).DirectoryName);
+
+            if (folderInfo == null)
+            {
+                return Decision.Accept();
+            }
+
+            if (folderInfo.FullSeason)
+            {
+                return Decision.Accept();
+            }
+
+            var unexpected = localEpisode.ParsedEpisodeInfo.EpisodeNumbers.Where(f => !folderInfo.EpisodeNumbers.Contains(f)).ToList();
+
+            if (unexpected.Any())
+            {
+                _logger.Debug("Unexpected episode number(s) in file: {0}", unexpected);
+
+                if (unexpected.Count == 1)
+                {
+                    return Decision.Reject("Episode Number {0} was unexpected", unexpected.First());
+                }
+
+                return Decision.Reject("Episode Numbers {0} were unexpected", String.Join(", ", unexpected));
+            }
+
+            return Decision.Accept();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
@@ -1,35 +1,41 @@
 ﻿using NLog;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 {
     public class NotSampleSpecification : IImportDecisionEngineSpecification
     {
-        private readonly ISampleService _sampleService;
+        private readonly IDetectSample _detectSample;
         private readonly Logger _logger;
 
-        public NotSampleSpecification(ISampleService sampleService,
+        public NotSampleSpecification(IDetectSample detectSample,
                                       Logger logger)
         {
-            _sampleService = sampleService;
+            _detectSample = detectSample;
             _logger = logger;
         }
 
-        public string RejectionReason { get { return "Sample"; } }
-
-        public bool IsSatisfiedBy(LocalEpisode localEpisode)
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
         {
             if (localEpisode.ExistingFile)
             {
                 _logger.Debug("Existing file, skipping sample check");
-                return true;
+                return Decision.Accept();
             }
 
-            return !_sampleService.IsSample(localEpisode.Series,
-                                            localEpisode.Quality,
-                                            localEpisode.Path,
-                                            localEpisode.Size,
-                                            localEpisode.SeasonNumber);
+            var sample = _detectSample.IsSample(localEpisode.Series,
+                                                localEpisode.Quality,
+                                                localEpisode.Path,
+                                                localEpisode.Size,
+                                                localEpisode.SeasonNumber);
+
+            if (sample)
+            {
+                return Decision.Reject("Sample");
+            }
+
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using NLog;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 
@@ -14,18 +15,16 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             _logger = logger;
         }
 
-        public string RejectionReason { get { return "Not an upgrade for existing episode file(s)"; } }
-
-        public bool IsSatisfiedBy(LocalEpisode localEpisode)
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
         {
             var qualityComparer = new QualityModelComparer(localEpisode.Series.Profile);
             if (localEpisode.Episodes.Any(e => e.EpisodeFileId != 0 && qualityComparer.Compare(e.EpisodeFile.Value.Quality, localEpisode.Quality) > 0))
             {
                 _logger.Debug("This file isn't an upgrade for all episodes. Skipping {0}", localEpisode.Path);
-                return false;
+                return Decision.Reject("Not an upgrade for existing episode file(s)");
             }
 
-            return true;
+            return Decision.Accept();
         }
     }
 }

--- a/src/NzbDrone.Core/Metadata/ExistingMetadataService.cs
+++ b/src/NzbDrone.Core/Metadata/ExistingMetadataService.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Metadata
                     {
                         try
                         {
-                            var localEpisode = _parsingService.GetLocalEpisode(possibleMetadataFile, message.Series, false);
+                            var localEpisode = _parsingService.GetLocalEpisode(possibleMetadataFile, message.Series);
 
                             if (localEpisode == null)
                             {

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -561,8 +561,9 @@
     <Compile Include="MediaFiles\EpisodeImport\ImportDecisionMaker.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ImportResultType.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ManualImportService.cs" />
-    <Compile Include="MediaFiles\EpisodeImport\SampleService.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\DetectSample.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FreeSpaceSpecification.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Specifications\MatchesFolderSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FullSeasonSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotSampleSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotUnpackingSpecification.cs" />

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Parser
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 //Episodes with single digit episode number (S01E1, S01E5E6, etc)
-                new Regex(@"^(?<title>.*?)(?:\W?S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]){1,2}(?<episode>\d{1}))+)+(\W+|_|$)(?!\\)",
+                new Regex(@"^(?<title>.*?)(?:(?:_|-|\s|\.)S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]){1,2}(?<episode>\d{1}))+)+(\W+|_|$)(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 //Anime - Title Absolute Episode Number (e66)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -13,7 +13,8 @@ namespace NzbDrone.Core.Parser
 {
     public interface IParsingService
     {
-        LocalEpisode GetLocalEpisode(string filename, Series series, bool sceneSource);
+        LocalEpisode GetLocalEpisode(string filename, Series series);
+        LocalEpisode GetLocalEpisode(string filename, Series series, ParsedEpisodeInfo folderInfo, bool sceneSource);
         Series GetSeries(string title);
         RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 tvRageId = 0, SearchCriteriaBase searchCriteria = null);
         RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Int32 seriesId, IEnumerable<Int32> episodeIds);
@@ -39,9 +40,25 @@ namespace NzbDrone.Core.Parser
             _logger = logger;
         }
 
-        public LocalEpisode GetLocalEpisode(string filename, Series series, bool sceneSource)
+        public LocalEpisode GetLocalEpisode(string filename, Series series)
         {
-            var parsedEpisodeInfo = Parser.ParsePath(filename);
+            return GetLocalEpisode(filename, series, null, false);
+        }
+
+        public LocalEpisode GetLocalEpisode(string filename, Series series, ParsedEpisodeInfo folderInfo, bool sceneSource)
+        {
+            ParsedEpisodeInfo parsedEpisodeInfo;
+
+            if (folderInfo != null)
+            {
+                parsedEpisodeInfo = folderInfo.JsonClone();
+                parsedEpisodeInfo.Quality = QualityParser.ParseQuality(Path.GetFileName(filename));
+            }
+
+            else
+            {
+                parsedEpisodeInfo = Parser.ParsePath(filename);                
+            }
 
             if (parsedEpisodeInfo == null || parsedEpisodeInfo.IsPossibleSpecialEpisode)
             {

--- a/src/NzbDrone.Core/Parser/SceneChecker.cs
+++ b/src/NzbDrone.Core/Parser/SceneChecker.cs
@@ -1,4 +1,6 @@
-﻿namespace NzbDrone.Core.Parser
+﻿using System;
+
+namespace NzbDrone.Core.Parser
 {
     public static class SceneChecker
     {
@@ -10,10 +12,14 @@
             if (title.Contains(" ")) return false;
 
             var parsedTitle = Parser.ParseTitle(title);
-            if (parsedTitle == null
-                || parsedTitle.ReleaseGroup == null
-                || parsedTitle.Quality.Quality == Qualities.Quality.Unknown
-                || string.IsNullOrWhiteSpace(parsedTitle.SeriesTitle)) return false;
+
+            if (parsedTitle == null ||
+                parsedTitle.ReleaseGroup == null ||
+                parsedTitle.Quality.Quality == Qualities.Quality.Unknown ||
+                String.IsNullOrWhiteSpace(parsedTitle.SeriesTitle))
+            {
+                return false;
+            }
 
             return true;
         }

--- a/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
@@ -91,7 +91,6 @@
     <Compile Include="LoggingTest.cs" />
     <Compile Include="MockerExtensions.cs" />
     <Compile Include="NzbDroneRunner.cs" />
-    <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionExtensions.cs" />
     <Compile Include="StringExtensions.cs" />


### PR DESCRIPTION
@kayone @Taloth 

This will use the folder name when its:

- Parsable
- Contains only one non-sample file
- Not a full season

This means we can clean up a lot of hashed release logic and we'll properly handle DirFixes.