### PR TITLE
Preserve startup arguments during restart

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/StartupContext.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace NzbDrone.Common.EnvironmentInfo
 {

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using NLog;
 using NzbDrone.Common;
 using NzbDrone.Common.Disk;

--- a/src/NzbDrone.Host/SpinService.cs
+++ b/src/NzbDrone.Host/SpinService.cs
@@ -14,12 +14,14 @@ namespace NzbDrone.Host
     {
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IProcessProvider _processProvider;
+        private readonly IStartupContext _startupContext;
         private readonly Logger _logger;
 
-        public SpinService(IRuntimeInfo runtimeInfo, IProcessProvider processProvider, Logger logger)
+        public SpinService(IRuntimeInfo runtimeInfo, IProcessProvider processProvider, IStartupContext startupContext, Logger logger)
         {
             _runtimeInfo = runtimeInfo;
             _processProvider = processProvider;
+            _startupContext = startupContext;
             _logger = logger;
         }
 
@@ -30,13 +32,29 @@ namespace NzbDrone.Host
                 Thread.Sleep(1000);
             }
 
-            _logger.Debug("wait loop was terminated.");
+            _logger.Debug("Wait loop was terminated.");
 
             if (_runtimeInfo.RestartPending)
             {
-                _logger.Info("attemptig restart.");
-                _processProvider.SpawnNewProcess(_runtimeInfo.ExecutingApplication, "--restart --nobrowser");
+                var restartArgs = GetRestartArgs();
+
+                _logger.Info("Attempting restart with arguments: {0}", restartArgs);
+                _processProvider.SpawnNewProcess(_runtimeInfo.ExecutingApplication, restartArgs);
             }
+        }
+
+        private string GetRestartArgs()
+        {
+            var args = _startupContext.PreservedArguments;
+
+            args += " /restart";
+
+            if (!args.Contains("/nobrowser"))
+            {
+                args += " /nobrowser";
+            }
+
+            return args;
         }
     }
 }


### PR DESCRIPTION
@kayone @Taloth 

Same as during an update we will preserve the arguments passed in when Sonarr was opened.

Closes #325