### PR TITLE
Alter calendar tooltip container. Fixes #857

### DIFF
--- a/src/UI/Calendar/CalendarView.js
+++ b/src/UI/Calendar/CalendarView.js
@@ -90,7 +90,7 @@ module.exports = Marionette.ItemView.extend({
 
                 element.find('.chart').tooltip({
                     title     : 'Episode is downloading - {0}% {1}'.format(progress.toFixed(1), releaseTitle),
-                    container : '.fc-content-skeleton'
+                    container : '.fc'
                 });
             }
         }
@@ -271,7 +271,7 @@ module.exports = Marionette.ItemView.extend({
         element.find('.fc-time').after('<span class="status pull-right"><i class="{0}"></i></span>'.format(icon));
         element.find('.status').tooltip({
             title     : tooltip,
-            container : '.fc-content-skeleton'
+            container : '.fc'
         });
     },
 


### PR DESCRIPTION
This fixes #857 by making the tooltip's container slightly broader.

<img width="322" alt="screen shot 2015-11-15 at 8 53 51 pm" src="https://cloud.githubusercontent.com/assets/430255/11173389/600af902-8bdb-11e5-8534-7f28af475ec5.png">
