### PR TITLE
Notification API Cleanup

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.Validation;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.NotificationTests
+{
+    [TestFixture]
+    public class NotificationBaseFixture : TestBase
+    {
+        class TestSetting : IProviderConfig
+        {
+            public NzbDroneValidationResult Validate()
+            {
+                return new NzbDroneValidationResult();
+            }
+        }
+
+        class TestNotificationWithOnDownload : NotificationBase<TestSetting>
+        {
+            public override string Name => "TestNotification";
+            public override string Link => "";
+
+
+            public override ValidationResult Test()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void OnDownload(DownloadMessage downloadMessage)
+            {
+                TestLogger.Info("OnDownload was called");
+            }
+
+        }
+
+        class TestNotificationWithAllEvents : NotificationBase<TestSetting>
+        {
+            public override string Name => "TestNotification";
+            public override string Link => "";
+
+
+            public override ValidationResult Test()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void OnGrab(GrabMessage grabMessage)
+            {
+                TestLogger.Info("OnGrab was called");
+            }
+
+            public override void OnDownload(DownloadMessage message)
+            {
+                TestLogger.Info("OnDownload was called");
+            }
+
+            public override void OnRename(Series series)
+            {
+                TestLogger.Info("OnRename was called");
+            }
+
+        }
+
+        class TestNotificationWithNoEvents : NotificationBase<TestSetting>
+        {
+            public override string Name => "TestNotification";
+            public override string Link => "";
+
+
+            public override ValidationResult Test()
+            {
+                throw new NotImplementedException();
+            }
+
+          
+        }
+
+        [Test]
+        public void should_support_OnUpgrade_should_link_to_OnDownload()
+        {
+            var notification = new TestNotificationWithOnDownload();
+
+            notification.SupportsOnDownload.Should().BeTrue();
+            notification.SupportsOnUpgrade.Should().BeTrue();
+
+            notification.SupportsOnGrab.Should().BeFalse();
+            notification.SupportsOnRename.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_support_all_if_implemented()
+        {
+            var notification = new TestNotificationWithAllEvents();
+
+            notification.SupportsOnGrab.Should().BeTrue();
+            notification.SupportsOnDownload.Should().BeTrue();
+            notification.SupportsOnUpgrade.Should().BeTrue();
+            notification.SupportsOnRename.Should().BeTrue();
+        }
+
+
+        [Test]
+        public void should_support_none_if_none_are_implemented()
+        {
+            var notification = new TestNotificationWithNoEvents();
+
+            notification.SupportsOnGrab.Should().BeFalse();
+            notification.SupportsOnDownload.Should().BeFalse();
+            notification.SupportsOnUpgrade.Should().BeFalse();
+            notification.SupportsOnRename.Should().BeFalse();
+        }
+    }
+
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -288,6 +288,7 @@
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchSeriesComparerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />
+    <Compile Include="NotificationTests\NotificationBaseFixture.cs" />
     <Compile Include="NotificationTests\SynologyIndexerFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\CleanTitleFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\EpisodeTitleCollapseFixture.cs" />

--- a/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
+++ b/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.Boxcar
 {
@@ -15,28 +14,17 @@ namespace NzbDrone.Core.Notifications.Boxcar
         }
 
         public override string Link => "https://boxcar.io/client";
+        public override string Name => "Boxcar";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE , message.Message, Settings);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Boxcar";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -24,6 +24,8 @@ namespace NzbDrone.Core.Notifications.CustomScript
             _logger = logger;
         }
 
+        public override string Name => "Custom Script";
+
         public override string Link => "https://github.com/Sonarr/Sonarr/wiki/Custom-Post-Processing-Scripts";
 
         public override void OnGrab(GrabMessage message)
@@ -95,7 +97,6 @@ namespace NzbDrone.Core.Notifications.CustomScript
             ExecuteScript(environmentVariables);
         }
 
