### PR TITLE
Consistent formatting for MediaInfo in various locations

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
@@ -2,10 +2,10 @@
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 
-namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
+namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
 {
     [TestFixture]
-    public class FormattedAudioChannelsFixture
+    public class FormatAudioChannelsFixture
     {
         [Test]
         public void should_subtract_one_from_AudioChannels_as_total_channels_if_LFE_in_AudioChannelPositionsText()
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 AudioChannelPositionsText = "Front: L C R, Side: L R, LFE"
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(5.1m);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(5.1m);
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 AudioChannelPositionsText = "Front: L R"
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(2);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(2);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 2
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(0);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(0);
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 3
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(2);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(2);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 3
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(2);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(2);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 3
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(5.1m);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(5.1m);
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 3
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(7.1m);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(7.1m);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 SchemaRevision = 3
             };
 
-            mediaInfoModel.FormattedAudioChannels.Should().Be(7.1m);
+            MediaInfoFormatter.FormatAudioChannels(mediaInfoModel).Should().Be(7.1m);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioChannelsFixture.cs
@@ -1,11 +1,12 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
 {
     [TestFixture]
-    public class FormatAudioChannelsFixture
+    public class FormatAudioChannelsFixture : TestBase
     {
         [Test]
         public void should_subtract_one_from_AudioChannels_as_total_channels_if_LFE_in_AudioChannelPositionsText()

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,0 +1,77 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+
+namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
+{
+    [TestFixture]
+    public class FormatAudioCodecFixture
+    {
+        [Test]
+        public void should_return_AC3_for_AC_3()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "AC-3"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("AC3");
+        }
+
+        [Test]
+        public void should_return_EAC3_for_E_AC_3()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "E-AC-3"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("EAC3");
+        }
+
+        [Test]
+        public void should_return_MP3_for_MPEG_Audio_with_Layer_3_for_the_profile()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "MPEG Audio",
+                AudioProfile = "Layer 3"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("MP3");
+        }
+
+        [Test]
+        public void should_return_MPEG_Audio_for_MPEG_Audio_without_Layer_3_for_the_profile()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "MPEG Audio"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("MPEG Audio");
+        }
+
+        [Test]
+        public void should_return_DTS_for_DTS()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "DTS"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("DTS");
+        }
+
+        [Test]
+        public void should_default_to_AudioFormat()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                AudioFormat = "Other Audio Format"
+            };
+
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be(mediaInfoModel.AudioFormat);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,32 +1,25 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
 {
     [TestFixture]
-    public class FormatAudioCodecFixture
+    public class FormatAudioCodecFixture : TestBase
     {
-        [Test]
-        public void should_return_AC3_for_AC_3()
+        [TestCase("AC-3", "AC3")]
+        [TestCase("E-AC-3", "EAC3")]
+        [TestCase("MPEG Audio", "MPEG Audio")]
+        [TestCase("DTS", "DTS")]
+        public void should_format_audio_format(string audioFormat, string expectedFormat)
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                AudioFormat = "AC-3"
+                AudioFormat = audioFormat
             };
 
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("AC3");
-        }
-
-        [Test]
-        public void should_return_EAC3_for_E_AC_3()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                AudioFormat = "E-AC-3"
-            };
-
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("EAC3");
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be(expectedFormat);
         }
 
         [Test]
@@ -42,29 +35,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         }
 
         [Test]
