### PR TITLE
Remove torrent from client when they're moved

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -37,11 +37,12 @@ namespace NzbDrone.Core.Download
         {
             if (!_configService.RemoveCompletedDownloads ||
                 message.TrackedDownload.DownloadItem.Removed ||
-                message.TrackedDownload.DownloadItem.IsReadOnly ||
                 message.TrackedDownload.DownloadItem.Status == DownloadItemStatus.Downloading)
             {
                 return;
             }
+
+            if (message.TrackedDownload.DownloadItem.IsReadOnly && _configService.CopyUsingHardlinks) return;
 
             RemoveFromDownloadClient(message.TrackedDownload);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR will make it possible to remove seeding torrents from clients when the files are moved/removed from the downloads folder by Sonarr.

#### Todos
- [ ] Tests
- [ ] Documentation