### PR TITLE
Filter iCal feed by tags

### DIFF
--- a/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupUnusedTagsFixture.cs
+++ b/src/NzbDrone.Core.Test/Housekeeping/Housekeepers/CleanupUnusedTagsFixture.cs
@@ -1,0 +1,43 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Download.Pending;
+using NzbDrone.Core.Housekeeping.Housekeepers;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.Tags;
+using NzbDrone.Core.Restrictions;
+
+namespace NzbDrone.Core.Test.Housekeeping.Housekeepers
+{
+    [TestFixture]
+    public class CleanupUnusedTagsFixture : DbTest<CleanupUnusedTags, Tag>
+    {
+        [Test]
+        public void should_delete_unused_tags()
+        {
+            var tags = Builder<Tag>.CreateListOfSize(2).BuildList();
+
+            Db.InsertMany(tags);
+            Subject.Clean();
+            AllStoredModels.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_delete_used_tags()
+        {
+            var tags = Builder<Tag>.CreateListOfSize(2).BuildList();
+            Db.InsertMany(tags);
+
+            var restrictions = Builder<Restriction>.CreateListOfSize(2)
+                .All()
+                .With(v => v.Tags.Add(tags[0].Id))
+                .BuildList();
+            Db.InsertMany(restrictions);
+
+            Subject.Clean();
+            AllStoredModels.Should().HaveCount(1);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedIndexerStatusFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedHistoryItemsFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedMetadataFilesFixture.cs" />
+    <Compile Include="Housekeeping\Housekeepers\CleanupUnusedTagsFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedPendingReleasesFixture.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureRunScheduledTasksFixture.cs" />
     <Compile Include="Http\HttpProxySettingsProviderFixture.cs" />

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/CleanupUnusedTags.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Marr.Data;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Housekeeping.Housekeepers
+{
+    public class CleanupUnusedTags : IHousekeepingTask
+    {
+        private readonly IMainDatabase _database;
+
+        public CleanupUnusedTags(IMainDatabase database)
+        {
+            _database = database;
+        }
+
+        public void Clean()
+        {
+            var mapper = _database.GetDataMapper();
+
+            var usedTags = new[] { "Series", "Notifications", "DelayProfiles", "Restrictions" }
+                .SelectMany(v => GetUsedTags(v, mapper))
+                .Distinct()
+                .ToArray();
+
+            var usedTagsList = string.Join(",", usedTags.Select(d => d.ToString()).ToArray());
+
+            mapper.ExecuteNonQuery($"DELETE FROM Tags WHERE NOT Id IN ({usedTagsList})");
+        }
+
+        private int[] GetUsedTags(string table, IDataMapper mapper)
+        {
+            return mapper.ExecuteReader($"SELECT DISTINCT Tags FROM {table} WHERE NOT Tags = '[]'", reader => reader.GetString(0))
+                         .SelectMany(Json.Deserialize<List<int>>)
+                         .Distinct()
+                         .ToArray();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -545,6 +545,7 @@
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedIndexerStatus.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedHistoryItems.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedMetadataFiles.cs" />
+    <Compile Include="Housekeeping\Housekeepers\CleanupUnusedTags.cs" />
     <Compile Include="Housekeeping\Housekeepers\CleanupOrphanedPendingReleases.cs" />
     <Compile Include="Housekeeping\Housekeepers\DeleteBadMediaCovers.cs" />
     <Compile Include="Housekeeping\Housekeepers\FixFutureRunScheduledTasks.cs" />

--- a/src/NzbDrone.Core/Tags/TagRepository.cs
+++ b/src/NzbDrone.Core/Tags/TagRepository.cs
@@ -1,11 +1,13 @@
-﻿using NzbDrone.Core.Datastore;
+﻿using System;
+using System.Linq;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Tags
 {
     public interface ITagRepository : IBasicRepository<Tag>
     {
-
+        Tag GetByLabel(string label);
     }
 
     public class TagRepository : BasicRepository<Tag>, ITagRepository
@@ -13,6 +15,18 @@ namespace NzbDrone.Core.Tags
         public TagRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+        }
+
+        public Tag GetByLabel(string label)
+        {
+            var model = Query.Where(c => c.Label == label).SingleOrDefault();
+
+            if (model == null)
+            {
+                throw new InvalidOperationException("Didn't find tag with label " + label);
+            }
+
+            return model;
         }
     }
 }

--- a/src/NzbDrone.Core/Tags/TagService.cs
+++ b/src/NzbDrone.Core/Tags/TagService.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Tags
     public interface ITagService
     {
         Tag GetTag(int tagId);
+        Tag GetTag(string tag);
         List<Tag> All();
         Tag Add(Tag tag);
         Tag Update(Tag tag);
@@ -28,6 +29,18 @@ namespace NzbDrone.Core.Tags
         public Tag GetTag(int tagId)
         {
             return _repo.Get(tagId);
+        }
+
+        public Tag GetTag(string tag)
+        {
+            if (tag.All(char.IsDigit))
+            {
+                return _repo.Get(int.Parse(tag));
+            }
+            else
+            {
+                return _repo.GetByLabel(tag);
+            }
         }
 
         public List<Tag> All()

--- a/src/UI/Calendar/CalendarFeedView.js
+++ b/src/UI/Calendar/CalendarFeedView.js
@@ -1,6 +1,7 @@
 var Marionette = require('marionette');
 var StatusModel = require('../System/StatusModel');
 require('../Mixins/CopyToClipboard');
+require('../Mixins/TagInput');
 
 module.exports = Marionette.Layout.extend({
     template : 'Calendar/CalendarFeedViewTemplate',
@@ -8,6 +9,7 @@ module.exports = Marionette.Layout.extend({
     ui : {
         includeUnmonitored : '.x-includeUnmonitored',
         premiersOnly       : '.x-premiersOnly',
+        tags               : '.x-tags',
         icalUrl            : '.x-ical-url',
         icalCopy           : '.x-ical-copy',
         icalWebCal         : '.x-ical-webcal'
@@ -15,12 +17,15 @@ module.exports = Marionette.Layout.extend({
 
     events : {
         'click .x-includeUnmonitored' : '_updateUrl',
-        'click .x-premiersOnly'       : '_updateUrl'
+        'click .x-premiersOnly'       : '_updateUrl',
+        'itemAdded .x-tags'           : '_updateUrl',
+        'itemRemoved .x-tags'         : '_updateUrl'
     },
 
     onShow : function() {
         this._updateUrl();
         this.ui.icalCopy.copyToClipboard(this.ui.icalUrl);
+        this.ui.tags.tagInput({ allowNew: false });
     },
 
     _updateUrl : function() {
@@ -32,6 +37,10 @@ module.exports = Marionette.Layout.extend({
 
         if (this.ui.premiersOnly.prop('checked')) {
             icalUrl += 'premiersOnly=true&';
+        }
+
+        if (this.ui.tags.val()) {
+            icalUrl += 'tags=' + this.ui.tags.val() + '&';
         }
 
         icalUrl += 'apikey=' + window.NzbDrone.ApiKey;

--- a/src/UI/Calendar/CalendarFeedViewTemplate.hbs
+++ b/src/UI/Calendar/CalendarFeedViewTemplate.hbs
@@ -42,6 +42,17 @@
                 </div>
             </div>
             <div class="form-group">
+                <label class="col-sm-3 control-label">Tags</label>
+
+                <div class="col-sm-1 col-sm-push-5 help-inline">
+                    <i class="icon-sonarr-form-info" title="One or more tags only show matching series" />
+                </div>
+
+                <div class="col-sm-5 col-sm-pull-1">
+                    <input type="text" class="form-control x-tags">
+                </div>
+            </div>
+            <div class="form-group">
                 <label class="col-sm-3 control-label">iCal feed</label>
                 <div class="col-sm-1 col-sm-push-8 help-inline">
                     <i class="icon-sonarr-form-info" title="Copy this url into your clients subscription form or use the subscribe button if your browser support webcal" />


### PR DESCRIPTION
Filter ical feed by tags. The UI uses the tag input, without the ability to add new tags.
It adds it as integers to the query params.
The feed endpoint supports both integers and tag labels.

Also added housekeeping logic to cleanup unused tags.