### PR TITLE
Upgraded mono version check (3.10 minimum and 4.4.x)

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.HealthCheck.Checks;
 using NzbDrone.Core.Test.Framework;
@@ -22,76 +21,40 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                   .Returns(string.Format("{0} (tarball Wed Sep 25 16:35:44 CDT 2013)", version));
         }
 
-        [Test]
-        public void should_return_warning_when_mono_3_0()
+        [TestCase("3.10")]
+        [TestCase("4.0.0.0")]
+        [TestCase("4.2")]
+        [TestCase("4.6")]
+        public void should_return_ok(string version)
         {
-            GivenOutput("3.0.0.1");
+            GivenOutput(version);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [TestCase("2.10.2")]
+        [TestCase("2.10.8.1")]
+        [TestCase("3.0.0.1")]
+        [TestCase("3.2.0.1")]
+        [TestCase("3.2.1")]
+        [TestCase("3.2.7")]
+        [TestCase("3.6.1")]
+        [TestCase("3.8")]
+        public void should_return_warning(string version)
+        {
+            GivenOutput(version);
 
             Subject.Check().ShouldBeWarning();
         }
 
-        [Test]
-        public void should_return_warning_when_mono_2_10_8()
+
+        [TestCase("4.4.0")]
+        [TestCase("4.4.1")]
+        public void should_return_error(string version)
         {
-            GivenOutput("2.10.8.1");
+            GivenOutput(version);
 
-            Subject.Check().ShouldBeWarning();
-        }
-
-        [Test]
-        public void should_return_warning_when_mono_2_10_2()
-        {
-            GivenOutput("2.10.2");
-
-            Subject.Check().ShouldBeWarning();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_3_2()
-        {
-            GivenOutput("3.2.0.1");
-
-            Subject.Check().ShouldBeOk();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_4_0()
-        {
-            GivenOutput("4.0.0.0");
-
-            Subject.Check().ShouldBeOk();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_3_2_7()
-        {
-            GivenOutput("3.2.7");
-
-            Subject.Check().ShouldBeOk();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_3_2_1()
-        {
-            GivenOutput("3.2.1");
-
-            Subject.Check().ShouldBeOk();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_3_6_1()
-        {
-            GivenOutput("3.6.1");
-
-            Subject.Check().ShouldBeOk();
-        }
-
-        [Test]
-        public void should_return_ok_when_mono_3_10()
-        {
-            GivenOutput("3.10");
-
-            Subject.Check().ShouldBeOk();
+            Subject.Check().ShouldBeError();
         }
     }
 }

--- a/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
@@ -39,14 +39,20 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     return new HealthCheck(GetType(), HealthCheckResult.Error, "your mono version 3.4.0 has a critical bug, you should upgrade to a higher version");
                 }
 
-                if (version >= new Version(3, 2))
+                if (version >= new Version(4, 4, 0) && version < new Version(4, 5))
                 {
-                    _logger.Debug("mono version is 3.2 or better: {0}", version.ToString());
+                    _logger.Debug("mono version {0}", version);
+                    return new HealthCheck(GetType(), HealthCheckResult.Error, $"your mono version {version} has a bug that causes issues connecting to indexers/download clients");
+                }
+
+                if (version >= new Version(3, 10))
+                {
+                    _logger.Debug("mono version is 3.10 or better: {0}", version.ToString());
                     return new HealthCheck(GetType());
                 }
             }
 
-            return new HealthCheck(GetType(), HealthCheckResult.Warning, "mono version is less than 3.2, upgrade for improved stability");
+            return new HealthCheck(GetType(), HealthCheckResult.Warning, "mono version is less than 3.10, upgrade for improved stability");
         }
 
         public override bool CheckOnConfigChange


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Health check warning if the user is running under 3.10 since that is our recommended minimum (as lower versions had various issues) and an error if running 4.4.x because it has a bug that breaks connecting to indexers/download clients