### PR TITLE
Sorting by torrent peers priority increased

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.DecisionEngine
             var comparers = new List<CompareDelegate>
             {
                 ComparePeersIfTorrent,
-				CompareQuality,
+                CompareQuality,
                 CompareProtocol,
                 CompareEpisodeCount,
                 CompareEpisodeNumber,

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -23,11 +23,11 @@ namespace NzbDrone.Core.DecisionEngine
         {
             var comparers = new List<CompareDelegate>
             {
-                CompareQuality,
+                ComparePeersIfTorrent,
+				CompareQuality,
                 CompareProtocol,
                 CompareEpisodeCount,
                 CompareEpisodeNumber,
-                ComparePeersIfTorrent,
                 CompareAgeIfUsenet,
                 CompareSize
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This would first sort by peers in a torrent result, then by the other sorts. Hopefully making a given quality have a ordered list by quality, then health.
