### PR TITLE
Changed exit statement to "Press enter to exit..." to match use of ReadLine()

### DIFF
--- a/src/NzbDrone.Console/ConsoleApp.cs
+++ b/src/NzbDrone.Console/ConsoleApp.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Console
                 System.Console.WriteLine("");
                 Logger.Fatal(exception.Message + ". This can happen if another instance of Sonarr is already running another application is using the same port (default: 8989) or the user has insufficient permissions");
                 System.Console.WriteLine("Press any key to exit...");
-                System.Console.ReadLine();
+                System.Console.ReadKey();
                 Environment.Exit(1);
             }
             catch (Exception e)
@@ -34,7 +34,7 @@ namespace NzbDrone.Console
                 System.Console.WriteLine("");
                 Logger.Fatal(e, "EPIC FAIL!");
                 System.Console.WriteLine("Press any key to exit...");
-                System.Console.ReadLine();
+                System.Console.ReadKey();
                 Environment.Exit(1);
             }
 

--- a/src/NzbDrone.Console/ConsoleApp.cs
+++ b/src/NzbDrone.Console/ConsoleApp.cs
@@ -24,8 +24,8 @@ namespace NzbDrone.Console
                 System.Console.WriteLine("");
                 System.Console.WriteLine("");
                 Logger.Fatal(exception.Message + ". This can happen if another instance of Sonarr is already running another application is using the same port (default: 8989) or the user has insufficient permissions");
-                System.Console.WriteLine("Press any key to exit...");
-                System.Console.ReadKey();
+                System.Console.WriteLine("Press enter to exit...");
+                System.Console.ReadLine();
                 Environment.Exit(1);
             }
             catch (Exception e)
@@ -33,8 +33,8 @@ namespace NzbDrone.Console
                 System.Console.WriteLine("");
                 System.Console.WriteLine("");
                 Logger.Fatal(e, "EPIC FAIL!");
-                System.Console.WriteLine("Press any key to exit...");
-                System.Console.ReadKey();
+                System.Console.WriteLine("Press enter to exit...");
+                System.Console.ReadLine();
                 Environment.Exit(1);
             }
 


### PR DESCRIPTION
#### Description
Minor fix to match input request in NzbDrone.Console/ConsoleApp.cs
Changed "Press any key to exit..." prompt to "Press enter to exit..."