-        public override string Name => "Custom Script";
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -10,6 +10,9 @@ namespace NzbDrone.Core.Notifications.Email
     {
         private readonly IEmailService _emailService;
 
+        public override string Name => "Email";
+
+
         public Email(IEmailService emailService)
         {
             _emailService = emailService;
@@ -19,27 +22,18 @@ namespace NzbDrone.Core.Notifications.Email
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string subject = "Sonarr [TV] - Grabbed";
-            var body = string.Format("{0} sent to queue.", grabMessage.Message);
+            var body = $"{grabMessage.Message} sent to queue.";
 
-            _emailService.SendEmail(Settings, subject, body);
+            _emailService.SendEmail(Settings, EPISODE_GRABBED_TITLE_BRANDED, body);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string subject = "Sonarr [TV] - Downloaded";
-            var body = string.Format("{0} Downloaded and sorted.", message.Message);
+            var body = $"{message.Message} Downloaded and sorted.";
 
-            _emailService.SendEmail(Settings, subject, body);
+            _emailService.SendEmail(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, body);
         }
 
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Email";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Growl/Growl.cs
+++ b/src/NzbDrone.Core/Notifications/Growl/Growl.cs
@@ -9,6 +9,9 @@ namespace NzbDrone.Core.Notifications.Growl
     {
         private readonly IGrowlService _growlService;
 
+        public override string Name => "Growl";
+
+
         public Growl(IGrowlService growlService)
         {
             _growlService = growlService;
@@ -18,25 +21,14 @@ namespace NzbDrone.Core.Notifications.Growl
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _growlService.SendNotification(title, grabMessage.Message, "GRAB", Settings.Host, Settings.Port, Settings.Password);
+            _growlService.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, "GRAB", Settings.Host, Settings.Port, Settings.Password);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _growlService.SendNotification(title, message.Message, "DOWNLOAD", Settings.Host, Settings.Port, Settings.Password);
+            _growlService.SendNotification(EPISODE_GRABBED_TITLE, message.Message, "DOWNLOAD", Settings.Host, Settings.Port, Settings.Password);
         }
 
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Growl";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.Join
 {
@@ -14,29 +13,19 @@ namespace NzbDrone.Core.Notifications.Join
             _proxy = proxy;
         }
 
-        public override string Link => "https://joinjoaomgcd.appspot.com/";
+        public override string Name => "Join";
+
+        public override string Link => "https://joaoapps.com/join/";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Sonarr - Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE_BRANDED, Message.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Sonarr - Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Join";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -4,7 +4,7 @@ using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
 
-namespace NzbDrone.Core.Notifications.MediaBrowser
+namespace NzbDrone.Core.Notifications.Emby
 {
     public class MediaBrowser : NotificationBase<MediaBrowserSettings>
     {
@@ -15,25 +15,23 @@ namespace NzbDrone.Core.Notifications.MediaBrowser
             _mediaBrowserService = mediaBrowserService;
         }
 
-        public override string Link => "http://mediabrowser.tv/";
+        public override string Link => "https://emby.media/";
+        public override string Name => "Emby (Media Browser)";
+
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Sonarr - Grabbed";
-
             if (Settings.Notify)
             {
-                _mediaBrowserService.Notify(Settings, title, grabMessage.Message);
+                _mediaBrowserService.Notify(Settings, EPISODE_GRABBED_TITLE_BRANDED, grabMessage.Message);
             }
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Sonarr - Downloaded";
-
             if (Settings.Notify)
             {
-                _mediaBrowserService.Notify(Settings, title, message.Message);
+                _mediaBrowserService.Notify(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message);
             }
 
             if (Settings.UpdateLibrary)
@@ -50,7 +48,6 @@ namespace NzbDrone.Core.Notifications.MediaBrowser
             }
         }
 
-        public override string Name => "Emby (Media Browser)";
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -4,7 +4,7 @@ using NLog;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
 
