### PR TITLE
Added Sonarr-icon to Boxcar notification

### DIFF
--- a/src/NzbDrone.Core/Notifications/Boxcar/BoxcarProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Boxcar/BoxcarProxy.cs
@@ -77,6 +77,7 @@ namespace NzbDrone.Core.Notifications.Boxcar
                 request.AddParameter("notification[title]", title);
                 request.AddParameter("notification[long_message]", message);
                 request.AddParameter("notification[source_name]", "Sonarr");
+                request.AddParameter("notification[icon_url]", "https://raw.githubusercontent.com/Sonarr/Sonarr/7818f0c59b787312f0bcbc5c0eafc3c9dd7e5451/Logo/64.png");
 
                 client.ExecuteAndValidate(request);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Now there is a small Sonarr icon next to the Boxcar notification.