### PR TITLE
Added support for alternate pid file location

### DIFF
--- a/src/NzbDrone.Common/ConsoleService.cs
+++ b/src/NzbDrone.Common/ConsoleService.cs
@@ -27,6 +27,10 @@ namespace NzbDrone.Common
             Console.WriteLine("                 /{0} Install the application as a Windows Service ({1}).", StartupContext.INSTALL_SERVICE, ServiceProvider.NZBDRONE_SERVICE_NAME);
             Console.WriteLine("                 /{0} Uninstall already installed Windows Service ({1}).", StartupContext.UNINSTALL_SERVICE, ServiceProvider.NZBDRONE_SERVICE_NAME);
             Console.WriteLine("                 /{0} Don't open NzbDrone in a browser", StartupContext.NO_BROWSER);
+            if (!OsInfo.IsWindows)
+            {
+                Console.WriteLine("                 /{0}=PATH Path of file to write process identifier to", StartupContext.PID_FILE);
+            }
             Console.WriteLine("                 <No Arguments>  Run application in console mode.");
         }
 

--- a/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
@@ -73,7 +73,12 @@ namespace NzbDrone.Common.EnvironmentInfo
 
                 if (Args.ContainsKey(APPDATA))
                 {
-                    args = "/data=" + Args[APPDATA];
+                    args = "/" + APPDATA + "=" + Args[APPDATA];
+                }
+
+                if (Args.ContainsKey(PID_FILE))
+                {
+                    args += " /" + PID_FILE + "=" + Args[PID_FILE];
                 }
 
                 if (Flags.Contains(NO_BROWSER))

--- a/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Common.EnvironmentInfo
         public const string HELP = "?";
         public const string TERMINATE = "terminateexisting";
         public const string RESTART = "restart";
+        public const string PID_FILE = "pidfile";
 
         public StartupContext(params string[] args)
         {

--- a/src/NzbDrone.Common/Processes/PidFileProvider.cs
+++ b/src/NzbDrone.Common/Processes/PidFileProvider.cs
@@ -12,16 +12,16 @@ namespace NzbDrone.Common.Processes
 
     public class PidFileProvider : IProvidePidFile
     {
-        private readonly IStartupContext _startupContext;
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IProcessProvider _processProvider;
+        private readonly IStartupContext _startupContext;
         private readonly Logger _logger;
 
-        public PidFileProvider(IStartupContext startupContext, IAppFolderInfo appFolderInfo, IProcessProvider processProvider, Logger logger)
+        public PidFileProvider(IAppFolderInfo appFolderInfo, IProcessProvider processProvider, IStartupContext startupContext, Logger logger)
         {
-            _startupContext = startupContext;
             _appFolderInfo = appFolderInfo;
             _processProvider = processProvider;
+            _startupContext = startupContext;
             _logger = logger;
         }
 

--- a/src/NzbDrone.Common/Processes/PidFileProvider.cs
+++ b/src/NzbDrone.Common/Processes/PidFileProvider.cs
@@ -12,12 +12,14 @@ namespace NzbDrone.Common.Processes
 
     public class PidFileProvider : IProvidePidFile
     {
+        private readonly IStartupContext _startupContext;
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IProcessProvider _processProvider;
         private readonly Logger _logger;
 
-        public PidFileProvider(IAppFolderInfo appFolderInfo, IProcessProvider processProvider, Logger logger)
+        public PidFileProvider(IStartupContext startupContext, IAppFolderInfo appFolderInfo, IProcessProvider processProvider, Logger logger)
         {
+            _startupContext = startupContext;
             _appFolderInfo = appFolderInfo;
             _processProvider = processProvider;
             _logger = logger;
@@ -30,7 +32,18 @@ namespace NzbDrone.Common.Processes
                 return;
             }
 
-            var filename = Path.Combine(_appFolderInfo.AppDataFolder, "nzbdrone.pid");
+            string filename;
+
+            if (_startupContext.Args.ContainsKey(StartupContext.PID_FILE))
+            {
+                filename = _startupContext.Args[StartupContext.PID_FILE];
+                _logger.Info("Using custom location for PID file: " + filename);
+            }
+            else
+            {
+                filename = Path.Combine(_appFolderInfo.AppDataFolder, "nzbdrone.pid");
+            }
+
             try
             {
                 File.WriteAllText(filename, _processProvider.GetCurrentProcess().Id.ToString());


### PR DESCRIPTION
I've added support for writing the pid file to an alternate location using a /pidfile=PATH command line switch because it's customary to store the pid file in /var/run/<proc>.pid whereas the other files Sonarr writes are better placed in /var/lib (or /var/cache depending on their purpose). The switch is only visible on non-Windows platforms.