-namespace NzbDrone.Core.Notifications.MediaBrowser
+namespace NzbDrone.Core.Notifications.Emby
 {
     public class MediaBrowserProxy
     {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
@@ -5,7 +5,7 @@ using NLog;
 using NzbDrone.Core.Rest;
 using NzbDrone.Core.Tv;
 
-namespace NzbDrone.Core.Notifications.MediaBrowser
+namespace NzbDrone.Core.Notifications.Emby
 {
     public interface IMediaBrowserService
     {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using FluentValidation;
+﻿using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
-namespace NzbDrone.Core.Notifications.MediaBrowser
+namespace NzbDrone.Core.Notifications.Emby
 {
     public class MediaBrowserSettingsValidator : AbstractValidator<MediaBrowserSettings>
     {
@@ -41,7 +40,7 @@ namespace NzbDrone.Core.Notifications.MediaBrowser
         public bool UpdateLibrary { get; set; }
 
         [JsonIgnore]
-        public string Address => string.Format("{0}:{1}", Host, Port);
+        public string Address => $"{Host}:{Port}";
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host) && Port > 0;
 

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -8,6 +8,12 @@ namespace NzbDrone.Core.Notifications
 {
     public abstract class NotificationBase<TSettings> : INotification where TSettings : IProviderConfig, new()
     {
+        protected const string EPISODE_GRABBED_TITLE = "Episode Grabbed";
+        protected const string EPISODE_DOWNLOADED_TITLE = "Episode Downloaded";
+
+        protected const string EPISODE_GRABBED_TITLE_BRANDED = "Sonarr - " + EPISODE_GRABBED_TITLE;
+        protected const string EPISODE_DOWNLOADED_TITLE_BRANDED = "Sonarr - " + EPISODE_DOWNLOADED_TITLE;
+
         public abstract string Name { get; }
 
         public Type ConfigContract => typeof(TSettings);
@@ -21,14 +27,25 @@ namespace NzbDrone.Core.Notifications
 
         public abstract string Link { get; }
 
-        public abstract void OnGrab(GrabMessage grabMessage);
-        public abstract void OnDownload(DownloadMessage message); 
-        public abstract void OnRename(Series series);
+        public virtual void OnGrab(GrabMessage grabMessage)
+        {
 
-        public virtual bool SupportsOnGrab => true;
-        public virtual bool SupportsOnDownload => true;
-        public virtual bool SupportsOnUpgrade => true;
-        public virtual bool SupportsOnRename => true;
+        }
+
+        public virtual void OnDownload(DownloadMessage message)
+        {
+
+        }
+
+        public virtual void OnRename(Series series)
+        {
+
+        }
+
+        public bool SupportsOnGrab => HasConcreteImplementation("OnGrab");
+        public bool SupportsOnRename => HasConcreteImplementation("OnRename");
+        public bool SupportsOnDownload => HasConcreteImplementation("OnDownload");
+        public bool SupportsOnUpgrade => SupportsOnDownload;
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 
@@ -38,6 +55,19 @@ namespace NzbDrone.Core.Notifications
         }
 
         public virtual object RequestAction(string action, IDictionary<string, string> query) { return null; }
+
+
+        private bool HasConcreteImplementation(string methodName)
+        {
+            var method = GetType().GetMethod(methodName);
+
+            if (method == null)
+            {
+                throw new MissingMethodException(GetType().Name, Name);
+            }
+
+            return !method.DeclaringType.IsAbstract;
+        }
 
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotifyMyAndroid/NotifyMyAndroid.cs
+++ b/src/NzbDrone.Core/Notifications/NotifyMyAndroid/NotifyMyAndroid.cs
@@ -1,8 +1,6 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.NotifyMyAndroid
 {
@@ -15,29 +13,18 @@ namespace NzbDrone.Core.Notifications.NotifyMyAndroid
             _proxy = proxy;
         }
 
-        public override string Link => "http://www.notifymyandroid.com/";
+        public override string Link => "https://www.notifymyandroid.com/";
+        public override string Name => "Notify My Android";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotifyMyAndroidPriority)Settings.Priority);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Notify My Android";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Plex/PlexClient.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexClient.cs
@@ -9,32 +9,24 @@ namespace NzbDrone.Core.Notifications.Plex
     {
         private readonly IPlexClientService _plexClientService;
 
+        public override string Link => "https://www.plex.tv/";
+        public override string Name => "Plex Media Center";
+
         public PlexClient(IPlexClientService plexClientService)
         {
             _plexClientService = plexClientService;
         }
 
-        public override string Link => "http://www.plexapp.com/";
-
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string header = "Sonarr [TV] - Grabbed";
-            _plexClientService.Notify(Settings, header, grabMessage.Message);
+            _plexClientService.Notify(Settings, EPISODE_GRABBED_TITLE_BRANDED, grabMessage.Message);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string header = "Sonarr [TV] - Downloaded";
-            _plexClientService.Notify(Settings, header, message.Message);
+            _plexClientService.Notify(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message);
         }
 
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Plex Media Center";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Plex/PlexHomeTheater.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexHomeTheater.cs
@@ -20,30 +20,18 @@ namespace NzbDrone.Core.Notifications.Plex
             _logger = logger;
         }
 
+        public override string Name => "Plex Home Theater";
         public override string Link => "https://plex.tv/";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string header = "Sonarr - Grabbed";
-
-            Notify(Settings, header, grabMessage.Message);
+            Notify(Settings, EPISODE_GRABBED_TITLE_BRANDED, grabMessage.Message);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string header = "Sonarr - Downloaded";
-
-            Notify(Settings, header, message.Message);
+            Notify(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message);
         }
-
-        public override void OnRename(Series series)
-        {
-            
-        }
-
-        public override string Name => "Plex Home Theater";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {
@@ -65,7 +53,7 @@ namespace NzbDrone.Core.Notifications.Plex
             }
             catch (SocketException ex)
             {
-                var logMessage = string.Format("Unable to connect to PHT Host: {0}:{1}", Settings.Host, Settings.Port);
+                var logMessage = $"Unable to connect to PHT Host: {Settings.Host}:{Settings.Port}";
                 _logger.Debug(ex, logMessage);
             }
         }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
@@ -14,11 +14,8 @@ namespace NzbDrone.Core.Notifications.Plex
             _plexServerService = plexServerService;
         }
 
