### PR TITLE
Updater fixes and logging

### DIFF
--- a/src/LogentriesNLog/fastJSON/JSON.cs
+++ b/src/LogentriesNLog/fastJSON/JSON.cs
@@ -24,6 +24,7 @@ namespace LogentriesNLog.fastJSON
             SerializeNullValues = false;
             UseOptimizedDatasetSchema = false;
             UsingGlobalTypes = false;
+            UseUTCDateTime = true;
         }
         public bool UseOptimizedDatasetSchema = true;
         public bool UseFastGuid = true;
@@ -39,7 +40,7 @@ namespace LogentriesNLog.fastJSON
             return ToJSON(obj, UseSerializerExtension, UseFastGuid, UseOptimizedDatasetSchema, SerializeNullValues);
         }
 
-      
+
         public string ToJSON(object obj,
                              bool enableSerializerExtensions,
                              bool enableFastGuid,
@@ -49,13 +50,13 @@ namespace LogentriesNLog.fastJSON
             return new JSONSerializer(enableOptimizedDatasetSchema, enableFastGuid, enableSerializerExtensions, serializeNullValues, IndentOutput).ConvertToJSON(obj);
         }
 
-      
+
         public T ToObject<T>(string json)
         {
             return (T)ToObject(json, typeof(T));
         }
 
-      
+
         public object ToObject(string json, Type type)
         {
             var ht = new JsonParser(json).Decode() as Dictionary<string, object>;
@@ -320,7 +321,7 @@ namespace LogentriesNLog.fastJSON
                 }
             }
 
-           
+
             _getterscache.Add(type, getters);
             return getters;
         }
@@ -448,7 +449,7 @@ namespace LogentriesNLog.fastJSON
 #if !SILVERLIGHT
                         else if (pi.isDictionary || pi.isHashtable)
                             oset = CreateDictionary((ArrayList)v, pi.pt, pi.GenericTypes, globaltypes);
-#else 
+#else
                         else if (pi.isDictionary)
                             oset = CreateDictionary((List<object>)v, pi.pt, pi.GenericTypes, globaltypes);
 #endif

--- a/src/LogentriesNLog/fastJSON/JsonSerializer.cs
+++ b/src/LogentriesNLog/fastJSON/JsonSerializer.cs
@@ -170,6 +170,8 @@ namespace LogentriesNLog.fastJSON
             _output.Append(dt.Minute.ToString("00", NumberFormatInfo.InvariantInfo));
             _output.Append(":");
             _output.Append(dt.Second.ToString("00", NumberFormatInfo.InvariantInfo));
+            _output.Append(".");
+            _output.Append(dt.Millisecond.ToString("000", NumberFormatInfo.InvariantInfo));
 
             if (JSON.Instance.UseUTCDateTime)
                 _output.Append("Z");

--- a/src/NzbDrone.Update/NzbDrone.Update.csproj
+++ b/src/NzbDrone.Update/NzbDrone.Update.csproj
@@ -58,6 +58,7 @@
     <Compile Include="UpdateContainerBuilder.cs" />
     <Compile Include="UpdateEngine\BackupAndRestore.cs" />
     <Compile Include="UpdateEngine\BackupAppData.cs" />
+    <Compile Include="UpdateEngine\DetectExistingVersion.cs" />
     <Compile Include="UpdateEngine\DetectApplicationType.cs" />
     <Compile Include="UpdateEngine\InstallUpdateService.cs" />
     <Compile Include="UpdateEngine\StartNzbDrone.cs" />

--- a/src/NzbDrone.Update/UpdateApp.cs
+++ b/src/NzbDrone.Update/UpdateApp.cs
@@ -40,7 +40,6 @@ namespace NzbDrone.Update
 
                 _container = UpdateContainerBuilder.Build(startupArgument);
 
-                Logger.Info("Updating Sonarr to version {0}", BuildInfo.Version);
                 _container.Resolve<UpdateApp>().Start(args);
 
                 Logger.Info("Update completed successfully");
@@ -56,7 +55,6 @@ namespace NzbDrone.Update
             var startupContext = ParseArgs(args);
             var targetFolder = GetInstallationDirectory(startupContext);
 
-            Logger.Info("Starting update process. Target Path:{0}", targetFolder);
             _installUpdateService.Start(targetFolder, startupContext.ProcessId);
         }
 

--- a/src/NzbDrone.Update/UpdateEngine/BackupAndRestore.cs
+++ b/src/NzbDrone.Update/UpdateEngine/BackupAndRestore.cs
@@ -27,13 +27,14 @@ namespace NzbDrone.Update.UpdateEngine
         public void Backup(string source)
         {
             _logger.Info("Creating backup of existing installation");
-            _diskTransferService.TransferFolder(source, _appFolderInfo.GetUpdateBackUpFolder(), TransferMode.Copy, false);
+            _diskTransferService.MirrorFolder(source, _appFolderInfo.GetUpdateBackUpFolder());
         }
 
         public void Restore(string target)
         {
             _logger.Info("Attempting to rollback upgrade");
-            _diskTransferService.TransferFolder(_appFolderInfo.GetUpdateBackUpFolder(), target, TransferMode.Copy, false);
+            var count = _diskTransferService.MirrorFolder(_appFolderInfo.GetUpdateBackUpFolder(), target);
+            _logger.Info("Rolled back {0} files", count);
         }
     }
 }

--- a/src/NzbDrone.Update/UpdateEngine/BackupAppData.cs
+++ b/src/NzbDrone.Update/UpdateEngine/BackupAppData.cs
@@ -34,7 +34,15 @@ namespace NzbDrone.Update.UpdateEngine
             _logger.Info("Backing up appdata (database/config)");
             var backupFolderAppData = _appFolderInfo.GetUpdateBackUpAppDataFolder();
 
-            _diskProvider.CreateFolder(backupFolderAppData);
+            if (_diskProvider.FolderExists(backupFolderAppData))
+            {
+                _diskProvider.EmptyFolder(backupFolderAppData);
+            }
+            else
+            {
+                _diskProvider.CreateFolder(backupFolderAppData);
+            }
+
 
             try
             {

--- a/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
+++ b/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using NLog;
+
+namespace NzbDrone.Update.UpdateEngine
+{
+    public interface IDetectExistingVersion
+    {
+        string GetExistingVersion(string targetFolder);
+    }
+
+    public class DetectExistingVersion : IDetectExistingVersion
+    {
+        private readonly Logger _logger;
+
+        public DetectExistingVersion(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public string GetExistingVersion(string targetFolder)
+        {
+            try
+            {
+                var targetExecutable = Path.Combine(targetFolder, "NzbDrone.exe");
+
+                if (File.Exists(targetExecutable))
+                {
+                    var versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(targetExecutable);
+
+                    return versionInfo.FileVersion;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Failed to get existing version from {0}", targetFolder);
+            }
+
+            return "(unknown)";
+        }
+    }
+}


### PR DESCRIPTION
When emptying the install dir fails, due to permission issues, the rollback logic kicks in. But instead of just restoring the missing files, it rewrites everything and pukes over the same permission issue.
Usually this doesn't corrupt the install (coz it follows the same sequence), but it logs a Fatal twice.

So I changed it to a MirrorFolder function that compares source and target folders and files and applies only the changes required.

Also added the current version to the logging, so we know what the original version was and which version is being installed.

I didn't test it yet.
