### PR TITLE
Parse /proc/mounts to get additional mountpoints on linux

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -24,6 +24,10 @@ namespace NzbDrone.Common.Test.DiskTests
         {
             Mocker.GetMock<IDiskProvider>(MockBehavior.Strict);
 
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(v => v.GetMount(It.IsAny<string>()))
+                .Returns((IMount)null);
+
             WithEmulatedDiskProvider();
 
             WithExistingFile(_sourcePath);

--- a/src/NzbDrone.Common/Disk/DriveInfoMount.cs
+++ b/src/NzbDrone.Common/Disk/DriveInfoMount.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Common.Disk
+{
+    public class DriveInfoMount : IMount
+    {
+        private readonly DriveInfo _driveInfo;
+
+        public DriveInfoMount(DriveInfo driveInfo)
+        {
+            _driveInfo = driveInfo;
+        }
+
+        public long AvailableFreeSpace
+        {
+            get { return _driveInfo.AvailableFreeSpace; }
+        }
+
+        public string DriveFormat
+        {
+            get { return _driveInfo.DriveFormat; }
+        }
+
+        public DriveType DriveType
+        {
+            get { return _driveInfo.DriveType; }
+        }
+
+        public bool IsReady
+        {
+            get { return _driveInfo.IsReady; }
+        }
+
+        public string Name
+        {
+            get { return _driveInfo.Name; }
+        }
+
+        public string RootDirectory
+        {
+            get { return _driveInfo.RootDirectory.FullName; }
+        }
+
+        public long TotalFreeSpace
+        {
+            get { return _driveInfo.TotalFreeSpace; }
+        }
+
+        public long TotalSize
+        {
+            get { return _driveInfo.TotalSize; }
+        }
+
+        public string VolumeLabel
+        {
+            get { return _driveInfo.VolumeLabel; }
+        }
+
+        public string VolumeName
+        {
+            get
+            {
+                if (VolumeLabel.IsNullOrWhiteSpace())
+                {
+                    return Name;
+                }
+
+                return string.Format("{0} ({1})", Name, VolumeLabel);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Common/Disk/FileSystemLookupService.cs
+++ b/src/NzbDrone.Common/Disk/FileSystemLookupService.cs
@@ -103,12 +103,12 @@ namespace NzbDrone.Common.Disk
 
         private List<FileSystemModel> GetDrives()
         {
-            return _diskProvider.GetDrives()
+            return _diskProvider.GetMounts()
                                 .Select(d => new FileSystemModel
                                              {
                                                  Type = FileSystemEntityType.Drive,
-                                                 Name = GetVolumeName(d),
-                                                 Path = d.Name,
+                                                 Name = d.VolumeLabel,
+                                                 Path = d.RootDirectory,
                                                  LastModified = null
                                              })
                                 .ToList();
@@ -156,16 +156,6 @@ namespace NzbDrone.Common.Disk
             }
 
             return path;
-        }
-
-        private string GetVolumeName(DriveInfo driveInfo)
-        {
-            if (driveInfo.VolumeLabel.IsNullOrWhiteSpace())
-            {
-                return driveInfo.Name;
-            }
-
-            return string.Format("{0} ({1})", driveInfo.Name, driveInfo.VolumeLabel);
         }
         
         private string GetParent(string path)

--- a/src/NzbDrone.Common/Disk/IDiskProvider.cs
+++ b/src/NzbDrone.Common/Disk/IDiskProvider.cs
@@ -40,11 +40,11 @@ namespace NzbDrone.Common.Disk
         void SetPermissions(string filename, WellKnownSidType accountSid, FileSystemRights rights, AccessControlType controlType);
         FileAttributes GetFileAttributes(string path);
         void EmptyFolder(string path);
-        string[] GetFixedDrives();
         string GetVolumeLabel(string path);
         FileStream OpenReadStream(string path);
         FileStream OpenWriteStream(string path);
-        List<DriveInfo> GetDrives();
+        List<IMount> GetMounts();
+        IMount GetMount(string path);
         List<DirectoryInfo> GetDirectoryInfos(string path);
         List<FileInfo> GetFileInfos(string path);
     }

--- a/src/NzbDrone.Common/Disk/IMount.cs
+++ b/src/NzbDrone.Common/Disk/IMount.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Common.Disk
+{
+    public interface IMount
+    {
+        long AvailableFreeSpace { get; }
+        string DriveFormat { get; }
+        DriveType DriveType { get; }
+        bool IsReady { get; }
+        string Name { get; }
+        string RootDirectory { get; }
+        long TotalFreeSpace { get; }
+        long TotalSize { get; }
+        string VolumeLabel { get; }
+    }
+}

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -73,8 +73,14 @@ namespace NzbDrone.Common.Extensions
 
         public static bool IsParentPath(this string parentPath, string childPath)
         {
-            parentPath = parentPath.TrimEnd(Path.DirectorySeparatorChar);
-            childPath = childPath.TrimEnd(Path.DirectorySeparatorChar);
+            if (parentPath != "/")
+            {
+                parentPath = parentPath.TrimEnd(Path.DirectorySeparatorChar);
+            }
+            if (childPath != "/")
+            {
+                childPath = childPath.TrimEnd(Path.DirectorySeparatorChar);
+            }
 
             var parent = new DirectoryInfo(parentPath);
             var child = new DirectoryInfo(childPath);

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -72,6 +72,8 @@
     <Compile Include="ConvertBase32.cs" />
     <Compile Include="Crypto\HashProvider.cs" />
     <Compile Include="Disk\FileSystemLookupService.cs" />
+    <Compile Include="Disk\DriveInfoMount.cs" />
+    <Compile Include="Disk\IMount.cs" />
     <Compile Include="Disk\RelativeFileSystemModel.cs" />
     <Compile Include="Disk\FileSystemModel.cs" />
     <Compile Include="Disk\FileSystemResult.cs" />

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -58,7 +59,7 @@ namespace NzbDrone.Core.DiskSpace
 
         private IEnumerable<DiskSpace> GetFixedDisksFreeSpace()
         {
-            return GetDiskSpace(_diskProvider.GetFixedDrives(), true);
+            return GetDiskSpace(_diskProvider.GetMounts().Where(d => d.DriveType == DriveType.Fixed).Select(d => d.RootDirectory), true);
         }
 
         private IEnumerable<DiskSpace> GetDiskSpace(IEnumerable<string> paths, bool suppressWarnings = false)

--- a/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/MappedNetworkDriveValidator.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using FluentValidation.Validators;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation.Paths
 {
@@ -31,17 +32,11 @@ namespace NzbDrone.Core.Validation.Paths
 
             if (!DriveRegex.IsMatch(path)) return true;
             
-            var drives = _diskProvider.GetDrives();
+            var mount = _diskProvider.GetMount(path);
 
-            foreach (var drive in drives)
+            if (mount != null && mount.DriveType == DriveType.Network)
             {
-                if (path.StartsWith(drive.Name, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    if (drive.DriveType == DriveType.Network)
-                    {
-                        return false;
-                    }
-                }
+                return false;
             }
 
             return true;

--- a/src/NzbDrone.Mono/DiskProvider.cs
+++ b/src/NzbDrone.Mono/DiskProvider.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using Mono.Unix;
 using Mono.Unix.Native;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
-using Mono.Unix;
 
 namespace NzbDrone.Mono
 {
@@ -15,26 +15,28 @@ namespace NzbDrone.Mono
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(DiskProvider));
 
+        private readonly IProcMountProvider _procMountProvider;
+
+        public DiskProvider(IProcMountProvider procMountProvider)
+        {
+            _procMountProvider = procMountProvider;
+        }
+
         public override long? GetAvailableSpace(string path)
         {
             Ensure.That(path, () => path).IsValidPath();
 
-            var root = GetPathRoot(path);
-
-            if (!FolderExists(root))
-                throw new DirectoryNotFoundException(root);
-
             try
             {
-                var driveInfo = GetDriveInfo(path);
+                var mount = GetMount(path);
 
-                if (driveInfo == null)
+                if (mount == null)
                 {
                     Logger.Debug("Unable to get free space for '{0}', unable to find suitable drive", path);
                     return null;
                 }
 
-                return driveInfo.AvailableFreeSpace;
+                return mount.AvailableFreeSpace;
             }
             catch (InvalidOperationException ex)
             {
@@ -116,22 +118,25 @@ namespace NzbDrone.Mono
             }
         }
 
+        public override System.Collections.Generic.List<IMount> GetMounts()
+        {
+            return base.GetMounts()
+                       .Concat(_procMountProvider.GetMounts())
+                       .DistinctBy(v => v.RootDirectory)
+                       .ToList();
+        }
+
         public override long? GetTotalSize(string path)
         {
             Ensure.That(path, () => path).IsValidPath();
 
-            var root = GetPathRoot(path);
-
-            if (!FolderExists(root))
-                throw new DirectoryNotFoundException(root);
-
             try
             {
-                var driveInfo = GetDriveInfo(path);
+                var mount = GetMount(path);
 
-                if (driveInfo == null) return null;
+                if (mount == null) return null;
 
-                return driveInfo.TotalSize;
+                return mount.TotalSize;
             }
             catch (InvalidOperationException e)
             {
@@ -139,18 +144,6 @@ namespace NzbDrone.Mono
             }
 
             return null;
-        }
-
-        private DriveInfo GetDriveInfo(string path)
-        {
-            var drives = DriveInfo.GetDrives();
-
-            return
-                drives.Where(drive => drive.IsReady &&
-                                      drive.Name.IsNotNullOrWhiteSpace() &&
-                                      path.StartsWith(drive.Name, StringComparison.CurrentCultureIgnoreCase))
-                      .OrderByDescending(drive => drive.Name.Length)
-                      .FirstOrDefault();
         }
 
         public override bool TryCreateHardLink(string source, string destination)

--- a/src/NzbDrone.Mono/NzbDrone.Mono.csproj
+++ b/src/NzbDrone.Mono/NzbDrone.Mono.csproj
@@ -71,6 +71,8 @@
     <Compile Include="DiskProvider.cs" />
     <Compile Include="LinuxPermissionsException.cs" />
     <Compile Include="MonoRuntimeProvider.cs" />
+    <Compile Include="ProcMount.cs" />
+    <Compile Include="ProcMountProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Mono/ProcMount.cs
+++ b/src/NzbDrone.Mono/ProcMount.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using Mono.Unix;
+
+namespace NzbDrone.Mono
+{
+    public class ProcMount : IMount
+    {
+        private readonly UnixDriveInfo _unixDriveInfo;
+
+        public ProcMount(DriveType driveType, string name, string mount, string type, Dictionary<string, string> options)
+        {
+            DriveType = driveType;
+            Name = name;
+            RootDirectory = mount;
+            DriveFormat = type;
+
+            _unixDriveInfo = new UnixDriveInfo(mount);
+        }
+
+        public long AvailableFreeSpace
+        {
+            get { return _unixDriveInfo.AvailableFreeSpace; }
+        }
+
+        public string DriveFormat { get; private set; }
+
+        public DriveType DriveType { get; private set; }
+
+        public bool IsReady
+        {
+            get { return _unixDriveInfo.IsReady; }
+        }
+
+        public string Name { get; private set; }
+
+        public string RootDirectory { get; private set; }
+
+        public long TotalFreeSpace
+        {
+            get { return _unixDriveInfo.TotalFreeSpace; }
+        }
+
+        public long TotalSize
+        {
+            get { return _unixDriveInfo.TotalSize; }
+        }
+
+        public string VolumeLabel
+        {
+            get { return _unixDriveInfo.VolumeLabel; }
+        }
+    }
+}

--- a/src/NzbDrone.Mono/ProcMountProvider.cs
+++ b/src/NzbDrone.Mono/ProcMountProvider.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using Mono.Unix;
+
+namespace NzbDrone.Mono
+{
+    public interface IProcMountProvider
+    {
+        List<IMount> GetMounts();
+    }
+
+    public class ProcMountProvider : IProcMountProvider
+    {
+        private static string[] _fixedTypes = new [] { "ext3", "ext2", "ext4", "vfat", "fuseblk", "xfs", "jfs", "msdos", "ntfs", "minix", "hfs", "hfsplus", "qnx4", "ufs", "btrfs" };
+        private static string[] _networkDriveTypes = new [] { "cifs", "nfs", "nfs4", "nfsd", "sshfs" };
+
+        private static Dictionary<string, bool> _fileSystems;
+
+        private readonly Logger _logger;
+
+        public ProcMountProvider(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public List<IMount> GetMounts()
+        {
+            try
+            {
+                if (File.Exists(@"/proc/mounts"))
+                {
+                    var lines = File.ReadAllLines(@"/proc/mounts");
+
+                    return lines.Select(ParseLine).OfType<IMount>().ToList();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.DebugException("Failed to retrieve mounts from /proc/mounts", ex);
+            }
+
+            return new List<IMount>();
+        }
+
+        private Dictionary<string, bool> GetFileSystems()
+        {
+            if (_fileSystems == null)
+            {
+                var result = new Dictionary<string, bool>();
+                try
+                {
+                    if (File.Exists(@"/proc/filesystems"))
+                    {
+                        var lines = File.ReadAllLines(@"/proc/filesystems");
+
+                        foreach (var line in lines)
+                        {
+                            var split = line.Split('\t');
+
+                            result.Add(split[1], split[0] != "nodev");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.DebugException("Failed to get filesystem types from /proc/filesystems, using default set.", ex);
+                }
+                
+                if (result.Empty())
+                {
+                    foreach (var type in _fixedTypes)
+                    {
+                        result.Add(type, true);
+                    }
+                }
+
+                _fileSystems = result;
+            }
+
+            return _fileSystems;
+        }
+
+        private IMount ParseLine(string line)
+        {
+            var split = line.Split(' ');
+
+            if (split.Length != 6)
+            {
+                _logger.Debug("Unable to parser /proc/mount line: {0}", line);
+            }
+
+            var name = split[0];
+            var mount = split[1];
+            var type = split[2];
+            var options = ParseOptions(split[3]);
+
+            var driveType = DriveType.Unknown;
+            
+            if (name.StartsWith("/dev/") || GetFileSystems().GetValueOrDefault(type, false))
+            {
+                // Not always fixed, but lets assume it.
+                driveType = DriveType.Fixed;
+            }
+
+            if (_networkDriveTypes.Contains(type))
+            {
+                driveType = DriveType.Network;
+            }
+
+            if (type == "zfs")
+            {
+                driveType = DriveType.Fixed;
+            }
+
+            return new ProcMount(driveType, name, mount, type, options);
+        }
+
+        private Dictionary<string, string> ParseOptions(string options)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (var option in options.Split(','))
+            {
+                var split = option.Split(new[] { '=' }, 2);
+
+                result.Add(split[0], split.Length == 2 ? split[1] : string.Empty);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This gives us a few neat features.
* More drives in System->Disk Space, including zfs. (fixes https://github.com/Sonarr/Sonarr/issues/423)
* Detection capability for CIFS mounts. (can't do a healthcheck without false positives)
* Force full transaction operation when move/copy to/from CIFS mounts, but not when moving inside it. (Better workaround for the partial-file issues)

Some concerns:
* Needs try catch, to prevent breaking way more important code such as updates.
* Half of the DiskTransferService becomes a candidate to refactor. Using the .partial~ is still nice, but strictly not needed.
* Won't work on FreeBSD (doesn't always have /proc/) but that should be okay.
* Can't always discern between system fs mounts (proc/tmp/run... etc) and real filesystems. stuff without nodev is easy, that's just a drive, /dev/ mounts too, but zfs is a nodev, so atm I keep a list of those special cases.