### PR TITLE
Fix z-index on scroll to top button

### DIFF
--- a/src/UI/Content/theme.less
+++ b/src/UI/Content/theme.less
@@ -81,6 +81,7 @@
 
   .opacity   (0.2);
   position  : fixed;
+  z-index   : 9999;
   bottom    : 50px;
   right     : 50px;
   display   : none;


### PR DESCRIPTION
Near the bottom of the page, there's a small area where the scroll to top button can no longer hover. This is because part of the footer has a "higher" z-index.

Confirmed in Chrome and Firefox. IE doesn't appear to be affected. Here's some screenshots with an added black bar to explain the overlay issue.

Before:
<img width="147" alt="screen shot 2015-11-05 at 7 58 19 pm" src="https://cloud.githubusercontent.com/assets/430255/10987292/9df647da-83f7-11e5-8520-fd3764e469ae.png">

After:
<img width="129" alt="screen shot 2015-11-05 at 7 58 26 pm" src="https://cloud.githubusercontent.com/assets/430255/10987293/9df72682-83f7-11e5-9efa-1e23f6796dcb.png">


Just an FYI, I tried to sign the CLA but was met with a server error.

