### PR TITLE
Update license expression to SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/Sonarr/Sonarr.git"
   },
   "author": "",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "gitHead": "9ff7aa1bf7fe38c4c5bdb92f56c8ad556916ed67",
   "readmeFilename": "readme.md",
   "dependencies": {


### PR DESCRIPTION
When using `npm install` I received an error stating that the `license` field in `package.json` did not conform to the new SPDX standard.

Considering that the previous license was `BSD`, I have updated it to the `BSD-3-Clause`: the most relevant valid expression.