### PR TITLE
selecting range with shift-key in Series Editor should now work

### DIFF
--- a/src/UI/Cells/SelectAllCell.js
+++ b/src/UI/Cells/SelectAllCell.js
@@ -4,14 +4,16 @@ var BackgridSelectAll = require('backgrid.selectall');
 
 module.exports = BackgridSelectAll.extend({
     enterEditMode : function(e) {
-        if (e.shiftKey && this.model.collection.lastToggled) {
-            this._selectRange();
+        var collection = this.column.get('sortedCollection') || this.model.collection;
+
+        if (e.shiftKey && collection.lastToggled) {
+            this._selectRange(collection);
         }
 
         var checked = $(e.target).prop('checked');
 
-        this.model.collection.lastToggled = this.model;
-        this.model.collection.checked = checked;
+        collection.lastToggled = this.model;
+        collection.checked = checked;
     },
 
     onChange : function(e) {
@@ -20,8 +22,7 @@ module.exports = BackgridSelectAll.extend({
         this.model.trigger('backgrid:selected', this.model, checked);
     },
 
-    _selectRange : function() {
-        var collection = this.model.collection;
+    _selectRange : function(collection) {
         var lastToggled = collection.lastToggled;
         var checked = collection.checked;
 
@@ -38,7 +39,7 @@ module.exports = BackgridSelectAll.extend({
             model.trigger('backgrid:select', model, checked);
         });
 
-        this.model.collection.lastToggled = undefined;
-        this.model.collection.checked = undefined;
+        collection.lastToggled = undefined;
+        collection.checked = undefined;
     }
 });

--- a/src/UI/Series/Editor/SeriesEditorLayout.js
+++ b/src/UI/Series/Editor/SeriesEditorLayout.js
@@ -145,6 +145,8 @@ module.exports = Marionette.Layout.extend({
             return;
         }
 
+        this.columns[0].sortedCollection = this.seriesCollection;
+
         this.editorGrid = new Backgrid.Grid({
             collection : this.seriesCollection,
             columns    : this.columns,


### PR DESCRIPTION
@markus101

A hack imo.

Problem is that this.model.collection points to the original unsorted collection and thus messes up the indexes.
Strangely enough I couldn't find a collection property on the cell, so this hack piggybacks it via column.

Any suggestions are welcome.