### PR TITLE
'missing' series episodes patch

### DIFF
--- a/src/UI/Mixins/AsFilteredCollection.js
+++ b/src/UI/Mixins/AsFilteredCollection.js
@@ -50,7 +50,7 @@ module.exports = function() {
                 return model.get(self.state.filterKey) >= self.state.filterValue;
             }
             else if (self.state.filterType === 'ne') {
-                return !(model.get(self.state.filterKey) === self.state.filterValue);
+                return model.get(self.state.filterKey) !== self.state.filterValue;
             }
             else {
                 return model.get(self.state.filterKey) === self.state.filterValue;

--- a/src/UI/Mixins/AsFilteredCollection.js
+++ b/src/UI/Mixins/AsFilteredCollection.js
@@ -37,6 +37,21 @@ module.exports = function() {
             else if (self.state.filterType === 'contains') {
                 return model.get(self.state.filterKey).toLowerCase().indexOf(self.state.filterValue.toLowerCase()) > -1;
             }
+            else if (self.state.filterType === 'lt') {
+                return model.get(self.state.filterKey) < self.state.filterValue;
+            }
+            else if (self.state.filterType === 'gt') {
+                return model.get(self.state.filterKey) > self.state.filterValue;
+            }
+            else if (self.state.filterType === 'le') {
+                return model.get(self.state.filterKey) <= self.state.filterValue;
+            }
+            else if (self.state.filterType === 'ge') {
+                return model.get(self.state.filterKey) >= self.state.filterValue;
+            }
+            else if (self.state.filterType === 'ne') {
+                return !(model.get(self.state.filterKey) === self.state.filterValue);
+            }
             else {
                 return model.get(self.state.filterKey) === self.state.filterValue;
             }

--- a/src/UI/Series/Index/SeriesIndexLayout.js
+++ b/src/UI/Series/Index/SeriesIndexLayout.js
@@ -199,7 +199,7 @@ module.exports = Marionette.Layout.extend({
                     key      : 'missing',
                     title    : '',
                     tooltip  : 'Missing',
-                    icon     : 'icon-sonarr-edit',
+                    icon     : 'icon-sonarr-missing',
                     callback : this._setFilter
                 }
             ]

--- a/src/UI/Series/Index/SeriesIndexLayout.js
+++ b/src/UI/Series/Index/SeriesIndexLayout.js
@@ -194,6 +194,13 @@ module.exports = Marionette.Layout.extend({
                     tooltip  : 'Ended Only',
                     icon     : 'icon-sonarr-series-ended',
                     callback : this._setFilter
+                },
+                {
+                    key      : 'missing',
+                    title    : '',
+                    tooltip  : 'Missing',
+                    icon     : 'icon-sonarr-edit',
+                    callback : this._setFilter
                 }
             ]
         };

--- a/src/UI/Series/SeriesCollection.js
+++ b/src/UI/Series/SeriesCollection.js
@@ -63,6 +63,11 @@ var Collection = PageableCollection.extend({
         'monitored'  : [
             'monitored',
             true
+        ],
+        'missing'  : [
+            'percentOfEpisodes',
+            100,
+            'lt'
         ]
     },
 


### PR DESCRIPTION
This pull request implements a new Series filtering option to the main "Series" index page. When selected, it lists only those series that have missing episodes (i.e. percentOfEpisodes < 100).

Since I had to implement the 'lt' filter operator for this, I went ahead and created 'gt', 'le', 'ge' and 'ne' as well, just for completeness sake.

I just used the "wrench" icon for the button, I figured I'd let someone else who has better design skills pick something more appropriate.