### PR TITLE
Show unknown series on queue

### DIFF
--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -48,24 +48,23 @@ namespace NzbDrone.Core.Queue
             {
                 foreach (var episode in trackedDownload.RemoteEpisode.Episodes)
                 {
-                    yield return MapEpisode(trackedDownload, episode);
+                    yield return MapQueueItem(trackedDownload, episode);
                 }
             }
             else
             {
-                // FIXME: Present queue items with unknown series/episodes
+                yield return MapQueueItem(trackedDownload, null);
             }
         }
 
-        private Queue MapEpisode(TrackedDownload trackedDownload, Episode episode)
+        private Queue MapQueueItem(TrackedDownload trackedDownload, Episode episode)
         {
             var queue = new Queue
             {
-                Id = HashConverter.GetHashInt31(string.Format("trackedDownload-{0}-ep{1}", trackedDownload.DownloadItem.DownloadId, episode.Id)),
                 Series = trackedDownload.RemoteEpisode.Series,
                 Episode = episode,
                 Quality = trackedDownload.RemoteEpisode.ParsedEpisodeInfo.Quality,
-                Title = trackedDownload.DownloadItem.Title,
+                Title = Parser.Parser.RemoveFileExtension(trackedDownload.DownloadItem.Title),
                 Size = trackedDownload.DownloadItem.TotalSize,
                 Sizeleft = trackedDownload.DownloadItem.RemainingSize,
                 Timeleft = trackedDownload.DownloadItem.RemainingTime,
@@ -76,6 +75,15 @@ namespace NzbDrone.Core.Queue
                 DownloadId = trackedDownload.DownloadItem.DownloadId,
                 Protocol = trackedDownload.Protocol
             };
+
+            if (episode != null)
+            {
+                queue.Id = HashConverter.GetHashInt31(string.Format("trackedDownload-{0}-ep{1}", trackedDownload.DownloadItem.DownloadId, episode.Id));
+            }
+            else
+            {
+                queue.Id = HashConverter.GetHashInt31(string.Format("trackedDownload-{0}", trackedDownload.DownloadItem.DownloadId));
+            }
 
             if (queue.Timeleft.HasValue)
             {

--- a/src/UI/Activity/Queue/QueueLayout.js
+++ b/src/UI/Activity/Queue/QueueLayout.js
@@ -3,7 +3,7 @@ var Backgrid = require('backgrid');
 var QueueCollection = require('./QueueCollection');
 var SeriesTitleCell = require('../../Cells/SeriesTitleCell');
 var EpisodeNumberCell = require('../../Cells/EpisodeNumberCell');
-var EpisodeTitleCell = require('../../Cells/EpisodeTitleCell');
+var QueueTitleCell = require('./QueueTitleCell');
 var QualityCell = require('../../Cells/QualityCell');
 var QueueStatusCell = require('./QueueStatusCell');
 var QueueActionsCell = require('./QueueActionsCell');
@@ -39,9 +39,9 @@ module.exports = Marionette.Layout.extend({
         },
         {
             name      : 'episodeTitle',
-            label     : 'Episode Title',
-            cell      : EpisodeTitleCell,
-            cellValue : 'episode'
+            label     : 'Title',
+            cell      : QueueTitleCell,
+            cellValue : 'this'
         },
         {
             name     : 'quality',

--- a/src/UI/Activity/Queue/QueueTitleCell.js
+++ b/src/UI/Activity/Queue/QueueTitleCell.js
@@ -1,0 +1,27 @@
+var vent = require('vent');
+var EpisodeTitleCell = require('../../Cells/EpisodeTitleCell');
+
+module.exports = EpisodeTitleCell.extend({
+
+    render : function() {
+        var episode = this._getEpisode();
+
+        if (episode) {
+            EpisodeTitleCell.prototype.render.call(this);
+        } else {
+            this.$el.text(this.cellValue.get('title'));
+        }
+
+        return this;
+    },
+
+    _getEpisode : function() {
+        var episode = this.cellValue.get('episode');
+
+        if (episode && episode.get('id')) {
+            return episode;
+        } else {
+            return null;
+        }
+    }
+});

--- a/src/UI/Cells/EpisodeTitleCell.js
+++ b/src/UI/Cells/EpisodeTitleCell.js
@@ -15,14 +15,36 @@ module.exports = NzbDroneCell.extend({
             title = 'TBA';
         }
 
-        this.$el.html(title);
+        this.$el.text(title);
         return this;
     },
 
+    _refresh : function() {
+        this.$el.toggleClass('clickable', this._getEpisode());
+
+        NzbDroneCell.prototype._refresh.call(this);
+    },
+
+    _getEpisode : function() {
+        var episode = this.cellValue;
+
+        if (episode && episode.get('id')) {
+            return episode;
+        } else {
+            return null;
+        }
+    },
+
     _showDetails : function() {
+        var episode = this._getEpisode();
+
+        if (!episode) {
+            return;
+        }
+
         var hideSeriesLink = this.column.get('hideSeriesLink');
         vent.trigger(vent.Commands.ShowEpisodeDetails, {
-            episode        : this.cellValue,
+            episode        : episode,
             hideSeriesLink : hideSeriesLink
         });
     }

--- a/src/UI/Cells/SeriesTitleTemplate.hbs
+++ b/src/UI/Cells/SeriesTitleTemplate.hbs
@@ -1,1 +1,5 @@
+{{#if title}}
 <a href="{{route}}">{{title}}</a>
+{{else}}
+Unknown
+{{/if}}

--- a/src/UI/Cells/cells.less
+++ b/src/UI/Cells/cells.less
@@ -16,13 +16,8 @@
 .episode-title-cell {
   .text-overflow();
 
-  color: #428bca;
-  text-decoration: none;
-
-  &:focus, &:hover {
-    color: #2a6496;
-    text-decoration: underline;
-    cursor: pointer;
+  &.clickable {
+    .clickable-text-decoration();
   }
 
   @media @lg {
@@ -184,10 +179,6 @@ td.delete-episode-file-cell {
 
 .series-status-cell {
   width: 16px;
-}
-
-.episode-number-cell {
-  cursor : default;
 }
 
 .backup-type-cell {

--- a/src/UI/Shared/Styles/clickable.less
+++ b/src/UI/Shared/Styles/clickable.less
@@ -1,3 +1,16 @@
 .clickable {
   cursor: pointer;
 }
+
+.clickable-text-decoration {
+  .clickable();
+
+  color: #428bca;
+  text-decoration: none;
+
+  &:focus, &:hover {
+    color: #2a6496;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
@markus101 @kayone 

Not finished. 

Till now we've hidden all CDH items for which no series/episodes can be determined.
Showing them on the queue allows the user to properly import it via Manual Import. The advantage is that it's bound to the download client, so IsReadOnly/Hardlinking works.

There's one problem that's not easy to deal with. I talked to kayone about this.
Basically, this change will show all download client items that couldn't be identified. Also from deleted series, movies or whatever.

One option is to add a new table to keep track of the downloadIds of deleted series. And add "Ignore" and "Ignore All" buttons on the queue UI.
Possible problem with this solution is that you won't be able to download the same infohash again.

Another solution is to just educate ppl to remove those items from the download client history (or apply different label/category). But not everyone will want that.

Anyway, everything in this commit is to show the items on the UI.
