### PR TITLE
Prevent the premature deletion of a download when slowly importing season pack

### DIFF
--- a/src/NzbDrone.App.Test/ContainerFixture.cs
+++ b/src/NzbDrone.App.Test/ContainerFixture.cs
@@ -14,6 +14,7 @@ using FluentAssertions;
 using System.Linq;
 using NzbDrone.Common.Composition;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Download.TrackedDownloads;
 
 namespace NzbDrone.App.Test
 {
@@ -64,11 +65,28 @@ namespace NzbDrone.App.Test
         }
 
         [Test]
-        [Ignore("need to fix this at some point")]
         public void should_return_same_instance_of_singletons()
         {
             var first = _container.ResolveAll<IHandle<ApplicationShutdownRequested>>().OfType<Scheduler>().Single();
             var second = _container.ResolveAll<IHandle<ApplicationShutdownRequested>>().OfType<Scheduler>().Single();
+
+            first.Should().BeSameAs(second);
+        }
+
+        [Test]
+        public void should_return_same_instance_of_singletons_by_different_same_interface()
+        {
+            var first = _container.ResolveAll<IHandle<EpisodeGrabbedEvent>>().OfType<DownloadMonitoringService>().Single();
+            var second = _container.ResolveAll<IHandle<EpisodeGrabbedEvent>>().OfType<DownloadMonitoringService>().Single();
+
+            first.Should().BeSameAs(second);
+        }
+
+        [Test]
+        public void should_return_same_instance_of_singletons_by_different_interfaces()
+        {
+            var first = _container.ResolveAll<IHandle<EpisodeGrabbedEvent>>().OfType<DownloadMonitoringService>().Single();
+            var second = (DownloadMonitoringService)_container.Resolve<IExecute<CheckForFinishedDownloadCommand>>();
 
             first.Should().BeSameAs(second);
         }

--- a/src/NzbDrone.Common.Test/TPLTests/DebouncerFixture.cs
+++ b/src/NzbDrone.Common.Test/TPLTests/DebouncerFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Common.Test.TPLTests
         }
 
         [Test]
-        public void should_throttle_cals()
+        public void should_throttle_calls()
         {
             var counter = new Counter();
             var debounceFunction = new Debouncer(counter.Hit, TimeSpan.FromMilliseconds(50));
@@ -64,6 +64,62 @@ namespace NzbDrone.Common.Test.TPLTests
 
         }
 
+        [Test]
+        public void should_hold_the_call_while_paused()
+        {
+            var counter = new Counter();
+            var debounceFunction = new Debouncer(counter.Hit, TimeSpan.FromMilliseconds(50));
 
+            debounceFunction.Pause();
+
+            debounceFunction.Execute();
+            debounceFunction.Execute();
+
+            Thread.Sleep(100);
+
+            counter.Count.Should().Be(0);
+
+            debounceFunction.Execute();
+            debounceFunction.Execute();
+
+            Thread.Sleep(100);
+
+            counter.Count.Should().Be(0);
+
+            debounceFunction.Resume();
+
+            Thread.Sleep(20);
+
+            counter.Count.Should().Be(0);
+
+            Thread.Sleep(100);
+
+            counter.Count.Should().Be(1);
+        }
+
+        [Test]
+        public void should_handle_pause_reentrancy()
+        {
+            var counter = new Counter();
+            var debounceFunction = new Debouncer(counter.Hit, TimeSpan.FromMilliseconds(50));
+
+            debounceFunction.Pause();
+            debounceFunction.Pause();
+
+            debounceFunction.Execute();
+            debounceFunction.Execute();
+
+            debounceFunction.Resume();
+
+            Thread.Sleep(100);
+
+            counter.Count.Should().Be(0);
+
+            debounceFunction.Resume();
+
+            Thread.Sleep(100);
+
+            counter.Count.Should().Be(1);
+        }
     }
 }

--- a/src/NzbDrone.Common/Composition/Container.cs
+++ b/src/NzbDrone.Common/Composition/Container.cs
@@ -51,7 +51,9 @@ namespace NzbDrone.Common.Composition
 
         public void RegisterSingleton(Type service, Type implementation)
         {
-            _container.Register(service, implementation).AsSingleton();
+            var factory = CreateSingletonImplementationFactory(implementation);
+
+            _container.Register(service, factory);
         }
 
         public IEnumerable<T> ResolveAll<T>() where T : class
@@ -59,9 +61,23 @@ namespace NzbDrone.Common.Composition
             return _container.ResolveAll<T>();
         }
 
-        public void RegisterAllAsSingleton(Type registrationType, IEnumerable<Type> implementationList)
+        public void RegisterAllAsSingleton(Type service, IEnumerable<Type> implementationList)
         {
-            _container.RegisterMultiple(registrationType, implementationList).AsSingleton();
+            foreach (var implementation in implementationList)
+            {
+                var factory = CreateSingletonImplementationFactory(implementation);
+
+                _container.Register(service, factory, implementation.FullName);
+            }
+        }
+
+        private Func<TinyIoCContainer, NamedParameterOverloads, object> CreateSingletonImplementationFactory(Type implementation)
+        {
+            const string singleImplPrefix = "singleImpl_";
+
+            _container.Register(implementation, implementation, singleImplPrefix + implementation.FullName).AsSingleton();
+
+            return (c, p) => _container.Resolve(implementation, singleImplPrefix + implementation.FullName);
         }
 
         public bool IsTypeRegistered(Type type)


### PR DESCRIPTION
@markus101 

Should fix the problem, but I didn't test it in integration environment.

Also changed IHandleAsync to IHandle, seemed to make sense to do it sync now.