### PR TITLE
Series/season metadata also created on episode import.

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
@@ -53,8 +53,9 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
                   .Setup(s => s.BuildSeasonPath(It.IsAny<Series>(), It.IsAny<int>()))
                   .Returns(@"C:\Test\TV\Series\Season 01".AsOsAgnostic());
 
+            var rootFolder = @"C:\Test\TV".AsOsAgnostic();
             Mocker.GetMock<IDiskProvider>()
-                  .Setup(s => s.FolderExists(@"C:\Test\TV"))
+                  .Setup(s => s.FolderExists(rootFolder))
                   .Returns(true);
 
             Mocker.GetMock<IDiskProvider>()

--- a/src/NzbDrone.Core/MediaFiles/Events/EpisodeFolderCreatedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/EpisodeFolderCreatedEvent.cs
@@ -1,0 +1,20 @@
+using NzbDrone.Common.Messaging;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.MediaFiles.Events
+{
+    public class EpisodeFolderCreatedEvent : IEvent
+    {
+        public Series Series { get; private set; }
+        public EpisodeFile EpisodeFile { get; private set; }
+        public string SeriesFolder { get; set; }
+        public string SeasonFolder { get; set; }
+        public string EpisodeFolder { get; set; }
+
+        public EpisodeFolderCreatedEvent(Series series, EpisodeFile episodeFile)
+        {
+            Series = series;
+            EpisodeFile = episodeFile;
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -608,6 +608,7 @@
     <Compile Include="MediaFiles\Events\EpisodeDownloadedEvent.cs" />
     <Compile Include="MediaFiles\Events\EpisodeFileAddedEvent.cs" />
     <Compile Include="MediaFiles\Events\EpisodeFileDeletedEvent.cs" />
+    <Compile Include="MediaFiles\Events\EpisodeFolderCreatedEvent.cs" />
     <Compile Include="MediaFiles\Events\EpisodeImportedEvent.cs" />
     <Compile Include="MediaFiles\Events\SeriesRenamedEvent.cs" />
     <Compile Include="MediaFiles\Events\SeriesScanSkippedEvent.cs" />

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Organizer
     {
         string BuildFileName(List<Episode> episodes, Series series, EpisodeFile episodeFile, NamingConfig namingConfig = null);
         string BuildFilePath(Series series, Int32 seasonNumber, String fileName, String extension);
+        string BuildSeasonPath(Series series, Int32 seasonNumber);
         BasicNamingConfig GetBasicNamingConfig(NamingConfig nameSpec);
         string GetSeriesFolder(Series series, NamingConfig namingConfig = null);
         string GetSeasonFolder(Series series, Int32 seasonNumber, NamingConfig namingConfig = null);
@@ -138,29 +139,32 @@ namespace NzbDrone.Core.Organizer
         {
             Ensure.That(extension, () => extension).IsNotNullOrWhiteSpace();
 
-            string path = series.Path;
+            var path = BuildSeasonPath(series, seasonNumber);
+
+            return Path.Combine(path, fileName + extension);
+        }
+
+        public string BuildSeasonPath(Series series, int seasonNumber)
+        {
+            var path = series.Path;
 
             if (series.SeasonFolder)
             {
-                string seasonFolder;
-
                 if (seasonNumber == 0)
                 {
-                    seasonFolder = "Specials";
+                    path = Path.Combine(path, "Specials");
                 }
-
                 else
                 {
-                    var nameSpec = _namingConfigService.GetConfig();
-                    seasonFolder = GetSeasonFolder(series, seasonNumber, nameSpec);
+                    var seasonFolder = GetSeasonFolder(series, seasonNumber);
+
+                    seasonFolder = CleanFileName(seasonFolder);
+
+                    path = Path.Combine(path, seasonFolder);
                 }
-
-                seasonFolder = CleanFileName(seasonFolder);
-
-                path = Path.Combine(path, seasonFolder);
             }
 
-            return Path.Combine(path, fileName + extension);
+            return path;
         }
 
         public BasicNamingConfig GetBasicNamingConfig(NamingConfig nameSpec)


### PR DESCRIPTION
Fixes #545

@markus101 Just a quick look for sign-off.

The idea is that on folder creation an event is raised. Atm only used to update metadata.
That should only happen when the series/season folders didn't exist yet.