### PR TITLE
Cloudflare captcha

### DIFF
--- a/src/NzbDrone.Api/Extensions/Pipelines/RequestLoggingPipeline.cs
+++ b/src/NzbDrone.Api/Extensions/Pipelines/RequestLoggingPipeline.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Api.Extensions.Pipelines
         {
             if (request.Url.Query.IsNotNullOrWhiteSpace())
             {
-                return string.Concat(request.Url.Path, request.Url.Query);
+                return string.Concat(request.Url.Path, "?", request.Url.Query);
             }
             else
             {

--- a/src/NzbDrone.Api/ProviderModuleBase.cs
+++ b/src/NzbDrone.Api/ProviderModuleBase.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Api
 
             Get["schema"] = x => GetTemplates();
             Post["test"] = x => Test(ReadResourceFromRequest(true));
-            Post["connectData/{stage}"] = x => ConnectData(x.stage, ReadResourceFromRequest(true));
+            Post["action/{action}"] = x => RequestAction(x.action, ReadResourceFromRequest(true));
 
             GetResourceAll = GetAll;
             GetResourceById = GetProviderById;
@@ -183,13 +183,13 @@ namespace NzbDrone.Api
         }
 
 
-        private Response ConnectData(string stage, TProviderResource providerResource)
+        private Response RequestAction(string action, TProviderResource providerResource)
         {
             var providerDefinition = GetDefinition(providerResource, true, false);
 
-            if (!providerDefinition.Enable) return "{}";
+            var query = ((IDictionary<string, object>)Request.Query.ToDictionary()).ToDictionary(k => k.Key, k => k.Value.ToString());
 
-            object data = _providerFactory.ConnectData(providerDefinition, stage, (IDictionary<string, object>) Request.Query.ToDictionary());
+            var data = _providerFactory.RequestAction(providerDefinition, action, query);
             Response resp = JsonConvert.SerializeObject(data);
             resp.ContentType = "application/json";
             return resp;

--- a/src/NzbDrone.Common/Http/Dispatchers/CurlHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/CurlHttpDispatcher.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                         default:
                             throw new NotSupportedException(string.Format("HttpCurl method {0} not supported", request.Method));
                     }
-                    curlEasy.UserAgent = UserAgentBuilder.UserAgent;
+                    curlEasy.UserAgent = request.UseSimplifiedUserAgent ? UserAgentBuilder.UserAgentSimplified : UserAgentBuilder.UserAgent; ;
                     curlEasy.FollowLocation = request.AllowAutoRedirect;
 
                     if (request.RequestTimeout != TimeSpan.Zero)

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Common.Http.Dispatchers
             webRequest.AutomaticDecompression = DecompressionMethods.GZip;
 
             webRequest.Method = request.Method.ToString();
-            webRequest.UserAgent = UserAgentBuilder.UserAgent;
+            webRequest.UserAgent = request.UseSimplifiedUserAgent ? UserAgentBuilder.UserAgentSimplified : UserAgentBuilder.UserAgent;
             webRequest.KeepAlive = request.ConnectionKeepAlive;
             webRequest.AllowAutoRedirect = request.AllowAutoRedirect;
             webRequest.CookieContainer = cookies;

--- a/src/NzbDrone.Common/Http/HttpRequest.cs
+++ b/src/NzbDrone.Common/Http/HttpRequest.cs
@@ -34,6 +34,7 @@ namespace NzbDrone.Common.Http
         public byte[] ContentData { get; set; }
         public string ContentSummary { get; set; }
         public bool SuppressHttpError { get; set; }
+        public bool UseSimplifiedUserAgent { get; set; }
         public bool AllowAutoRedirect { get; set; }
         public bool ConnectionKeepAlive { get; set; }
         public bool LogResponseContent { get; set; }

--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Common.Http
         public Dictionary<string, string> Segments { get; private set; }
         public HttpHeader Headers { get; private set; }
         public bool SuppressHttpError { get; set; }
+        public bool UseSimplifiedUserAgent { get; set; }
         public bool AllowAutoRedirect { get; set; }
         public bool ConnectionKeepAlive { get; set; }
         public bool LogResponseContent { get; set; }
@@ -99,6 +100,7 @@ namespace NzbDrone.Common.Http
         {
             request.Method = Method;
             request.SuppressHttpError = SuppressHttpError;
+            request.UseSimplifiedUserAgent = UseSimplifiedUserAgent;
             request.AllowAutoRedirect = AllowAutoRedirect;
             request.ConnectionKeepAlive = ConnectionKeepAlive;
             request.LogResponseContent = LogResponseContent;

--- a/src/NzbDrone.Common/Http/UserAgentBuilder.cs
+++ b/src/NzbDrone.Common/Http/UserAgentBuilder.cs
@@ -6,12 +6,16 @@ namespace NzbDrone.Common.Http
     public static class UserAgentBuilder
     {
         public static string UserAgent { get; private set; }
+        public static string UserAgentSimplified { get; private set; }
 
         static UserAgentBuilder()
         {
-            UserAgent = string.Format("Sonarr/{0} ({1} {2}) ",
+            UserAgent = string.Format("Sonarr/{0} ({1} {2})",
                 BuildInfo.Version,
                 OsInfo.Os, OsInfo.Version.ToString(2));
+
+            UserAgentSimplified = string.Format("Sonarr/{0}",
+                BuildInfo.Version.ToString(2));
         }
     }
 }

--- a/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
+++ b/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
@@ -30,6 +30,7 @@ namespace NzbDrone.Core.Annotations
         Hidden,
         Tag,
         Action,
-        Url
+        Url,
+        Captcha
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Download
 
         public ProviderDefinition Definition { get; set; }
 
-        public object ConnectData(string stage, IDictionary<string, object> query) { return null; }
+        public virtual object RequestAction(string action, IDictionary<string, string> query) { return null; }
 
         protected TSettings Settings
         {

--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareCaptchaException.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareCaptchaException.cs
@@ -1,0 +1,19 @@
+using NzbDrone.Common.Exceptions;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Http.CloudFlare
+{
+    public class CloudFlareCaptchaException : NzbDroneException
+    {
+        public HttpResponse Response { get; set; }
+
+        public CloudFlareCaptchaRequest CaptchaRequest { get; set; }
+
+        public CloudFlareCaptchaException(HttpResponse response, CloudFlareCaptchaRequest captchaRequest)
+            : base("Unable to access {0}, blocked by CloudFlare CAPTCHA. Likely due to shared-IP VPN.", response.Request.Url.Host)
+        {
+            Response = response;
+            CaptchaRequest = captchaRequest;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareCaptchaRequest.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareCaptchaRequest.cs
@@ -1,0 +1,15 @@
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Http.CloudFlare
+{
+    public class CloudFlareCaptchaRequest
+    {
+        public string Host { get; set; }
+        public string SiteKey { get; set; }
+
+        public string Ray { get; set; }
+        public string SecretToken { get; set; }
+
+        public HttpUri ResponseUrl { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
@@ -1,0 +1,56 @@
+﻿using System.Net;
+using System.Text.RegularExpressions;
+using NLog;
+using NzbDrone.Common.Exceptions;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.Http.CloudFlare
+{
+    public class CloudFlareHttpInterceptor : IHttpRequestInterceptor
+    {
+        private readonly Logger _logger;
+
+        private const string _cloudFlareChallengeScript = "cdn-cgi/scripts/cf.challenge.js";
+        private static readonly Regex _cloudFlareRegex = new Regex(@"data-ray=""(?<Ray>[\w-_]+)"".*?data-sitekey=""(?<SiteKey>[\w-_]+)"".*?data-stoken=""(?<SecretToken>[\w-_]+)""", RegexOptions.Compiled);
+
+        public CloudFlareHttpInterceptor(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public HttpRequest PreRequest(HttpRequest request)
+        {
+            return request;
+        }
+
+        public HttpResponse PostResponse(HttpResponse response)
+        {
+            if (response.StatusCode == HttpStatusCode.Forbidden && response.Content.Contains(_cloudFlareChallengeScript))
+            {
+                _logger.Error("CloudFlare CAPTCHA block on {0}", response.Request.Url);
+                throw new CloudFlareCaptchaException(response, CreateCaptchaRequest(response));
+            }
+
+            return response;
+        }
+
+        private CloudFlareCaptchaRequest CreateCaptchaRequest(HttpResponse response)
+        {
+            var match = _cloudFlareRegex.Match(response.Content);
+
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            return new CloudFlareCaptchaRequest
+            {
+                Host = response.Request.Url.Host,
+                SiteKey = match.Groups["SiteKey"].Value,
+                Ray = match.Groups["Ray"].Value,
+                SecretToken = match.Groups["SecretToken"].Value,
+                ResponseUrl = response.Request.Url + new HttpUri("/cdn-cgi/l/chk_captcha")
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.TPL;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Http.CloudFlare;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser;
@@ -21,7 +22,7 @@ namespace NzbDrone.Core.Indexers
     {
         protected const int MaxNumResultsPerQuery = 1000;
 
-        private readonly IHttpClient _httpClient;
+        protected readonly IHttpClient _httpClient;
 
         public override bool SupportsRss { get { return true; } }
         public override bool SupportsSearch { get { return true; } }
@@ -312,6 +313,10 @@ namespace NzbDrone.Core.Indexers
             catch (RequestLimitReachedException)
             {
                 _logger.Warn("Request limit reached");
+            }
+            catch (CloudFlareCaptchaException)
+            {
+                return new ValidationFailure("CaptchaToken", "Site protected by CloudFlare CAPTCHA. Valid CAPTCHA token required.");
             }
             catch (UnsupportedFeedException ex)
             {

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -65,7 +65,8 @@ namespace NzbDrone.Core.Indexers
         }
 
         public virtual ProviderDefinition Definition { get; set; }
-        public object ConnectData(string stage, IDictionary<string, object> query) { return null; }
+
+        public virtual object RequestAction(string action, IDictionary<string, string> query) { return null; }
 
         protected TSettings Settings
         {

--- a/src/NzbDrone.Core/Indexers/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/Rarbg.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Http.CloudFlare;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Rarbg
 {
@@ -29,6 +34,79 @@ namespace NzbDrone.Core.Indexers.Rarbg
         public override IParseIndexerResponse GetParser()
         {
             return new RarbgParser();
+        }
+
+        public override object RequestAction(string action, IDictionary<string, string> query)
+        {
+            if (action == "checkCaptcha")
+            {
+                Settings.Validate().Filter("BaseUrl").ThrowOnError();
+
+                try
+                {
+                    var request = new HttpRequestBuilder(Settings.BaseUrl.Trim('/'))
+                           .Resource("/pubapi_v2.php?get_token=get_token")
+                           .Accept(HttpAccept.Json)
+                           .Build();
+
+                    _httpClient.Get(request);
+                }
+                catch (CloudFlareCaptchaException ex)
+                {
+                    return new
+                    {
+                        captchaRequest = new
+                        {
+                            host = ex.CaptchaRequest.Host,
+                            ray = ex.CaptchaRequest.Ray,
+                            siteKey = ex.CaptchaRequest.SiteKey,
+                            secretToken = ex.CaptchaRequest.SecretToken,
+                            responseUrl = ex.CaptchaRequest.ResponseUrl.FullUri,
+                        }                    
+                    };
+                }
+
+                return new
+                {
+                    captchaToken = ""
+                };
+            }
+            else if (action == "getCaptchaCookie")
+            {
+                if (query["responseUrl"].IsNullOrWhiteSpace())
+                {
+                    throw new BadRequestException("QueryParam responseUrl invalid.");
+                }
+
+                if (query["ray"].IsNullOrWhiteSpace())
+                {
+                    throw new BadRequestException("QueryParam ray invalid.");
+                }
+
+                if (query["captchaResponse"].IsNullOrWhiteSpace())
+                {
+                    throw new BadRequestException("QueryParam captchaResponse invalid.");
+                }
+
+                var request = new HttpRequestBuilder(query["responseUrl"])
+                    .AddQueryParam("id", query["ray"])
+                    .AddQueryParam("g-recaptcha-response", query["captchaResponse"])
+                    .Build();
+
+                request.UseSimplifiedUserAgent = true;
+                request.AllowAutoRedirect = false;
+
+                var response = _httpClient.Get(request);
+
+                var cfClearanceCookie = response.GetCookies()["cf_clearance"];
+
+                return new
+                {
+                    captchaToken = cfClearanceCookie
+                };
+            }
+
+            return new { };
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -79,6 +79,12 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 .Resource("/pubapi_v2.php")
                 .Accept(HttpAccept.Json);
 
+            if (Settings.CaptchaToken.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.UseSimplifiedUserAgent = true;
+                requestBuilder.SetCookie("cf_clearance", Settings.CaptchaToken);
+            }
+
             requestBuilder.AddQueryParam("mode", mode);
 
             if (tvdbId.HasValue)

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgSettings.cs
@@ -29,6 +29,9 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
         [FieldDefinition(1, Type = FieldType.Checkbox, Label = "Ranked Only", HelpText = "Only include ranked results.")]
         public bool RankedOnly { get; set; }
+        
+        [FieldDefinition(2, Type = FieldType.Captcha, Label = "CAPTCHA Token", HelpText = "CAPTCHA Clearance token used to handle CloudFlare Anti-DDOS measures on shared-ip VPNs.")]
+        public string CaptchaToken { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Metadata/MetadataBase.cs
+++ b/src/NzbDrone.Core/Metadata/MetadataBase.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Metadata
         public abstract List<ImageFileResult> SeasonImages(Series series, Season season);
         public abstract List<ImageFileResult> EpisodeImages(Series series, EpisodeFile episodeFile);
 
-        public object ConnectData(string stage, IDictionary<string, object> query) { return null; }
+        public virtual object RequestAction(string action, IDictionary<string, string> query) { return null; }
 
         protected TSettings Settings
         {

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Notifications
             return GetType().Name;
         }
 
-        public virtual object ConnectData(string stage, IDictionary<string, object> query) { return null; }
+        public virtual object RequestAction(string action, IDictionary<string, string> query) { return null; }
 
     }
 }

--- a/src/NzbDrone.Core/Notifications/Twitter/OAuthToken.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/OAuthToken.cs
@@ -1,0 +1,9 @@
+
+namespace NzbDrone.Core.Notifications.Twitter
+{
+    public class OAuthToken
+    {
+        public string AccessToken { get; set; }
+        public string AccessTokenSecret { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Notifications.Twitter
         void SendNotification(string message, TwitterSettings settings);
         ValidationFailure Test(TwitterSettings settings);
         string GetOAuthRedirect(string consumerKey, string consumerSecret, string callbackUrl);
-        object GetOAuthToken(string consumerKey, string consumerSecret, string oauthToken, string oauthVerifier);
+        OAuthToken GetOAuthToken(string consumerKey, string consumerSecret, string oauthToken, string oauthVerifier);
     }
 
     public class TwitterService : ITwitterService
@@ -43,14 +43,14 @@ namespace NzbDrone.Core.Notifications.Twitter
             return HttpUtility.ParseQueryString(response.Content);
         }
 
-        public object GetOAuthToken(string consumerKey, string consumerSecret, string oauthToken, string oauthVerifier)
+        public OAuthToken GetOAuthToken(string consumerKey, string consumerSecret, string oauthToken, string oauthVerifier)
         {
             // Creating a new instance with a helper method
             var oAuthRequest = OAuthRequest.ForAccessToken(consumerKey, consumerSecret, oauthToken, "", oauthVerifier);
             oAuthRequest.RequestUrl = "https://api.twitter.com/oauth/access_token";
             var qscoll = OAuthQuery(oAuthRequest);
             
-            return new
+            return new OAuthToken
             {
                 AccessToken = qscoll["oauth_token"],
                 AccessTokenSecret = qscoll["oauth_token_secret"]

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -19,6 +20,10 @@ namespace NzbDrone.Core.Notifications.Twitter
             RuleFor(c => c.DirectMessage).Equal(true)
                                          .WithMessage("Using Direct Messaging is recommended, or use a private account.")
                                          .AsWarning();
+
+            RuleFor(c => c.AuthorizeNotification).Empty()
+                                                 .When(c => c.AccessToken.IsNullOrWhiteSpace() || c.AccessTokenSecret.IsNullOrWhiteSpace())
+                                                 .WithMessage("Authenticate app.");
         }
     }
 

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -527,6 +527,9 @@
     <Compile Include="Housekeeping\HousekeepingCommand.cs" />
     <Compile Include="Housekeeping\HousekeepingService.cs" />
     <Compile Include="Housekeeping\IHousekeepingTask.cs" />
+    <Compile Include="Http\CloudFlare\CloudFlareCaptchaException.cs" />
+    <Compile Include="Http\CloudFlare\CloudFlareCaptchaRequest.cs" />
+    <Compile Include="Http\CloudFlare\CloudFlareHttpInterceptor.cs" />
     <Compile Include="Http\HttpProxySettingsProvider.cs" />
     <Compile Include="Http\TorcacheHttpInterceptor.cs" />
     <Compile Include="Indexers\BitMeTv\BitMeTv.cs" />
@@ -810,6 +813,7 @@
     <Compile Include="Notifications\Synology\SynologyIndexer.cs" />
     <Compile Include="Notifications\Synology\SynologyIndexerProxy.cs" />
     <Compile Include="Notifications\Synology\SynologyIndexerSettings.cs" />
+    <Compile Include="Notifications\Twitter\OAuthToken.cs" />
     <Compile Include="Notifications\Twitter\TwitterException.cs" />
     <Compile Include="Notifications\Webhook\WebhookEpisode.cs" />
     <Compile Include="Notifications\Webhook\WebhookException.cs" />
@@ -1054,6 +1058,7 @@
     <Compile Include="Validation\FolderValidator.cs" />
     <Compile Include="Validation\IpValidation.cs" />
     <Compile Include="Validation\LanguageValidator.cs" />
+    <Compile Include="Validation\NzbDroneValidationExtensions.cs" />
     <Compile Include="Validation\NzbDroneValidationFailure.cs" />
     <Compile Include="Validation\NzbDroneValidationResult.cs" />
     <Compile Include="Validation\NzbDroneValidationState.cs" />

--- a/src/NzbDrone.Core/ThingiProvider/IProvider.cs
+++ b/src/NzbDrone.Core/ThingiProvider/IProvider.cs
@@ -12,6 +12,6 @@ namespace NzbDrone.Core.ThingiProvider
         IEnumerable<ProviderDefinition> DefaultDefinitions { get; }
         ProviderDefinition Definition { get; set; }
         ValidationResult Test();
-        object ConnectData(string stage, IDictionary<string, object> query);
+        object RequestAction(string stage, IDictionary<string, string> query);
     }
 }

--- a/src/NzbDrone.Core/ThingiProvider/IProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/IProviderFactory.cs
@@ -20,6 +20,6 @@ namespace NzbDrone.Core.ThingiProvider
         void SetProviderCharacteristics(TProvider provider, TProviderDefinition definition);
         TProvider GetInstance(TProviderDefinition definition);
         ValidationResult Test(TProviderDefinition definition);
-        object ConnectData(TProviderDefinition definition, string stage, IDictionary<string, object> query );
+        object RequestAction(TProviderDefinition definition, string action, IDictionary<string, string> query);
     }
 }

--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -81,9 +81,9 @@ namespace NzbDrone.Core.ThingiProvider
             return GetInstance(definition).Test();
         }
 
-        public object ConnectData(TProviderDefinition definition, string stage, IDictionary<string, object> query)
+        public object RequestAction(TProviderDefinition definition, string action, IDictionary<string, string> query)
         {
-            return GetInstance(definition).ConnectData(stage, query);
+            return GetInstance(definition).RequestAction(action, query);
         }
 
         public List<TProvider> GetAvailableProviders()

--- a/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
+++ b/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using FluentValidation;
+
+namespace NzbDrone.Core.Validation
+{
+    public static class NzbDroneValidationExtensions
+    {
+        public static NzbDroneValidationResult Filter(this NzbDroneValidationResult result, params string[] fields)
+        {
+            var failures = result.Failures.Where(v => fields.Contains(v.PropertyName)).ToArray();
+
+            return new NzbDroneValidationResult(failures);
+        }
+
+        public static void ThrowOnError(this NzbDroneValidationResult result)
+        {
+            if (!result.IsValid)
+            {
+                throw new ValidationException(result.Errors);
+            }
+        }
+    }
+}

--- a/src/UI/Form/ActionTemplate.hbs
+++ b/src/UI/Form/ActionTemplate.hbs
@@ -2,6 +2,6 @@
     <label class="col-sm-3 control-label"></label>
 
     <div class="col-sm-5">
-        <button class="form-control {{name}}" data-value="{{value}}">{{label}}</button>
+        <button class="form-control {{name}}" validation-name="{{name}}" data-value="{{value}}">{{label}}</button>
     </div>
 </div>

--- a/src/UI/Form/CaptchaTemplate.hbs
+++ b/src/UI/Form/CaptchaTemplate.hbs
@@ -1,0 +1,14 @@
+<div class="form-group {{#if advanced}}advanced-setting{{/if}}">
+    <label class="col-sm-3 control-label">{{label}}</label>
+
+    <div class="col-sm-5">
+        <div class="input-group">
+            <input type="text" name="fields.{{order}}.value" validation-name="{{name}}" spellcheck="false" class="form-control x-captcha" readonly />
+            <span class="input-group-btn"><button class="btn btn-primary x-captcha-refresh" title="Refresh CAPTCHA Token"><i class="icon-sonarr-refresh" /></button></span>
+        </div>
+    </div>
+
+    <span class="col-sm-1 help-inline">
+        <i class="icon-sonarr-form-warning" title="Expires periodically and will need to be refreshed. Refreshing the CAPTCHA Token will embed a temporary Google reCaptcha widget on this page."/>
+    </span>
+</div>

--- a/src/UI/Form/FormBuilder.js
+++ b/src/UI/Form/FormBuilder.js
@@ -49,6 +49,10 @@ var _fieldBuilder = function(field) {
         return _templateRenderer.call(field, 'Form/ActionTemplate');
     }
 
+    if (field.type === 'captcha') {
+        return _templateRenderer.call(field, 'Form/CaptchaTemplate');
+    }
+
     return _templateRenderer.call(field, 'Form/TextboxTemplate');
 };
 

--- a/src/UI/Settings/Indexers/Edit/IndexerEditView.js
+++ b/src/UI/Settings/Indexers/Edit/IndexerEditView.js
@@ -1,3 +1,5 @@
+var _ = require('underscore');
+var $ = require('jquery');
 var vent = require('vent');
 var Marionette = require('marionette');
 var DeleteView = require('../Delete/IndexerDeleteView');
@@ -12,7 +14,8 @@ var view = Marionette.ItemView.extend({
     template : 'Settings/Indexers/Edit/IndexerEditViewTemplate',
 
     events : {
-        'click .x-back' : '_back'
+        'click .x-back'            : '_back',
+        'click .x-captcha-refresh' : '_onRefreshCaptcha'
     },
 
     _deleteView : DeleteView,
@@ -38,6 +41,77 @@ var view = Marionette.ItemView.extend({
         }
 
         require('../Add/IndexerSchemaModal').open(this.targetCollection);
+    },
+
+    _onRefreshCaptcha : function(event) {
+        var self = this;
+
+        var target = $(event.target).parents('.input-group');
+
+        this.ui.indicator.show();
+
+        this.model.requestAction("checkCaptcha")
+            .then(function(result) {
+                if (!result.captchaRequest) {
+                    self.model.setFieldValue('CaptchaToken', '');
+
+                    return result;
+                }
+
+                return self._showCaptcha(target, result.captchaRequest);
+            })
+            .always(function() {
+                self.ui.indicator.hide();
+            });
+    },
+
+    _showCaptcha : function(target, captchaRequest) {
+        var self = this;
+
+        var widget = $('<div class="g-recaptcha"></div>').insertAfter(target);
+
+        return this._loadRecaptchaWidget(widget[0], captchaRequest.siteKey, captchaRequest.secretToken)
+            .then(function(captchaResponse) {
+                target.parents('.form-group').removeAllErrors();
+                widget.remove();
+
+                var queryParams = {
+                    responseUrl    : captchaRequest.responseUrl,
+                    ray            : captchaRequest.ray,
+                    captchaResponse: captchaResponse
+                };
+
+                return self.model.requestAction("getCaptchaCookie", queryParams);
+            })
+            .then(function(response) {
+                self.model.setFieldValue('CaptchaToken', response.captchaToken);
+            });
+    },
+
+    _loadRecaptchaWidget : function(widget, sitekey, stoken) {
+        var promise = $.Deferred();
+
+        var renderWidget = function() {
+            window.grecaptcha.render(widget, {
+              'sitekey'  : sitekey,
+              'stoken'   : stoken,
+              'callback' : promise.resolve
+            });
+        };
+
+        if (window.grecaptcha) {
+            renderWidget();
+        } else {
+            window.grecaptchaLoadCallback = function() {
+                delete window.grecaptchaLoadCallback;
+                renderWidget();
+            };
+
+            $.getScript('https://www.google.com/recaptcha/api.js?onload=grecaptchaLoadCallback&render=explicit')
+             .fail(function() { promise.reject(); });
+        }
+
+        return promise;
     }
 });
 

--- a/src/UI/jQuery/jquery.validation.js
+++ b/src/UI/jQuery/jquery.validation.js
@@ -75,6 +75,8 @@ module.exports = function() {
     };
 
     $.fn.removeAllErrors = function() {
+        this.removeClass('has-error');
+        this.removeClass('has-warning');
         this.find('.has-error').removeClass('has-error');
         this.find('.has-warning').removeClass('has-warning');
         this.find('.error').removeClass('error');


### PR DESCRIPTION
#### Description
The result of a weeks worth of evenings. (you're welcome ppl)
Basically we extract the cloudflare captcha challenge code from the html page, and present only a reCaptcha widget.
The CAPTCHA token does expire and will need to be manually renewed. (atm rarbg has 7 days, but that will be changed to 30 days later)

#### Todos
- [ ] Add warning about it expiring (optionally we could add a date to the UI?)
- [ ] Retest Twitter (likely broken)

#### Issues

Closes: #1410 
Ref: rarbg/torrentapi#11

#### Preview:

Add Rarbg & run Test:
![image](https://cloud.githubusercontent.com/assets/6383890/17571435/762634d8-5f50-11e6-8a9f-c5f780eb6fec.png)

Sonarr notices Captcha Response, click Refresh Token to do the CAPTCHA challenge:
![image](https://cloud.githubusercontent.com/assets/6383890/17571457/89786e16-5f50-11e6-8937-5e41ef842467.png)

UI loads google reCaptcha scripts and widget:
![image](https://cloud.githubusercontent.com/assets/6383890/17571467/91a05ebe-5f50-11e6-9316-ebdc14cce0fe.png)

Sonarr gets CloudFlare clearance cookie using reCaptcha response as proof:
![image](https://cloud.githubusercontent.com/assets/6383890/17571476/9688a800-5f50-11e6-8a9c-5103fda8c8f7.png)
