### PR TITLE
Settings: Remove misleading placeholder, fix error-message

### DIFF
--- a/src/NzbDrone.Core/Validation/IpValidation.cs
+++ b/src/NzbDrone.Core/Validation/IpValidation.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Validation
                 }
 
                 return parsedAddress.AddressFamily == AddressFamily.InterNetwork;
-            }).WithMessage("Must be a valid IPv4 Address");
+            }).WithMessage("Must contain wildcard (*) or a valid IPv4 Address");
         }
 
         public static IRuleBuilderOptions<T, string> NotListenAllIp4Address<T>(this IRuleBuilder<T, string> ruleBuilder)

--- a/src/UI/Settings/General/GeneralViewTemplate.hbs
+++ b/src/UI/Settings/General/GeneralViewTemplate.hbs
@@ -11,7 +11,7 @@
             </div>
 
             <div class="col-sm-4 col-sm-pull-1">
-                <input type="text" placeholder="*" name="bindAddress" class="form-control" />
+                <input type="text" name="bindAddress" class="form-control" />
             </div>
         </div>
 


### PR DESCRIPTION
Alternatives:
 - Allow empty value (parse as wildcard)
 - Before POST, replace empty value with "*"