### PR TITLE
Fix: When removing pending items from the queue remove all releases for that episode

### DIFF
--- a/src/NzbDrone.Api/Queue/QueueActionModule.cs
+++ b/src/NzbDrone.Api/Queue/QueueActionModule.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Api.Queue
 
             if (pendingRelease != null)
             {
-                _pendingReleaseService.RemovePendingQueueItem(id);
+                _pendingReleaseService.RemovePendingQueueItems(pendingRelease.Id);
 
                 return new object().AsResponse();
             }

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Download.Pending;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
+{
+    [TestFixture]
+    public class RemovePendingFixture : CoreTest<PendingReleaseService>
+    {
+
+        private List<PendingRelease> _pending;
+
+        [SetUp]
+        public void Setup()
+        {
+            _pending = new List<PendingRelease>();
+
+            Mocker.GetMock<IPendingReleaseRepository>()
+                 .Setup(s => s.AllBySeriesId(It.IsAny<int>()))
+                 .Returns(_pending);
+
+            Mocker.GetMock<IPendingReleaseRepository>()
+                  .Setup(s => s.Get(It.IsAny<int>()))
+                  .Returns<int>(r => _pending.Single(c => c.Id == r));
+        }
+
+        private void AddPending(int id, int seasonNumber, int[] episodes)
+        {
+            _pending.Add(new PendingRelease
+             {
+                 Id = id,
+                 ParsedEpisodeInfo = new ParsedEpisodeInfo { SeasonNumber = seasonNumber, EpisodeNumbers = episodes }
+             });
+        }
+
+        [Test]
+        public void should_remove_same_release()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 3 });
+
+            Subject.RemovePendingQueueItems(1);
+
+            AssertRemoved(1);
+        }
+
+
+        [Test]
+        public void should_remove_multiple_releases_release()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 2, seasonNumber: 2, episodes: new[] { 2 });
+            AddPending(id: 3, seasonNumber: 2, episodes: new[] { 3 });
+            AddPending(id: 4, seasonNumber: 2, episodes: new[] { 3 });
+
+            Subject.RemovePendingQueueItems(3);
+
+            AssertRemoved(3, 4);
+        }
+
+        [Test]
+        public void should_not_remove_diffrent_season()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 2, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 3, seasonNumber: 3, episodes: new[] { 1 });
+            AddPending(id: 4, seasonNumber: 3, episodes: new[] { 1 });
+
+            Subject.RemovePendingQueueItems(1);
+
+            AssertRemoved(1, 2);
+        }
+
+        [Test]
+        public void should_not_remove_diffrent_episodes()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 2, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 3, seasonNumber: 2, episodes: new[] { 2 });
+            AddPending(id: 4, seasonNumber: 2, episodes: new[] { 3 });
+
+            Subject.RemovePendingQueueItems(1);
+
+            AssertRemoved(1, 2);
+        }
+
+        [Test]
+        public void should_not_remove_multiepisodes()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 2, seasonNumber: 2, episodes: new[] { 1, 2 });
+
+            Subject.RemovePendingQueueItems(1);
+
+            AssertRemoved(1);
+        }
+
+        [Test]
+        public void should_not_remove_singleepisodes()
+        {
+            AddPending(id: 1, seasonNumber: 2, episodes: new[] { 1 });
+            AddPending(id: 2, seasonNumber: 2, episodes: new[] { 1, 2 });
+
+            Subject.RemovePendingQueueItems(2);
+
+            AssertRemoved(2);
+        }
+
+
+        private void AssertRemoved(params int[] ids)
+        {
+            Mocker.GetMock<IPendingReleaseRepository>().Verify(c => c.DeleteMany(It.Is<IEnumerable<int>>(s => s.SequenceEqual(ids))));
+        }
+    }
+
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Download\DownloadClientTests\UTorrentTests\UTorrentFixture.cs" />
     <Compile Include="Download\DownloadServiceFixture.cs" />
     <Compile Include="Download\FailedDownloadServiceFixture.cs" />
+    <Compile Include="Download\Pending\PendingReleaseServiceTests\RemovePendingFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\RemoveRejectedFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\RemoveGrabbedFixture.cs" />
     <Compile Include="Download\Pending\PendingReleaseServiceTests\AddFixture.cs" />


### PR DESCRIPTION
Right now, we only delete the current release being shown, which is annoying. lets say 2x720p releases and 2x1080p releases have been tracked by sonarr, and I have a delay for the episode. I decide that I'm behind on the show and I just don't want it to download that episode, I would have to remove it from the queue four times. it could also cause the user to think the remove button is broken since the episode they deleted keeps reappearing, not knowing that each time they are deleting the next release.