### PR TITLE
Support for Slack notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace NzbDrone.Core.Notifications.Slack.Payloads
 {

--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
@@ -4,19 +4,12 @@ namespace NzbDrone.Core.Notifications.Slack.Payloads
 {
     public class Attachment
     {
-        [JsonProperty("fallback")]
         public string Fallback { get; set; }
 
-        [JsonProperty("title")]
         public string Title { get; set; }
 
-        [JsonProperty("title_link")]
-        public string TitleLink { get; set; }
-
-        [JsonProperty("text")]
         public string Text { get; set; }
 
-        [JsonProperty("color")]
         public string Color { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/Attachment.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Notifications.Slack.Payloads
+{
+    public class Attachment
+    {
+        [JsonProperty("fallback")]
+        public string Fallback { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("title_link")]
+        public string TitleLink { get; set; }
+
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("color")]
+        public string Color { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace NzbDrone.Core.Notifications.Slack.Payloads

--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
@@ -5,16 +5,13 @@ namespace NzbDrone.Core.Notifications.Slack.Payloads
 {
     public class SlackPayload
     {
-        [JsonProperty("text")]
         public string Text { get; set; }
 
-        [JsonProperty("username")]
         public string Username { get; set; }
 
         [JsonProperty("icon_emoji")]
         public string IconEmoji { get; set; }
 
-        [JsonProperty("attachments")]
         public List<Attachment> Attachments { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Payloads/SlackPayload.cs
@@ -4,18 +4,20 @@ using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 
-namespace NzbDrone.Core.Notifications.Slack
+namespace NzbDrone.Core.Notifications.Slack.Payloads
 {
     public class SlackPayload
     {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
         [JsonProperty("username")]
         public string Username { get; set; }
 
         [JsonProperty("icon_emoji")]
         public string IconEmoji { get; set; }
 
-        [JsonProperty("text")]
-        public string Text { get; set; }
-
+        [JsonProperty("attachments")]
+        public List<Attachment> Attachments { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -20,14 +20,13 @@ namespace NzbDrone.Core.Notifications.Slack
 
         public override string Link
         {
-            get { return "https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts"; }
+            get { return "https://my.slack.com/services/new/incoming-webhook/"; }
         }
 
         public override void OnGrab(GrabMessage message)
         {
             _logger.Trace("OnGrab: {0}", message);
             _service.OnGrab(message, Settings);
-
         }
 
         public override void OnDownload(DownloadMessage message)

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -12,8 +12,6 @@ namespace NzbDrone.Core.Notifications.Slack
         private readonly Logger _logger;
         private readonly ISlackService _service;
 
-        public override bool SupportsOnUpgrade => false;
-
         public Slack(Logger logger, ISlackService service)
         {
             _logger = logger;

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Processes;
+using NzbDrone.Core.Rest;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.Validation;
+using RestSharp;
+
+namespace NzbDrone.Core.Notifications.Slack
+{
+    public class Slack : NotificationBase<SlackSettings>
+    {
+        private readonly Logger _logger;
+        private readonly ISlackService _service;
+
+        public override bool SupportsOnUpgrade => false;
+
+        public Slack(Logger logger, ISlackService service)
+        {
+            _logger = logger;
+            _service = service;
+        }
+
+        public override string Link
+        {
+            get { return "https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts"; }
+        }
+
+        public override void OnGrab(GrabMessage message)
+        {
+            _logger.Trace("OnGrab: {0}", message);
+            var series = message.Series;
+            var remoteEpisode = message.Episode;
+            var releaseGroup = remoteEpisode.ParsedEpisodeInfo.ReleaseGroup;
+            var data = new Dictionary<string,string>();
+
+            data.Add("$EventType", "Grab");
+            data.Add("$Series_Id", series.Id.ToString());
+            data.Add("$Series_Title", series.Title);
+            data.Add("$Series_TvdbId", series.TvdbId.ToString());
+            data.Add("$Series_Type", series.SeriesType.ToString());
+            data.Add("$Release_SeasonNumber", remoteEpisode.ParsedEpisodeInfo.SeasonNumber.ToString());
+            data.Add("$Release_EpisodeNumbers", string.Join(",", remoteEpisode.Episodes.Select(e => e.EpisodeNumber)));
+            data.Add("$Release_Title", remoteEpisode.Release.Title);
+            data.Add("$Release_Indexer", remoteEpisode.Release.Indexer);
+            data.Add("$Release_Size", remoteEpisode.Release.Size.ToString());
+            data.Add("$Release_ReleaseGroup", releaseGroup);
+
+            _service.OnGrab(data, Settings);
+
+        }
+
+        public override void OnDownload(DownloadMessage message)
+        {
+            _logger.Trace("OnDownload: {0}", message);
+
+            var series = message.Series;
+            var episodeFile = message.EpisodeFile;
+            var sourcePath = message.SourcePath;
+            var data = new Dictionary<string, string>();
+
+            data.Add("$EventType", "Download");
+            data.Add("$Series_Id", series.Id.ToString());
+            data.Add("$Series_Title", series.Title);
+            data.Add("$Series_Path", series.Path);
+            data.Add("$Series_TvdbId", series.TvdbId.ToString());
+            data.Add("$Series_Type", series.SeriesType.ToString());
+            data.Add("$EpisodeFile_Id", episodeFile.Id.ToString());
+            data.Add("$EpisodeFile_RelativePath", episodeFile.RelativePath);
+            data.Add("$EpisodeFile_Path", Path.Combine(series.Path, episodeFile.RelativePath));
+            data.Add("$EpisodeFile_SeasonNumber", episodeFile.SeasonNumber.ToString());
+            data.Add("$EpisodeFile_EpisodeNumbers", string.Join(",", episodeFile.Episodes.Value.Select(e => e.EpisodeNumber)));
+            data.Add("$EpisodeFile_EpisodeAirDates", string.Join(",", episodeFile.Episodes.Value.Select(e => e.AirDate)));
+            data.Add("$EpisodeFile_EpisodeAirDatesUtc", string.Join(",", episodeFile.Episodes.Value.Select(e => e.AirDateUtc)));
+            data.Add("$EpisodeFile_Quality", episodeFile.Quality.Quality.Name);
+            data.Add("$EpisodeFile_QualityVersion", episodeFile.Quality.Revision.Version.ToString());
+            data.Add("$EpisodeFile_ReleaseGroup", episodeFile.ReleaseGroup ?? string.Empty);
+            data.Add("$EpisodeFile_SceneName", episodeFile.SceneName ?? string.Empty);
+            data.Add("$EpisodeFile_SourcePath", sourcePath);
+            data.Add("$EpisodeFile_SourceFolder", Path.GetDirectoryName(sourcePath));
+
+            _service.OnDownload(data, Settings);
+        }
+
+        public override void OnRename(Series series)
+        {
+            _logger.Trace("OnRename: {0}", series);
+            var data = new Dictionary<string, string>();
+
+            data.Add("$EventType", "Rename");
+            data.Add("$Series_Id", series.Id.ToString());
+            data.Add("$Series_Title", series.Title);
+            data.Add("$Series_Path", series.Path);
+            data.Add("$Series_TvdbId", series.TvdbId.ToString());
+            data.Add("$Series_Type", series.SeriesType.ToString());
+
+            _service.OnRename(data, Settings);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "Slack";
+            }
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            failures.AddIfNotNull(_service.Test(Settings));
+
+            return new ValidationResult(failures);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -1,18 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NLog;
-using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Common.Processes;
-using NzbDrone.Core.Rest;
 using NzbDrone.Core.Tv;
-using NzbDrone.Core.Validation;
-using RestSharp;
+
 
 namespace NzbDrone.Core.Notifications.Slack
 {

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -37,72 +37,20 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnGrab(GrabMessage message)
         {
             _logger.Trace("OnGrab: {0}", message);
-            var series = message.Series;
-            var remoteEpisode = message.Episode;
-            var releaseGroup = remoteEpisode.ParsedEpisodeInfo.ReleaseGroup;
-            var data = new Dictionary<string,string>();
-
-            data.Add("$EventType", "Grab");
-            data.Add("$Series_Id", series.Id.ToString());
-            data.Add("$Series_Title", series.Title);
-            data.Add("$Series_TvdbId", series.TvdbId.ToString());
-            data.Add("$Series_Type", series.SeriesType.ToString());
-            data.Add("$Release_SeasonNumber", remoteEpisode.ParsedEpisodeInfo.SeasonNumber.ToString());
-            data.Add("$Release_EpisodeNumbers", string.Join(",", remoteEpisode.Episodes.Select(e => e.EpisodeNumber)));
-            data.Add("$Release_Title", remoteEpisode.Release.Title);
-            data.Add("$Release_Indexer", remoteEpisode.Release.Indexer);
-            data.Add("$Release_Size", remoteEpisode.Release.Size.ToString());
-            data.Add("$Release_ReleaseGroup", releaseGroup);
-
-            _service.OnGrab(data, Settings);
+            _service.OnGrab(message, Settings);
 
         }
 
         public override void OnDownload(DownloadMessage message)
         {
             _logger.Trace("OnDownload: {0}", message);
-
-            var series = message.Series;
-            var episodeFile = message.EpisodeFile;
-            var sourcePath = message.SourcePath;
-            var data = new Dictionary<string, string>();
-
-            data.Add("$EventType", "Download");
-            data.Add("$Series_Id", series.Id.ToString());
-            data.Add("$Series_Title", series.Title);
-            data.Add("$Series_Path", series.Path);
-            data.Add("$Series_TvdbId", series.TvdbId.ToString());
-            data.Add("$Series_Type", series.SeriesType.ToString());
-            data.Add("$EpisodeFile_Id", episodeFile.Id.ToString());
-            data.Add("$EpisodeFile_RelativePath", episodeFile.RelativePath);
-            data.Add("$EpisodeFile_Path", Path.Combine(series.Path, episodeFile.RelativePath));
-            data.Add("$EpisodeFile_SeasonNumber", episodeFile.SeasonNumber.ToString());
-            data.Add("$EpisodeFile_EpisodeNumbers", string.Join(",", episodeFile.Episodes.Value.Select(e => e.EpisodeNumber)));
-            data.Add("$EpisodeFile_EpisodeAirDates", string.Join(",", episodeFile.Episodes.Value.Select(e => e.AirDate)));
-            data.Add("$EpisodeFile_EpisodeAirDatesUtc", string.Join(",", episodeFile.Episodes.Value.Select(e => e.AirDateUtc)));
-            data.Add("$EpisodeFile_Quality", episodeFile.Quality.Quality.Name);
-            data.Add("$EpisodeFile_QualityVersion", episodeFile.Quality.Revision.Version.ToString());
-            data.Add("$EpisodeFile_ReleaseGroup", episodeFile.ReleaseGroup ?? string.Empty);
-            data.Add("$EpisodeFile_SceneName", episodeFile.SceneName ?? string.Empty);
-            data.Add("$EpisodeFile_SourcePath", sourcePath);
-            data.Add("$EpisodeFile_SourceFolder", Path.GetDirectoryName(sourcePath));
-
-            _service.OnDownload(data, Settings);
+            _service.OnDownload(message, Settings);
         }
 
         public override void OnRename(Series series)
         {
-            _logger.Trace("OnRename: {0}", series);
-            var data = new Dictionary<string, string>();
-
-            data.Add("$EventType", "Rename");
-            data.Add("$Series_Id", series.Id.ToString());
-            data.Add("$Series_Title", series.Title);
-            data.Add("$Series_Path", series.Path);
-            data.Add("$Series_TvdbId", series.TvdbId.ToString());
-            data.Add("$Series_Type", series.SeriesType.ToString());
-
-            _service.OnRename(data, Settings);
+            _logger.Trace("OnRename: {0}", series);          
+            _service.OnRename(series, Settings);
         }
 
         public override string Name

--- a/src/NzbDrone.Core/Notifications/Slack/SlackExeption.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackExeption.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.Notifications.Slack
+{
+    class SlackExeption : NzbDroneException
+    {
+        public SlackExeption(string message) : base(message)
+        {
+        }
+
+        public SlackExeption(string message, Exception innerException, params object[] args) : base(message, innerException, args)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/SlackExeption.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackExeption.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using NzbDrone.Common.Exceptions;
 
 namespace NzbDrone.Core.Notifications.Slack

--- a/src/NzbDrone.Core/Notifications/Slack/SlackPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackPayload.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Notifications.Slack
+{
+    public class SlackPayload
+    {
+        [JsonProperty("username")]
+        public string Username { get; set; }
+
+        [JsonProperty("icon_emoji")]
+        public string IconEmoji { get; set; }
+
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Notifications.Slack
                         Fallback = message.Message,
                         Title = message.Series.Title,
                         TitleLink = $"http://www.imdb.com/title/{message.Series.ImdbId}/",
-                        Text = message.Message,
+                        Text = message.Episode.Release.Title,
                         Color = "warning"
                     }
                 }

--- a/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Core.Notifications.Slack.Payloads;

--- a/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
@@ -50,19 +50,8 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             try
             {
-                // Mock OnRenamePayload
-                var data = new Dictionary<string, string>
-                {
-                    {"$EventType", "Rename"},
-                    {"$Series_Id", "1"},
-                    {"$Series_Title", "How I met your mother"},
-                    {"$Series_Path", @"C:\path to somthing.mp4"},
-                    {"$Series_TvdbId", "123123123123"},
-                    {"$Series_Type", "Standard"}
-                };
-
-
-                this.OnRename(data, settings);
+                var message = string.Format("Test message from Sonarr posted at {0}", DateTime.Now);
+                NotifySlack(message, settings);
             }
             catch (SlackExeption ex)
             {
@@ -75,7 +64,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var payload = new SlackPayload()
             {
-                IconEmoji = ":ghost:",
+                IconEmoji = settings.Icon,
                 Text = text,
                 Username = settings.BotName
             };
@@ -98,7 +87,6 @@ namespace NzbDrone.Core.Notifications.Slack
 
         private string ConvertUserInput(string payloadText, Dictionary<string, string> mapping)
         {
-
             var text = payloadText;
             foreach (var variable in mapping)
             {

--- a/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
@@ -30,18 +30,17 @@ namespace NzbDrone.Core.Notifications.Slack
 
         public void OnDownload(DownloadMessage message, SlackSettings settings)
         {
-            var payload = new SlackPayload()
+            var payload = new SlackPayload
             {
                 IconEmoji = settings.Icon,
-                Username = settings.BotName,
+                Username = settings.Username,
                 Text = "Downloaded",
-                Attachments = new List<Attachment>()
+                Attachments = new List<Attachment>
                 {
                     new Attachment()
                     {
                         Fallback = message.Message,
                         Title = message.Series.Title,
-                        TitleLink = $"http://www.imdb.com/title/{message.Series.ImdbId}/",
                         Text = message.Message,
                         Color = "good"
                     }
@@ -53,17 +52,16 @@ namespace NzbDrone.Core.Notifications.Slack
 
         public void OnRename(Series series, SlackSettings settings)
         {
-            var payload = new SlackPayload()
+            var payload = new SlackPayload
             {
                 IconEmoji = settings.Icon,
-                Username = settings.BotName,
+                Username = settings.Username,
                 Text = "Renamed",
-                Attachments = new List<Attachment>()
+                Attachments = new List<Attachment>
                 {
-                    new Attachment()
+                    new Attachment
                     {
                         Title = series.Title,
-                        TitleLink = $"http://www.imdb.com/title/{series.ImdbId}/",
                     }
                 }
             };
@@ -73,18 +71,17 @@ namespace NzbDrone.Core.Notifications.Slack
 
         public void OnGrab(GrabMessage message, SlackSettings settings)
         {
-            var payload = new SlackPayload()
+            var payload = new SlackPayload
             {
                 IconEmoji = settings.Icon,
-                Username = settings.BotName,
+                Username = settings.Username,
                 Text = "Grabbed",
-                Attachments = new List<Attachment>()
+                Attachments = new List<Attachment>
                 {
-                    new Attachment()
+                    new Attachment
                     {
                         Fallback = message.Message,
                         Title = message.Series.Title,
-                        TitleLink = $"http://www.imdb.com/title/{message.Series.ImdbId}/",
                         Text = message.Message,
                         Color = "warning"
                     }
@@ -98,20 +95,22 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             try
             {
-                var message = string.Format("Test message from Sonarr posted at {0}", DateTime.Now);
-                var payload = new SlackPayload()
+                var message = $"Test message from Sonarr posted at {DateTime.Now}";
+                var payload = new SlackPayload
                 {
                     IconEmoji = settings.Icon,
-                    Username = settings.BotName,
+                    Username = settings.Username,
                     Text = message
                 };
 
                 NotifySlack(payload, settings);
+                
             }
             catch (SlackExeption ex)
             {
                 return new NzbDroneValidationFailure("Unable to post", ex.Message);
             }
+
             return null;
         }
 

--- a/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackService.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Core.Rest;
+using NzbDrone.Core.Validation;
+using RestSharp;
+
+namespace NzbDrone.Core.Notifications.Slack
+{
+    public interface ISlackService
+    {
+        void OnDownload(Dictionary<string,string> mapping, SlackSettings settings);
+        void OnRename(Dictionary<string, string> mapping, SlackSettings settings);
+        void OnGrab(Dictionary<string, string> mapping, SlackSettings settings);
+        ValidationFailure Test(SlackSettings settings);
+    }
+
+    public class SlackService : ISlackService
+    {
+        private readonly Logger _logger;
+
+        public SlackService(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public void OnDownload(Dictionary<string, string> mapping, SlackSettings settings)
+        {
+            var text = ConvertUserInput(settings.OnDownloadPayload, mapping);
+            NotifySlack(text, settings);
+        }
+
+        public void OnRename(Dictionary<string, string> mapping, SlackSettings settings)
+        {
+            var text = ConvertUserInput(settings.OnRenamePayload, mapping);
+            NotifySlack(text, settings);
+        }
+
+        public void OnGrab(Dictionary<string, string> mapping, SlackSettings settings)
+        {
+            var text = ConvertUserInput(settings.OnGrabPayload, mapping);
+            NotifySlack(text, settings);
+        }
+
+        public ValidationFailure Test(SlackSettings settings)
+        {
+            try
+            {
+                // Mock OnRenamePayload
+                var data = new Dictionary<string, string>
+                {
+                    {"$EventType", "Rename"},
+                    {"$Series_Id", "1"},
+                    {"$Series_Title", "How I met your mother"},
+                    {"$Series_Path", @"C:\path to somthing.mp4"},
+                    {"$Series_TvdbId", "123123123123"},
+                    {"$Series_Type", "Standard"}
+                };
+
+
+                this.OnRename(data, settings);
+            }
+            catch (SlackExeption ex)
+            {
+                return new NzbDroneValidationFailure("Unable to post", ex.Message);
+            }
+            return null;
+        }
+
+        private void NotifySlack(string text, SlackSettings settings)
+        {
+            var payload = new SlackPayload()
+            {
+                IconEmoji = ":ghost:",
+                Text = text,
+                Username = settings.BotName
+            };
+
+            try
+            {
+                var client = RestClientFactory.BuildClient(settings.WebHookUrl);
+                var request = new RestRequest(Method.POST) { RequestFormat = DataFormat.Json };
+                request.JsonSerializer = new JsonNetSerializer();
+                request.AddBody(payload);
+                client.ExecuteAndValidate(request);
+            }
+            catch (RestException ex)
+            {
+                _logger.Error(ex, "Unable to post payload {0}", text);
+                throw new SlackExeption("Unable to post payload", ex);
+            }
+        }
+
+
+        private string ConvertUserInput(string payloadText, Dictionary<string, string> mapping)
+        {
+
+            var text = payloadText;
+            foreach (var variable in mapping)
+            {
+                text = Replace(text, variable.Key, variable.Value, StringComparison.OrdinalIgnoreCase);
+            }
+            return text;
+        }
+
+        private string Replace(string str, string old, string @new, StringComparison comparison)
+        {
+            @new = @new ?? "";
+            if (string.IsNullOrEmpty(str) || string.IsNullOrEmpty(old) || old.Equals(@new, comparison))
+                return str;
+            int foundAt;
+            while ((foundAt = str.IndexOf(old, 0, StringComparison.CurrentCultureIgnoreCase)) != -1)
+                str = str.Remove(foundAt, old.Length).Insert(foundAt, @new);
+            return str;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Slack
         public SlackSettingsValidator()
         {
             RuleFor(c => c.WebHookUrl).IsValidUrl();
-            RuleFor(c => c.BotName).NotEmpty();
+            RuleFor(c => c.Username).NotEmpty();
             RuleFor(c => c.Icon).NotEmpty();
         }
     }
@@ -19,13 +19,13 @@ namespace NzbDrone.Core.Notifications.Slack
     {
         private static readonly SlackSettingsValidator Validator = new SlackSettingsValidator();
 
-        [FieldDefinition(0, Label = "WebHookUrl", HelpText = "slack channel webhook url.", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
+        [FieldDefinition(0, Label = "Webhook URL", HelpText = "Slack channel webhook url", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
         public string WebHookUrl { get; set; }
 
-        [FieldDefinition(1, Label = "BotName", HelpText = "Name to be used for the notification.",Type = FieldType.Textbox)]
-        public string BotName { get; set; }
+        [FieldDefinition(1, Label = "Username", HelpText = "Choose the username that this integration will post as", Type = FieldType.Textbox)]
+        public string Username { get; set; }
 
-        [FieldDefinition(2, Label = "Icon", HelpText = "Icon to use.", Type = FieldType.Textbox, HelpLink = "http://www.emoji-cheat-sheet.com/")]
+        [FieldDefinition(2, Label = "Icon", HelpText = "Change the icon that is used for messages from this integration", Type = FieldType.Textbox, HelpLink = "http://www.emoji-cheat-sheet.com/")]
         public string Icon { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+using NzbDrone.Core.Validation.Paths;
+
+namespace NzbDrone.Core.Notifications.Slack
+{
+    public class SlackSettingsValidator : AbstractValidator<SlackSettings>
+    {
+        public SlackSettingsValidator()
+        {
+            RuleFor(c => c.WebHookUrl).IsValidUrl();
+            RuleFor(c => c.BotName).NotEmpty();
+            RuleFor(c => c.Icon).NotEmpty();
+            RuleFor(c => c.OnGrabPayload).NotEmpty();
+            RuleFor(c => c.OnDownloadPayload).NotEmpty();
+            RuleFor(c => c.OnRenamePayload).NotEmpty();
+        }
+    }
+
+    public class SlackSettings : IProviderConfig
+    {
+        private static readonly SlackSettingsValidator Validator = new SlackSettingsValidator();
+
+        [FieldDefinition(0, Label = "WebHookUrl", HelpText = "slack channel webhook url.", Type = FieldType.Url)]
+        public string WebHookUrl { get; set; }
+
+        [FieldDefinition(1, Label = "BotName", HelpText = "Name to be used for the notification.",Type = FieldType.Textbox)]
+        public string BotName { get; set; }
+
+        [FieldDefinition(2, Label = "Icon", HelpText = "Icon to use.", Type = FieldType.Textbox)]
+        public string Icon { get; set; }
+
+        [FieldDefinition(3, Label = "OnGrabPayload", HelpText = "Text to be posted on slack on grab.", Type = FieldType.Textbox)]
+        public string OnGrabPayload { get; set; }
+
+        [FieldDefinition(4, Label = "OnDownloadPayload", HelpText = "Text to be posted on slack on download.", Type = FieldType.Textbox)]
+        public string OnDownloadPayload { get; set; }
+
+        [FieldDefinition(5, Label = "OnRenamePayload", HelpText = "Text to be posted on slack on rename.", Type = FieldType.Textbox)]
+        public string OnRenamePayload { get; set; }
+
+
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -14,9 +14,6 @@ namespace NzbDrone.Core.Notifications.Slack
             RuleFor(c => c.WebHookUrl).IsValidUrl();
             RuleFor(c => c.BotName).NotEmpty();
             RuleFor(c => c.Icon).NotEmpty();
-            RuleFor(c => c.OnGrabPayload).NotEmpty();
-            RuleFor(c => c.OnDownloadPayload).NotEmpty();
-            RuleFor(c => c.OnRenamePayload).NotEmpty();
         }
     }
 
@@ -32,17 +29,6 @@ namespace NzbDrone.Core.Notifications.Slack
 
         [FieldDefinition(2, Label = "Icon", HelpText = "Icon to use.", Type = FieldType.Textbox, HelpLink = "http://www.emoji-cheat-sheet.com/")]
         public string Icon { get; set; }
-
-        [FieldDefinition(3, Label = "OnGrabPayload", HelpText = "Text to be posted on slack on grab.", Type = FieldType.Textbox)]
-        public string OnGrabPayload { get; set; }
-
-        [FieldDefinition(4, Label = "OnDownloadPayload", HelpText = "Text to be posted on slack on download.", Type = FieldType.Textbox)]
-        public string OnDownloadPayload { get; set; }
-
-        [FieldDefinition(5, Label = "OnRenamePayload", HelpText = "Text to be posted on slack on rename.", Type = FieldType.Textbox)]
-        public string OnRenamePayload { get; set; }
-
-
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -24,13 +24,13 @@ namespace NzbDrone.Core.Notifications.Slack
     {
         private static readonly SlackSettingsValidator Validator = new SlackSettingsValidator();
 
-        [FieldDefinition(0, Label = "WebHookUrl", HelpText = "slack channel webhook url.", Type = FieldType.Url)]
+        [FieldDefinition(0, Label = "WebHookUrl", HelpText = "slack channel webhook url.", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
         public string WebHookUrl { get; set; }
 
         [FieldDefinition(1, Label = "BotName", HelpText = "Name to be used for the notification.",Type = FieldType.Textbox)]
         public string BotName { get; set; }
 
-        [FieldDefinition(2, Label = "Icon", HelpText = "Icon to use.", Type = FieldType.Textbox)]
+        [FieldDefinition(2, Label = "Icon", HelpText = "Icon to use.", Type = FieldType.Textbox, HelpLink = "http://www.emoji-cheat-sheet.com/")]
         public string Icon { get; set; }
 
         [FieldDefinition(3, Label = "OnGrabPayload", HelpText = "Text to be posted on slack on grab.", Type = FieldType.Textbox)]

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using FluentValidation;
+﻿using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
-using NzbDrone.Core.Validation.Paths;
 
 namespace NzbDrone.Core.Notifications.Slack
 {

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -777,9 +777,10 @@
     <Compile Include="Notifications\Plex\PlexHomeTheaterSettings.cs" />
     <Compile Include="Notifications\Plex\PlexClientService.cs" />
     <Compile Include="Notifications\PushBullet\PushBulletException.cs" />
+    <Compile Include="Notifications\Slack\Payloads\Attachment.cs" />
+    <Compile Include="Notifications\Slack\Payloads\SlackPayload.cs" />
     <Compile Include="Notifications\Slack\Slack.cs" />
     <Compile Include="Notifications\Slack\SlackExeption.cs" />
-    <Compile Include="Notifications\Slack\SlackPayload.cs" />
     <Compile Include="Notifications\Slack\SlackService.cs" />
     <Compile Include="Notifications\Slack\SlackSettings.cs" />
     <Compile Include="Notifications\Synology\SynologyException.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -777,6 +777,11 @@
     <Compile Include="Notifications\Plex\PlexHomeTheaterSettings.cs" />
     <Compile Include="Notifications\Plex\PlexClientService.cs" />
     <Compile Include="Notifications\PushBullet\PushBulletException.cs" />
+    <Compile Include="Notifications\Slack\Slack.cs" />
+    <Compile Include="Notifications\Slack\SlackExeption.cs" />
+    <Compile Include="Notifications\Slack\SlackPayload.cs" />
+    <Compile Include="Notifications\Slack\SlackService.cs" />
+    <Compile Include="Notifications\Slack\SlackSettings.cs" />
     <Compile Include="Notifications\Synology\SynologyException.cs" />
     <Compile Include="Notifications\Synology\SynologyIndexer.cs" />
     <Compile Include="Notifications\Synology\SynologyIndexerProxy.cs" />


### PR DESCRIPTION
Implemented slack as a notification channel through webhooks
Supports the variables found in
https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts in
the form "$EventType"

Has the properties
WebHookUrl (URL): `https://hooks.slack.com/TXXXXX/BXXXXX/XXXXXXXXXX`
BotName (String): `Sonarr`
Icon (String): `:ghost:` (http://www.emoji-cheat-sheet.com/)
OnGrabPayload (String): `$EventType: $Series_Title - S$Release_SeasonNumberE$Release_EpisodeNumbers $Release_Title`
OnDownloadPayload (String): `$EventType: $Series_Title - S$EpisodeFile_SeasonNumber:E$EpisodeFile_EpisodeNumbers $EpisodeFile_SceneName ($EpisodeFile_Quality)`
OnRenamePayload (String): `$EventType: $Series_Title`
