### PR TITLE
Allow downloads to be tracked by the source name in addition to the download name

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.TrackedDownloads;
+using NzbDrone.Core.History;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.EpisodeImport;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
+using NzbDrone.Core.Indexers;
+using System.Linq;
+
+namespace NzbDrone.Core.Test.Download
+{
+    [TestFixture]
+    public class TrackedDownloadServiceFixture : CoreTest<TrackedDownloadService>
+    {
+        private void GivenAHistoryWithADownload()
+        {
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.Is<string>(sr => sr == "35238")))
+                .Returns(new List<History.History>(){
+                 new History.History(){
+                     DownloadId = "35238",
+                     SourceTitle = "Tv Series S01",
+                     SeriesId = 5,
+                     EpisodeId = 4
+                 }
+                });
+        }
+
+        [Test]
+        public void should_track_downloads_using_the_source_title_if_it_cannot_be_found_using_the_download_title()
+        {
+            GivenAHistoryWithADownload();
+
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series() { Id = 5 },
+                Episodes = new List<Episode> { new Episode { Id = 4 } },
+                ParsedEpisodeInfo = new ParsedEpisodeInfo()
+                {
+                    SeriesTitle = "tvseries",
+                    SeasonNumber = 1
+                }
+            };
+
+            Mocker.GetMock<IParsingService>()
+               .Setup(s => s.Map(It.Is<ParsedEpisodeInfo>(i => i.SeasonNumber == 1 && i.SeriesTitle == "tvseries"), It.IsAny<int>(), It.IsAny<IEnumerable<int>>()))
+               .Returns(remoteEpisode);
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem()
+            {
+                Title = "The torrent release folder",
+                DownloadId = "35238",
+            };
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+
+            trackedDownload.RemoteEpisode.Series.Id.Should().Be(5);
+            trackedDownload.RemoteEpisode.Episodes.First().Id.Should().Be(4);
+            trackedDownload.RemoteEpisode.ParsedEpisodeInfo.SeasonNumber.Should().Be(1);
+            trackedDownload.RemoteEpisode.ParsedEpisodeInfo.SeriesTitle.Should().Be("tvseries");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -175,6 +175,7 @@
     <None Include="Files\Indexers\Rarbg\RecentFeed_v2.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Compile Include="Download\TrackedDownloads\TrackedDownloadServiceFixture.cs" />
     <Compile Include="FluentTest.cs" />
     <Compile Include="Framework\CoreTest.cs" />
     <Compile Include="Framework\DbTest.cs" />

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Download
 {
@@ -27,12 +28,14 @@ namespace NzbDrone.Core.Download
         private readonly IDownloadedEpisodesImportService _downloadedEpisodesImportService;
         private readonly IParsingService _parsingService;
         private readonly Logger _logger;
+        private readonly ISeriesService _seriesService;
 
         public CompletedDownloadService(IConfigService configService,
                                         IEventAggregator eventAggregator,
                                         IHistoryService historyService,
                                         IDownloadedEpisodesImportService downloadedEpisodesImportService,
                                         IParsingService parsingService,
+                                        ISeriesService seriesService,
                                         Logger logger)
         {
             _configService = configService;
@@ -41,6 +44,7 @@ namespace NzbDrone.Core.Download
             _downloadedEpisodesImportService = downloadedEpisodesImportService;
             _parsingService = parsingService;
             _logger = logger;
+            _seriesService = seriesService;
         }
 
         public void Process(TrackedDownload trackedDownload, bool ignoreWarnings = false)
@@ -80,8 +84,16 @@ namespace NzbDrone.Core.Download
 
                 if (series == null)
                 {
-                    trackedDownload.Warn("Series title mismatch, automatic import is not possible.");
-                    return;
+                    if (historyItem != null)
+                    {
+                        series = _seriesService.GetSeries(historyItem.SeriesId);
+                    }
+
+                    if (series == null)
+                    {
+                        trackedDownload.Warn("Series title mismatch, automatic import is not possible.");
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
I am working getting an anime indexer working and it has the issue that the torrent name isn't in a format that Sonarr supports so it doesn't track when added to the download client.  

I changed it so that if its unable to match using the download name then it looks up the history item using the download id and uses the source title which works as the name supplied by the indexer rather than inside the torrent file is in the correct format.