### PR TITLE
Shorten 'MPEG-2 Video' codec name to 'MPEG2' when renaming files.

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -470,6 +470,10 @@ namespace NzbDrone.Core.Organizer
                     }
                     break;
 
+                case "MPEG-2 Video":
+                    videoCodec = "MPEG2";
+                    break;
+
                 default:
                     videoCodec = episodeFile.MediaInfo.VideoCodec;
                     break;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This shortens the  'MPEG-2 Video' to 'MPEG2' so when using the renamer, files look like;
`Land Girls - S01E01 - Childhood's End [DVD MPEG2 AC3 2.0].mkv`
vs.
`Land Girls - S01E01 - Childhood's End [DVD MPEG-2 Video AC3 2.0].mkv`
