### PR TITLE
Revised caching mechanism in XemService and SceneMappingService

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Api.Calendar
             var episodes = _episodeService.EpisodesBetweenDates(start, end, false);
             var icalCalendar = new iCalendar();
 
-            foreach (var episode in episodes)
+            foreach (var episode in episodes.OrderBy(v => v.AirDateUtc.Value))
             {
                 var occurrence = icalCalendar.Create<Event>();
                 occurrence.UID = "NzbDrone_episode_" + episode.Id.ToString();

--- a/src/NzbDrone.Api/Calendar/CalendarModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarModule.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Api.Calendar
 
             var resources = ToListResource(() => _episodeService.EpisodesBetweenDates(start, end, includeUnmonitored));
 
-            return resources;
+            return resources.OrderBy(e => e.AirDateUtc).ToList();
         }
     }
 }

--- a/src/NzbDrone.Api/Episodes/EpisodeModuleWithSignalR.cs
+++ b/src/NzbDrone.Api/Episodes/EpisodeModuleWithSignalR.cs
@@ -79,15 +79,8 @@ namespace NzbDrone.Api.Episodes
         {
             var resources =  base.ToListResource(modelList);
 
-            var withSeries = LoadSeries(resources);
+            return LoadSeries(resources);
 
-            return withSeries.OrderByDescending(e => e.AirDateUtc.HasValue)
-                             .ThenBy(e => e.AirDateUtc.Value)
-                             .ThenBy(e => e.SeriesTitle)
-                             .ThenByDescending(e => e.SeasonNumber != 0)
-                             .ThenBy(e => e.SeasonNumber)
-                             .ThenBy(e => e.EpisodeNumber)
-                             .ToList();
         }
 
         public void Handle(EpisodeGrabbedEvent message)

--- a/src/NzbDrone.Common.Test/CacheTests/CachedDictionaryFixture.cs
+++ b/src/NzbDrone.Common.Test/CacheTests/CachedDictionaryFixture.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Cache;
+
+namespace NzbDrone.Common.Test.CacheTests
+{
+    [TestFixture]
+    public class CachedDictionaryFixture
+    {
+        private CachedDictionary<string> _cachedString;
+        private DictionaryWorker _worker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _worker = new DictionaryWorker();
+            _cachedString = new CachedDictionary<string>(_worker.GetDict, TimeSpan.FromMilliseconds(100));
+        }
+
+        [Test]
+        public void should_not_fetch_on_create()
+        {
+            _worker.HitCount.Should().Be(0);
+        }
+
+        [Test]
+        public void should_fetch_on_first_call()
+        {
+            var result = _cachedString.Get("Hi");
+
+            _worker.HitCount.Should().Be(1);
+
+            result.Should().Be("Value");
+        }
+
+        [Test]
+        public void should_fetch_once()
+        {
+            var result1 = _cachedString.Get("Hi");
+            var result2 = _cachedString.Get("HitCount");
+
+            _worker.HitCount.Should().Be(1);
+        }
+
+        [Test]
+        public void should_auto_refresh_after_lifetime()
+        {
+            var result1 = _cachedString.Get("Hi");
+
+            Thread.Sleep(200);
+
+            var result2 = _cachedString.Get("Hi");
+
+            _worker.HitCount.Should().Be(2);
+        }
+
+        [Test]
+        public void should_refresh_early_if_requested()
+        {
+            var result1 = _cachedString.Get("Hi");
+
+            Thread.Sleep(10);
+
+            _cachedString.RefreshIfExpired(TimeSpan.FromMilliseconds(1));
+
+            var result2 = _cachedString.Get("Hi");
+
+            _worker.HitCount.Should().Be(2);
+        }
+
+        [Test]
+        public void should_not_refresh_early_if_not_expired()
+        {
+            var result1 = _cachedString.Get("Hi");
+
+            _cachedString.RefreshIfExpired(TimeSpan.FromMilliseconds(50));
+
+            var result2 = _cachedString.Get("Hi");
+
+            _worker.HitCount.Should().Be(1);
+        }
+    }
+
+    public class DictionaryWorker
+    {
+        public int HitCount { get; private set; }
+
+        public Dictionary<string, string> GetDict()
+        {
+            HitCount++;
+
+            var result = new Dictionary<string, string>();
+            result["Hi"] = "Value";
+            result["HitCount"] = "Hit count is " + HitCount;
+
+            return result;
+        }
+    }
+}

