### PR TITLE
qbittorrent: allow removal of torrents that reached the configured max ratio

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -253,13 +253,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         [Test]
         public void should_return_status_with_outputdirs()
         {
-            var configItems = new Dictionary<string, Object>();
-
-            configItems.Add("save_path", @"C:\Downloads\Finished\QBittorrent".AsOsAgnostic());
+            var config = new QBittorrentPreferences
+            {
+                SavePath = @"C:\Downloads\Finished\QBittorrent".AsOsAgnostic()
+            };
 
             Mocker.GetMock<IQBittorrentProxy>()
                 .Setup(v => v.GetConfig(It.IsAny<QBittorrentSettings>()))
-                .Returns(configItems);
+                .Returns(config);
 
             var result = Subject.GetStatus();
 

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrent.cs
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         {
             var config = _proxy.GetConfig(Settings);
 
-            var destDir = new OsPath((string)config.GetValueOrDefault("save_path"));
+            var destDir = new OsPath(config.SavePath);
 
             return new DownloadClientStatus
             {

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrent.cs
@@ -227,6 +227,16 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         DetailedDescription = "Sonarr will not attempt to import completed downloads without a category."
                     };
                 }
+
+                // Complain if qBittorrent is configured to remove torrents on max ratio
+                var config = _proxy.GetConfig(Settings);
+                if (config.MaxRatioEnabled && config.RemoveOnMaxRatio)
+                {
+                    return new NzbDroneValidationFailure(String.Empty, "QBittorrent is configured to remove torrents when they reach their Share Ratio Limit")
+                    {
+                        DetailedDescription = "Sonarr will be unable to perform Completed Download Handling as configured. You can fix this in qBittorrent ('Tools -> Options...' in the menu) by changing 'Options -> BitTorrent -> Share Ratio Limiting' from 'Remove them' to 'Pause them'."
+                    };
+                }
             }
             catch (DownloadClientAuthenticationException ex)
             {

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentPreferences.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentPreferences.cs
@@ -7,5 +7,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
     {
         [JsonProperty(PropertyName = "save_path")]
         public string SavePath { get; set; } // Default save path for torrents, separated by slashes
+
+        [JsonProperty(PropertyName = "max_ratio_enabled")]
+        public bool MaxRatioEnabled { get; set; } // True if share ratio limit is enabled
+
+        [JsonProperty(PropertyName = "max_ratio")]
+        public float MaxRatio { get; set; } // Get the global share ratio limit
+
+        [JsonProperty(PropertyName = "max_ratio_act")]
+        public bool RemoveOnMaxRatio { get; set; } // Action performed when a torrent reaches the maximum share ratio. [false = pause, true = remove]
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentPreferences.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentPreferences.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Download.Clients.QBittorrent
+{
+    // qbittorrent settings from the list returned by /query/preferences
+    public class QBittorrentPreferences
+    {
+        [JsonProperty(PropertyName = "save_path")]
+        public string SavePath { get; set; } // Default save path for torrents, separated by slashes
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentProxy.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
     public interface IQBittorrentProxy
     {
         int GetVersion(QBittorrentSettings settings);
-        Dictionary<string, Object> GetConfig(QBittorrentSettings settings);
+        QBittorrentPreferences GetConfig(QBittorrentSettings settings);
         List<QBittorrentTorrent> GetTorrents(QBittorrentSettings settings);
 
         void AddTorrentFromUrl(string torrentUrl, QBittorrentSettings settings);
@@ -47,10 +47,10 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             return response;
         }
 
-        public Dictionary<string, object> GetConfig(QBittorrentSettings settings)
+        public QBittorrentPreferences GetConfig(QBittorrentSettings settings)
         {
             var request = BuildRequest(settings).Resource("/query/preferences");
-            var response = ProcessRequest<Dictionary<string, object>>(request, settings);
+            var response = ProcessRequest<QBittorrentPreferences>(request, settings);
 
             return response;
         }

--- a/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/qBittorrent/QBittorrentTorrent.cs
@@ -21,5 +21,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         [JsonProperty(PropertyName = "save_path")]
         public string SavePath { get; set; } // Torrent save path
+
+        public float Ratio { get; set; } // Torrent share ratio
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -401,6 +401,7 @@
     <Compile Include="Download\Clients\NzbVortex\Responses\NzbVortexVersionResponse.cs" />
     <Compile Include="Download\Clients\Pneumatic\Pneumatic.cs" />
     <Compile Include="Download\Clients\Pneumatic\PneumaticSettings.cs" />
+    <Compile Include="Download\Clients\QBittorrent\QBittorrentPreferences.cs" />
     <Compile Include="Download\Clients\rTorrent\RTorrentDirectoryValidator.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrent.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentPriority.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Track QBittorrent's configured `max_ratio`, and compare that against each torrent's `share_ratio` to determine whether the torrent has finished seeding. If it has, allow Sonarr to remove and delete the completed torrent.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* https://github.com/Sonarr/Sonarr/issues/1316
