### PR TITLE
Pushbullet: Source device support

### DIFF
--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletProxy.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletProxy.cs
@@ -5,6 +5,7 @@ using FluentValidation.Results;
 using NLog;
 using RestSharp;
 using NzbDrone.Core.Rest;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Notifications.PushBullet
 {
@@ -150,6 +151,11 @@ namespace NzbDrone.Core.Notifications.PushBullet
                 request.AddParameter("type", "note");
                 request.AddParameter("title", title);
                 request.AddParameter("body", message);
+
+                if (settings.SenderId.IsNotNullOrWhiteSpace())
+                {
+                    request.AddParameter("source_device_iden", settings.SenderId);
+                }
 
                 client.Authenticator = new HttpBasicAuthenticator(settings.ApiKey, string.Empty);
                 client.ExecuteAndValidate(request);

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
@@ -33,6 +33,9 @@ namespace NzbDrone.Core.Notifications.PushBullet
         [FieldDefinition(2, Label = "Channel Tags", HelpText = "List of Channel Tags to send notifications to", Type = FieldType.Tag)]
         public IEnumerable<string> ChannelTags { get; set; }
 
+        [FieldDefinition(3, Label = "Sender ID", HelpText = "The device ID to send notifications from, use device_iden in the device's URL on pushbullet.com (leave blank to send from yourself)")]
+        public string SenderId { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
Pushbullet allows you to create a new device via the API. This new field allows the user to specify an ID of a device to send from. Similar to #641, but instead of public channels, you get a private device to organise pushes from Sonarr.

![image](https://cloud.githubusercontent.com/assets/1753736/12652579/54835f1a-c5e3-11e5-882f-e4d8af4a7728.png)

![image](https://cloud.githubusercontent.com/assets/1753736/12652587/5c681d2e-c5e3-11e5-98de-100de04c3138.png)
