### PR TITLE
Option to convert ical feed items to all-day events

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Api.Calendar
             var end = DateTime.Today.AddDays(futureDays);
             var unmonitored = false;
             var premiersOnly = false;
+            var asAllDay = false;
             var tags = new List<int>();
 
             // TODO: Remove start/end parameters in v3, they don't work well for iCal
@@ -46,6 +47,7 @@ namespace NzbDrone.Api.Calendar
             var queryFutureDays = Request.Query.FutureDays;
             var queryUnmonitored = Request.Query.Unmonitored;
             var queryPremiersOnly = Request.Query.PremiersOnly;
+            var queryAsAllDay = Request.Query.AsAllDay;
             var queryTags = Request.Query.Tags;
 
             if (queryStart.HasValue) start = DateTime.Parse(queryStart.Value);
@@ -71,6 +73,11 @@ namespace NzbDrone.Api.Calendar
             if (queryPremiersOnly.HasValue)
             {
                 premiersOnly = bool.Parse(queryPremiersOnly.Value);
+            }
+
+            if (queryAsAllDay.HasValue)
+            {
+                asAllDay = bool.Parse(queryAsAllDay.Value);
             }
 
             if (queryTags.HasValue)
@@ -102,10 +109,18 @@ namespace NzbDrone.Api.Calendar
                 var occurrence = calendar.Create<Event>();
                 occurrence.Uid = "NzbDrone_episode_" + episode.Id;
                 occurrence.Status = episode.HasFile ? EventStatus.Confirmed : EventStatus.Tentative;
-                occurrence.Start = new CalDateTime(episode.AirDateUtc.Value) { HasTime = true };
-                occurrence.End = new CalDateTime(episode.AirDateUtc.Value.AddMinutes(episode.Series.Runtime)) { HasTime = true };
                 occurrence.Description = episode.Overview;
                 occurrence.Categories = new List<string>() { episode.Series.Network };
+
+                if (asAllDay)
+                {
+                    occurrence.Start = new CalDateTime(episode.AirDateUtc.Value) { HasTime = false };
+                }
+                else
+                {
+                    occurrence.Start = new CalDateTime(episode.AirDateUtc.Value) { HasTime = true };
+                    occurrence.End = new CalDateTime(episode.AirDateUtc.Value.AddMinutes(episode.Series.Runtime)) { HasTime = true };
+                }
 
                 switch (episode.Series.SeriesType)
                 {

--- a/src/UI/Calendar/CalendarFeedView.js
+++ b/src/UI/Calendar/CalendarFeedView.js
@@ -9,6 +9,7 @@ module.exports = Marionette.Layout.extend({
     ui : {
         includeUnmonitored : '.x-includeUnmonitored',
         premiersOnly       : '.x-premiersOnly',
+        asAllDay           : '.x-asAllDay',
         tags               : '.x-tags',
         icalUrl            : '.x-ical-url',
         icalCopy           : '.x-ical-copy',
@@ -18,6 +19,7 @@ module.exports = Marionette.Layout.extend({
     events : {
         'click .x-includeUnmonitored' : '_updateUrl',
         'click .x-premiersOnly'       : '_updateUrl',
+        'click .x-asAllDay'           : '_updateUrl',
         'itemAdded .x-tags'           : '_updateUrl',
         'itemRemoved .x-tags'         : '_updateUrl'
     },
@@ -29,7 +31,7 @@ module.exports = Marionette.Layout.extend({
     },
 
     _updateUrl : function() {
-        var icalUrl = window.location.host + StatusModel.get('urlBase') + '/feed/calendar/NzbDrone.ics?';
+        var icalUrl = window.location.host + StatusModel.get('urlBase') + '/feed/calendar/Sonarr.ics?';
 
         if (this.ui.includeUnmonitored.prop('checked')) {
             icalUrl += 'unmonitored=true&';
@@ -37,6 +39,10 @@ module.exports = Marionette.Layout.extend({
 
         if (this.ui.premiersOnly.prop('checked')) {
             icalUrl += 'premiersOnly=true&';
+        }
+
+        if (this.ui.asAllDay.prop('checked')) {
+            icalUrl += 'asAllDay=true&';
         }
 
         if (this.ui.tags.val()) {

--- a/src/UI/Calendar/CalendarFeedViewTemplate.hbs
+++ b/src/UI/Calendar/CalendarFeedViewTemplate.hbs
@@ -42,6 +42,24 @@
                 </div>
             </div>
             <div class="form-group">
+                <label class="col-sm-3 control-label">Show as All-Day Events</label>
+
+                <div class="col-sm-4">
+                    <div class="input-group">
+                        <label class="checkbox toggle well">
+                            <input type="checkbox" name="asAllDay" class="form-control x-asAllDay"/>
+
+                            <p>
+                                <span>Yes</span>
+                                <span>No</span>
+                            </p>
+
+                            <div class="btn btn-primary slide-button"/>
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
                 <label class="col-sm-3 control-label">Tags</label>
 
                 <div class="col-sm-1 col-sm-push-5 help-inline">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As a European watching mostly American shows, the iCal feed events all take place around midnight, which (in my case) is collapsed by default. Since I don't really care for the exact air time of each episode (it takes a while before they are available anyway), I would prefer the ability of having all-day events for each episode. 

The following toggle enables this feature.
![image](https://cloud.githubusercontent.com/assets/1564254/21999487/af070ab8-dc3a-11e6-944a-d26ea7fa4dec.png)

#### Issues Fixed or Closed by this PR

* None. This was just a random idea that came up. Since it's not that intrusive, I thought I'd just propose it anyway.
