### PR TITLE
UI: (Prototype) User definable link to file

### DIFF
--- a/src/UI/Cells/FileLinkCell.js
+++ b/src/UI/Cells/FileLinkCell.js
@@ -1,0 +1,40 @@
+var vent = require('vent');
+var Backgrid = require('backgrid');
+
+module.exports = Backgrid.Cell.extend({
+    className : 'file-link-cell',
+
+    render : function() {
+        function setCustomReplace() {
+            while (true) {
+                localStorage.fileLinkReplace = window.prompt("Set characters that shall be replaced:", "/mnt/");
+                localStorage.fileLinkReplaceWith = window.prompt("Set what aforeselected characters shall be replaced with", "smb://192.168.1.1/main/");
+
+                var link = makeLink();
+                if (window.confirm("Link will be: " + link + ". Click OK if this is correct or you give up. To later modify, clear localStorage.")) {
+                    return link;
+                }
+            }
+        }
+
+        function makeLink() {
+            if (localStorage.hasOwnProperty("fileLinkReplace") && localStorage.hasOwnProperty("fileLinkReplaceWith")) {
+                return path.replace(localStorage.fileLinkReplace, localStorage.fileLinkReplaceWith);
+            } else {
+                if (window.confirm("Pattern for defining link to " + path + " has not been created. Do it now?")) {
+                    return setCustomReplace();
+                }
+            }
+        }
+
+        path = this.model.get('path');
+        var link = makeLink();
+        if (link) {
+            this.$el.empty();
+            this.$el.html('<a><i class="icon-open-file x-open-file" title="Open"></a>');
+            this.$("a").prop("href", link);
+        }
+
+        return this;
+    },
+});

--- a/src/UI/Cells/cells.less
+++ b/src/UI/Cells/cells.less
@@ -170,7 +170,7 @@ td.episode-status-cell, td.quality-cell, td.history-quality-cell, td.progress-ce
   width : 80px;
 }
 
-td.delete-episode-file-cell {
+td.delete-episode-file-cell, td.file-link-cell {
   .clickable();
 
   text-align : center;

--- a/src/UI/Content/icons.less
+++ b/src/UI/Content/icons.less
@@ -236,6 +236,10 @@
   .fa-icon-color(@brand-danger);
 }
 
+.icon-open-file {
+  .fa-icon-content(@fa-var-external-link);
+}
+
 .icon-sonarr-search {
   .fa-icon-content(@fa-var-search);
 }

--- a/src/UI/Episode/Summary/EpisodeSummaryLayout.js
+++ b/src/UI/Episode/Summary/EpisodeSummaryLayout.js
@@ -5,6 +5,7 @@ var EpisodeFileModel = require('../../Series/EpisodeFileModel');
 var EpisodeFileCollection = require('../../Series/EpisodeFileCollection');
 var FileSizeCell = require('../../Cells/FileSizeCell');
 var QualityCell = require('../../Cells/QualityCell');
+var FileLinkCell = require('../../Cells/FileLinkCell');
 var DeleteEpisodeFileCell = require('../../Cells/DeleteEpisodeFileCell');
 var NoFileView = require('./NoFileView');
 var LoadingView = require('../../Shared/LoadingView');
@@ -36,6 +37,12 @@ module.exports = Marionette.Layout.extend({
             cell     : QualityCell,
             sortable : false,
             editable : true
+        },
+        {
+            name     : 'this',
+            label    : '',
+            cell     : FileLinkCell,
+            sortable : false
         },
         {
             name     : 'this',


### PR DESCRIPTION
Example implementation of a direct link to the media file.

In most browsers, the link must be right-clicked then opened, due to security measures. There must also exist an application which can open it. In my instance `smb://` is launched by the media player Bomi, which has Samba support, so I can create a link to match the expected path.