### PR TITLE
Changing Transmission to check the protocol (RPC) version instead the client version.

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         void AddTorrentFromData(byte[] torrentData, string downloadDirectory, TransmissionSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, TransmissionSettings settings);
         Dictionary<string, object> GetConfig(TransmissionSettings settings);
-        string GetVersion(TransmissionSettings settings);
+        string GetProtocolVersion(TransmissionSettings settings);
         void RemoveTorrent(string hash, bool removeData, TransmissionSettings settings);
         void MoveTorrentToTopInQueue(string hashString, TransmissionSettings settings);
     }
@@ -94,12 +94,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             ProcessRequest("torrent-set", arguments, settings);
         }
 
-        public string GetVersion(TransmissionSettings settings)
+        public string GetProtocolVersion(TransmissionSettings settings)
         {
-            // Gets the transmission version.
             var config = GetConfig(settings);
 
-            var version = config["version"];
+            var version = config["rpc-version"];
 
             return version.ToString();
         }


### PR DESCRIPTION
This is a pre-requisite for supporting Vuze (#1273), which is also based on the Transmission protocol, but uses a different client version.
I believe this is a more correct approach for validating supported Transmission version, as the RPC version value is absolute.