### PR TITLE
Change default Newznab/Torznab indexer categories to TV

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public NewznabSettings()
         {
-            Categories = new[] { 5030, 5040 };
+            Categories = new[] { 5000 };
             AnimeCategories = Enumerable.Empty<int>();
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Over at the Jackett project we occasionally get issues due to an incorrect category configuration. The root cause is the fact that some trackers don't have TV SD/HD categories (just a TV cat). In this case the releases won't be found with the current default cat settings.
Due to that I would like to propose this change of the default categories.

#### Todos

#### Issues Fixed or Closed by this PR

