### PR TITLE
Adding other TV categories by default

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public NewznabSettings()
         {
-            Categories = new[] { 5030, 5040 };
+            Categories = new[] { 5010, 5030, 5040, 5045 };
             AnimeCategories = Enumerable.Empty<int>();
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Lot of users don't know about other categories because it's only shown in the advanced settings. Also adding them by default can't hurt IMHO. Specially the WEB-DL category.

nZEDb Categories:
- WEB-DL: 5010
- UDH: 5045
- TV Docu: 5080 (Did not include TV Docu yet. Please comment if this is wanted.)

#### Todos
- None

#### Issues Fixed or Closed by this PR
None