--- a/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
@@ -66,6 +66,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CacheTests\CachedDictionaryFixture.cs" />
     <Compile Include="CacheTests\CachedFixture.cs" />
     <Compile Include="CacheTests\CachedManagerFixture.cs" />
     <Compile Include="ConfigFileProviderTest.cs" />

--- a/src/NzbDrone.Common/Cache/CacheManager.cs
+++ b/src/NzbDrone.Common/Cache/CacheManager.cs
@@ -6,8 +6,9 @@ namespace NzbDrone.Common.Cache
 {
     public interface ICacheManager
     {
-        ICached<T> GetCache<T>(Type host, string name);
         ICached<T> GetCache<T>(Type host);
+        ICached<T> GetCache<T>(Type host, string name);
+        ICachedDictionary<T> GetCacheDictionary<T>(Type host, string name, Func<IDictionary<string, T>> fetchFunc = null, TimeSpan? lifeTime = null);
         void Clear();
         ICollection<ICached> Caches { get; }
     }
@@ -22,12 +23,6 @@ namespace NzbDrone.Common.Cache
 
         }
 
-        public ICached<T> GetCache<T>(Type host)
-        {
-            Ensure.That(host, () => host).IsNotNull();
-            return GetCache<T>(host, host.FullName);
-        }
-
         public void Clear()
         {
             _cache.Clear();
@@ -35,12 +30,26 @@ namespace NzbDrone.Common.Cache
 
         public ICollection<ICached> Caches { get { return _cache.Values; } }
 
+        public ICached<T> GetCache<T>(Type host)
+        {
+            Ensure.That(host, () => host).IsNotNull();
+            return GetCache<T>(host, host.FullName);
+        }
+
         public ICached<T> GetCache<T>(Type host, string name)
         {
             Ensure.That(host, () => host).IsNotNull();
             Ensure.That(name, () => name).IsNotNullOrWhiteSpace();
 
             return (ICached<T>)_cache.Get(host.FullName + "_" + name, () => new Cached<T>());
+        }
+
+        public ICachedDictionary<T> GetCacheDictionary<T>(Type host, string name, Func<IDictionary<string, T>> fetchFunc = null, TimeSpan? lifeTime = null)
+        {
+            Ensure.That(host, () => host).IsNotNull();
+            Ensure.That(name, () => name).IsNotNullOrWhiteSpace();
+
+            return (ICachedDictionary<T>)_cache.Get("dict_" + host.FullName + "_" + name, () => new CachedDictionary<T>(fetchFunc, lifeTime));
         }
     }
 }

