### PR TITLE
Diskstation: Fix for key not found, returning a generic error instead

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id1",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Waiting,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -83,7 +83,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id2",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Finished,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id2",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Seeding,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id3",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Downloading,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -152,7 +152,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id4",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Error,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id5",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Seeding,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "a.mkv",
                 Additional = new DownloadStationTaskAdditional
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id6",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Seeding,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id6",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Finished,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "a.mkv",
                 Additional = new DownloadStationTaskAdditional
@@ -244,7 +244,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id6",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Finished,
-                Type = DownloadStationTaskType.BT,
+                Type = DownloadStationTaskType.BT.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id1",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Waiting,
-                Type = DownloadStationTaskType.NZB,
+                Type = DownloadStationTaskType.NZB.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id2",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Finished,
-                Type = DownloadStationTaskType.NZB,
+                Type = DownloadStationTaskType.NZB.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id2",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Seeding,
-                Type = DownloadStationTaskType.NZB,
+                Type = DownloadStationTaskType.NZB.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id3",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Downloading,
-                Type = DownloadStationTaskType.NZB,
+                Type = DownloadStationTaskType.NZB.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional
@@ -150,7 +150,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                 Id = "id4",
                 Size = 1000,
                 Status = DownloadStationTaskStatus.Error,
-                Type = DownloadStationTaskType.NZB,
+                Type = DownloadStationTaskType.NZB.ToString(),
                 Username = "admin",
                 Title = "title",
                 Additional = new DownloadStationTaskAdditional

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
@@ -15,8 +15,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         public long Size { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
-        public DownloadStationTaskType Type { get; set; }
+        /// <summary>
+        /// /// Possible values are: BT, NZB, http, ftp, eMule and https
+        /// </summary>
+        public string Type { get; set; }
 
         [JsonProperty(PropertyName = "status_extra")]
         public Dictionary<string, string> StatusExtra { get; set; }
@@ -34,7 +36,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
     public enum DownloadStationTaskType
     {
-        BT, NZB, http, ftp, eMule
+        BT, NZB, http, ftp, eMule, https
     }
 
     public enum DownloadStationTaskStatus

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationProxy.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             {
                 var response = ProcessRequest<DownloadStationTaskInfoResponse>(DiskStationApi.DownloadStationTask, arguments, settings, "get tasks");
 
-                return response.Data.Tasks.Where(t => t.Type == type);
+                return response.Data.Tasks.Where(t => t.Type == type.ToString());
             }
             catch (DownloadClientException e)
             {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
@@ -83,16 +83,23 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
             {
                 return AuthMessages[Code];
             }
+
             if (api == DiskStationApi.DownloadStationTask && DownloadStationTaskMessages.ContainsKey(Code))
             {
                 return DownloadStationTaskMessages[Code];
             }
+
             if (api == DiskStationApi.FileStationList && FileStationMessages.ContainsKey(Code))
             {
                 return FileStationMessages[Code];
             }
 
-            return CommonMessages[Code];
+            if (CommonMessages.ContainsKey(Code))
+            {
+                return CommonMessages[Code];
+            }
+
+            return $"{ Code } - Unknown error";
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Returns a generic error message if error-code is not in the dictionary.

#### Issues Fixed or Closed by this PR
#1700 
