### PR TITLE
New: Support for TLS 1.1 and 1.2 connections when .net 4.5 is installed

### DIFF
--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Properties\SharedAssemblyInfo.cs" />
     <Compile Include="Reflection\ReflectionExtensions.cs" />
     <Compile Include="Extensions\ResourceExtensions.cs" />
+    <Compile Include="Security\SecurityProtocolPolicy.cs" />
     <Compile Include="Security\X509CertificateValidationPolicy.cs" />
     <Compile Include="Serializer\HttpUriConverter.cs" />
     <Compile Include="Serializer\IntConverter.cs" />

--- a/src/NzbDrone.Common/Security/SecurityProtocolPolicy.cs
+++ b/src/NzbDrone.Common/Security/SecurityProtocolPolicy.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Net;
+using NLog;
+using NzbDrone.Common.Instrumentation;
+
+namespace NzbDrone.Common.Security
+{
+    public static class SecurityProtocolPolicy
+    {
+        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(SecurityProtocolPolicy));
+
+        private const SecurityProtocolType Tls11 = (SecurityProtocolType)768;
+        private const SecurityProtocolType Tls12 = (SecurityProtocolType)3072;
+
+        public static void Register()
+        {
+            try
+            {
+                // TODO: In v3 we should drop support for SSL3 because its very insecure. Only leaving it enabled because some people might rely on it.
+                var protocol = SecurityProtocolType.Ssl3 | SecurityProtocolType.Tls;
+
+                if (Enum.IsDefined(typeof(SecurityProtocolType), Tls11))
+                {
+                    ServicePointManager.SecurityProtocol |= Tls11;
+                }
+
+                if (Enum.IsDefined(typeof(SecurityProtocolType), Tls12))
+                {
+                    ServicePointManager.SecurityProtocol |= Tls12;
+                }
+
+                ServicePointManager.SecurityProtocol = protocol;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Failed to set TLS security protocol.");
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                 yield return GetDefinition("DrunkenSlug", GetSettings("https://api.drunkenslug.com"));
                 yield return GetDefinition("Nzb.su", GetSettings("https://api.nzb.su"));
                 yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
-                yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws"));
+                yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", 5010, 5030, 5040, 5045));
                 yield return GetDefinition("NZBgeek", GetSettings("https://api.nzbgeek.info"));
                 yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));
                 yield return GetDefinition("Nzbs.org", GetSettings("http://nzbs.org", 5000));

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Host
             try
             {
                 X509CertificateValidationPolicy.Register();
+                SecurityProtocolPolicy.Register();
 
                 Logger.Info("Starting Sonarr - {0} - Version {1}", Assembly.GetCallingAssembly().Location, Assembly.GetExecutingAssembly().GetName().Version);
 

--- a/src/NzbDrone.Host/Owin/OwinHostController.cs
+++ b/src/NzbDrone.Host/Owin/OwinHostController.cs
@@ -34,8 +34,6 @@ namespace NzbDrone.Host.Owin
 
         public void StartServer()
         {
-            X509CertificateValidationPolicy.Register();
-
             if (OsInfo.IsWindows)
             {
                 if (_runtimeInfo.IsAdmin)

--- a/src/NzbDrone.Update/UpdateApp.cs
+++ b/src/NzbDrone.Update/UpdateApp.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Update
                 Logger.Info("Starting Sonarr Update Client");
 
                 X509CertificateValidationPolicy.Register();
+                SecurityProtocolPolicy.Register();
 
                 _container = UpdateContainerBuilder.Build(startupArgument);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Support for TLS 1.1 and TLS 1.2 when making HTTP requests. SSL3 and TLS are also still supported, SSL3 should be dropped for security reasons, but left a note to do that in v3.
