### PR TITLE
Fix: Renaming {Release Group} to string.Empty instead of "Sonarr" if …

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -703,13 +703,13 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         }
 
         [Test]
-        public void should_use_Sonarr_as_release_group_when_not_available()
+        public void should_not_use_anything_as_release_group_when_not_available()
         {
             _episodeFile.ReleaseGroup = null;
             _namingConfig.StandardEpisodeFormat = "{Release Group}";
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
-                   .Should().Be("Sonarr");
+                   .Should().Be(string.Empty);
         }
 
         [TestCase("{Episode Title}{-Release Group}", "City Sushi")]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -425,7 +425,7 @@ namespace NzbDrone.Core.Organizer
         {
             tokenHandlers["{Original Title}"] = m => GetOriginalTitle(episodeFile);
             tokenHandlers["{Original Filename}"] = m => GetOriginalFileName(episodeFile);
-            tokenHandlers["{Release Group}"] = m => episodeFile.ReleaseGroup ?? m.DefaultValue("Sonarr");
+            tokenHandlers["{Release Group}"] = m => episodeFile.ReleaseGroup ?? m.DefaultValue(string.Empty);
         }
 
         private void AddQualityTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Series series, EpisodeFile episodeFile)


### PR DESCRIPTION
Fix: Renaming {Release Group} to string.Empty instead of "Sonarr" if none is found during renaming.

Issue #1229 