### PR TITLE
Added theme-color meta for mobile chrome.

### DIFF
--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -6,7 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-capable" content="yes"/>
+    
+    <!-- Used for Chrome, Opera, and Firefox OS -->
     <meta name="theme-color" content="#f5f5f5"/>
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#f5f5f5">
+    
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
 
     <link href="/Content/bootstrap.css" rel='stylesheet' type='text/css'/>

--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -3,10 +3,11 @@
 <head>
     <title>Sonarr</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="theme-color" content="#f5f5f5"/>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
 
     <link href="/Content/bootstrap.css" rel='stylesheet' type='text/css'/>
     <link href="/Content/bootstrap.toggle-switch.css" rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
This will cause the Chrome header / status bar color for Android 5.0+ and Chrome 39+.

Also self-closed other meta tags for consistency (was already there for the http-equiv).