### PR TITLE
Update package.json license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/Sonarr/Sonarr.git"
   },
   "author": "",
-  "license": "BSD",
+  "license": "GPL-3.0",
   "gitHead": "9ff7aa1bf7fe38c4c5bdb92f56c8ad556916ed67",
   "readmeFilename": "readme.md",
   "dependencies": {


### PR DESCRIPTION
The `readme.md` specifies that the license for the project is GPLv3, but the value contained in the `package.json` license field was `BSD`. I have changed it to the `GPL-3.0` SPDX license string both so npm doesn't throw any warnings about license string validity and to better reflect the license of the project.