### PR TITLE
Allow startup on case sensitive file systems

### DIFF
--- a/osx/Sonarr
+++ b/osx/Sonarr
@@ -4,7 +4,7 @@
 DIR=$(cd "$(dirname "$0")"; pwd)
  
 #change these values to match your app
-EXE_PATH="$DIR/nzbdrone.exe"
+EXE_PATH="$DIR/NzbDrone.exe"
 APPNAME="Sonarr"
  
 #set up environment


### PR DESCRIPTION
Fixed EXE_PATH to match NzbDrone.exe’s capitalisation, so that on mac case sensitive systems, Sonarr boot up without modifications.