### PR TITLE
Add wrapping to fix long paths in labels. Fixes #875

### DIFF
--- a/src/UI/Series/series.less
+++ b/src/UI/Series/series.less
@@ -433,7 +433,10 @@
     .label {
       display       : inline-block;
       margin-bottom : 2px;
-      padding       : 4px 6px 3px 6px
+      padding       : 4px 6px 3px 6px;
+      max-width     : 100%;
+      white-space   : normal;
+      word-wrap     : break-word;
     }
   }
 


### PR DESCRIPTION
This fixes #875. Tested at various resolutions on Chrome, Firefox and IE. It coincidentally also fixes a bug where the label might overflow out of its parent column as seen in the Large Before screenshot below.

Before (Large):
<img width="1158" alt="screen shot 2015-11-05 at 8 10 19 pm" src="https://cloud.githubusercontent.com/assets/430255/11172129/dea8547c-8bc6-11e5-9cd1-7bc4d321fe7a.png">

Before (Small):
<img width="397" alt="screen shot 2015-11-05 at 8 10 26 pm" src="https://cloud.githubusercontent.com/assets/430255/11172146/0d9942f0-8bc7-11e5-98d8-7ae15981ad40.png">

After (Large):
<img width="946" alt="screen shot 2015-11-05 at 8 10 34 pm" src="https://cloud.githubusercontent.com/assets/430255/11172150/17358256-8bc7-11e5-857f-3b4e1ab7ef8f.png">

After (Small):
<img width="362" alt="screen shot 2015-11-05 at 8 10 39 pm" src="https://cloud.githubusercontent.com/assets/430255/11172152/1c6d4434-8bc7-11e5-8dd9-a93fa239a8e6.png">

After (Bonus - path with no spaces):
<img width="375" alt="screen shot 2015-11-05 at 8 13 24 pm" src="https://cloud.githubusercontent.com/assets/430255/11172154/242873c4-8bc7-11e5-82d3-51c777d94762.png">
