### PR TITLE
Add tests for CurlHttpClient and fix some bugs they uncovered

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -218,6 +218,9 @@ Function PackageTests()
     Write-Host "Adding NzbDrone.Core.dll.config (for dllmap)"
     Copy-Item "$sourceFolder\NzbDrone.Core\NzbDrone.Core.dll.config" -Destination $testPackageFolder -Force
 
+    Write-Host "Copying CurlSharp libraries"
+    Copy-Item $sourceFolder\ExternalModules\CurlSharp\libs\i386\* $testPackageFolder
+
     Write-Host "##teamcity[progressFinish 'Creating Test Package']"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -224,6 +224,9 @@ PackageTests()
     echo "Adding CurlSharp.dll.config (for dllmap)"
     cp $sourceFolder/NzbDrone.Common/CurlSharp.dll.config $testPackageFolder
 
+    echo "Copying CurlSharp libraries"
+    cp $sourceFolder/ExternalModules/CurlSharp/libs/i386/* $testPackageFolder
+
     echo "##teamcity[progressFinish 'Creating Test Package']"
 }
 

--- a/integration_mono.sh
+++ b/integration_mono.sh
@@ -5,3 +5,4 @@ NUNIT="$TESTDIR/NUnit.Runners.2.6.1/tools/nunit-console-x86.exe"
 mono --debug --runtime=v4.0 $NUNIT $EXCLUDE -xml:NzbDrone.Api.Result.xml $TESTDIR/NzbDrone.Api.Test.dll
 mono --debug --runtime=v4.0 $NUNIT $EXCLUDE -xml:NzbDrone.Core.Result.xml $TESTDIR/NzbDrone.Core.Test.dll
 mono --debug --runtime=v4.0 $NUNIT $EXCLUDE -xml:NzbDrone.Integration.Result.xml $TESTDIR/NzbDrone.Integration.Test.dll
+mono --debug --runtime=v4.0 $NUNIT $EXCLUDE -xml:NzbDrone.Common.Result.xml $TESTDIR/NzbDrone.Common.Test.dll

--- a/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -142,6 +142,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
+  <PropertyGroup>
+    <PostBuildEvent Condition="'$(Configuration)|$(OS)' == 'Debug|Windows_NT'">xcopy /s /y "$(SolutionDir)\ExternalModules\CurlSharp\libs\i386\*" "$(TargetDir)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NzbDrone.Common/Http/HttpHeader.cs
+++ b/src/NzbDrone.Common/Http/HttpHeader.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpHeader : Dictionary<string, object>
     {
-        public HttpHeader(NameValueCollection headers)
+        public HttpHeader(NameValueCollection headers) : base(StringComparer.OrdinalIgnoreCase)
         {
             foreach (var key in headers.AllKeys)
             {
@@ -17,7 +17,7 @@ namespace NzbDrone.Common.Http
             }
         }
 
-        public HttpHeader()
+        public HttpHeader() : base(StringComparer.OrdinalIgnoreCase)
         {
 
         }


### PR DESCRIPTION
This updates HttpTestFixture.cs so that all the tests are run in the normal way and using curl.

I've added a couple of tests (for https and malformed cookie expiry dates) and made a few fixes so that all the tests pass.