### PR TITLE
Added support to override Copy vs Move import logic for Manual Import

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceFixture.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.Download
             {
                 Series = new Series(),
                 Episodes = new List<Episode> { new Episode { Id = 1 } }
-            }; 
+            };
         }
 
 
@@ -77,11 +77,11 @@ namespace NzbDrone.Core.Test.Download
                 .Setup(s => s.MostRecentForDownloadId(_trackedDownload.DownloadItem.DownloadId))
                 .Returns((History.History)null);
         }
-        
+
         private void GivenSuccessfulImport()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                 .Returns(new List<ImportResult>
                     {
                         new ImportResult(new ImportDecision(new LocalEpisode() { Path = @"C:\TestPath\Droned.S01E01.mkv" }))
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Test.Download
             GivenNoGrabbedHistory();
             GivenSeriesMatch();
             GivenSuccessfulImport();
-            
+
             Subject.Process(_trackedDownload);
 
             AssertCompletedDownload();
@@ -179,13 +179,13 @@ namespace NzbDrone.Core.Test.Download
         public void should_mark_as_imported_if_all_episodes_were_imported()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"})),
-                               
+
                                 new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E02.mkv"}))
@@ -200,13 +200,13 @@ namespace NzbDrone.Core.Test.Download
         public void should_not_mark_as_imported_if_all_files_were_rejected()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}, new Rejection("Rejected!")), "Test Failure"),
-                               
+
                                 new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E02.mkv"},new Rejection("Rejected!")), "Test Failure")
@@ -224,13 +224,13 @@ namespace NzbDrone.Core.Test.Download
         public void should_not_mark_as_imported_if_no_episodes_were_parsed()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}, new Rejection("Rejected!")), "Test Failure"),
-                               
+
                                 new ImportResult(
                                    new ImportDecision(
                                        new LocalEpisode {Path = @"C:\TestPath\Droned.S01E02.mkv"},new Rejection("Rejected!")), "Test Failure")
@@ -247,7 +247,7 @@ namespace NzbDrone.Core.Test.Download
         public void should_not_mark_as_imported_if_all_files_were_skipped()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}),"Test Failure"),
@@ -271,7 +271,7 @@ namespace NzbDrone.Core.Test.Download
             };
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"})),
@@ -294,7 +294,7 @@ namespace NzbDrone.Core.Test.Download
             };
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"})),
@@ -314,7 +314,7 @@ namespace NzbDrone.Core.Test.Download
             GivenABadlyNamedDownload();
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}))
@@ -323,7 +323,7 @@ namespace NzbDrone.Core.Test.Download
             Mocker.GetMock<ISeriesService>()
                   .Setup(v => v.GetSeries(It.IsAny<int>()))
                   .Returns(BuildRemoteEpisode().Series);
-           
+
             Subject.Process(_trackedDownload);
 
             AssertCompletedDownload();
@@ -335,7 +335,7 @@ namespace NzbDrone.Core.Test.Download
             GivenABadlyNamedDownload();
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}))
@@ -370,7 +370,7 @@ namespace NzbDrone.Core.Test.Download
             };
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                   .Returns(new List<ImportResult>
                            {
                                new ImportResult(new ImportDecision(new LocalEpisode {Path = @"C:\TestPath\Droned.S01E01.mkv"}))
@@ -408,7 +408,7 @@ namespace NzbDrone.Core.Test.Download
         private void AssertNoAttemptedImport()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                .Verify(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()), Times.Never());
+                .Verify(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()), Times.Never());
 
             AssertNoCompletedDownload();
         }
@@ -424,7 +424,7 @@ namespace NzbDrone.Core.Test.Download
         private void AssertCompletedDownload()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                .Verify(v => v.ProcessPath(_trackedDownload.DownloadItem.OutputPath.FullPath, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem), Times.Once());
