### PR TITLE
Fix: xbuild doesn't support /m parameter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -74,7 +74,7 @@ BuildWithXbuild()
     export MONO_IOMAP=case
     CheckExitCode xbuild /t:Clean $slnFile
     mono $nuget restore $slnFile
-    CheckExitCode xbuild /p:Configuration=Release /p:Platform=x86 /t:Build /m /p:AllowedReferenceRelatedFileExtensions=.pdb $slnFile
+    CheckExitCode xbuild /p:Configuration=Release /p:Platform=x86 /t:Build /p:AllowedReferenceRelatedFileExtensions=.pdb $slnFile
 }
 
 Build()


### PR DESCRIPTION
Passing the /m parameter to xbuild causes an error.  See:
http://stackoverflow.com/questions/32220678/xbuild-reporting-too-many-project-files-but-works-with-msbuild