### PR TITLE
Reenabled calling synoindex after renaming

### DIFF
--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
@@ -61,14 +61,6 @@ namespace NzbDrone.Core.Notifications.Synology
             }
         }
 
-        public override bool SupportsOnRename
-        {
-            get
-            {
-                return false;
-            }
-        }
-
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();


### PR DESCRIPTION
AfterRename/OnRename was implemented a year ago already when it was
disabled in 0f2bba061537e2de72f560b8c474f366201a2ab0, I assume it was
by mistake.

Right now it's super annoying, as I have to update the synoindex library manually after every single renaming done in Sonarr.