### PR TITLE
Add "Force" priority for NZBGet

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetPriority.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetPriority.cs
@@ -6,6 +6,7 @@
         Low = -50,
         Normal = 0,
         High = 50,
-        VeryHigh = 100
+        VeryHigh = 100,
+        Force = 900
     }
 }


### PR DESCRIPTION
The force priority allows NZBs to be downloaded even if the general queue is in a paused state. The use case here is setting recently released items to be downloaded even if the queue is paused. This is a quite common pattern on ISPs that have download quotas (e.g.: most in Australia) where downloading huge archives may need to be paced but shows being currently aired should be fetched for viewing as soon as they are available.

The existence of this priority is buried in their API [docs](http://nzbget.net/RPC_API_reference#Method_.22append.22) and in forum [posts](http://nzbget.net/forum/viewtopic.php?f=3&t=1177) but has been supported for a while (as of r1000). It also shows up [in the NZBGet UI](http://take.ms/gTojP). On older clients, the NZBGet UI will just show "Priority: 900" instead of the friendly label. They will be prioritised above other items in the queue but won't bypass the paused state. In other words, NZBGet models priorities as numeric values so this is compatible with old versions and new versions will treat this value specially when encountered.

----

Note to maintainers: I tried to sign the CLA but [got a 500 error](http://take.ms/yTQgT) from CLAHub. Let me know if there's an alternate way you'd like me to sign the contributor agreement. I am not very familiar with the source of this project and it's been several years since I did any C# or .NET so if I've missed something (UI/tests/etc) that needs to be bundled with this change, I'm happy to do it with some guidance.

Thanks!