-        public override string Link => "http://www.plexapp.com/";
-
-        public override void OnGrab(GrabMessage grabMessage)
-        {
-        }
+        public override string Link => "https://www.plex.tv/";
+        public override string Name => "Plex Media Server";
 
         public override void OnDownload(DownloadMessage message)
         {
@@ -37,10 +34,6 @@ namespace NzbDrone.Core.Notifications.Plex
                 _plexServerService.UpdateLibrary(series, Settings);
             }
         }
-
-        public override string Name => "Plex Media Server";
-
-        public override bool SupportsOnGrab => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
@@ -15,29 +15,18 @@ namespace NzbDrone.Core.Notifications.Prowl
             _prowlService = prowlService;
         }
 
-        public override string Link => "http://www.prowlapp.com/";
+        public override string Link => "https://www.prowlapp.com/";
+        public override string Name => "Prowl";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _prowlService.SendNotification(title, grabMessage.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
+            _prowlService.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _prowlService.SendNotification(title, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
+            _prowlService.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Prowl";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.PushBullet
 {
@@ -14,29 +13,19 @@ namespace NzbDrone.Core.Notifications.PushBullet
             _proxy = proxy;
         }
 
+        public override string Name => "Pushbullet";
         public override string Link => "https://www.pushbullet.com/";
+
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Sonarr - Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE_BRANDED, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Sonarr - Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Pushbullet";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Pushalot/Pushalot.cs
+++ b/src/NzbDrone.Core/Notifications/Pushalot/Pushalot.cs
@@ -15,29 +15,19 @@ namespace NzbDrone.Core.Notifications.Pushalot
             _proxy = proxy;
         }
 
-        public override string Link => "https://www.Pushalot.com/";
+        public override string Name => "Pushalot";
+        public override string Link => "https://pushalot.com/";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Pushalot";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.Pushover
 {
@@ -14,29 +13,18 @@ namespace NzbDrone.Core.Notifications.Pushover
             _proxy = proxy;
         }
 
+        public override string Name => "Pushover";
         public override string Link => "https://pushover.net/";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Pushover";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -22,7 +22,6 @@ namespace NzbDrone.Core.Notifications.Slack
         }
 
         public override string Name => "Slack";
