### PR TITLE
Fixed: XEM series with only alternate season titles.

### DIFF
--- a/src/NzbDrone.Core.Test/DataAugmentation/Scene/SceneMappingServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/DataAugmentation/Scene/SceneMappingServiceFixture.cs
@@ -201,6 +201,121 @@ namespace NzbDrone.Core.Test.DataAugmentation.Scene
             seasonNumber.Should().Be(expectedSeasonNumber);
         }
 
+        [Test]
+        public void should_return_alternate_title_for_global_season()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu 1", ParseTerm = "fudanshikoukouseikatsu1", SearchTerm = "Fudanshi Koukou Seikatsu 1", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = null },
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu 2", ParseTerm = "fudanshikoukouseikatsu2", SearchTerm = "Fudanshi Koukou Seikatsu 2", TvdbId = 100, SeasonNumber = -1, SceneSeasonNumber = null },
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu 3", ParseTerm = "fudanshikoukouseikatsu3", SearchTerm = "Fudanshi Koukou Seikatsu 3", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = -1 },
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu 4", ParseTerm = "fudanshikoukouseikatsu4", SearchTerm = "Fudanshi Koukou Seikatsu 4", TvdbId = 100, SeasonNumber = -1, SceneSeasonNumber = -1 },
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            var names = Subject.GetSceneNames(100, new List<int> { 10 }, new List<int> { 10 });
+            names.Should().HaveCount(4);
+        }
+
+        [Test]
+        public void should_return_alternate_title_for_season()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu", ParseTerm = "fudanshikoukouseikatsu", SearchTerm = "Fudanshi Koukou Seikatsu", TvdbId = 100, SeasonNumber = 1, SceneSeasonNumber = null }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            var names = Subject.GetSceneNames(100, new List<int> { 1 }, new List<int> { 10 });
+            names.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void should_not_return_alternate_title_for_season()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu", ParseTerm = "fudanshikoukouseikatsu", SearchTerm = "Fudanshi Koukou Seikatsu", TvdbId = 100, SeasonNumber = 1, SceneSeasonNumber = null }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            var names = Subject.GetSceneNames(100, new List<int> { 2 }, new List<int> { 10 });
+            names.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_return_alternate_title_for_sceneseason()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu", ParseTerm = "fudanshikoukouseikatsu", SearchTerm = "Fudanshi Koukou Seikatsu", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = 1 }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            var names = Subject.GetSceneNames(100, new List<int> { 10 }, new List<int> { 1 });
+            names.Should().HaveCount(1);
+        }
+
+        [Test]
+        public void should_not_return_alternate_title_for_sceneseason()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu", ParseTerm = "fudanshikoukouseikatsu", SearchTerm = "Fudanshi Koukou Seikatsu", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = 1 }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            var names = Subject.GetSceneNames(100, new List<int> { 10 }, new List<int> { 2 });
+            names.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_return_alternate_title_for_fairy_tail()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fairy Tail S2", ParseTerm = "fairytails2", SearchTerm = "Fairy Tail S2", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = 2 }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            Subject.GetSceneNames(100, new List<int> { 4 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 5 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 6 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 7 }, new List<int> { 20 }).Should().BeEmpty();
+
+            Subject.GetSceneNames(100, new List<int> { 20 }, new List<int> { 1 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 20 }, new List<int> { 2 }).Should().NotBeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 20 }, new List<int> { 3 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 20 }, new List<int> { 4 }).Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_return_alternate_title_for_fudanshi()
+        {
+            var mappings = new List<SceneMapping>
+            {
+                new SceneMapping { Title = "Fudanshi Koukou Seikatsu", ParseTerm = "fudanshikoukouseikatsu", SearchTerm = "Fudanshi Koukou Seikatsu", TvdbId = 100, SeasonNumber = null, SceneSeasonNumber = 1 }
+            };
+
+            Mocker.GetMock<ISceneMappingRepository>().Setup(c => c.All()).Returns(mappings);
+
+            Subject.GetSceneNames(100, new List<int> { 1 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 2 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 3 }, new List<int> { 20 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 4 }, new List<int> { 20 }).Should().BeEmpty();
+
+            Subject.GetSceneNames(100, new List<int> { 1 }, new List<int> { 1 }).Should().NotBeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 2 }, new List<int> { 2 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 3 }, new List<int> { 3 }).Should().BeEmpty();
+            Subject.GetSceneNames(100, new List<int> { 4 }, new List<int> { 4 }).Should().BeEmpty();
+        }
+
         private void AssertNoUpdate()
         {
             _provider1.Verify(c => c.GetSceneMappings(), Times.Once());
@@ -216,7 +331,7 @@ namespace NzbDrone.Core.Test.DataAugmentation.Scene
 
             foreach (var sceneMapping in _fakeMappings)
             {
-                Subject.GetSceneNamesBySeasonNumbers(sceneMapping.TvdbId, _fakeMappings.Select(m => m.SeasonNumber.Value)).Should().Contain(sceneMapping.SearchTerm);
+                Subject.GetSceneNames(sceneMapping.TvdbId, _fakeMappings.Select(m => m.SeasonNumber.Value).Distinct().ToList(), new List<int>()).Should().Contain(sceneMapping.SearchTerm);
                 Subject.FindTvdbId(sceneMapping.ParseTerm).Should().Be(sceneMapping.TvdbId);
             }
         }

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/NzbSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/NzbSearchServiceFixture.cs
@@ -52,11 +52,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
                 .Returns<int, int>((i, j) => _xemEpisodes.Where(d => d.SeasonNumber == j).ToList());
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.GetSceneNamesBySeasonNumbers(It.IsAny<int>(), It.IsAny<IEnumerable<int>>()))
-                  .Returns(new List<string>());
-
-            Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.GetSceneNamesBySceneSeasonNumbers(It.IsAny<int>(), It.IsAny<IEnumerable<int>>()))
+                  .Setup(s => s.GetSceneNames(It.IsAny<int>(), It.IsAny<List<int>>(), It.IsAny<List<int>>()))
                   .Returns(new List<string>());
         }
 
