### PR TITLE
Delete data manually after finished seeding

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation.cs
@@ -119,7 +119,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                _proxy.RemoveTorrent(ParseDownloadId(downloadId), deleteData, Settings);
+                if (deleteData)
+                {
+                    DeleteItemData(downloadId);
+                }
+                _proxy.RemoveTorrent(ParseDownloadId(downloadId), Settings);
                 _logger.Debug("{0} removed correctly", downloadId);
                 return;
             }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStation.cs
@@ -117,20 +117,13 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         public override void RemoveItem(string downloadId, bool deleteData)
         {
-            try
+            if (deleteData)
             {
-                if (deleteData)
-                {
-                    DeleteItemData(downloadId);
-                }
-                _proxy.RemoveTorrent(ParseDownloadId(downloadId), Settings);
-                _logger.Debug("{0} removed correctly", downloadId);
-                return;
+                DeleteItemData(downloadId);
             }
-            catch (DownloadClientException e)
-            {
-                _logger.Error(e);
-            }
+
+            _proxy.RemoveTorrent(ParseDownloadId(downloadId), Settings);
+            _logger.Debug("{0} removed correctly", downloadId);
         }
 
         protected OsPath GetOutputPath(OsPath outputPath, DownloadStationTorrent torrent, string serialNumber)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
@@ -111,7 +111,6 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             };
 
             var response = ProcessRequest(DiskStationApi.DownloadStationTask, arguments, settings, $"remove item {downloadId}");
-            _logger.Trace("Item {0} removed from Download Station", downloadId);        
         }
 
         public IEnumerable<int> GetApiVersion(DownloadStationSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
     {
         IEnumerable<DownloadStationTorrent> GetTorrents(DownloadStationSettings settings);
         Dictionary<string, object> GetConfig(DownloadStationSettings settings);
-        void RemoveTorrent(string downloadId, bool deleteData, DownloadStationSettings settings);
+        void RemoveTorrent(string downloadId, DownloadStationSettings settings);
         void AddTorrentFromUrl(string url, string downloadDirectory, DownloadStationSettings settings);
         void AddTorrentFromData(byte[] torrentData, string filename, string downloadDirectory, DownloadStationSettings settings);
         IEnumerable<int> GetApiVersion(DownloadStationSettings settings);
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             return response.Data;
         }
 
-        public void RemoveTorrent(string downloadId, bool deleteData, DownloadStationSettings settings)
+        public void RemoveTorrent(string downloadId, DownloadStationSettings settings)
         {
             var arguments = new Dictionary<string, object>
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
DS doesn't support deleting files when removing the torrent after it has finished seeding.

#### Issues Fixed or Closed by this PR

#1676
