### PR TITLE
CSS: Use color red instead of grey when disabled

### DIFF
--- a/src/UI/Settings/DownloadClient/DownloadClientItemViewTemplate.hbs
+++ b/src/UI/Settings/DownloadClient/DownloadClientItemViewTemplate.hbs
@@ -7,7 +7,7 @@
         {{#if enable}}
             <span class="label label-success">Enabled</span>
         {{else}}
-            <span class="label label-default">Not Enabled</span>
+            <span class="label label-danger">Not Enabled</span>
         {{/if}}
     </div>
 </div>

--- a/src/UI/Settings/Indexers/IndexerItemViewTemplate.hbs
+++ b/src/UI/Settings/Indexers/IndexerItemViewTemplate.hbs
@@ -8,7 +8,7 @@
             {{#if enableRss}}
                 <span class="label label-success">RSS</span>
             {{else}}
-                <span class="label label-default">RSS</span>
+                <span class="label label-danger">RSS</span>
             {{/if}}
         {{else}}
             <span class="label label-default label-disabled">RSS</span>
@@ -18,7 +18,7 @@
             {{#if enableSearch}}
                 <span class="label label-success">Search</span>
             {{else}}
-                <span class="label label-default">Search</span>
+                <span class="label label-danger">Search</span>
             {{/if}}
         {{else}}
             <span class="label label-default label-disabled">Search</span>

--- a/src/UI/Settings/Metadata/MetadataItemViewTemplate.hbs
+++ b/src/UI/Settings/Metadata/MetadataItemViewTemplate.hbs
@@ -7,7 +7,7 @@
         {{#if enable}}
             <span class="label label-success">Enabled</span>
         {{else}}
-            <span class="label label-default">Not Enabled</span>
+            <span class="label label-danger">Not Enabled</span>
         {{/if}}
         <hr>
         {{#each fields}}

--- a/src/UI/Settings/Notifications/NotificationItemViewTemplate.hbs
+++ b/src/UI/Settings/Notifications/NotificationItemViewTemplate.hbs
@@ -7,13 +7,13 @@
         {{#if onGrab}}
             <span class="label label-success">On Grab</span>
         {{else}}
-            <span class="label label-default">On Grab</span>
+            <span class="label label-danger">On Grab</span>
         {{/if}}
 
         {{#if onDownload}}
             <span class="label label-success">On Download</span>
         {{else}}
-            <span class="label label-default">On Download</span>
+            <span class="label label-danger">On Download</span>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
This makes the off-state color consistent with the toggle switches, and easier to recognize.