--- a/src/NzbDrone.Common/Cache/CachedDictionary.cs
+++ b/src/NzbDrone.Common/Cache/CachedDictionary.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace NzbDrone.Common.Cache
+{
+
+    public class CachedDictionary<TValue> : ICachedDictionary<TValue>
+    {
+        private readonly Func<IDictionary<string, TValue>> _fetchFunc;
+        private readonly TimeSpan? _ttl;
+
+        private DateTime _lastRefreshed = DateTime.MinValue;
+        private ConcurrentDictionary<string, TValue> _items = new ConcurrentDictionary<string, TValue>();
+
+        public CachedDictionary(Func<IDictionary<string, TValue>> fetchFunc = null, TimeSpan? ttl = null)
+        {
+            _fetchFunc = fetchFunc;
+            _ttl = ttl;
+        }
+
+        public bool IsExpired(TimeSpan ttl)
+        {
+            return _lastRefreshed.Add(ttl) < DateTime.UtcNow;
+        }
+
+        public void RefreshIfExpired()
+        {
+            if (_ttl.HasValue && _fetchFunc != null)
+            {
+                RefreshIfExpired(_ttl.Value);
+            }
+        }
+
+        public void RefreshIfExpired(TimeSpan ttl)
+    {
+            if (IsExpired(ttl))
+            {
+                Refresh();
+            }
+        }
+
+        public void Refresh()
+        {
+            if (_fetchFunc == null)
+            {
+                throw new InvalidOperationException("Cannot update cache without data source.");
+            }
+
+            Update(_fetchFunc());
+            ExtendTTL();
+        }
+
+        public void Update(IDictionary<string, TValue> items)
+        {
+            _items = new ConcurrentDictionary<string, TValue>(items);
+            ExtendTTL();
+        }
+
+        public void ExtendTTL()
+        {
+            _lastRefreshed = DateTime.UtcNow;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public ICollection<TValue> Values
+        {
+            get
+            {
+                RefreshIfExpired();
+                return _items.Values;
+            }
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        public int Count
+        {
+            get
+            {
+                RefreshIfExpired();
+                return _items.Count;
+            }
+        }
+
+        public TValue Get(string key)
+        {
+            RefreshIfExpired();
+
+            TValue result;
+
+            if (!_items.TryGetValue(key, out result))
+            {
+                throw new KeyNotFoundException(string.Format("Item {0} not found in cache.", key));
+            }
+
+            return result;
+        }
+
+        public TValue Find(string key)
+        {
+            RefreshIfExpired();
+
+            TValue result;
+
+            _items.TryGetValue(key, out result);
+
+            return result;
+        }
+
+        public void Clear()
+        {
+            _items.Clear();
+            _lastRefreshed = DateTime.MinValue;
+        }
+
+        public void ClearExpired()
+        {
+            if (!_ttl.HasValue)
+            {
+                throw new InvalidOperationException("Checking expiry without ttl not possible.");
+            }
+
+            if (IsExpired(_ttl.Value))
+            {
+                Clear();
+            }
+        }
+
+        public void Remove(string key)
+        {
+            TValue item;
+            _items.TryRemove(key, out item);
+        }
+    }
+}

--- a/src/NzbDrone.Common/Cache/ICachedDictionary.cs
+++ b/src/NzbDrone.Common/Cache/ICachedDictionary.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NzbDrone.Common.Cache
+{
+    public interface ICachedDictionary<TValue> : ICached
+    {
+        void RefreshIfExpired();
+        void RefreshIfExpired(TimeSpan ttl);
+        void Refresh();
+        void Update(IDictionary<string, TValue> items);
+        void ExtendTTL();
+        TValue Get(string key);
+        TValue Find(string key);
+        bool IsExpired(TimeSpan ttl);
+    }
+}

--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -28,7 +28,6 @@ namespace NzbDrone.Common.Http
         private readonly Logger _logger;
         private readonly IRateLimitService _rateLimitService;
         private readonly ICached<CookieContainer> _cookieContainerCache;
-        private readonly ICached<bool> _curlTLSFallbackCache;
         private readonly List<IHttpRequestInterceptor> _requestInterceptors;
         private readonly IHttpDispatcher _httpDispatcher;
 

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -64,7 +64,9 @@
     <Compile Include="ArchiveService.cs" />
     <Compile Include="Cache\Cached.cs" />
     <Compile Include="Cache\CacheManager.cs" />
+    <Compile Include="Cache\CachedDictionary.cs" />
     <Compile Include="Cache\ICached.cs" />
+    <Compile Include="Cache\ICachedDictionary.cs" />
     <Compile Include="Cloud\CloudClient.cs" />
     <Compile Include="Composition\Container.cs" />
     <Compile Include="Composition\ContainerBuilderBase.cs" />

--- a/src/NzbDrone.Core.Test/DataAugmentation/SceneNumbering/XemServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/DataAugmentation/SceneNumbering/XemServiceFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.DataAugmentation.Xem.Model;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Tv.Events;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.DataAugmentation.SceneNumbering
 {
@@ -144,6 +145,25 @@ namespace NzbDrone.Core.Test.DataAugmentation.SceneNumbering
 
             Mocker.GetMock<ISeriesService>()
                   .Verify(v => v.UpdateSeries(It.IsAny<Series>()), Times.Never());
+
+            ExceptionVerification.ExpectedWarns(1);
+        }
+
+        [Test]
+        public void should_not_clear_scenenumbering_if_thexem_throws()
+        {
+            GivenExistingMapping();
+
+            Mocker.GetMock<IXemProxy>()
+                  .Setup(v => v.GetXemSeriesIds())
+                  .Throws(new InvalidOperationException());
+
+            Subject.Handle(new SeriesUpdatedEvent(_series));
+
+            Mocker.GetMock<ISeriesService>()
+                  .Verify(v => v.UpdateSeries(It.IsAny<Series>()), Times.Never());
+
+            ExceptionVerification.ExpectedWarns(1);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Tv/Events/SeriesRefreshStartingEvent.cs
+++ b/src/NzbDrone.Core/Tv/Events/SeriesRefreshStartingEvent.cs
@@ -4,5 +4,11 @@ namespace NzbDrone.Core.Tv.Events
 {
     public class SeriesRefreshStartingEvent : IEvent
     {
+        public bool ManualTrigger { get; set; }
+
+        public SeriesRefreshStartingEvent(bool manualTrigger)
+        {
+            ManualTrigger = manualTrigger;
+        }
     }
 }

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Tv
 
         public void Execute(RefreshSeriesCommand message)
         {
-            _eventAggregator.PublishEvent(new SeriesRefreshStartingEvent());
+            _eventAggregator.PublishEvent(new SeriesRefreshStartingEvent(message.Trigger == CommandTrigger.Manual));
 
             if (message.SeriesId.HasValue)
             {

--- a/src/UI/Calendar/CalendarView.js
+++ b/src/UI/Calendar/CalendarView.js
@@ -160,7 +160,8 @@ module.exports = Marionette.ItemView.extend({
                 allDay      : false,
                 statusLevel : self._getStatusLevel(model, end),
                 downloading : QueueCollection.findEpisode(model.get('id')),
-                model       : model
+                model       : model,
+                sortOrder   : (model.get('seasonNumber') == 0 ? 1000000 : model.get('seasonNumber') * 10000) + model.get('episodeNumber')
             };
 
             events.push(event);

--- a/src/UI/JsLibraries/fullcalendar.js
+++ b/src/UI/JsLibraries/fullcalendar.js
@@ -4439,7 +4439,8 @@ function compareSegs(seg1, seg2) {
 	return seg1.eventStartMS - seg2.eventStartMS || // earlier events go first
 		seg2.eventDurationMS - seg1.eventDurationMS || // tie? longer events go first
 		seg2.event.allDay - seg1.event.allDay || // tie? put all-day events first (booleans cast to 0/1)
-		(seg1.event.title || '').localeCompare(seg2.event.title); // tie? alphabetically by title
+		(seg1.event.title || '').localeCompare(seg2.event.title) || // tie? alphabetically by title
+        seg1.event.sortOrder - seg2.event.sortOrder; // tie? use sortOrder
 }
 
 fc.compareSegs = compareSegs; // export


### PR DESCRIPTION
Added CachedDictionary that's basically an auto-refreshing cache. Used in both places now.

I haven't tested it thoroughly.

One concern I already noticed is that the SceneMappings are used in the API to add alternativetitles, meaning the api call may wait for an external timeout. Not that bad though, coz in the past we used to do SceneMapping refresh on Appstart event.