+                .Verify(v => v.ProcessPath(_trackedDownload.DownloadItem.OutputPath.FullPath, ImportMode.Auto, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem), Times.Once());
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(v => v.PublishEvent(It.IsAny<DownloadCompletedEvent>()), Times.Once());

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesCommandServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesCommandServiceFixture.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                 .Returns(new List<ImportResult>());
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
                 .Returns(new List<ImportResult>());
 
             var downloadItem = Builder<DownloadClientItem>.CreateNew()
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder });
 
-            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), null, null), Times.Once());
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), ImportMode.Auto, null, null), Times.Once());
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFile });
 
-            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), null, null), Times.Once());
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), ImportMode.Auto, null, null), Times.Once());
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder, DownloadClientId = "sab1" });
 
-            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem), Times.Once());
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, ImportMode.Auto, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem), Times.Once());
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder, DownloadClientId = "sab1" });
 
-            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, null, null), Times.Once());
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(_downloadFolder, ImportMode.Auto, null, null), Times.Once());
 
             ExceptionVerification.ExpectedWarns(1);
         }
@@ -154,9 +154,19 @@ namespace NzbDrone.Core.Test.MediaFiles
         {
             Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFolder });
 
-            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), null, null), Times.Never());
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), ImportMode.Auto, null, null), Times.Never());
 
             ExceptionVerification.ExpectedWarns(1);
+        }
+
+        [Test]
+        public void should_override_import_mode()
+        {
+            GivenExistingFile(_downloadFile);
+
+            Subject.Execute(new DownloadedEpisodesScanCommand() { Path = _downloadFile, ImportMode = ImportMode.Copy });
+
+            Mocker.GetMock<IDownloadedEpisodesImportService>().Verify(c => c.ProcessPath(It.IsAny<string>(), ImportMode.Copy, null, null), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(true);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
                   .Returns(new List<ImportResult>());
         }
 
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(true);
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
-            
+
             VerifyNoImport();
         }
 
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         public void should_not_delete_folder_if_no_files_were_imported()
         {
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), false, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), false, null, ImportMode.Auto))
                   .Returns(new List<ImportResult>());
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
                   .Returns(imported.Select(i => new ImportResult(i)).ToList());
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
                   .Returns(imported.Select(i => new ImportResult(i)).ToList());
 
             Mocker.GetMock<IDetectSample>()
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
                   .Returns(imported.Select(i => new ImportResult(i)).ToList());
 
             Mocker.GetMock<IDetectSample>()
@@ -342,7 +342,7 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Returns(imported);
 
             Mocker.GetMock<IImportApprovedEpisodes>()
-                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null))
+                  .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto))
                   .Returns(new List<ImportResult>());
 
             Mocker.GetMock<IDetectSample>()
@@ -365,13 +365,13 @@ namespace NzbDrone.Core.Test.MediaFiles
 
         private void VerifyNoImport()
         {
-            Mocker.GetMock<IImportApprovedEpisodes>().Verify(c => c.Import(It.IsAny<List<ImportDecision>>(), true, null),
+            Mocker.GetMock<IImportApprovedEpisodes>().Verify(c => c.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto),
                 Times.Never());
         }
 
         private void VerifyImport()
         {
-            Mocker.GetMock<IImportApprovedEpisodes>().Verify(c => c.Import(It.IsAny<List<ImportDecision>>(), true, null),
+            Mocker.GetMock<IImportApprovedEpisodes>().Verify(c => c.Import(It.IsAny<List<ImportDecision>>(), true, null, ImportMode.Auto),
                 Times.Once());
         }
     }

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             }
 
             Mocker.GetMock<IUpgradeMediaFiles>()
-                  .Setup(s => s.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<LocalEpisode>(), false))
+                  .Setup(s => s.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<LocalEpisode>(), It.IsAny<bool>()))
                   .Returns(new EpisodeFileMoveResult());
 
             _downloadClientItem = Builder<DownloadClientItem>.CreateNew().Build();
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             all.AddRange(_approvedDecisions);
 
             var result = Subject.Import(all, false);
-            
+
             result.Should().HaveCount(all.Count);
             result.Where(i => i.Result == ImportResultType.Imported).Should().HaveCount(_approvedDecisions.Count);
         }
