### PR TITLE
updating nzbplanet.net api url to reflect recent change

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
                 yield return GetDefinition("NZBFinder.ws", GetSettings("https://www.nzbfinder.ws"));
                 yield return GetDefinition("NZBgeek", GetSettings("https://api.nzbgeek.info"));
-                yield return GetDefinition("nzbplanet.net", GetSettings("https://nzbplanet.net"));
+                yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));
                 yield return GetDefinition("Nzbs.org", GetSettings("http://nzbs.org", 5000));
                 yield return GetDefinition("OZnzb.com", GetSettings("https://api.oznzb.com"));
                 yield return GetDefinition("PFmonkey", GetSettings("https://www.pfmonkey.com"));


### PR DESCRIPTION
Nzbplanet.net recently updated their API URL from `https://nzbplanet.net` to `https://api.nzbplanet.net`. This pull request simply updates the default value suggested when creating a nzbplanet.net Indexer.

Here is a snippet from their news page:
```
The new Api server is now up and synced, To use the new Api server you will need to
change your Api to https or http://api.nzbplanet.net.
```