-        public void should_return_MPEG_Audio_for_MPEG_Audio_without_Layer_3_for_the_profile()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                AudioFormat = "MPEG Audio"
-            };
-
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("MPEG Audio");
-        }
-
-        [Test]
-        public void should_return_DTS_for_DTS()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                AudioFormat = "DTS"
-            };
-
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be("DTS");
-        }
-
-        [Test]
-        public void should_default_to_AudioFormat()
+        public void should_return_AudioFormat_by_default()
         {
             var mediaInfoModel = new MediaInfoModel
             {
@@ -72,6 +43,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
             };
 
             MediaInfoFormatter.FormatAudioCodec(mediaInfoModel).Should().Be(mediaInfoModel.AudioFormat);
+            ExceptionVerification.ExpectedErrors(1);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -1,0 +1,98 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+
+namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
+{
+    [TestFixture]
+    public class FormatVideoCodecFixture
+    {
+        [Test]
+        public void should_default_to_x264_if_codec_is_AVC()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "AVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("x264");
+        }
+
+        [Test]
+        public void should_return_to_x264_if_codec_is_AVC_and_source_title_does_not_contain_h264()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "AVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.x264.720p-Sonarr").Should().Be("x264");
+        }
+
+        [Test]
+        public void should_return_to_h264_if_codec_is_AVC_and_source_title_contains_h264()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "AVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.h264.720p-Sonarr").Should().Be("h264");
+        }
+
+        [Test]
+        public void should_default_to_x265_if_codec_is_HEVC()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "V_MPEGH/ISO/HEVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("x265");
+        }
+
+        [Test]
+        public void should_return_to_x265_if_codec_is_HEVC_and_source_title_does_not_contain_h265()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "V_MPEGH/ISO/HEVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.x265.720p-Sonarr").Should().Be("x265");
+        }
+
+        [Test]
+        public void should_return_to_h265_if_codec_is_HEVC_and_source_title_contains_h265()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "V_MPEGH/ISO/HEVC"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.h265.720p-Sonarr").Should().Be("h265");
+        }
+
+        [Test]
+        public void should_return_to_MPEG2_if_video_codec_is_MPEG_2_Video()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "MPEG-2 Video"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("MPEG2");
+        }
+
+        [Test]
+        public void should_return_to_video_codec_by_default()
+        {
+            var mediaInfoModel = new MediaInfoModel
+            {
+                VideoCodec = "VideoCodec"
+            };
+
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be(mediaInfoModel.VideoCodec);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -1,91 +1,32 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
 {
     [TestFixture]
-    public class FormatVideoCodecFixture
+    public class FormatVideoCodecFixture : TestBase
     {
-        [Test]
-        public void should_default_to_x264_if_codec_is_AVC()
+        [TestCase("AVC", null, "x264")]
+        [TestCase("AVC", "source.title.x264.720p-Sonarr", "x264")]
+        [TestCase("AVC", "source.title.h264.720p-Sonarr", "h264")]
+        [TestCase("V_MPEGH/ISO/HEVC", null, "x265")]
+        [TestCase("V_MPEGH/ISO/HEVC", "source.title.x265.720p-Sonarr", "x265")]
+        [TestCase("V_MPEGH/ISO/HEVC", "source.title.h265.720p-Sonarr", "h265")]
+        [TestCase("MPEG-2 Video", null, "MPEG2")]
+        public void should_format_video_codec_with_source_title(string videoCodec, string sceneName, string expectedFormat)
         {
             var mediaInfoModel = new MediaInfoModel
             {
-                VideoCodec = "AVC"
+                VideoCodec = videoCodec
             };
 
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("x264");
+            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, sceneName).Should().Be(expectedFormat);
         }
 
         [Test]
-        public void should_return_to_x264_if_codec_is_AVC_and_source_title_does_not_contain_h264()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "AVC"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.x264.720p-Sonarr").Should().Be("x264");
-        }
-
-        [Test]
-        public void should_return_to_h264_if_codec_is_AVC_and_source_title_contains_h264()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "AVC"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.h264.720p-Sonarr").Should().Be("h264");
-        }
-
-        [Test]
-        public void should_default_to_x265_if_codec_is_HEVC()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "V_MPEGH/ISO/HEVC"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("x265");
-        }
-
-        [Test]
-        public void should_return_to_x265_if_codec_is_HEVC_and_source_title_does_not_contain_h265()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "V_MPEGH/ISO/HEVC"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.x265.720p-Sonarr").Should().Be("x265");
-        }
-
-        [Test]
-        public void should_return_to_h265_if_codec_is_HEVC_and_source_title_contains_h265()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "V_MPEGH/ISO/HEVC"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, "source.title.h265.720p-Sonarr").Should().Be("h265");
-        }
-
-        [Test]
-        public void should_return_to_MPEG2_if_video_codec_is_MPEG_2_Video()
-        {
-            var mediaInfoModel = new MediaInfoModel
-            {
-                VideoCodec = "MPEG-2 Video"
-            };
-
-            MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be("MPEG2");
-        }
-
-        [Test]
-        public void should_return_to_video_codec_by_default()
+        public void should_return_VideoCodec_by_default()
         {
             var mediaInfoModel = new MediaInfoModel
             {
@@ -93,6 +34,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
             };
 
             MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be(mediaInfoModel.VideoCodec);
+            ExceptionVerification.ExpectedErrors(1);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -286,7 +286,9 @@
     <Compile Include="MediaFiles\EpisodeImport\Specifications\UpgradeSpecificationFixture.cs" />
     <Compile Include="MediaFiles\ImportApprovedEpisodesFixture.cs" />
     <Compile Include="MediaFiles\MediaFileRepositoryFixture.cs" />
-    <Compile Include="MediaFiles\MediaInfo\FormattedAudioChannelsFixture.cs" />
+    <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatAudioCodecFixture.cs" />
+    <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatVideoCodecFixture.cs" />
+    <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatAudioChannelsFixture.cs" />
     <Compile Include="Messaging\Commands\CommandQueueManagerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchSeriesComparerFixture.cs" />

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -11,6 +11,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Extras.Metadata.Files;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
@@ -247,7 +248,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         var video = new XElement("video");
                         video.Add(new XElement("aspect", (float)episodeFile.MediaInfo.Width / (float)episodeFile.MediaInfo.Height));
                         video.Add(new XElement("bitrate", episodeFile.MediaInfo.VideoBitrate));
-                        video.Add(new XElement("codec", episodeFile.MediaInfo.VideoCodec));
+                        video.Add(new XElement("codec", MediaInfoFormatter.FormatVideoCodec(episodeFile.MediaInfo, episodeFile.SceneName)));
                         video.Add(new XElement("framerate", episodeFile.MediaInfo.VideoFps));
                         video.Add(new XElement("height", episodeFile.MediaInfo.Height));
                         video.Add(new XElement("scantype", episodeFile.MediaInfo.ScanType));
@@ -264,11 +265,11 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         var audio = new XElement("audio");
                         audio.Add(new XElement("bitrate", episodeFile.MediaInfo.AudioBitrate));
                         audio.Add(new XElement("channels", episodeFile.MediaInfo.AudioChannels));
-                        audio.Add(new XElement("codec", GetAudioCodec(episodeFile.MediaInfo.AudioFormat)));
+                        audio.Add(new XElement("codec", MediaInfoFormatter.FormatAudioCodec(episodeFile.MediaInfo)));
                         audio.Add(new XElement("language", episodeFile.MediaInfo.AudioLanguages));
                         streamDetails.Add(audio);
 
-                        if (episodeFile.MediaInfo.Subtitles != null && episodeFile.MediaInfo.Subtitles.Length > 0)
+                        if (episodeFile.MediaInfo.Subtitles.IsNotNullOrWhiteSpace())
                         {
                             var subtitle = new XElement("subtitle");
                             subtitle.Add(new XElement("language", episodeFile.MediaInfo.Subtitles));
@@ -378,16 +379,6 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         private string GetEpisodeImageFilename(string episodeFilePath)
         {
             return Path.ChangeExtension(episodeFilePath, "").Trim('.') + "-thumb.jpg";
-        }
-
-        private string GetAudioCodec(string audioCodec)
-        {
-            if (audioCodec == "AC-3")
-            {
-                return "AC3";
-            }
-
-            return audioCodec;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Core.MediaFiles.MediaInfo
+{
+    public static class MediaInfoFormatter
+    {
+        public static decimal FormatAudioChannels(MediaInfoModel mediaInfo)
+        {
+            var audioChannelPositions = mediaInfo.AudioChannelPositions;
+            var audioChannelPositionsText = mediaInfo.AudioChannelPositionsText;
+            var audioChannels = mediaInfo.AudioChannels;
+
+            if (audioChannelPositions.IsNullOrWhiteSpace())
+            {
+                if (audioChannelPositionsText.IsNullOrWhiteSpace())
+                {
+                    if (mediaInfo.SchemaRevision >= 3)
+                    {
+                        return audioChannels;
+                    }
+
+                    return 0;
+                }
+
+                return mediaInfo.AudioChannelPositionsText.ContainsIgnoreCase("LFE") ? audioChannels - 1 + 0.1m : audioChannels;
+            }
+
+            return audioChannelPositions.Replace("Object Based / ", "")
+                                        .Split(new string[] { " / " }, StringSplitOptions.None)
+                                        .First()
+                                        .Split('/')
+                                        .Sum(s => decimal.Parse(s, CultureInfo.InvariantCulture));
+        }
+
+        public static string FormatAudioCodec(MediaInfoModel mediaInfo)
+        {
+            var audioFormat = mediaInfo.AudioFormat;
+
+            if (audioFormat == "AC-3")
+            {
+                return "AC3";
+            }
+
+            if (audioFormat == "E-AC-3")
+            {
+                return "EAC3";
+            }
+
+            if (audioFormat == "MPEG Audio")
+            {
+                return mediaInfo.AudioProfile == "Layer 3" ? "MP3" : audioFormat;
+            }
+
+            return audioFormat;
+        }
+
+        public static string FormatVideoCodec(MediaInfoModel mediaInfo, string sceneName)
+        {
+            var videoCodec = mediaInfo.VideoCodec;
+
+            if (videoCodec == "AVC")
+            {
+                return sceneName.IsNotNullOrWhiteSpace() && Path.GetFileNameWithoutExtension(sceneName).Contains("h264")
+                    ? "h264"
+                    : "x264";
+            }
+
+            if (videoCodec == "V_MPEGH/ISO/HEVC")
+            {
+                return sceneName.IsNotNullOrWhiteSpace() && Path.GetFileNameWithoutExtension(sceneName).Contains("h265")
+                    ? "h265"
+                    : "x265";
+            }
+
+            if (videoCodec == "MPEG-2 Video")
+            {
+                return "MPEG2";
+            }
+
+            return videoCodec;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -2,12 +2,16 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using NLog;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Instrumentation;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
 {
     public static class MediaInfoFormatter
     {
+        private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(MediaInfoFormatter));
+
         public static decimal FormatAudioChannels(MediaInfoModel mediaInfo)
         {
             var audioChannelPositions = mediaInfo.AudioChannelPositions;
@@ -55,6 +59,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return mediaInfo.AudioProfile == "Layer 3" ? "MP3" : audioFormat;
             }
 
+            if (audioFormat == "DTS")
+            {
+                return "DTS";
+            }
+
+            Logger.Error("Unknown audio format: {0}", audioFormat);
             return audioFormat;
         }
 
@@ -81,6 +91,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "MPEG2";
             }
 
+            Logger.Error("Unknown video codec: {0}", videoCodec);
             return videoCodec;
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -27,33 +27,5 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string Subtitles { get; set; }
         public string ScanType { get; set; }
         public int SchemaRevision { get; set; }
-
-        [JsonIgnore]
-        public decimal FormattedAudioChannels
-        {
-            get
-            {
-                if (AudioChannelPositions.IsNullOrWhiteSpace())
-                {
-                    if (AudioChannelPositionsText.IsNullOrWhiteSpace())
-                    {
-                        if (SchemaRevision >= 3)
-                        {
-                            return AudioChannels;
-                        }
-
-                        return 0;
-                    }
-
-                    return AudioChannelPositionsText.ContainsIgnoreCase("LFE") ? AudioChannels - 1 + 0.1m : AudioChannels;
-                }
-
-                return AudioChannelPositions.Replace("Object Based / ", "")
-                                            .Split(new string[] { " / " }, StringSplitOptions.None)
-                                            .First()
-                                            .Split('/')
-                                            .Sum(s => decimal.Parse(s, CultureInfo.InvariantCulture));
-            }
-        }
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -768,6 +768,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="MediaFiles\MediaFileTableCleanupService.cs" />
+    <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatter.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoLib.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoModel.cs" />
     <Compile Include="MediaFiles\MediaInfo\UpdateMediaInfoService.cs" />


### PR DESCRIPTION
Fixed: Stream details for MP3 and EAC3 in Kodi metadata
Closes #1534

#### Database Migration
NO

#### Description
This will allow us to consistently format MediaInfo in various locations as well as expose in on the API with the same consistency. There is a bit of duplication everywhere this is used right now, we could either add additional properties to the `MediaInfoModel` and always format them when returning them or only do that in the API module and leave the rest as-is. Even if we did it when returning the `EpisodeFile`s we'd still need to handle the case when importing a new episode file. Thoughts?

#### Issues Fixed or Closed by this PR

* #1534