@@ -252,6 +248,19 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
             criteria.Count.Should().Be(0);
+        }
+
+        [Test]
+        public void getscenenames_should_use_seasonnumber_if_no_scene_seasonnumber_is_available()
+        {
+            WithEpisodes();
+
+            var allCriteria = WatchForSearchCriteria();
+
+            Subject.SeasonSearch(_xemSeries.Id, 7, false, true);
+
+            Mocker.GetMock<ISceneMappingService>()
+                  .Verify(v => v.GetSceneNames(_xemSeries.Id, It.Is<List<int>>(l => l.Contains(7)), It.Is<List<int>>(l => l.Contains(7))), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -233,12 +233,9 @@ namespace NzbDrone.Core.IndexerSearch
             var spec = new TSpec();
 
             spec.Series = series;
-            spec.SceneTitles = _sceneMapping.GetSceneNamesBySeasonNumbers(series.TvdbId, episodes.Select(e => e.SeasonNumber))
-                                            .Concat(_sceneMapping.GetSceneNamesBySceneSeasonNumbers(series.TvdbId, 
-                                                episodes.Where(v => v.SceneSeasonNumber.HasValue)
-                                                        .Select(e => e.SceneSeasonNumber.Value)))
-                                            .Distinct()
-                                            .ToList();
+            spec.SceneTitles = _sceneMapping.GetSceneNames(series.TvdbId,
+                                                           episodes.Select(e => e.SeasonNumber).Distinct().ToList(),
+                                                           episodes.Select(e => e.SceneSeasonNumber ?? e.SeasonNumber).Distinct().ToList());
 
             spec.Episodes = episodes;
 

--- a/src/UI/Series/Details/EpisodeNumberCell.js
+++ b/src/UI/Series/Details/EpisodeNumberCell.js
@@ -20,14 +20,7 @@ module.exports = NzbDroneCell.extend({
         var alternateTitles = [];
 
         if (reqres.hasHandler(reqres.Requests.GetAlternateNameBySeasonNumber)) {
-
-            if (this.model.get('sceneSeasonNumber') > 0) {
-                alternateTitles = reqres.request(reqres.Requests.GetAlternateNameBySceneSeasonNumber, this.model.get('seriesId'), this.model.get('sceneSeasonNumber'));
-            }
-
-            if (alternateTitles.length === 0) {
-                alternateTitles = reqres.request(reqres.Requests.GetAlternateNameBySeasonNumber, this.model.get('seriesId'), this.model.get('seasonNumber'));
-            }
+            alternateTitles = reqres.request(reqres.Requests.GetAlternateNameBySeasonNumber, this.model.get('seriesId'), this.model.get('seasonNumber'), this.model.get('sceneSeasonNumber'));
         }
 
         if (this.model.get('sceneSeasonNumber') > 0 || this.model.get('sceneEpisodeNumber') > 0 || this.model.has('sceneAbsoluteEpisodeNumber') || alternateTitles.length > 0) {

--- a/src/UI/Series/Details/SeriesDetailsLayout.js
+++ b/src/UI/Series/Details/SeriesDetailsLayout.js
@@ -174,20 +174,19 @@ module.exports = Marionette.Layout.extend({
             return self.episodeFileCollection.get(episodeFileId);
         });
 
-        reqres.setHandler(reqres.Requests.GetAlternateNameBySeasonNumber, function(seriesId, seasonNumber) {
+        reqres.setHandler(reqres.Requests.GetAlternateNameBySeasonNumber, function(seriesId, seasonNumber, sceneSeasonNumber) {
             if (self.model.get('id') !== seriesId) {
                 return [];
             }
-
-            return _.where(self.model.get('alternateTitles'), { seasonNumber : seasonNumber });
-        });
-
-        reqres.setHandler(reqres.Requests.GetAlternateNameBySceneSeasonNumber, function(seriesId, sceneSeasonNumber) {
-            if (self.model.get('id') !== seriesId) {
-                return [];
+            
+            if (sceneSeasonNumber === undefined) {
+                sceneSeasonNumber = seasonNumber;
             }
-
-            return _.where(self.model.get('alternateTitles'), { sceneSeasonNumber : sceneSeasonNumber });
+            
+            return _.where(self.model.get('alternateTitles'),
+                function(alt) {
+                    return alt.sceneSeasonNumber === sceneSeasonNumber || alt.seasonNumber === seasonNumber;
+                });
         });
 
         $.when(this.episodeCollection.fetch(), this.episodeFileCollection.fetch()).done(function() {

--- a/src/UI/reqres.js
+++ b/src/UI/reqres.js
@@ -4,8 +4,7 @@ var reqres = new Wreqr.RequestResponse();
 
 reqres.Requests = {
     GetEpisodeFileById                  : 'GetEpisodeFileById',
-    GetAlternateNameBySeasonNumber      : 'GetAlternateNameBySeasonNumber',
-    GetAlternateNameBySceneSeasonNumber : 'GetAlternateNameBySceneSeasonNumber'
+    GetAlternateNameBySeasonNumber      : 'GetAlternateNameBySeasonNumber'
 };
 
 module.exports = reqres;


### PR DESCRIPTION
Xem scene naming exceptions are stored in the db as seasonNumber: null sceneSeasonNumber: x.
But for episodes without mapping Sonarr doesn't have a SceneSeasonNumber specified for the episode, so wouldn't use the naming exception.

This commit basically uses episode.SeasonNumber as episode.SceneSeasonNumber if none was specified.

I included several tests to check the specific behavior, in the hopes of not breaking it in the future.

I also adjusted the UI to show the alt title on the episode scene popout.