### PR TITLE
Feature: Add the ability to receive Join notifications.

### DIFF
--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using FluentValidation.Results;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public class Join : NotificationBase<JoinSettings>
+    {
+        private readonly IJoinProxy _proxy;
+
+        public Join(IJoinProxy proxy)
+        {
+            _proxy = proxy;
+        }
+
+        public override string Link
+        {
+            get { return "https://joinjoaomgcd.appspot.com/"; }
+        }
+
+        public override void OnGrab(GrabMessage grabMessage)
+        {
+            const string title = "Episode Grabbed";
+
+            _proxy.SendNotification(title, grabMessage.Message, Settings);
+        }
+
+        public override void OnDownload(DownloadMessage message)
+        {
+            const string title = "Episode Downloaded";
+
+            _proxy.SendNotification(title, message.Message, Settings);
+        }
+
+        public override void OnRename(Series series)
+        {
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return "Join";
+            }
+        }
+
+        public override bool SupportsOnRename
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            failures.AddIfNotNull(_proxy.Test(Settings));
+
+            return new ValidationResult(failures);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinAuthException.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinAuthException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public class JoinAuthException : JoinException
+    {
+        public JoinAuthException(string message) : base(message)
+        {
+        }
+
+        public JoinAuthException(string message, Exception innerException, params object[] args) : base(message, innerException, args)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinException.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public class JoinException : NzbDroneException
+    {
+        public JoinException(string message) : base(message)
+        {
+        }
+
+        public JoinException(string message, Exception innerException, params object[] args) : base(message, innerException, args)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using FluentValidation.Results;
+using NLog;
+using RestSharp;
+using NzbDrone.Core.Rest;
+using NzbDrone.Common.Serializer;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public interface IJoinProxy
+    {
+        void SendNotification(string title, string message, JoinSettings settings);
+        ValidationFailure Test(JoinSettings settings);
+    }
+
+    public class JoinProxy : IJoinProxy
+    {
+        private readonly Logger _logger;
+        private const string URL = "https://joinjoaomgcd.appspot.com/_ah/api/messaging/v1/sendPush?";
+
+        public JoinProxy(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public void SendNotification(string title, string message, JoinSettings settings)
+        {
+            var request = new RestRequest(Method.GET);
+
+            try
+            {
+                SendNotification(title, message, request, settings);
+            }
+            catch (JoinException ex)
+            {
+                _logger.Error(ex, "Unable to send Join message.");
+                throw new JoinException("Unable to send Join notifications. " + ex.Message);
+            }
+        }
+
+        public ValidationFailure Test(JoinSettings settings)
+        {
+
+            const string title = "Test Notification";
+            const string body = "This is a test message from Sonarr.";
+            try
+            {
+                SendNotification(title, body, settings);
+                return null;
+            }
+            catch (JoinException ex)
+            {
+                _logger.Error(ex, "Unable to send test Join message.");
+                return new ValidationFailure("APIKey", ex.Message);
+            }
+        }
+
+        private void SendNotification(string title, string message, RestRequest request, JoinSettings settings)
+        {
+            try
+            {
+                var client = RestClientFactory.BuildClient(URL);
+
+                request.AddParameter("deviceId", "group.all");
+                request.AddParameter("apikey", settings.APIKey);
+                request.AddParameter("title", "[Sonarr] " + title);
+                request.AddParameter("text", message);
+                request.AddParameter("icon", "https://cdn.rawgit.com/Sonarr/Sonarr/develop/Logo/256.png"); // Use the Sonarr logo.
+
+                var response = client.ExecuteAndValidate(request);
+                var res = Json.Deserialize<JoinResponseModel>(response.Content);
+
+                if (res.success) return;
+
+                if (res.errorMessage != null)
+                {
+                    throw new JoinException(res.errorMessage);
+                }
+                if (res.userAuthError)
+                {
+                    throw new JoinException("Authentication failed.");
+                }
+                throw new JoinException("Unknown error.  Join message failed to send.");      
+            }
+            catch(Exception e)
+            {
+                throw new JoinException(e.Message, e);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
@@ -42,9 +42,9 @@ namespace NzbDrone.Core.Notifications.Join
 
         public ValidationFailure Test(JoinSettings settings)
         {
-
             const string title = "Test Notification";
             const string body = "This is a test message from Sonarr.";
+
             try
             {
                 SendNotification(title, body, settings);
@@ -78,11 +78,13 @@ namespace NzbDrone.Core.Notifications.Join
                 {
                     throw new JoinException(res.errorMessage);
                 }
+
                 if (res.userAuthError)
                 {
-                    throw new JoinException("Authentication failed.");
+                    throw new JoinAuthException("Authentication failed.");
                 }
-                throw new JoinException("Unknown error.  Join message failed to send.");      
+
+                throw new JoinException("Unknown error. Join message failed to send.");      
             }
             catch(Exception e)
             {

--- a/src/NzbDrone.Core/Notifications/Join/JoinResponseModel.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinResponseModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public class JoinResponseModel
+    {
+        public bool success { get; set; }
+        public bool userAuthError { get; set; }
+        public string errorMessage { get; set; }
+        public string kind { get; set; }
+        public string etag { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.Join
     {
         private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();
 
-        [FieldDefinition(0, Label = "API Key", HelpText = "The API Key from your Join account settings (click Join API button): https://joinjoaomgcd.appspot.com/", HelpLink = "https://joinjoaomgcd.appspot.com/")]
+        [FieldDefinition(0, Label = "API Key", HelpText = "The API Key from your Join account settings (click Join API button).", HelpLink = "https://joinjoaomgcd.appspot.com/")]
         public string APIKey { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications.Join
+{
+    public class JoinSettingsValidator : AbstractValidator<JoinSettings>
+    {
+        public JoinSettingsValidator()
+        {
+            RuleFor(c => c.APIKey).NotEmpty();
+        }
+    }
+
+    public class JoinSettings : IProviderConfig
+    {
+        private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();
+
+        [FieldDefinition(0, Label = "API Key", HelpText = "The API Key from your Join account settings (click Join API button): https://joinjoaomgcd.appspot.com/", HelpLink = "https://joinjoaomgcd.appspot.com/")]
+        public string APIKey { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -779,6 +779,11 @@
     <Compile Include="Metadata\MetadataType.cs" />
     <Compile Include="MetadataSource\IProvideSeriesInfo.cs" />
     <Compile Include="MetadataSource\ISearchForNewSeries.cs" />
+    <Compile Include="Notifications\Join\JoinResponseModel.cs" />
+    <Compile Include="Notifications\Join\Join.cs" />
+    <Compile Include="Notifications\Join\JoinException.cs" />
+    <Compile Include="Notifications\Join\JoinProxy.cs" />
+    <Compile Include="Notifications\Join\JoinSettings.cs" />
     <Compile Include="Notifications\Boxcar\Boxcar.cs" />
     <Compile Include="Notifications\Boxcar\BoxcarException.cs" />
     <Compile Include="Notifications\Boxcar\BoxcarProxy.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -779,6 +779,7 @@
     <Compile Include="Metadata\MetadataType.cs" />
     <Compile Include="MetadataSource\IProvideSeriesInfo.cs" />
     <Compile Include="MetadataSource\ISearchForNewSeries.cs" />
+    <Compile Include="Notifications\Join\JoinAuthException.cs" />
     <Compile Include="Notifications\Join\JoinResponseModel.cs" />
     <Compile Include="Notifications\Join\Join.cs" />
     <Compile Include="Notifications\Join\JoinException.cs" />


### PR DESCRIPTION
#### Description
Allows a user to use the Join API to send a notification of actions taken by Sonarr to all of their devices.

Right now this only supports sending to every device on their account.  However, it could be expanded to allow sending only to specific devices by someone with a bit more time.

#### Issues Fixed or Closed by this PR

Fixes #1197 

