### PR TITLE
Extrapolate scene numbering but won't auto import

### DIFF
--- a/src/NzbDrone.Api/Episodes/EpisodeResource.cs
+++ b/src/NzbDrone.Api/Episodes/EpisodeResource.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Api.Episodes
         public Nullable<Int32> SceneAbsoluteEpisodeNumber { get; set; }
         public Nullable<Int32> SceneEpisodeNumber { get; set; }
         public Nullable<Int32> SceneSeasonNumber { get; set; }
+        public Boolean UnverifiedSceneNumbering { get; set; }
         public DateTime? EndTime { get; set; }
         public DateTime? GrabDate { get; set; }
         public String SeriesTitle { get; set; }

--- a/src/NzbDrone.Core/Datastore/Migration/092_add_unverifiedscenenumbering.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/092_add_unverifiedscenenumbering.cs
@@ -1,0 +1,14 @@
+﻿using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(92)]
+    public class add_unverifiedscenenumbering : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Episodes").AddColumn("UnverifiedSceneNumbering").AsBoolean().WithDefaultValue(false);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UnverifiedSceneNumberingSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UnverifiedSceneNumberingSpecification.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using NLog;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Parser.Model;
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
+{
+    public class UnverifiedSceneNumberingSpecification : IImportDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public UnverifiedSceneNumberingSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public Decision IsSatisfiedBy(LocalEpisode localEpisode)
+        {
+            if (localEpisode.Episodes.Any(v => v.UnverifiedSceneNumbering))
+            {
+                _logger.Debug("This file uses unverified scene numbers, will not auto-import until numbering is confirmed on TheXEM. Skipping {0}", localEpisode.Path);
+                return Decision.Reject("This show has individual episode mappings on TheXEM but the mapping for this episode has not been confirmed yet by their administrators. TheXEM needs manual input.");
+            }
+
+            return Decision.Accept();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -264,6 +264,7 @@
     <Compile Include="Datastore\Migration\083_additonal_blacklist_columns.cs" />
     <Compile Include="Datastore\Migration\082_add_fanzub_settings.cs" />
     <Compile Include="Datastore\Migration\088_pushbullet_devices_channels_list.cs" />
+    <Compile Include="Datastore\Migration\092_add_unverifiedscenenumbering.cs" />
     <Compile Include="Datastore\Migration\090_update_kickass_url.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
@@ -621,6 +622,7 @@
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotSampleSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotUnpackingSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\SameEpisodesImportSpecification.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Specifications\UnverifiedSceneNumberingSpecification.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\UpgradeSpecification.cs" />
     <Compile Include="MediaFiles\Events\EpisodeDownloadedEvent.cs" />
     <Compile Include="MediaFiles\Events\EpisodeFileAddedEvent.cs" />

--- a/src/NzbDrone.Core/Tv/Episode.cs
+++ b/src/NzbDrone.Core/Tv/Episode.cs
@@ -29,6 +29,7 @@ namespace NzbDrone.Core.Tv
         public Nullable<Int32> SceneAbsoluteEpisodeNumber { get; set; }
         public Nullable<Int32> SceneSeasonNumber { get; set; }
         public Nullable<Int32> SceneEpisodeNumber { get; set; }
+        public bool UnverifiedSceneNumbering { get; set; }
         public Ratings Ratings { get; set; }
         public List<MediaCover.MediaCover> Images { get; set; }
 

--- a/src/UI/Series/Details/EpisodeWarningCell.js
+++ b/src/UI/Series/Details/EpisodeWarningCell.js
@@ -7,10 +7,12 @@ module.exports = NzbDroneCell.extend({
     render : function() {
         this.$el.empty();
 
-        if (SeriesCollection.get(this.model.get('seriesId')).get('seriesType') === 'anime') {
-            if (this.model.get('seasonNumber') > 0 && !this.model.has('absoluteEpisodeNumber')) {
-                this.$el.html('<i class="icon-sonarr-form-warning" title="Episode does not have an absolute episode number"></i>');
-            }
+        if (this.model.get('unverifiedSceneNumbering')) {
+            this.$el.html('<i class="icon-sonarr-form-warning" title="Scene number hasn\'t been verified yet."></i>');
+        }
+
+        else if (SeriesCollection.get(this.model.get('seriesId')).get('seriesType') === 'anime' && this.model.get('seasonNumber') > 0 && !this.model.has('absoluteEpisodeNumber')) {
+            this.$el.html('<i class="icon-sonarr-form-warning" title="Episode does not have an absolute episode number"></i>');
         }
 
         this.delegateEvents();


### PR DESCRIPTION
Work in progress.

I ran into the problem that thexem had mappings for early episodes in a season, where tvdb had higher numbers. A new episode got released and overwrote one of the older ones coz Sonarr blindly assumed those newer episodes were mapped 1 to 1.

As discussed there are two options: We can extrapolate numbering ourselves, or prevent import.

This PR fills in numbering for old (unmapped) seasons, as well as future seasons. Unless there's a season number mismatch.
The idea was to create a ImportSpec that would block the import if series.(UseSeasonNumbering = true and episode.SceneEpisodeNumber = null.) But after thinking about it a bit more it seems ugly to do it that way.

So instead I think we should add an extra field to Episode. 'UnknownSceneNumbering' = true.
We could set that flag for every episode in a season if there is at least one episode in that season with mappings. That gives us a clean ImportSpec to warn on.
Additionally, it allows us to be more aggressive with extrapolation. Extrapolating shifted episode numbering, and shifted season number, as long as all extrapolated episodes get that flag set.
The added bonus is that users maintaining thexem can be alerted more easily.
We could add an Advanced config option that disables the ImportSpec.

Lemme know what you think about that idea.
