### PR TITLE
Dots should not be removed from indexer queries

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -12,12 +12,25 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("Star Wars: The Clone Wars", Result = "Star+Wars+The+Clone+Wars")]
         [TestCase("Hawaii Five-0", Result = "Hawaii+Five+0")]
         [TestCase("Franklin & Bash", Result = "Franklin+and+Bash")]
-        [TestCase("Chicago P.D.", Result = "Chicago+P.D.")]
         [TestCase("Kourtney And Khloé Take The Hamptons", Result = "Kourtney+And+Khloe+Take+The+Hamptons")]
         public string should_replace_some_special_characters(string input)
         {
             Subject.SceneTitles = new List<string> { input };
+            if (Subject.QueryTitles.Count > 1)
+            {
+                return "Too many titles";
+            }
+
             return Subject.QueryTitles.First();
+        }
+
+        [TestCase("Chicago P.D.", Result = "Chicago+P.D.|Chicago+PD")]
+        [TestCase("Aldnoah.Zero", Result = "Aldnoah.Zero|AldnoahZero")]
+        [TestCase("R.O.D Read Or Die", Result = "R.O.D+Read+Or+Die|ROD+Read+Or+Die")]
+        public string should_replace_and_include_original_strings_for_dotted_titles(string input)
+        {
+            Subject.SceneTitles = new List<string> { input };
+            return Subject.QueryTitles.Aggregate((a, b) => a + "|" + b);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("Star Wars: The Clone Wars", Result = "Star+Wars+The+Clone+Wars")]
         [TestCase("Hawaii Five-0", Result = "Hawaii+Five+0")]
         [TestCase("Franklin & Bash", Result = "Franklin+and+Bash")]
-        [TestCase("Chicago P.D.", Result = "Chicago+PD")]
+        [TestCase("Chicago P.D.", Result = "Chicago+P.D.")]
         [TestCase("Kourtney And Khloé Take The Hamptons", Result = "Kourtney+And+Khloe+Take+The+Hamptons")]
         public string should_replace_some_special_characters(string input)
         {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -10,8 +10,8 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"[`']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NonWordLessDot = new Regex(@"(?!\.)[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public Series Series { get; set; }
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
             cleanTitle = cleanTitle.Replace("&", "and");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
-            cleanTitle = NonWord.Replace(cleanTitle, "+");
+            cleanTitle = NonWordLessDot.Replace(cleanTitle, "+");
 
             //remove any repeating +s
             cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -210,8 +210,9 @@ namespace NzbDrone.Core.IndexerSearch
             var searchSpec = Get<SpecialEpisodeSearchCriteria>(series, episodes);
             // build list of queries for each episode in the form: "<series> <episode-title>"
             searchSpec.EpisodeQueryTitles = episodes.Where(e => !String.IsNullOrWhiteSpace(e.Title))
-                                                    .SelectMany(e => searchSpec.QueryTitles.Select(title => title + " " + SearchCriteriaBase.GetQueryTitle(e.Title)))
+                                                    .SelectMany(e => searchSpec.QueryTitles.Select(title => title + " " + SearchCriteriaBase.GetQueryTitle(e.Title).LastOrDefault()))
                                                     .ToArray();
+
 
             return Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
         }


### PR DESCRIPTION
I don't know of any reason why dots would want to be stripped from queries, whilst that class is used for parsing and indexers the replacement only affects queries.