### PR TITLE
Delaying Blackhole imports while they're still being updated

### DIFF
--- a/src/NzbDrone.Common/Crypto/HashConverter.cs
+++ b/src/NzbDrone.Common/Crypto/HashConverter.cs
@@ -10,12 +10,16 @@ namespace NzbDrone.Common.Crypto
 
         public static int GetHashInt31(string target)
         {
-            byte[] hash;
+            var hash = GetHash(target);
+            return BitConverter.ToInt32(hash, 0) & 0x7fffffff;
+        }
+
+        public static byte[] GetHash(string target)
+        {
             lock (Sha1)
             {
-                hash = Sha1.ComputeHash(Encoding.Default.GetBytes(target));
+                return Sha1.ComputeHash(Encoding.Default.GetBytes(target));
             }
-            return BitConverter.ToInt32(hash, 0) & 0x7fffffff;
         }
     }
 }

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -100,5 +100,10 @@ namespace NzbDrone.Common.Extensions
                              .Select(x => Convert.ToByte(input.Substring(x, 2), 16))
                              .ToArray();
         }
+
+        public static string ToHexString(this byte[] input)
+        {
+            return string.Concat(Array.ConvertAll(input, x => x.ToString("X2")));
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/ScanWatchFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/ScanWatchFolderFixture.cs
@@ -1,0 +1,94 @@
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Download;
+using NzbDrone.Test.Common;
+using System.Threading;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Download.Clients.Blackhole;
+
+namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
+{
+    [TestFixture]
+    public class ScanWatchFolderFixture : CoreTest<ScanWatchFolder>
+    {
+        protected readonly string _title = "Droned.S01E01.Pilot.1080p.WEB-DL-DRONE";
+        protected string _completedDownloadFolder = @"c:\blackhole\completed".AsOsAgnostic();
+        
+        protected void GivenCompletedItem()
+        {
+            var targetDir = Path.Combine(_completedDownloadFolder, _title);
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.GetDirectories(_completedDownloadFolder))
+                .Returns(new[] { targetDir });
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.GetFiles(targetDir, SearchOption.AllDirectories))
+                .Returns(new[] { Path.Combine(targetDir, "somefile.mkv") });
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.GetFileSize(It.IsAny<string>()))
+                .Returns(1000000);
+        }
+
+        protected void GivenChangedItem()
+        {
+            var currentSize = Mocker.GetMock<IDiskProvider>().Object.GetFileSize("abc");
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.GetFileSize(It.IsAny<string>()))
+                .Returns(currentSize + 1);
+        }
+        
+        private void VerifySingleItem(DownloadItemStatus status)
+        {
+            var items = Subject.GetItems(_completedDownloadFolder, TimeSpan.FromMilliseconds(50)).ToList();
+
+            items.Count.Should().Be(1);
+            items.First().Status.Should().Be(status);
+        }
+
+        [Test]
+        public void GetItems_should_considered_locked_files_queued()
+        {
+            GivenCompletedItem();
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(c => c.IsFileLocked(It.IsAny<string>()))
+                .Returns(true);
+
+            Thread.Sleep(60);
+
+            VerifySingleItem(DownloadItemStatus.Downloading);
+        }
+
+        [Test]
+        public void GetItems_should_considered_changing_files_queued()
+        {
+            GivenCompletedItem();
+
+            VerifySingleItem(DownloadItemStatus.Downloading);
+
+            // If we keep changing the file every 20ms we should stay Downloading.
+            for (int i = 0; i < 10; i++)
+            {
+                TestLogger.Info("Iteration {0}", i);
+
+                GivenChangedItem();
+
+                VerifySingleItem(DownloadItemStatus.Downloading);
+
+                Thread.Sleep(10);
+            }
+
+            // Until it remains unchanged for >=50ms.
+            Thread.Sleep(60);
+
+            VerifySingleItem(DownloadItemStatus.Completed);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Download;
-using NzbDrone.Core.Download.Clients.TorrentBlackhole;
+using NzbDrone.Core.Download.Clients.Blackhole;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -29,6 +29,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
             _completedDownloadFolder = @"c:\blackhole\completed".AsOsAgnostic();
             _blackholeFolder = @"c:\blackhole\torrent".AsOsAgnostic();
             _filePath = (@"c:\blackhole\torrent\" + _title + ".torrent").AsOsAgnostic();
+
+            Mocker.SetConstant<IScanWatchFolder>(Mocker.Resolve<ScanWatchFolder>());
 
             Subject.Definition = new DownloadClientDefinition();
             Subject.Definition.Settings = new TorrentBlackholeSettings
@@ -56,13 +58,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
         protected void GivenCompletedItem()
         {
             var targetDir = Path.Combine(_completedDownloadFolder, _title);
+
             Mocker.GetMock<IDiskProvider>()
                 .Setup(c => c.GetDirectories(_completedDownloadFolder))
                 .Returns(new[] { targetDir });
 
             Mocker.GetMock<IDiskProvider>()
                 .Setup(c => c.GetFiles(targetDir, SearchOption.AllDirectories))
-                .Returns(new[] { Path.Combine(_completedDownloadFolder, "somefile.mkv") });
+                .Returns(new[] { Path.Combine(targetDir, "somefile.mkv") });
 
             Mocker.GetMock<IDiskProvider>()
                 .Setup(c => c.GetFileSize(It.IsAny<string>()))
@@ -87,11 +90,23 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
         [Test]
         public void completed_download_should_have_required_properties()
         {
+            Subject.ScanGracePeriod = TimeSpan.Zero;
+
             GivenCompletedItem();
 
             var result = Subject.GetItems().Single();
 
             VerifyCompleted(result);
+        }
+
+        [Test]
+        public void partial_download_should_have_required_properties()
+        {
+            GivenCompletedItem();
+
+            var result = Subject.GetItems().Single();
+
+            VerifyPostprocessing(result);
         }
 
         [Test]
@@ -140,21 +155,6 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
             remoteEpisode.Release.DownloadUrl = null;
 
             Assert.Throws<ReleaseDownloadException>(() => Subject.Download(remoteEpisode));
-        }
-
-        [Test]
-        public void GetItems_should_considered_locked_files_queued()
-        {
-            GivenCompletedItem();
-
-            Mocker.GetMock<IDiskProvider>()
-                .Setup(c => c.IsFileLocked(It.IsAny<string>()))
-                .Returns(true);
-
-            var items = Subject.GetItems().ToList();
-
-            items.Count.Should().Be(1);
-            items.First().Status.Should().Be(DownloadItemStatus.Downloading);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
@@ -96,6 +96,15 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Downloading);
         }
 
+        protected void VerifyPostprocessing(DownloadClientItem downloadClientItem)
+        {
+            VerifyIdentifiable(downloadClientItem);
+
+            //downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
+            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            downloadClientItem.Status.Should().Be(DownloadItemStatus.Downloading);
+        }
+
         protected void VerifyCompleted(DownloadClientItem downloadClientItem)
         {
             VerifyIdentifiable(downloadClientItem);

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
@@ -23,8 +23,6 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         [SetUp]
         public void Setup()
         {
-            Mocker.SetConstant<IHttpClient>(Mocker.GetMock<IHttpClient>().Object);
-            Mocker.SetConstant<ICacheManager>(Mocker.Resolve<CacheManager>());
             Mocker.SetConstant<ITorrentRssSettingsDetector>(Mocker.Resolve<TorrentRssSettingsDetector>());
             Mocker.SetConstant<ITorrentRssParserFactory>(Mocker.Resolve<TorrentRssParserFactory>());
 

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -158,6 +158,7 @@
     <Compile Include="DecisionEngineTests\UpgradeDiskSpecificationFixture.cs" />
     <Compile Include="Download\CompletedDownloadServiceFixture.cs" />
     <Compile Include="Download\DownloadApprovedReportsTests\DownloadApprovedFixture.cs" />
+    <Compile Include="Download\DownloadClientTests\Blackhole\ScanWatchFolderFixture.cs" />
     <Compile Include="Download\DownloadClientTests\Blackhole\TorrentBlackholeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\Blackhole\UsenetBlackholeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DelugeTests\DelugeFixture.cs" />

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/ScanWatchFolder.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/ScanWatchFolder.cs
@@ -1,0 +1,196 @@
+﻿using NLog;
+using NzbDrone.Common.Cache;
+using NzbDrone.Common.Crypto;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Core.Download.Clients.Blackhole
+{
+    public interface IScanWatchFolder
+    {
+        IEnumerable<WatchFolderItem> GetItems(string watchFolder, TimeSpan waitPeriod);
+    }
+
+    public class ScanWatchFolder : IScanWatchFolder
+    {
+        private readonly Logger _logger;
+        private readonly IDiskProvider _diskProvider;
+        private readonly IDiskScanService _diskScanService;
+        private readonly ICached<Dictionary<string, WatchFolderItem>>  _watchFolderItemCache;
+
+        public ScanWatchFolder(ICacheManager cacheManager, IDiskScanService diskScanService, IDiskProvider diskProvider, Logger logger)
+        {
+            _logger = logger;
+            _diskProvider = diskProvider;
+            _diskScanService = diskScanService;
+            _watchFolderItemCache = cacheManager.GetCache<Dictionary<string, WatchFolderItem>>(GetType());
+        }
+
+        public IEnumerable<WatchFolderItem> GetItems(string watchFolder, TimeSpan waitPeriod)
+        {
+            var newWatchItems = new Dictionary<string, WatchFolderItem>();
+            var lastWatchItems = _watchFolderItemCache.Get(watchFolder, () => newWatchItems);
+            
+            foreach (var newWatchItem in GetDownloadItems(watchFolder, lastWatchItems, waitPeriod))
+            {
+                newWatchItems[newWatchItem.DownloadId] = newWatchItem;
+            }
+
+            _watchFolderItemCache.Set(watchFolder, newWatchItems, TimeSpan.FromMinutes(5));
+
+            return newWatchItems.Values;
+        }
+
+        private IEnumerable<WatchFolderItem> GetDownloadItems(string watchFolder, Dictionary<string, WatchFolderItem> lastWatchItems, TimeSpan waitPeriod)
+        {
+            foreach (var folder in _diskProvider.GetDirectories(watchFolder))
+            {
+                var title = FileNameBuilder.CleanFileName(Path.GetFileName(folder));
+
+                var newWatchItem = new WatchFolderItem
+                {
+                    DownloadId = Path.GetFileName(folder) + "_" + _diskProvider.FolderGetCreationTime(folder).Ticks,
+                    Title = title,
+
+                    OutputPath = new OsPath(folder),
+
+                    Status = DownloadItemStatus.Completed,
+                    RemainingTime = TimeSpan.Zero
+                };
+
+                var oldWatchItem = lastWatchItems.GetValueOrDefault(newWatchItem.DownloadId);
+
+                if (PreCheckWatchItemExpiry(newWatchItem, oldWatchItem))
+                {
+                    var files = _diskProvider.GetFiles(folder, SearchOption.AllDirectories);
+
+                    newWatchItem.TotalSize = files.Select(_diskProvider.GetFileSize).Sum();
+                    newWatchItem.Hash = GetHash(folder, files);
+
+                    if (files.Any(_diskProvider.IsFileLocked))
+                    {
+                        newWatchItem.Status = DownloadItemStatus.Downloading;
+                        newWatchItem.RemainingTime = null;
+                    }
+
+                    UpdateWatchItemExpiry(newWatchItem, oldWatchItem, waitPeriod);
+                }
+
+                yield return newWatchItem;
+            }
+
+            foreach (var videoFile in _diskScanService.GetVideoFiles(watchFolder, false))
+            {
+                var title = FileNameBuilder.CleanFileName(Path.GetFileName(videoFile));
+
+                var newWatchItem = new WatchFolderItem
+                {
+                    DownloadId = Path.GetFileName(videoFile) + "_" + _diskProvider.FileGetLastWrite(videoFile).Ticks,
+                    Title = title,
+
+                    OutputPath = new OsPath(videoFile),
+
+                    Status = DownloadItemStatus.Completed,
+                    RemainingTime = TimeSpan.Zero
+                };
+
+                var oldWatchItem = lastWatchItems.GetValueOrDefault(newWatchItem.DownloadId);
+
+                if (PreCheckWatchItemExpiry(oldWatchItem, newWatchItem))
+                {
+                    newWatchItem.TotalSize = _diskProvider.GetFileSize(videoFile);
+                    newWatchItem.Hash = GetHash(videoFile);
+
+                    if (_diskProvider.IsFileLocked(videoFile))
+                    {
+                        newWatchItem.Status = DownloadItemStatus.Downloading;
+                    }
+
+                    UpdateWatchItemExpiry(newWatchItem, oldWatchItem, waitPeriod);
+                }
+
+                yield return newWatchItem;
+            }
+        }
+
+        private static bool PreCheckWatchItemExpiry(WatchFolderItem newWatchItem, WatchFolderItem oldWatchItem)
+        {
+            if (oldWatchItem == null || oldWatchItem.LastChanged.AddHours(1) > DateTime.UtcNow)
+            {
+                return true;
+            }
+
+            newWatchItem.TotalSize = oldWatchItem.TotalSize;
+            newWatchItem.Hash = oldWatchItem.Hash;
+
+            return false;
+        }
+
+        private static void UpdateWatchItemExpiry(WatchFolderItem newWatchItem, WatchFolderItem oldWatchItem, TimeSpan waitPeriod)
+        {
+            if (oldWatchItem != null && newWatchItem.Hash == oldWatchItem.Hash)
+            {
+                newWatchItem.LastChanged = oldWatchItem.LastChanged;
+            }
+            else
+            {
+                newWatchItem.LastChanged = DateTime.UtcNow;
+            }
+
+            var remainingTime = waitPeriod - (DateTime.UtcNow - newWatchItem.LastChanged);
+
+            if (remainingTime > TimeSpan.Zero)
+            {
+                newWatchItem.RemainingTime = remainingTime;
+                newWatchItem.Status = DownloadItemStatus.Downloading;
+            }
+        }
+
+        private string GetHash(string folder, string[] files)
+        {
+            var data = new StringBuilder();
+
+            data.Append(folder);
+            try
+            {
+                data.Append(_diskProvider.FolderGetLastWrite(folder).ToBinary());
+            }
+            catch (Exception ex)
+            {
+                _logger.TraceException(string.Format("Ignored hashing error during scan for {0}", folder), ex);
+            }
+
+            foreach (var file in files.OrderBy(v => v))
+            {
+                data.Append(GetHash(file));
+            }
+
+            return HashConverter.GetHash(data.ToString()).ToHexString();
+        }
+
+        private string GetHash(string file)
+        {
+            var data = new StringBuilder();
+
+            data.Append(file);
+            try
+            {
+                data.Append(_diskProvider.FileGetLastWrite(file).ToBinary());
+                data.Append(_diskProvider.GetFileSize(file));
+            }
+            catch (Exception ex)
+            {
+                _logger.TraceException(string.Format("Ignored hashing error during scan for {0}", file), ex);
+            }
+
+            return HashConverter.GetHash(data.ToString()).ToHexString();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
-namespace NzbDrone.Core.Download.Clients.TorrentBlackhole
+namespace NzbDrone.Core.Download.Clients.Blackhole
 {
     public class TorrentBlackholeSettingsValidator : AbstractValidator<TorrentBlackholeSettings>
     {

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -13,13 +13,15 @@ using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.RemotePathMappings;
 
-namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
+namespace NzbDrone.Core.Download.Clients.Blackhole
 {
     public class UsenetBlackhole : UsenetClientBase<UsenetBlackholeSettings>
     {
-        private readonly IDiskScanService _diskScanService;
+        private readonly IScanWatchFolder _scanWatchFolder;
 
-        public UsenetBlackhole(IDiskScanService diskScanService,
+        public TimeSpan ScanGracePeriod { get; set; }
+
+        public UsenetBlackhole(IScanWatchFolder scanWatchFolder,
                                IHttpClient httpClient,
                                IConfigService configService,
                                IDiskProvider diskProvider,
@@ -27,7 +29,9 @@ namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
                                Logger logger)
             : base(httpClient, configService, diskProvider, remotePathMappingService, logger)
         {
-            _diskScanService = diskScanService;
+            _scanWatchFolder = scanWatchFolder;
+
+            ScanGracePeriod = TimeSpan.FromSeconds(30);
         }
 
         protected override string AddFromNzbFile(RemoteEpisode remoteEpisode, string filename, byte[] fileContent)
@@ -58,65 +62,22 @@ namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
 
         public override IEnumerable<DownloadClientItem> GetItems()
         {
-            foreach (var folder in _diskProvider.GetDirectories(Settings.WatchFolder))
+            foreach (var item in _scanWatchFolder.GetItems(Settings.WatchFolder, ScanGracePeriod))
             {
-                var title = FileNameBuilder.CleanFileName(Path.GetFileName(folder));
-
-                var files = _diskProvider.GetFiles(folder, SearchOption.AllDirectories);
-
-                var historyItem = new DownloadClientItem
+                yield return new DownloadClientItem
                 {
                     DownloadClient = Definition.Name,
-                    DownloadId = Definition.Name + "_" + Path.GetFileName(folder) + "_" + _diskProvider.FolderGetCreationTime(folder).Ticks,
+                    DownloadId = Definition.Name + "_" + item.DownloadId,
                     Category = "sonarr",
-                    Title = title,
+                    Title = item.Title,
 
-                    TotalSize = files.Select(_diskProvider.GetFileSize).Sum(),
+                    TotalSize = item.TotalSize,
+                    RemainingTime = item.RemainingTime,
 
-                    OutputPath = new OsPath(folder)
+                    OutputPath = item.OutputPath,
+
+                    Status = item.Status
                 };
-
-                if (files.Any(_diskProvider.IsFileLocked))
-                {
-                    historyItem.Status = DownloadItemStatus.Downloading;
-                }
-                else
-                {
-                    historyItem.Status = DownloadItemStatus.Completed;
-
-                    historyItem.RemainingTime = TimeSpan.Zero;
-                }
-
-                yield return historyItem;
-            }
-
-            foreach (var videoFile in _diskScanService.GetVideoFiles(Settings.WatchFolder, false))
-            {
-                var title = FileNameBuilder.CleanFileName(Path.GetFileName(videoFile));
-
-                var historyItem = new DownloadClientItem
-                {
-                    DownloadClient = Definition.Name,
-                    DownloadId = Definition.Name + "_" + Path.GetFileName(videoFile) + "_" + _diskProvider.FileGetLastWrite(videoFile).Ticks,
-                    Category = "sonarr",
-                    Title = title,
-
-                    TotalSize = _diskProvider.GetFileSize(videoFile),
-
-                    OutputPath = new OsPath(videoFile)
-                };
-
-                if (_diskProvider.IsFileLocked(videoFile))
-                {
-                    historyItem.Status = DownloadItemStatus.Downloading;
-                }
-                else
-                {
-                    historyItem.Status = DownloadItemStatus.Completed;
-                    historyItem.RemainingTime = TimeSpan.Zero;
-                }
-
-                yield return historyItem;
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
@@ -5,7 +5,7 @@ using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
-namespace NzbDrone.Core.Download.Clients.UsenetBlackhole
+namespace NzbDrone.Core.Download.Clients.Blackhole
 {
     public class UsenetBlackholeSettingsValidator : AbstractValidator<UsenetBlackholeSettings>
     {

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/WatchFolderItem.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/WatchFolderItem.cs
@@ -1,0 +1,22 @@
+﻿using NzbDrone.Common.Disk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Core.Download.Clients.Blackhole
+{
+
+    public class WatchFolderItem
+    {
+        public string DownloadId { get; set; }
+        public string Title { get; set; }
+        public long TotalSize { get; set; }
+        public TimeSpan? RemainingTime { get; set; }
+        public OsPath OutputPath { get; set; }
+        public DownloadItemStatus Status { get; set; }
+
+        public DateTime LastChanged { get; set; }
+        public string Hash { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -332,6 +332,8 @@
     <Compile Include="DiskSpace\DiskSpace.cs" />
     <Compile Include="DiskSpace\DiskSpaceService.cs" />
     <Compile Include="Download\CheckForFinishedDownloadCommand.cs" />
+    <Compile Include="Download\Clients\Blackhole\ScanWatchFolder.cs" />
+    <Compile Include="Download\Clients\Blackhole\WatchFolderItem.cs" />
     <Compile Include="Download\Clients\Deluge\Deluge.cs" />
     <Compile Include="Download\Clients\Deluge\DelugeError.cs" />
     <Compile Include="Download\Clients\Deluge\DelugeException.cs" />
@@ -414,8 +416,8 @@
     <Compile Include="Download\Clients\Sabnzbd\SabnzbdQueue.cs" />
     <Compile Include="Download\Clients\Sabnzbd\SabnzbdQueueItem.cs" />
     <Compile Include="Download\Clients\Sabnzbd\SabnzbdSettings.cs" />
-    <Compile Include="Download\Clients\TorrentBlackhole\TorrentBlackhole.cs" />
-    <Compile Include="Download\Clients\TorrentBlackhole\TorrentBlackholeSettings.cs" />
+    <Compile Include="Download\Clients\Blackhole\TorrentBlackhole.cs" />
+    <Compile Include="Download\Clients\Blackhole\TorrentBlackholeSettings.cs" />
     <Compile Include="Download\Clients\TorrentSeedConfiguration.cs" />
     <Compile Include="Download\Clients\rTorrent\RTorrent.cs" />
     <Compile Include="Download\Clients\rTorrent\RTorrentPriority.cs" />
@@ -430,8 +432,8 @@
     <Compile Include="Download\Clients\Transmission\TransmissionTorrent.cs" />
     <Compile Include="Download\Clients\Transmission\TransmissionTorrentStatus.cs" />
     <Compile Include="Download\Clients\Transmission\TransmissionPriority.cs" />
-    <Compile Include="Download\Clients\UsenetBlackhole\UsenetBlackhole.cs" />
-    <Compile Include="Download\Clients\UsenetBlackhole\UsenetBlackholeSettings.cs" />
+    <Compile Include="Download\Clients\Blackhole\UsenetBlackhole.cs" />
+    <Compile Include="Download\Clients\Blackhole\UsenetBlackholeSettings.cs" />
     <Compile Include="Download\Clients\uTorrent\UTorrentPriority.cs" />
     <Compile Include="Download\Clients\uTorrent\UTorrent.cs" />
     <Compile Include="Download\Clients\uTorrent\UTorrentProxy.cs" />

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -80,6 +80,8 @@ namespace NzbDrone.Test.Common.AutoMoq
         {
             if (_registeredMocks.ContainsKey(type) == false)
                 _registeredMocks.Add(type, mock);
+            if (mock != null)
+                _container.RegisterInstance(type, mock.Object);
         }
 
         public virtual void SetConstant<T>(T instance)


### PR DESCRIPTION
Basically creates a hash of the files name+date+sizes involved (not their actual contents, obviously).
And uses that to determine if the download changed.

The graceperiod is currently hardcoded to 30sec, which is fairly arbitrary since CDH is on a 1min cycle.
Effectively it means that all blackhole downloads are delayed for 1min.

@markus101 please note this PR includes the migration-test commit. Just look over that commit separately.