-
         public override string Link => "https://my.slack.com/services/new/incoming-webhook/";
 
         public override void OnGrab(GrabMessage message)

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexer.cs
@@ -16,12 +16,9 @@ namespace NzbDrone.Core.Notifications.Synology
             _indexerProxy = indexerProxy;
         }
 
-        public override string Link => "http://www.synology.com";
+        public override string Link => "https://www.synology.com";
+        public override string Name => "Synology Indexer";
 
-        public override void OnGrab(GrabMessage grabMessage)
-        {
-
-        }
 
         public override void OnDownload(DownloadMessage message)
         {
@@ -50,7 +47,6 @@ namespace NzbDrone.Core.Notifications.Synology
             }
         }
 
-        public override string Name => "Synology Indexer";
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.Telegram
 {
@@ -14,29 +13,18 @@ namespace NzbDrone.Core.Notifications.Telegram
             _proxy = proxy;
         }
 
+        public override string Name => "Telegram";
         public override string Link => "https://telegram.org/";
 
         public override void OnGrab(GrabMessage grabMessage)
         {
-            const string title = "Episode Grabbed";
-
-            _proxy.SendNotification(title, grabMessage.Message, Settings);
+            _proxy.SendNotification(EPISODE_GRABBED_TITLE, grabMessage.Message, Settings);
         }
 
         public override void OnDownload(DownloadMessage message)
         {
-            const string title = "Episode Downloaded";
-
-            _proxy.SendNotification(title, message.Message, Settings);
+            _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
-
-        public override void OnRename(Series series)
-        {
-        }
-
-        public override string Name => "Telegram";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
@@ -2,7 +2,6 @@
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Exceptions;
-using NzbDrone.Core.Tv;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Twitter
@@ -17,6 +16,7 @@ namespace NzbDrone.Core.Notifications.Twitter
             _twitterService = twitterService;
         }
 
+        public override string Name => "Twitter";
         public override string Link => "https://twitter.com/";
 
         public override void OnGrab(GrabMessage message)
@@ -27,10 +27,6 @@ namespace NzbDrone.Core.Notifications.Twitter
         public override void OnDownload(DownloadMessage message)
         {
             _twitterService.SendNotification($"Imported: {message.Message}", Settings);
-        }
-
-        public override void OnRename(Series series)
-        {
         }
 
         public override object RequestAction(string action, IDictionary<string, string> query)
@@ -73,10 +69,6 @@ namespace NzbDrone.Core.Notifications.Twitter
             }
             return new { };
         }
-
-        public override string Name => "Twitter";
-
-        public override bool SupportsOnRename => false;
 
         public override ValidationResult Test()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Cleaned up some of the API making them less boiler platy!



Two main parts:

-  `SupportsOnGrab` `SupportsOnDownload` etc, is no longer needed in the implementation, it's dynamically determined at runtime based on whether the implementation has overridden the matching method.  🎩 

- We had 20 different version of `Sonarr - Grabbed` text all over the place, now it all comes from base class, there is still room to make it even more DRY, but requires digging into the proxies etc. 

