### PR TITLE
Fix integration tests on mono

### DIFF
--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -33,19 +33,22 @@ namespace NzbDrone.Test.Common
             AppData = Path.Combine(Directory.GetCurrentDirectory(), "_intg_" + DateTime.Now.Ticks);
 
             var nzbdroneConsoleExe = "NzbDrone.Console.exe";
+            var nzbdroneDebugPath = "../../../../../_output/";
+            var nzbdroneReleasePath = "bin";
 
             if (OsInfo.IsNotWindows)
             {
                 nzbdroneConsoleExe = "NzbDrone.exe";
+                nzbdroneReleasePath = "../_output_mono/";
             }
 
             if (BuildInfo.IsDebug)
             {
-                Start("..\\..\\..\\..\\..\\_output\\NzbDrone.Console.exe");
+                Start(Path.Combine(nzbdroneDebugPath, nzbdroneConsoleExe));
             }
             else
             {
-                Start(Path.Combine("bin", nzbdroneConsoleExe));
+                Start(Path.Combine(nzbdroneReleasePath, nzbdroneConsoleExe));
             }
 
             while (true)


### PR DESCRIPTION
When running the integration tests on mono from _tests, it looks for bin/NzbDrone.exe which doesn't exist.  This changes the path to ../_output_mono/NzbDrone.exe so that the tests work.

I'm not sure if the path should ever be "bin" but I left it in so it doesn't break anything.

I also changed the default path to use / rather than \\ since that seems to be compatible with both windows and linux