@@ -222,6 +222,24 @@ namespace NzbDrone.Core.Test.MediaFiles
             results.Should().HaveCount(all.Count);
             results.Should().ContainSingle(d => d.Result == ImportResultType.Imported);
             results.Should().ContainSingle(d => d.Result == ImportResultType.Imported && d.ImportDecision.LocalEpisode.Size == fileDecision.LocalEpisode.Size);
+        }
+
+        [Test]
+        public void should_copy_readonly_downloads()
+        {
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true });
+
+            Mocker.GetMock<IUpgradeMediaFiles>()
+                  .Verify(v => v.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), _approvedDecisions.First().LocalEpisode, true), Times.Once());
+        }
+
+        [Test]
+        public void should_use_override_importmode()
+        {
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true }, ImportMode.Move);
+
+            Mocker.GetMock<IUpgradeMediaFiles>()
+                  .Verify(v => v.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), _approvedDecisions.First().LocalEpisode, false), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Download
         private void Import(TrackedDownload trackedDownload)
         {
             var outputPath = trackedDownload.DownloadItem.OutputPath.FullPath;
-            var importResults = _downloadedEpisodesImportService.ProcessPath(outputPath, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
+            var importResults = _downloadedEpisodesImportService.ProcessPath(outputPath, ImportMode.Auto, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
 
             if (importResults.Empty())
             {

--- a/src/NzbDrone.Core/MediaFiles/Commands/DownloadedEpisodesScanCommand.cs
+++ b/src/NzbDrone.Core/MediaFiles/Commands/DownloadedEpisodesScanCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.MediaFiles.Commands
@@ -18,5 +19,6 @@ namespace NzbDrone.Core.MediaFiles.Commands
         // Properties used by third-party apps, do not modify.
         public string Path { get; set; }
         public string DownloadClientId { get; set; }
+        public ImportMode ImportMode { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesCommandService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesCommandService.cs
@@ -70,17 +70,17 @@ namespace NzbDrone.Core.MediaFiles
                 {
                     _logger.Debug("External directory scan request for known download {0}. [{1}]", message.DownloadClientId, message.Path);
 
-                    return _downloadedEpisodesImportService.ProcessPath(message.Path, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
+                    return _downloadedEpisodesImportService.ProcessPath(message.Path, message.ImportMode, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
                 }
                 else
                 {
                     _logger.Warn("External directory scan request for unknown download {0}, attempting normal import. [{1}]", message.DownloadClientId, message.Path);
 
-                    return _downloadedEpisodesImportService.ProcessPath(message.Path);
+                    return _downloadedEpisodesImportService.ProcessPath(message.Path, message.ImportMode);
                 }
             }
 
-            return _downloadedEpisodesImportService.ProcessPath(message.Path);
+            return _downloadedEpisodesImportService.ProcessPath(message.Path, message.ImportMode);
         }
 
         public void Execute(DownloadedEpisodesScanCommand message)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportMode.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportMode.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport
+{
+    public enum ImportMode
+    {
+        Auto = 0,
+        Move = 1,
+        Copy = 2
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportCommand.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportCommand.cs
@@ -14,5 +14,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 return true;
             }
         }
+
+        public ImportMode ImportMode { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
         public void Execute(ManualImportCommand message)
         {
-            _logger.ProgressTrace("Manually importing {0} files", message.Files.Count);
+            _logger.ProgressTrace("Manually importing {0} files using mode {1}", message.Files.Count, message.ImportMode);
 
             var imported = new List<ImportResult>();
             var importedTrackedDownload = new List<ManuallyImportedFile>();
@@ -217,20 +217,19 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                     Size = 0
                 };
 
-                //TODO: Option to copy instead of import
                 //TODO: Cleanup non-tracked downloads
 
                 var importDecision = new ImportDecision(localEpisode);
 
                 if (file.DownloadId.IsNullOrWhiteSpace())
                 {
-                    imported.AddRange(_importApprovedEpisodes.Import(new List<ImportDecision> { importDecision }, !existingFile));
+                    imported.AddRange(_importApprovedEpisodes.Import(new List<ImportDecision> { importDecision }, !existingFile, null, message.ImportMode));
                 }
 
                 else
                 {
                     var trackedDownload = _trackedDownloadService.Find(file.DownloadId);
-                    var importResult = _importApprovedEpisodes.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem).First();
+                    var importResult = _importApprovedEpisodes.Import(new List<ImportDecision> { importDecision }, true, trackedDownload.DownloadItem, message.ImportMode).First();
 
                     imported.Add(importResult);
 

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -692,6 +692,7 @@
     <Compile Include="MediaFiles\Commands\BackendCommandAttribute.cs" />
     <Compile Include="MediaFiles\Commands\CleanUpRecycleBinCommand.cs" />
     <Compile Include="MediaFiles\Commands\DownloadedEpisodesScanCommand.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\ImportMode.cs" />
     <Compile Include="MediaFiles\Commands\RenameFilesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameSeriesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RescanSeriesCommand.cs" />

--- a/src/UI/ManualImport/ManualImportLayout.js
+++ b/src/UI/ManualImport/ManualImportLayout.js
@@ -27,7 +27,8 @@ module.exports = Marionette.Layout.extend({
     },
 
     ui : {
-        importButton : '.x-import'
+        importButton : '.x-import',
+        importMode   : '.x-importmode'
     },
 
     events : {
@@ -94,6 +95,7 @@ module.exports = Marionette.Layout.extend({
         this.folder = options.folder;
         this.downloadId = options.downloadId;
         this.title = options.title;
+        this.importMode = options.importMode || 'Move';
 
         this.templateHelpers = {
             title : this.title || this.folder
@@ -105,11 +107,13 @@ module.exports = Marionette.Layout.extend({
         if (this.folder || this.downloadId) {
             this._showLoading();
             this._loadCollection();
+            this.ui.importMode.val(this.importMode);
         }
 
         else {
             this._showSelectFolder();
             this.ui.importButton.hide();
+            this.ui.importMode.hide();
         }
     },
 
@@ -196,6 +200,8 @@ module.exports = Marionette.Layout.extend({
             return;
         }
 
+        var importMode = this.ui.importMode.val();
+
         CommandController.Execute('manualImport', {
             name  : 'manualImport',
             files : _.map(selected, function (file) {
@@ -206,7 +212,8 @@ module.exports = Marionette.Layout.extend({
                     quality    : file.get('quality'),
                     downloadId : file.get('downloadId')
                 };
-            })
+            }),
+            importMode : importMode
         });
 
         vent.trigger(vent.Commands.CloseModalCommand);

--- a/src/UI/ManualImport/ManualImportLayoutTemplate.hbs
+++ b/src/UI/ManualImport/ManualImportLayoutTemplate.hbs
@@ -13,6 +13,12 @@
             <div class="x-footer"></div>
         </div>
         <div class="modal-footer">
+            <div class="col-md-2 pull-left">
+                <select class="form-control x-importmode">
+                    <option value="Move">Move Files</option>
+                    <option value="Copy">Copy Files</option>
+                </select>
+            </div>
             <button class="btn btn-default" data-dismiss="modal">Cancel</button>
             <button class="btn btn-success x-import" disabled="disabled">Import</button>
         </div>


### PR DESCRIPTION
#### Database Migration

NO
#### Description
- DownloadedEpisodesScan command now has an importMode=['Move','Copy'] property to override default behavior. It defaults to whatever CDH is saying about the downloadId. If no downloadId is supplied, 'Move' is used as default.
- Manual Import UI now has a dropdown to change the mode. Defaults to 'Move'.
- Activity->Queue->Force Import sets the initial value of the dropdown to whatever CDH is saying about the download (so effectively, seeding torrent defaults to 'Copy')
#### Issues Fixed or Closed by this PR
- https://github.com/Sonarr/Sonarr/issues/606
