### PR TITLE
Allow multiple twitter notification recipients.

### DIFF
--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
@@ -83,9 +83,19 @@ namespace NzbDrone.Core.Notifications.Twitter
 
                 if (settings.DirectMessage)
                 {
-                    twitter.DirectMessage(message, settings.Mention);
-                }
+                    if(settings.Mention.Contains(","))
+					{
+						var recipients = settings.Mention.Replace(" ",string.Empty).Split(',');
 
+						foreach(var recipient in recipients)
+						{
+							twitter.DirectMessage(message,recipient);
+						}
+					}
+					else
+					{
+						twitter.DirectMessage(message, settings.Mention);	
+					}
                 else
                 {
                     if (settings.Mention.IsNotNullOrWhiteSpace())


### PR DESCRIPTION
#### Database Migration

YES | NO
#### Description

A few sentences describing the overall goals of the pull request's commits.
#### Todos
- [ ] Tests
- [ ] Documentation
#### Issues Fixed or Closed by this PR
- 

This change allows for multiple twitter notification recipients. Each twitter user account is separated by comma. Now my girlfriend and I can both be notified via DM when a new episodes are ready to watch.
