### PR TITLE
Release pushing

### DIFF
--- a/src/NzbDrone.Api/Indexers/ReleaseModuleBase.cs
+++ b/src/NzbDrone.Api/Indexers/ReleaseModuleBase.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Parser.Model;
+using Omu.ValueInjecter;
+using System.Linq;
+
+namespace NzbDrone.Api.Indexers
+{
+    public abstract class ReleaseModuleBase : NzbDroneRestModule<ReleaseResource>
+    {
+        protected virtual List<ReleaseResource> MapDecisions(IEnumerable<DownloadDecision> decisions)
+        {
+            var result = new List<ReleaseResource>();
+
+            foreach (var downloadDecision in decisions)
+            {
+                var release = MapDecision(downloadDecision, result.Count);
+
+                result.Add(release);
+            }
+
+            return result;
+        }
+
+        protected virtual ReleaseResource MapDecision(DownloadDecision decision, int initialWeight)
+        {
+            var release = new ReleaseResource();
+
+            release.InjectFrom(decision.RemoteEpisode.Release);
+            release.InjectFrom(decision.RemoteEpisode.ParsedEpisodeInfo);
+            release.InjectFrom(decision);
+            release.Rejections = decision.Rejections.Select(r => r.Reason).ToList();
+            release.DownloadAllowed = decision.RemoteEpisode.DownloadAllowed;
+            release.ReleaseWeight = initialWeight;
+
+            if (decision.RemoteEpisode.Series != null)
+            {
+                release.QualityWeight = decision.RemoteEpisode
+                                                        .Series
+                                                        .Profile
+                                                        .Value
+                                                        .Items
+                                                        .FindIndex(v => v.Quality == release.Quality.Quality) * 100;
+            }
+
+            release.QualityWeight += release.Quality.Revision.Real * 10;
+            release.QualityWeight += release.Quality.Revision.Version;
+
+            var torrentRelease = decision.RemoteEpisode.Release as TorrentInfo;
+
+            if (torrentRelease != null)
+            {
+                release.Protocol = DownloadProtocol.Torrent;
+                release.Seeders = torrentRelease.Seeders;
+                //TODO: move this up the chains
+                release.Leechers = torrentRelease.Peers - torrentRelease.Seeders;
+            }
+            else
+            {
+                release.Protocol = DownloadProtocol.Usenet;
+            }
+
+            return release;
+        }
+    }
+}

--- a/src/NzbDrone.Api/Indexers/ReleasePushModule.cs
+++ b/src/NzbDrone.Api/Indexers/ReleasePushModule.cs
@@ -1,0 +1,58 @@
+﻿using Nancy;
+using Nancy.ModelBinding;
+using FluentValidation;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Parser;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Api.Mapping;
+using NzbDrone.Api.Extensions;
+using NLog;
+
+namespace NzbDrone.Api.Indexers
+{
+    class ReleasePushModule : NzbDroneRestModule<ReleaseResource>
+    {
+        private readonly IMakeDownloadDecision _downloadDecisionMaker;
+        private readonly IProcessDownloadDecisions _downloadDecisionProcessor;
+        private readonly Logger _logger;
+
+        public ReleasePushModule(IMakeDownloadDecision downloadDecisionMaker,
+                                 IProcessDownloadDecisions downloadDecisionProcessor,
+                                 Logger logger)
+        {
+            _downloadDecisionMaker = downloadDecisionMaker;
+            _downloadDecisionProcessor = downloadDecisionProcessor;
+            _logger = logger;
+
+            Post["/push"] = x => ProcessRelease(this.Bind<ReleaseResource>());
+
+            PostValidator.RuleFor(s => s.Title).NotEmpty();
+            PostValidator.RuleFor(s => s.DownloadUrl).NotEmpty();
+            PostValidator.RuleFor(s => s.DownloadProtocol).NotEmpty();
+            PostValidator.RuleFor(s => s.PublishDate).NotEmpty();
+        }
+
+        private Response ProcessRelease(ReleaseResource release)
+        {
+            _logger.Info("Release pushed: {0}", release.Title);
+
+            var info = release.InjectTo<ReleaseInfo>();
+            info.Guid = "PUSH-" + info.DownloadUrl;
+
+            var decisions = _downloadDecisionMaker.GetRssDecision(new List<ReleaseInfo> { info });
+            var processed = _downloadDecisionProcessor.ProcessDecisions(decisions);
+
+            var status = processed.Grabbed.Any()  ? "grabbed"  :
+                         processed.Rejected.Any() ? "rejected" :
+                         processed.Pending.Any()  ? "pending"  :
+                                                    "error"    ;
+
+            return status.AsResponse();
+        }
+    }
+}

--- a/src/NzbDrone.Api/NzbDrone.Api.csproj
+++ b/src/NzbDrone.Api/NzbDrone.Api.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Extensions\Pipelines\CorsPipeline.cs" />
     <Compile Include="Frontend\Mappers\LoginHtmlMapper.cs" />
     <Compile Include="Frontend\Mappers\RobotsTxtMapper.cs" />
+    <Compile Include="Indexers\ReleaseModuleBase.cs" />
     <Compile Include="Indexers\ReleasePushModule.cs" />
     <Compile Include="Parse\ParseModule.cs" />
     <Compile Include="Parse\ParseResource.cs" />

--- a/src/NzbDrone.Api/NzbDrone.Api.csproj
+++ b/src/NzbDrone.Api/NzbDrone.Api.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Extensions\Pipelines\CorsPipeline.cs" />
     <Compile Include="Frontend\Mappers\LoginHtmlMapper.cs" />
     <Compile Include="Frontend\Mappers\RobotsTxtMapper.cs" />
+    <Compile Include="Indexers\ReleasePushModule.cs" />
     <Compile Include="Parse\ParseModule.cs" />
     <Compile Include="Parse\ParseResource.cs" />
     <Compile Include="ManualImport\ManualImportModule.cs" />

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NzbDrone.Common;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download.Pending;
-using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Download
 {


### PR DESCRIPTION
A new PR to finish off the changes from https://github.com/Sonarr/Sonarr/pull/631

I extracted ReleaseModule to a base class so I could use MapDecisions in both modules (instead of making an almost identical resource to map a DownloadDecision to a resource).

@Taloth @kayone Please take a quick look so we can close this one up.