### PR TITLE
Give calendar legend ul max width of 100%. Fixes #922

### DIFF
--- a/src/UI/Calendar/calendar.less
+++ b/src/UI/Calendar/calendar.less
@@ -212,7 +212,8 @@
   }
 
   .legend-labels {
-    width : 500px;
+    max-width : 100%;
+    width     : 500px;
 
     @media (max-width: @screen-xs-min) {
       width : 400px;


### PR DESCRIPTION
`.legend-labels` has set widths of 500px and 400px depending on the breakpoint. This adds a max-width of 100% so that it won't be larger than the container on screens smaller than 400px wide.

(On a side, completely unrelated note, I majorly screwed up some rebasing earlier... my git skills could be better.)