### PR TITLE
Improvements to History Specification

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -1,7 +1,6 @@
-using System.Linq;
+using System;
 using NLog;
-using NzbDrone.Core.Download;
-using NzbDrone.Core.Download.Clients.Sabnzbd;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.History;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -12,17 +11,14 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
     {
         private readonly IHistoryService _historyService;
         private readonly QualityUpgradableSpecification _qualityUpgradableSpecification;
-        private readonly IProvideDownloadClient _downloadClientProvider;
         private readonly Logger _logger;
 
         public HistorySpecification(IHistoryService historyService,
                                            QualityUpgradableSpecification qualityUpgradableSpecification,
-                                           IProvideDownloadClient downloadClientProvider,
                                            Logger logger)
         {
             _historyService = historyService;
             _qualityUpgradableSpecification = qualityUpgradableSpecification;
-            _downloadClientProvider = downloadClientProvider;
             _logger = logger;
         }
 
@@ -36,35 +32,17 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 return Decision.Accept();
             }
 
-            var downloadClients = _downloadClientProvider.GetDownloadClients();
-
-            foreach (var downloadClient in downloadClients.OfType<Sabnzbd>())
-            {
-                _logger.Debug("Performing history status check on report");
-                foreach (var episode in subject.Episodes)
-                {
-                    _logger.Debug("Checking current status of episode [{0}] in history", episode.Id);
-                    var mostRecent = _historyService.MostRecentForEpisode(episode.Id);
-
-                    if (mostRecent != null && mostRecent.EventType == HistoryEventType.Grabbed)
-                    {
-                        _logger.Debug("Latest history item is downloading, rejecting.");
-                        return Decision.Reject("Download has not been imported yet");
-                    }
-                }
-                return Decision.Accept();
-            }
-
+            _logger.Debug("Performing history status check on report");
             foreach (var episode in subject.Episodes)
             {
-                var bestQualityInHistory = _historyService.GetBestQualityInHistory(subject.Series.Profile, episode.Id);
-                if (bestQualityInHistory != null)
-                {
-                    _logger.Debug("Comparing history quality with report. History is {0}", bestQualityInHistory);
+                _logger.Debug("Checking current status of episode [{0}] in history", episode.Id);
+                var mostRecent = _historyService.MostRecentForEpisode(episode.Id);
 
-                    if (!_qualityUpgradableSpecification.IsUpgradable(subject.Series.Profile, bestQualityInHistory, subject.ParsedEpisodeInfo.Quality))
+                if (mostRecent != null && mostRecent.EventType == HistoryEventType.Grabbed && mostRecent.DownloadId.IsNullOrWhiteSpace() && mostRecent.Date.After(DateTime.UtcNow.AddHours(-1)))
+                {
+                    if (!_qualityUpgradableSpecification.IsUpgradable(subject.Series.Profile, mostRecent.Quality, subject.ParsedEpisodeInfo.Quality))
                     {
-                        return Decision.Reject("Existing file in history is of equal or higher quality: {0}", bestQualityInHistory);
+                        return Decision.Reject("Existing grab event in history is of equal or higher quality: {0}", mostRecent.Quality);
                     }
                 }
             }


### PR DESCRIPTION
Prevents grabbing if recent grab is less than an hour old and fixes a bug with invalid season passes and SAB.

Closes #837
Fixes #625