### PR TITLE
Default settings for text-editors, who support `editorconfig.org`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,13 +2,21 @@
 # editorconfig.org
 root = true
 
-[*]
-end_of_line = lf
+[*{.cs,.html,.js,.hbs}]
+end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+
+[*.less]
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
 
 # They have troubles with TABS. Use 2 spaces
 [{package.json,.travis.yml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@
 root = true
 
 [*{.cs,.html,.js,.hbs}]
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
@@ -11,7 +11,7 @@ indent_style = space
 indent_size = 4
 
 [*.less]
-end_of_line = crlf
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
@@ -20,5 +20,9 @@ indent_size = 2
 
 # They have troubles with TABS. Use 2 spaces
 [{package.json,.travis.yml}]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 indent_style = space
 indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# They have troubles with TABS. Use 2 spaces
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Default settings for text-editors, who support `editorconfig.org`

**Base styleguide**
* UTF-8
* `lf` - line endings (linux)
* 4 spaces for indentation
 
#### Todos
- [x] Tests (_not required_)
- [x] Documentation (Already documented in wiki)

#### Issues Fixed or Closed by this PR

* Nope