### PR TITLE
Removed hardcoded dot prefix from the transmission category [migration 81]

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/081_move_dot_prefix_to_transmission_categoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/081_move_dot_prefix_to_transmission_categoryFixture.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients.Sabnzbd;
+using NzbDrone.Core.Download.Clients.Transmission;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class move_dot_prefix_to_transmission_category : MigrationTest<Core.Datastore.Migration.move_dot_prefix_to_transmission_category>
+    {
+        [Test]
+        public void should_not_fail_if_no_transmission()
+        {
+            WithTestDb(c =>
+            {
+                c.Insert.IntoTable("DownloadClients").Row(new 
+                {
+                    Enable = 1,
+                    Name = "Sab",
+                    Implementation = "Sabnzbd",
+                    Settings = new SabnzbdSettings
+                    {
+                        Host = "127.0.0.1",
+                        TvCategory = "abc"
+                    }.ToJson(),
+                    ConfigContract = "SabnzbdSettings"
+                });
+            });
+
+            var items = Mocker.Resolve<DownloadClientRepository>().All();
+
+            items.Should().HaveCount(1);
+
+            items.First().Settings.As<SabnzbdSettings>().TvCategory.Should().Be("abc");
+        }
+
+        [Test]
+        public void should_be_updated_for_transmission()
+        {
+            WithTestDb(c =>
+            {
+                c.Insert.IntoTable("DownloadClients").Row(new
+                {
+                    Enable = 1,
+                    Name = "Trans",
+                    Implementation = "Transmission",
+                    Settings = new TransmissionSettings
+                    {
+                        Host = "127.0.0.1",
+                        TvCategory = "abc"
+                    }.ToJson(),
+                    ConfigContract = "TransmissionSettings"
+                });
+            });
+
+            var items = Mocker.Resolve<DownloadClientRepository>().All();
+
+            items.Should().HaveCount(1);
+
+            items.First().Settings.As<TransmissionSettings>().TvCategory.Should().Be(".abc");
+        }
+
+        [Test]
+        public void should_leave_empty_category_untouched()
+        {
+            WithTestDb(c =>
+            {
+                c.Insert.IntoTable("DownloadClients").Row(new
+                {
+                    Enable = 1,
+                    Name = "Trans",
+                    Implementation = "Transmission",
+                    Settings = new TransmissionSettings
+                    {
+                        Host = "127.0.0.1",
+                        TvCategory = ""
+                    }.ToJson(),
+                    ConfigContract = "TransmissionSettings"
+                });
+            });
+
+            var items = Mocker.Resolve<DownloadClientRepository>().All();
+
+            items.Should().HaveCount(1);
+
+            items.First().Settings.As<TransmissionSettings>().TvCategory.Should().Be("");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -228,7 +228,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             id.Should().NotBeNullOrEmpty();
 
             Mocker.GetMock<ITransmissionProxy>()
-                .Verify(v => v.AddTorrentFromData(It.IsAny<Byte[]>(), @"C:/Downloads/Finished/transmission/.nzbdrone", It.IsAny<TransmissionSettings>()), Times.Once());
+                .Verify(v => v.AddTorrentFromData(It.IsAny<Byte[]>(), @"C:/Downloads/Finished/transmission/nzbdrone", It.IsAny<TransmissionSettings>()), Times.Once());
         }
 
         [Test]
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             id.Should().NotBeNullOrEmpty();
 
             Mocker.GetMock<ITransmissionProxy>()
-                .Verify(v => v.AddTorrentFromData(It.IsAny<Byte[]>(), @"C:/Downloads/Finished/transmission/.nzbdrone", It.IsAny<TransmissionSettings>()), Times.Once());
+                .Verify(v => v.AddTorrentFromData(It.IsAny<Byte[]>(), @"C:/Downloads/Finished/transmission/nzbdrone", It.IsAny<TransmissionSettings>()), Times.Once());
         }
 
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
@@ -327,7 +327,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         {
             GivenTvCategory();
 
-            _downloading.DownloadDir = @"C:/Downloads/Finished/transmission/.nzbdrone";
+            _downloading.DownloadDir = @"C:/Downloads/Finished/transmission/nzbdrone";
 
             GivenTorrents(new List<TransmissionTorrent> 
                 {

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Datastore\Migration\074_disable_eztv.cs" />
     <Compile Include="Datastore\Migration\072_history_grabIdFixture.cs" />
     <Compile Include="Datastore\Migration\070_delay_profileFixture.cs" />
+    <Compile Include="Datastore\Migration\081_move_dot_prefix_to_transmission_categoryFixture.cs" />
     <Compile Include="Datastore\Migration\079_dedupe_tagsFixture.cs" />
     <Compile Include="Datastore\Migration\075_force_lib_updateFixture.cs" />
     <Compile Include="Datastore\ObjectDatabaseFixture.cs" />

--- a/src/NzbDrone.Core/Datastore/Migration/081_move_dot_prefix_to_transmission_category.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/081_move_dot_prefix_to_transmission_category.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using FluentMigrator;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(81)]
+    public class move_dot_prefix_to_transmission_category : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(UpdateTransmissionSettings);
+        }
+
+        private void UpdateTransmissionSettings(IDbConnection conn, IDbTransaction tran)
+        {
+            using (var cmd = conn.CreateCommand())
+            {
+                cmd.Transaction = tran;
+                cmd.CommandText = "SELECT Id, Settings FROM DownloadClients WHERE Implementation = 'Transmission'";
+
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        var id = reader.GetInt32(0);
+                        var settingsJson = reader.GetString(1);
+
+                        var settings = Json.Deserialize<Dictionary<string, object>>(settingsJson);
+
+                        var tvCategory = settings.GetValueOrDefault("tvCategory") as string;
+                        if (tvCategory.IsNotNullOrWhiteSpace())
+                        {
+                            settings["tvCategory"] = "." + tvCategory;
+
+                            using (var updateCmd = conn.CreateCommand())
+                            {
+                                updateCmd.Transaction = tran;
+                                updateCmd.CommandText = "UPDATE DownloadClients SET Settings = ? WHERE Id = ?";
+                                updateCmd.AddParameter(settings.ToJson());
+                                updateCmd.AddParameter(id);
+
+                                updateCmd.ExecuteNonQuery();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             var config = _proxy.GetConfig(Settings);
             var destDir = (String)config.GetValueOrDefault("download-dir");
 
-            return string.Format("{0}/.{1}", destDir.TrimEnd('/'), Settings.TvCategory);
+            return string.Format("{0}/{1}", destDir.TrimEnd('/'), Settings.TvCategory);
         }
 
         public override IEnumerable<DownloadClientItem> GetItems()
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 if (Settings.TvCategory.IsNotNullOrWhiteSpace())
                 {
                     var directories = outputPath.FullPath.Split('\\', '/');
-                    if (!directories.Contains(String.Format(".{0}", Settings.TvCategory))) continue;
+                    if (!directories.Contains(String.Format("{0}", Settings.TvCategory))) continue;
                 }
 
                 var item = new DownloadClientItem();

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Datastore\Migration\074_disable_eztv.cs" />
     <Compile Include="Datastore\Migration\073_clear_ratings.cs" />
     <Compile Include="Datastore\Migration\077_add_add_options_to_series.cs" />
+    <Compile Include="Datastore\Migration\081_move_dot_prefix_to_transmission_category.cs" />
     <Compile Include="Datastore\Migration\079_dedupe_tags.cs" />
     <Compile Include="Datastore\Migration\070_delay_profile.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />


### PR DESCRIPTION
With migration to add the dot to existing configured Transmission Settings so we don't break existing users.