### PR TITLE
Clean RSS feed before detecting type

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/TorrentRss/AlphaRatio.xml
+++ b/src/NzbDrone.Core.Test/Files/Indexers/TorrentRss/AlphaRatio.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <xhtml:meta xmlns:xhtml="http://www.w3.org/1999/xhtml" name="robots" content="noindex" />
+    <meta xmlns="http://pipes.yahoo.com" name="pipes" content="noprocess" />
+    <title>TV :: AlphaRatio</title>
+    <link>https://alpharatio.cc/</link>
+    <description>Personal RSS feed: TV</description>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 29 Nov 2016 11:01:28 +0000</lastBuildDate>
+    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+    <generator>Gazelle Feed Class</generator>
+
+    <item>
+      <title><![CDATA[TvHD 465989 465960 Good.Behavior.S01E03.PROPER.720p.HDTV.x264-KILLERS]]></title>
+      <description>
+        <![CDATA[MB                                                                <br />
+                                                      @@@@:      :                                                      <br />
+                                             :7 :::.7:@.:u7:.X5LF                                                       <br />
+                                          .LFq2    .B@B@B@B@B@B@B@                                                      <br />
+                                .. i@r            rB@B@B@B@B@B@B@@@:                                                    <br />
+                        :  :B@B@B@B@:             X@@@@@B@B@B@B@B@B@B@J                    .u@B.                        <br />
+                    :.YkuB@B@B@BM.                  @B@B@B@B@B@@@B@B@B@r                2B@B@B@B@i                      <br />
+                 @@@B@r@@@B@B:                      B@B@B@B@B@@@B@B@B@B@              i@B@B@B@BrO@@@@@                  <br />
+               @@@@B@B@BB,                          r:@B@B@@@B@@@B@q@@@BM @L:B.B,    @@B@B@B@BO@@@@B@B@B                <br />
+           jB@B@B@B@N.                              7   B@@@@@B@B@O  8B@.    @F     B@B@B@@@O@B@B@B@@@@@B.              <br />
+         i@B@B@B@:                                  7   @B@B@B@B@      B:    B:    i@B@B@B@BNB8B7     .B@@              <br />
+         @B@B@.                                     1G   @B@B@B@         @   ,     @B@:i @u  @:       0EB@              <br />
+         ;ir                                        ,      U@B@B         .@        B@B        L        B@B              <br />
+                                                    7       B@B@              q@Bv:@BP                 @B@              <br />
+         i@Bu                                       @     ,S@ @@             B@@@B@B@. BkU@B@    5Ui  @Y@B              <br />
+        @@B@v                                       B    :@iB B@@@B@B@M@     @B@@@B@BB @@7i iU  5i2vB@k B@              <br />
+      @B@B@B7                                       i       @ @B@B@B@B@B@B5  i@B@@@B@           r       @               <br />
+     @B@B@B@.                                               @ B@B@B@B@B@B@B@.  MB  @Bu      .   U      @Bi              <br />
+   k@P   @@@OBi                                            .@ @B@B@B@B@B@B@B.   @MBB@@      @F  @     7B@B              <br />
+   @B  @B@@@B@                                             0B@B@B@B@B@B@B@B@  B@B@B@B@F     B@B@B.    B@B               <br />
+   B  @B@B@B B:                                            B@B@B@B@@@B@@@BM  B@B@B@B@B@:  @B@;:B@@@: F@B                <br />
+   @. B@@@B@ @Bu i.       MX                       J          B@B@B@   @B.   @B@B@B@@ B@B@F Si k@@  B@BN                <br />
+  @@  @B@B@B@B@B B        @B@BOr:                  .i0F7@B:  B@B@      E@     @B@B@r@  B@B@B.   @B@B@B5                 <br />
+  B@B@B@@@B@B@B:           @B@B@B@Z:              B@B@B@B@B@B@@@B,     L@      @B@      B@B@B@B@B@B@B,                  <br />
+ :@B@B@B@B@B@B@:       Y@B@@@@@B@B@B@:                      7B@@@0     :@      L@        ,@B@B@B@B@B@B@B@.              <br />
+ JB@B@B@B@B@B@B@    U@B@@J,  @U.@@B@B@B                         B@F    i@      PB          @B@B@B@B@BG.@B@B@B,          <br />
+ r@B@B@B@B@B@B@B    ;             @B@B@                  :.     @  @J  r@      G@        @@:  .Z@@7    B@@@@@B@B@B@F    <br />
+ ,B@B@B@B@B@B@B@B5                 @B@@@            j@B5E@BXB@BvO      rB      OB       B@    B@@@r   B@B@B@B@B@B@B@B.  <br />
+  @B@B@B@B@B@@@B@i @@  .uO0 :v. @   @B@B            @@@   L:   ,@      .@      Z@ iB   B@B  @B@B@@@BNB@ :2@B@B@B@@@B@B  <br />
+ :@@B@B@B@B@@@B@B..@@@B@B@@.  :YY   B@@@:                       B,      B      .: u@  .@B@B     r@ OB       i@B@B@@@B@B <br />
+UB@B@B@B@B@@@B@B@B@B@B LJ,          @B@B.                       @.      @          Y  @BP   .rUB@B@B@B@Z7,   B@B@B@B@B@ <br />
+,@B@@@B@B@B@B@B@@@  i17.           @B@B@v                       O,      B            1B@B@B@B@@@B@@@B@B@B@B@B@B@B@BiB@Bv<br />
+:B@B@B@B@B@B@B@2@B                 B@B@B@                       k.     .@           M@@BOB@B@B@B@B@B@B@B@B@B@B@B@B@P @@B<br />
+i@B@B@@@B@B@B@B M@B           .7   @B@B@r                       B.     7B      @   YB@B@B@B@B@B@B@B@B@B@B@B@B@B@B@B@B@@@<br />
+u@@B@B@B@@@B@B@  B@B@       2U8.  5B@@E                         @,     r@      M   B@B@B@B@B@B@B@B@B@@@B@B@B@B@@@B@@@@@B<br />
+q@B@B@B@@@B@B@B.   @@@i2 @JX      :@B@                          BY     rB      @   G@@B@B@B@B@B@B@B@B@B@B@B@B@B@B@B@B@B@<br />
+BB@B@B@B@B@B@Bi      .             B@@:                         @B      @             @B@B@B@B@B@B@B@B@B@B@B@@@@@B@B@B@j<br />
+O@B@B@B@B@B@B@@@                  u@B@@                         Bu      B             @@B@B@B@BB8                0B@B@B <br />
+SB@B@B@B@B@B@B@B@B               @@B@@@B                                @             .BS                      r  @@@B@ <br />
+.@B@B@B@B@B@B@B@B@              B@B@@@B@Br     XB@Br                   7B          u        .vB       B:        B@B@B@B <br />
+ @@@@B@B@B@B@B@B@B@B@B         .@B@B@B@B@@M    i..@.                    i           i  i              P   @,jB   @@B    <br />
+ @B@B@B@B@B@B@B@B@B@B@B@i      @N@@@B@@@B@B@B                                          @                          B@E   <br />
+  @B@B@B@@@B@B@B@B@B@B@B@B    @ :  @@B@B@@@Mi                                          B              .           @@    <br />
+  F@B@@@B@B@B@B@B@@@B@B@B@,@  M    @.:v  X                                             i              B          :BM    <br />
+   i@B@B@B@B@@@B@B@B@@@@@B@B  L                                                      ,r  ,      ;    B@.        @B@,    <br />
+     ,M@B@B  @B@B@B@B@@@B@B@B@              rL                                        B   j     :jr@B@@r       @B@B@B   <br />
+              @B@B@B@B@B@B@B@B              .:                                         . .@ :       ,        @@@@B@@    <br />
+              ,@B@B@B@B@B@B@B   .@X r5BMB:     r ,,                                    7  B B@B            @B@B@B@@     <br />
+              L@@B@B@B@ 8B@B@    BM:@B@B@B@B@B@@8X80Mu:           FB@B@B@B@B@@@B@B@@@B@B  q uO@GMFLv@B@B@B@B@  B@Bu     <br />
+               @B@B@B@B k@  MYM@@@B@B@F ,.           :5@B@B7  Y@B@@@@@B@@@B@@@@@B@@@@@B@  B      :    B@B@B@  @@B@BL    <br />
+               B@@@@@@@ @@7   @EvB@BF                      B@B@B@@@@@B@BMB@B@B@B@@@B@B@B@ 7  .   .@u,    i@  B@B@77B@   <br />
+                B@B@B@@@O@     : 7.,                      :@B@@@B@B@B@,   .LB@@@B@B@B@B@B@B@ @    r@:  @::M @@B@B@M@B@  <br />
+            :i  @B@B@@@Bi5      ::                       v@B@@@B@B@B           B@@@B@@@B@@@B@@         B@@@B@B@B@B@B@B@i<br />
+           :    B@B@B@B@B@                               @B@B@B@@@B            LB@B@@@B@B@B@B@B@@5     @B@B@B@B@B@@@B@  <br />
+            .k@B@B@B@B@B@u.                              B@B@B@B@B2             @B@B@B@B@B@@@B@B@@@B@@@B@B@B@B@B@B@     <br />
+       :Lur:F@@@B@B@B@B@@@B                             B@B@B@B@B@               @@@B@B@B@B@B@@@B@B@B@B@B@B@B@B@B@J     <br />
+   .vBMi     :,,rB@B@B@B@BO                             @@@B@B@@@5              :i@@@B@B@B@@@B@B@B@B@@@B@@@B@B@B@@:     <br />
+  1r             @B@B@B@B@B@                           LB@B@B@B@Bq          N@Bi rB@B@B@B@B@B@B@@@B@B@B@B@B@B@@@B@      <br />
+               ,L. @@B@B@B@G Li                        .@B@B@B@B@B@@@B@.   B@B@viv@B@B@B@B@B@B@B@B@B@B@B@@@B@B@B@       <br />
+              r,   @@@@@B@@@B@: :                       B@B@B@B@B@B@@@B@     :B@ @S@B@B@B@B@B@B@@@B@B@B@@@B@B@B@        <br />
+                 .j iB@B@B@B@B@B@Bi:;  G @@BrLk .  i   M@B@B@@@B@@@                 GB@B@B@B@B@B@B@B@B@@@B@B@B@:        <br />
+               ,:   :   BUB@B@B@B@@@@@N0r@B@B B@B@  : :@B@B@B@@@B                    @B@B@B@B@B@B@B@B@B@B@B@. B         <br />
+              @i  ui   M .. @B@: B.@@B@BB:O @. B  @    i B@@@@@B@                   @@@B@B@B@@@B @@B@B@B@@@B  @ @       <br />
+            E@   @7     ;   .U  i   N@B@  B .@     @     @B@B@B@B@     v  .GB      @B@B@B@B@@@M: @B@B@B@B@BZ @  Y       <br />
+                       Bu  .@   M    7v7            @   :B@B@@@B@BU   @B@B@B@B@   BB@B@B@B@B@Bi  B@@@B@B@B@v            <br />
+                      5@   @7        L S            .q   .N@B@@@B@BBB@B@B@B@B@B@kqqSB@B@B@B@B@   @B@B@B@B@@r            <br />
+                      q    :         B Z             .:      2@B@B@B@..L. .    M@B@B@:@BiP  @B   B@@@B@B@B@             <br />
+                                     ;                        B@@@B@B. @@@B@: 2@B@B@          i  @B@@@B@B@B             <br />
+                                                               7@B@k@B@B@B@B@B@B@B@              B@B@@@@@Bi             <br />
+                                                                     jB@B@B@@@B@@O               @B@B@B@B@              <br />
+                                                                       B@B@B@B@k                 B@@@B@@@B              <br />
+                                                                         rPS:                    @B@ @B@B@              <br />
+                            .     ::   ,ui:,:   vL:,::                                           B@B B@B@B              <br />
+         .B@B@B@B@i  @B@@@B@5    @B@B   :@@@@@   OB@@@                                           @B@ @B@@@              <br />
+            @B@B@   FB@B@      7@B@B@    .@@@B    @B@B     iMB@B@S   .GB@B@.,B@@L   vG0Sqv;:@    L@@ ..E@B              <br />
+            B@@@B@@@B@B@B       .@B@@    :B@B@    B@B@   @B@B@..B@B@   @B@@@2.B@B@ @B@BBM        S@1   S@.              <br />
+            @B@B@B.  ,@B@B8      B@B@    .@B@@    @B@@   B@B@8:iii;Mv  i@B@M  .rr      B@B@B@B   k@r   EJ               <br />
+          S@B@B@B@   EB@B@B@B.  B@B@B@, r@B@B@1  @B@B@B: YB@@@r.      7@B@B@2      @@@@@@MB@B@   ,Bi                    <br />
+         :r,     .i ,:     .i: :i    ,:.i.    i,::    ::    :J@B@X7   i.    i:     r    :,:.     ,@ a                   <br />
+                                                                                                 .B n                   <br />
+                                       [ P R E S E N T S ]                                        @ t                   <br />
+                                                                                                  @ i                   <br />
+                                                                                                  0 /                   <br />
+                                                                                                  B 4                   <br />
+                                                                                                  @ 0                   <br />
+                                                                                                  . 4                   <br />
+                                                                                                                        <br />
+                    Good.Behavior.S01E03.PROPER.720p.HDTV.x264-KILLERS<br />
+<br />
+<br />
+                    Day: 2016-11-29<br />
+                    Resolution: 1280x720<br />
+                    Size: 1.02 GiB<br />
+                    FrameRate: 23.976<br />
+                    Length: 00:49:02.144<br />
+                    Bitrate: 2 535 Kbps<br />
+                    Note: FLEET is missing the last seg<br />
+<br />
+<br />
+          n***** We all miss you. Come back soon.]]>
+      </description>
+      <pubDate>Tue, 29 Nov 2016 10:55:58 +0000</pubDate>
+      <link>https://alpharatio.cc/torrents.php?action=download&amp;authkey=private_auth_key&amp;torrent_pass=private_torrent_pass&amp;id=465960</link>
+      <guid>https://alpharatio.cc/torrents.php?action=download&amp;authkey=private_auth_key&amp;torrent_pass=private_torrent_pass&amp;id=465960</guid>
+      <comments>https://alpharatio.cc/torrents.php?id=465989</comments>
+      <dc:creator>Anonymous</dc:creator>
+    </item>
+    <item>
+      <title><![CDATA[TvHD 465860 465831 WWE.RAW.2016.11.28.720p.HDTV.x264-KYR]]></title>
+      <description>
+        <![CDATA[&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&deg;&deg; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&deg; &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;&deg;&deg;&Uuml;&deg;&Ucirc;&Ucirc;&sup2;&szlig;&Uuml;&Ucirc;&Ucirc;&Uuml;&Uuml;&sup2; &Uuml;&szlig;&sup2; &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig; &Uuml;&szlig;&deg;&sup2;&deg;&sup2;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&plusmn;&sup2;&sup2; &Uuml;&Yacute; &THORN; &THORN;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&deg; &Ucirc;&Ucirc;&Yacute;&sup2;&THORN;&sup2;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&plusmn;&sup2;&Yacute;&Yacute;&THORN;&Ucirc;   &szlig;  &Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&sup2;&Ucirc;&Ucirc;&deg;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Yacute;&plusmn;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&THORN;&sup2;&THORN; &Yacute;      &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;            &szlig;&szlig;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&deg;&Ucirc;&sup2;&Ucirc;&THORN;&sup2; &Yacute;&sup2;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;                    &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&deg;&deg;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Yacute;&Ucirc;&Ucirc;&szlig;&Yacute;&sup2;&deg;&THORN;&THORN;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;                        &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&deg;&Ucirc;&Yacute;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&THORN;&THORN;&THORN;&Uuml;&Ucirc;&Ucirc;&deg;&sup2;&Yacute;&THORN;       &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;                          &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&sup2;&Yacute;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&deg;&Ucirc;&sup2;&THORN;&Ucirc;&Ucirc;&Ucirc; &THORN; &sup2;        &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;                            &sup2;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Yacute;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Yacute;&Ucirc; &sup2;  &Yacute;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;                             &Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&sup2;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Yacute;&Ucirc;&THORN;&Ucirc;&Ucirc;&THORN;&sup2;&THORN; &Yacute;&Yacute;  &Uuml;&Uuml;&Uuml;&Uuml;    &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;   &Uuml;&Uuml; &Uuml;                       &THORN;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&THORN;&Ucirc;&Ucirc;&sup2;&THORN;&deg;&THORN; &sup2;&Yacute; &szlig;&szlig;&szlig;&Ucirc;&Ucirc;&Ucirc;&sup2;  &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;  &Ucirc;&Ucirc;&sup2;&sup2;&Ucirc;&Ucirc;&sup2;                     &THORN;&Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&THORN;&Ucirc;&Yacute;&Ucirc;&Ucirc;&plusmn;&THORN; &sup2; &Yacute;&THORN; &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&THORN; &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;  &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&plusmn;             &Uuml;&Uuml;    &szlig;&sup2;&Ucirc;&Ucirc;<br />
+&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&THORN;&Yacute;&Ucirc;&Yacute;&Ucirc;&Ucirc;&deg;&Ucirc; &sup2; &THORN; &sup2; &Uuml;&szlig;&Ucirc;&Ucirc;&Ucirc;&szlig; &THORN;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Yacute;  &Ucirc;&Ucirc;&szlig;                 &Uuml;&Uuml;&Uuml;&szlig;&sup2;    &Ucirc;&Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&THORN;&THORN;&Ucirc;&Uuml;&sup2; &THORN;  &Yacute; &Yacute; &szlig;&szlig;&szlig;    &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&szlig;                     &sup2;&szlig;  &sup2;&THORN;&Yacute;   &THORN;&Ucirc;<br />
+&sup2;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Yacute;&Ucirc;&sup2;&THORN;&Ucirc;&Yacute;&Ucirc;&Yacute;  &Yacute; &Yacute; &THORN;         &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;                      &THORN;     &THORN;&Yacute;   &THORN;&Ucirc;<br />
+&plusmn;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&THORN;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Yacute;&THORN;&Ucirc;  &Yacute;&THORN;             &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;                        &Yacute;     &sup2;&Ucirc;&Uuml;  &Ucirc;&Ucirc;<br />
+&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&deg;&Ucirc; &szlig; &THORN;   &Yacute;   &Yacute;      &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&Uuml; &Yacute;                    &Uuml;&szlig;     &szlig;&Ucirc;&Ucirc;<br />
+&Ucirc;&sup2;&Ucirc;&Ucirc;&Yacute;&Yacute;&Yacute;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&sup2;&THORN;   &Yacute;       &sup2;&Uuml;&sup2;&Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&Ucirc;&szlig;&szlig;&szlig;                 &Uuml;&Uuml;&Uuml;&sup2;&szlig;       &Ucirc;&Ucirc;<br />
+&Ucirc;&Yacute;&Ucirc;&Ucirc;&THORN;&Yacute;&deg;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Yacute;&Ucirc;&sup2;&Yacute;      &Yacute;     &szlig;&szlig;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;                  &deg;  &szlig;&sup2;&szlig; &sup2;       &THORN;&Ucirc;<br />
+&Ucirc;&Ucirc;&deg;&Ucirc;&THORN;&Ucirc;&THORN;&THORN;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&sup2;&THORN;&Ucirc;  &Yacute;   &Yacute;  &Uuml;&Uuml;  &THORN;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Ucirc;&Uuml;&Uuml;              &plusmn;&deg;&deg;    &szlig;         &Ucirc;<br />
+&Ucirc;&Ucirc;&Ucirc;&THORN;&Yacute;&Ucirc;&THORN;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc; &sup2;&Yacute; &THORN;   &THORN;&deg;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;                &plusmn;&sup2;&plusmn;&plusmn;              &THORN;<br />
+&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Yacute;&Ucirc;&THORN;&Ucirc;&Ucirc;&Yacute;&sup2;&THORN;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Yacute;&THORN;&Yacute;  &Yacute;   &sup2;&szlig;  &Uuml;&szlig;&Yacute;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Uuml;            &Uuml;&Uuml;&sup2;&Ucirc;&Ucirc;&Ucirc;&sup2;&sup2;              &THORN;<br />
+&Ucirc;&Ucirc;&Yacute;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&deg;&Ucirc;&sup2;&THORN;&Yacute;&Ucirc;&deg;&Ucirc;&THORN; &Yacute;&Yacute;     &Uuml;&Uuml;&sup2;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&sup2;&Uuml;        &Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&plusmn;<br />
+&Ucirc;&szlig;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&THORN;&Ucirc;&sup2;&THORN;&Yacute;&Yacute;&Ucirc; &Yacute;&Yacute;&Yacute; &deg; &Yacute;&szlig;&Ucirc;&sup2;&Yacute;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;         &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+&Ucirc;&szlig;&szlig;&szlig; &szlig;&Uuml;&sup2;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&THORN;&Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&Ucirc; &sup2;&sup2;&plusmn;&plusmn;&THORN;  &szlig;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;         &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+        &Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Uuml;&szlig;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&sup2;&Yacute;&sup2;&Uuml;  &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&THORN;&Uuml;   &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute; &Uuml;             &THORN;<br />
+       &szlig;&sup2;&Ucirc;&THORN;&sup2;&Ucirc;&Ucirc;&Ucirc; &Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&THORN;&THORN;&Ucirc;&Ucirc;&sup2;&Ucirc;&sup2;&THORN;&sup2;&Yacute; &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&THORN;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;             &THORN;&Ucirc;<br />
+         &Uuml;&sup2;&szlig;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&sup2;&Ucirc;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;              &Yacute;&Ucirc;<br />
+        &szlig;  &Uuml;&Uuml;&szlig;&szlig;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Ucirc;&szlig;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;              &THORN; &Ucirc;<br />
+          &szlig; &szlig;&Ucirc;&Ucirc;&Uuml;&Uuml;&Yacute;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Uuml;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Uuml;&Uuml;&szlig;             &Yacute;&THORN;&sup2;<br />
+              &szlig;&Yacute;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Uuml;             &sup2; &Ucirc;&sup2;<br />
+                &Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&THORN;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;             &sup2; &THORN;&sup2;&deg;<br />
+               &szlig; &sup2;&THORN;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&sup2;              &sup2; &Uuml;&Ucirc;&sup2;<br />
+                  &THORN;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&Ucirc;               &sup2; &Uuml;&Ucirc;&sup2;&deg;<br />
+                 &Uuml;&szlig; &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&Yacute;&szlig;              &Uuml;&szlig; &Uuml;&Ucirc;&sup2;&deg;<br />
+                     &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&Uuml;&sup2;              &Uuml;&szlig; &Uuml;&Ucirc;&Ucirc;&sup2;&deg;<br />
+                      &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &Ucirc;&sup2;            &Uuml;&sup2;&szlig; &Uuml;&Ucirc;&Ucirc;&sup2;&plusmn;&deg;<br />
+                       &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &Ucirc;&sup2;         &Uuml;&Uuml;&szlig;&szlig;  &Uuml;&Ucirc;&Ucirc;&sup2;&plusmn;&deg;<br />
+                        &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &Ucirc;&sup2;      &Uuml;&Uuml;&szlig;&szlig;  &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&sup2;&plusmn;&deg;<br />
+                          &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &Ucirc;&sup2;   &Uuml;&Uuml;&szlig;&szlig;  &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&sup2;&plusmn;&deg;<br />
+                           &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;&Ucirc;&sup2;&Uuml;&Uuml;&szlig;&szlig;  &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&sup2;&sup2;&plusmn;&deg;<br />
+                             &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&szlig;&szlig;&szlig;&Uuml;&Uuml;&Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&sup2;&sup2;&plusmn;&plusmn;&deg;<br />
+                              &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&sup2;&sup2;&plusmn;&plusmn;&deg;<br />
+                               &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;  &deg;&sup2;&szlig;&sup2;&sup2;&sup2;&sup2;&plusmn;&plusmn;&deg;<br />
+                                &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;   &deg;&sup2;<br />
+                                 &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;  &deg;&plusmn;&Yacute;<br />
+                                  &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&deg;&deg;&plusmn;&sup2;<br />
+                                   &sup2;&Ucirc;&Ucirc;&Ucirc;&sup2;&szlig;&sup2;&sup2;&szlig;<br />
+                                    &Ucirc;&sup2;&Ucirc;<br />
+                                    &THORN;&sup2;&Yacute;<br />
+                                     &plusmn;<br />
+                                     &deg;<br />
+<br />
+                &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;            &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;           &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;<br />
+              &Uuml;&szlig;&szlig;&Ucirc;&Ucirc;&szlig; &szlig;&Ucirc;&sup2;        &Uuml;&szlig;&szlig;&Ucirc;&Ucirc;&szlig; &szlig;&Ucirc;&sup2;     &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig; &szlig;&Ucirc;&sup2;<br />
+                  &Ucirc;&Ucirc;&Ucirc;&deg;&plusmn;&Ucirc;&Yacute;  &sup2;&Ucirc;&Uuml;      &Ucirc;&Ucirc;&Ucirc;&deg;&plusmn;&Ucirc;&Yacute; &Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&deg;&plusmn;&Ucirc;&Yacute;<br />
+                  &THORN;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;   &Ucirc;&Ucirc;&Yacute;     &THORN;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Yacute;&Ucirc;&Ucirc;&Ucirc;&szlig;     &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Ucirc;&Ucirc;<br />
+         &Uuml;&Uuml;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;  &THORN;&Ucirc;&Ucirc;&Yacute;     &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc; &sup2;&Ucirc;&Yacute;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;<br />
+        &THORN;&Ucirc;&Ucirc;      &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;   &Ucirc;&Ucirc;&Ucirc;      &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2; &THORN;&Ucirc;&Ucirc;      &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+         &Ucirc;&Ucirc;&Yacute;    &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;    &Ucirc;&Ucirc;&Ucirc;      &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;  &Ucirc;&Ucirc;&Yacute;    &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;<br />
+         &THORN;&Ucirc;&sup2; &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Uuml;&Uuml;   &THORN;&Ucirc;&Ucirc;&Yacute;    &sup2;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;   &THORN;&Ucirc;&sup2; &Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Uuml;&Uuml;&Uuml;   &szlig;<br />
+          &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;&Ucirc;&Uuml; &sup2;&Ucirc;&Ucirc;&Uuml;&Uuml;&Uuml;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;    &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;&Ucirc;&Uuml;<br />
+          &THORN;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;    &szlig;&Ucirc;&Ucirc;&Ucirc;&deg;&THORN;&Ucirc;  &szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;     &THORN;&Ucirc;&Ucirc;&Ucirc;&szlig;&szlig;    &szlig;&Ucirc;&Ucirc;&Ucirc;&deg;&THORN;&Ucirc;<br />
+           &sup2;&Ucirc;&sup2;       &Ucirc;&Ucirc;&Ucirc;&Uuml;&Ucirc;&Yacute;       &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Yacute;      &sup2;&Ucirc;&Ucirc;       &Ucirc;&Ucirc;&Ucirc;&Uuml;&Ucirc;&Yacute;<br />
+           &THORN;&Ucirc;&Ucirc;&Yacute;     &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;       &THORN;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;       &THORN;&Ucirc;&Ucirc;&Yacute;     &Ucirc;&Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;<br />
+            &Ucirc;&Ucirc;&Ucirc;    &Ucirc;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;        &Ucirc;&szlig;&Ucirc;&Ucirc;&Ucirc;&Yacute;        &Ucirc;&Ucirc;&Ucirc;    &Ucirc;&szlig;&Ucirc;&Ucirc;&Ucirc;&Ucirc;<br />
+             &szlig;    &Ucirc;&deg;&THORN;&Ucirc;&Ucirc;&Ucirc;&Yacute;       &Ucirc;&deg;&THORN;&Ucirc;&Ucirc;&Ucirc;          &szlig;    &Ucirc;&deg;&THORN;&Ucirc;&Ucirc;&Ucirc;&Yacute;<br />
+                 &Ucirc;&plusmn;&deg;&Ucirc;&Ucirc;&Ucirc;&sup2;       &Ucirc;&plusmn;&deg;&Ucirc;&Ucirc;&Ucirc;&sup2;              &Ucirc;&plusmn;&deg;&Ucirc;&Ucirc;&Ucirc;&sup2;<br />
+                &THORN;&plusmn;&plusmn;&plusmn;&deg;&Ucirc;&Ucirc;       &THORN;&plusmn;&plusmn;&plusmn;&deg;&Ucirc;&Ucirc;              &THORN;&plusmn;&plusmn;&plusmn;&deg;&Ucirc;&Ucirc;    presents..<br />
+                &THORN;&sup2;&plusmn;&plusmn;&plusmn;&plusmn;&Yacute;       &THORN;&sup2;&plusmn;&plusmn;&plusmn;&plusmn;&Yacute;              &THORN;&sup2;&plusmn;&plusmn;&plusmn;&plusmn;&Yacute;<br />
+                 &Ucirc;&sup2;&sup2;&sup2;&Ucirc;&Uuml;     &Uuml;&sup2; &Ucirc;&sup2;&sup2;&sup2;&Ucirc;&Uuml;            &Uuml;&sup2; &Ucirc;&sup2;&sup2;&sup2;&Ucirc;&Uuml;    &Uuml;&sup2;<br />
+                  &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;   &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;   &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;<br />
+                   k  n  o  w       y  o  u  r       r  o  l  e<br />
+<br />
+   &uacute; &uacute;&uacute;--&Auml;-&Auml;-&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;-&Auml;-&Auml;--&uacute;&uacute; &uacute;<br />
+                WWE.RAW.2016.11.28.720p.HDTV.h264-KYR<br />
+   &uacute; &uacute;&uacute;--&Auml;-&Auml;-&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;-&Auml;-&Auml;--&uacute;&uacute; &uacute;<br />
+       &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;<br />
+      &Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc; &Ucirc;&sup2;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc; &Uuml;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;  &Ucirc;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&Uuml;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;<br />
+   &Uacute;&Auml;&Auml;&Ucirc; &szlig;&Uuml;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Ucirc;&sup2;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Uuml; &Ucirc;&Uuml;&Uuml;&deg;&Ucirc; &Uuml;&Ucirc;&szlig;&Auml;&Auml;&Ucirc; &Ucirc; &Ucirc; &Ucirc; &Uuml;&Ucirc;&Ucirc; &Ucirc; &Ucirc;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&uacute;&uacute; &uacute;<br />
+   &sup3;  &Ucirc; &Ucirc; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&Ucirc; &Ucirc;&Uuml;&szlig; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;  &Ucirc; &Ucirc;&Uuml;&Ucirc; &Ucirc;&deg;&Ucirc;&sup2;&Ucirc; &szlig; &Ucirc;<br />
+   &sup3;  &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;  &szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;<br />
+   &sup3;<br />
+   &sup3;     title&uacute;[ WWE RAW                                               ]&uacute;<br />
+   &sup3;     genre&uacute;[ Wrestling   ]&uacute;                crf&uacute;[ 23                ]&uacute;<br />
+   &sup3; rel. date&uacute;[ 11.28.16    ]&uacute;             format&uacute;[ x264              ]&uacute;<br />
+   &sup3;  air date&uacute;[ 11.28.16    ]&uacute;             source&uacute;[ HDTV              ]&uacute;<br />
+   &sup3;   runtime&uacute;[ 2h 13m 48s  ]&uacute;            bitrate&uacute;[ 4111kbps          ]&uacute;<br />
+   &sup3;  filesize&uacute;[ 4.28 GB     ]&uacute;            resolu.&uacute;[ 1280x720          ]&uacute;<br />
+   &sup3; rar count&uacute;[ 93x50mb     ]&uacute;             frames&uacute;[ 59.940            ]&uacute;<br />
+   &sup3;          &uacute;[                             audio&uacute;[ 384 kbps AC3 5.1  ]&uacute;<br />
+   &sup3;          &uacute;[                          location&uacute;[ USA               ]&uacute;<br />
+   &sup3;          &uacute;[                                                       ]&uacute;<br />
+   &sup3;      url &uacute;[ http://www.wwe.com                                    ]&uacute;     <br />
+   &sup3;<br />
+   &sup3;<br />
+   &sup3;                   &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;   &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;<br />
+   &sup3;                  &Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc; &Ucirc;&sup2;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc; &Uuml;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;  &Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;&Uuml; &Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc; &Uuml;&Uuml;&Ucirc;<br />
+   &sup3;        &uacute; &uacute;&uacute;&Auml;&Auml;&Auml;&Auml;&Auml;-&Ucirc; &szlig;&Uuml;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Ucirc;&sup2;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Uuml; &Ucirc;&Uuml;&Uuml;&deg;&Ucirc; &Uuml;&Ucirc;&szlig;&Auml;&Auml;&Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc;&Ucirc; &Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&Uuml;&Uuml;&deg;&Ucirc;&Auml;&Auml;&acute;<br />
+   &sup3;                  &Ucirc; &Ucirc; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&Ucirc; &Ucirc;&Uuml;&szlig; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;  &Ucirc; &Ucirc; &Ucirc; &szlig; &Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig; &Ucirc;  &sup3;<br />
+   &sup3;                  &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;  &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;  &sup3;<br />
+   &sup3;                                                                        &sup3;<br />
+   &sup3;                                                                        &sup3;<br />
+   &sup3;                                                  Enjoy!                &sup3;<br />
+   &sup3;                                                                        &sup3;<br />
+   &sup3;                                                                        &sup3;<br />
+   &sup3;   &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;                                 &sup3;<br />
+   &sup3;  &Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;&szlig;&Ucirc;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;  &Ucirc;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&Uuml;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;                                &sup3;<br />
+   &Atilde;&Auml;&Auml;&Ucirc; &Yacute;&szlig;&Ucirc; &szlig;&Uuml;&Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &szlig; &Ucirc;&Auml;&Auml;&Ucirc;&deg;&Ucirc; &Ucirc; &Ucirc; &Uuml;&Ucirc;&Ucirc; &Ucirc; &Ucirc;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;-&Auml;&Auml;&Auml;&Auml;&Auml;&uacute;&uacute; &uacute;        &sup3;<br />
+      &Ucirc; &szlig; &Ucirc; &Ucirc; &Ucirc; &szlig; &Ucirc; &szlig; &Ucirc; &Ucirc;&szlig;&szlig;  &Ucirc; &Ucirc; &Ucirc; &Ucirc;&deg;&Ucirc;&sup2;&Ucirc; &szlig; &Ucirc;                                &sup3;<br />
+      &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;    &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;                                &sup3;<br />
+                                                                            &sup3;<br />
+       group info                                                          &sup3;<br />
+                                                                            &sup3;<br />
+                Know Your Role and Shut Your Mouth!                         &sup3;<br />
+                                                                            &sup3;<br />
+       we are now looking for...                                           &sup3;<br />
+                                                                            &sup3;<br />
+         (a) capper(s) of cable, PPV, good upspeed advantageous             &sup3;<br />
+                              .. contact in the usual way.                  &sup3;<br />
+                                                                            &sup3;<br />
+       KYR respects...                                                     &sup3;<br />
+                                                                            &sup3;<br />
+                everyone keeping it real and oldschool. we love ya!         &sup3;<br />
+                                                                            &sup3;<br />
+                          &Uuml; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;                        &sup3;<br />
+                         &Uuml;&Uuml;&Uuml;&Uuml;&sup2; &Uuml;&Uuml;&Uuml; &Ucirc;&Uuml;&sup2; &Uuml;&Uuml;&Uuml; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml; &sup2;&Yacute;                       &sup3;<br />
+  &uacute; &uacute;&uacute;&Auml;&Auml;&Auml;&Auml;&Auml;--&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Ucirc; &Uuml;&Uuml; &Yacute;&THORN;&Ucirc;&Ucirc;&Yacute;&Uuml;&Uuml; &Yacute;&THORN;&Ucirc;&Ucirc;&Yacute;&szlig;&szlig;  &THORN;&Ucirc;&Ucirc;&Yacute;&THORN;&Ucirc; &Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&acute;<br />
+                         &Ucirc; &Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&szlig; &Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&sup2; &Ucirc;&Ucirc; &Uuml;&Ucirc;&Ucirc;&szlig; &Ucirc;&Yacute;    K N O W            &sup3;<br />
+   ascii crafted by      &Ucirc; &Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Uuml;  &THORN;&Ucirc;&Ucirc;&sup2;&szlig; &Uuml; &Ucirc;&Ucirc;&Ucirc;&Ucirc;&sup2;&Uuml; &szlig;&Ucirc;                        &sup3;<br />
+                         &Ucirc; &Ucirc;&Ucirc; &szlig;&Ucirc;&Ucirc;&sup2;  &Ucirc;&Ucirc; &Uuml;&sup2;&Ucirc; &Ucirc;&Ucirc; &szlig;&Ucirc;&Ucirc;&sup2; &sup2;&Yacute;       Y O U R         &sup3;<br />
+        h8`!HiGHONASCii  &Ucirc; &Ucirc;&Ucirc; &Yacute;&THORN;&Ucirc;&Ucirc;&Yacute; &Ucirc;&Ucirc; &Ucirc; &Ucirc; &Ucirc;&Ucirc; &Yacute;&THORN;&Ucirc;&Ucirc;&Yacute;&THORN;&Ucirc;                       &sup3;<br />
+                         &Ucirc; &Ucirc;&sup2; &Ucirc; &Ucirc;&Ucirc;&sup2; &Ucirc;&sup2; &Ucirc; &Ucirc; &Ucirc;&sup2; &Ucirc; &Ucirc;&Ucirc;&sup2; &Ucirc;           R O L E     &sup3;<br />
+  &uacute; &uacute;&uacute;&Auml;-&Auml;----&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Ucirc;&Uuml;&Uuml;&Uuml;&Uuml;&sup2;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&sup2; &Ucirc;&Uuml;&Uuml;&Uuml;&Uuml;&sup2;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&sup2; &Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Auml;&Ugrave;<br />
+     &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;    &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;   &Uuml;&Uuml;&Uuml; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;<br />
+  &deg;&plusmn;&sup2;&Ucirc; &Uuml;&szlig;&Ucirc; &Uuml;&szlig;&Ucirc; &Uuml;&szlig;&Ucirc; &Uuml;&szlig;&Ucirc;&sup2;&sup2;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc; &Ucirc;&sup2;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc; &Uuml;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc; &Uuml;&Uuml;&Ucirc;&sup2;&sup2;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Uuml;&szlig;&Ucirc;&sup2;&plusmn;&deg;<br />
+ &deg; &deg;&plusmn;&Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc;+&plusmn;&Ucirc; &szlig;&Uuml;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Ucirc;&plusmn;&Ucirc; &Uuml;&Ucirc;&Ucirc; &Uuml; &Ucirc;&Uuml;&Uuml;&deg;&Ucirc; &Uuml;&Ucirc;&Ucirc;&Uuml;&Uuml;&deg;&Ucirc;&plusmn;&plusmn;&Ucirc; &Uuml; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc;&plusmn;&deg; &deg;<br />
+  &deg;&plusmn;&sup2;&Ucirc;&Uuml;&szlig;&deg;&Ucirc;&Uuml;&szlig;&deg;&Ucirc;&Uuml;&szlig;&deg;&Ucirc;&Uuml;&szlig;&deg;&Ucirc;&sup2;&sup2;&Ucirc; &Ucirc; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&Ucirc; &Ucirc;&Uuml;&szlig; &Ucirc;&Uuml;&szlig;&szlig;&Ucirc;&Uuml;&szlig; &Ucirc;&sup2;&sup2;&Ucirc;&Uuml;&Ucirc; &Ucirc;&Uuml;&Ucirc; &Ucirc; &szlig;&Uuml;&Ucirc;&sup2;&plusmn;&deg;<br />
+     &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;  &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;    &szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;<br />
+                    &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;  &Uuml;&Uuml; &Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;&Uuml;<br />
+               &deg;&plusmn;&sup2;&sup2;&Ucirc;&szlig;&Uuml; &Ucirc;&deg;&Uuml;&szlig;&Ucirc;&szlig;&Ucirc;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&Uuml; &Uuml;&Ucirc;&Uuml;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&szlig;&Uuml;&deg;&Ucirc;&deg;&Ucirc;&deg;&Ucirc;&deg;&Ucirc;&sup2;&sup2;&plusmn;&deg;<br />
+              &deg; &deg;&plusmn;&plusmn;&Ucirc; &Ucirc;&Ucirc;&Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc; &Ucirc;&Ucirc; &Ucirc;&Ucirc;&deg;&Ucirc; &Ucirc; &Ucirc; &Yacute;&szlig;&Ucirc; &Ucirc; &Ucirc; &Ucirc;&plusmn;&plusmn;&deg; &deg;<br />
+               &deg;&plusmn;&sup2;&sup2;&Ucirc;&Uuml;&szlig;&deg;&Ucirc; &szlig; &Ucirc; &szlig; &Ucirc;&Uuml;&Ucirc; &Ucirc;&Ucirc;&deg;&Ucirc;&Ucirc; &Ucirc; &Ucirc; &Ucirc;&deg;&szlig; &Ucirc;&szlig;&Ucirc;&szlig;&Ucirc;&szlig;&Ucirc;&sup2;&sup2;&plusmn;&deg;<br />
+                    &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig; &szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;&szlig;]]>
+      </description>
+      <pubDate>Tue, 29 Nov 2016 05:08:18 +0000</pubDate>
+      <link>https://alpharatio.cc/torrents.php?action=download&amp;authkey=private_auth_key&amp;torrent_pass=private_torrent_pass&amp;id=465831</link>
+      <guid>https://alpharatio.cc/torrents.php?action=download&amp;authkey=private_auth_key&amp;torrent_pass=private_torrent_pass&amp;id=465831</guid>
+      <comments>https://alpharatio.cc/torrents.php?id=465860</comments>
+      <dc:creator>Anonymous</dc:creator>
+    </item>
+  </channel>
+</rss>

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
@@ -241,5 +241,22 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
             torrentInfo.DownloadProtocol.Should().Be(DownloadProtocol.Torrent);
             torrentInfo.DownloadUrl.Should().Be("http://storage.animetosho.org/torrents/4b58360143d59a55cbd922397a3eaa378165f3ff/DAYS%20-%2005%20%281280x720%20HEVC2%20AAC%29.torrent");            
         }
+
+        [Test]
+        public void should_parse_recent_feed_from_AlphaRatio()
+        {
+            GivenRecentFeedResponse("TorrentRss/AlphaRatio.xml");
+
+            var releases = Subject.FetchRecent();
+
+            releases.Should().HaveCount(2);
+            releases.Last().Should().BeOfType<TorrentInfo>();
+
+            var torrentInfo = releases.Last() as TorrentInfo;
+
+            torrentInfo.Title.Should().Be("TvHD 465860 465831 WWE.RAW.2016.11.28.720p.HDTV.x264-KYR");
+            torrentInfo.DownloadProtocol.Should().Be(DownloadProtocol.Torrent);
+            torrentInfo.DownloadUrl.Should().Be("https://alpharatio.cc/torrents.php?action=download&authkey=private_auth_key&torrent_pass=private_torrent_pass&id=465831");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssSettingsDetectorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssSettingsDetectorFixture.cs
@@ -201,6 +201,26 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
+        public void should_detect_rss_settings_for_AlphaRatio()
+        {
+            _indexerSettings.AllowZeroSize = true;
+
+            GivenRecentFeedResponse("TorrentRss/AlphaRatio.xml");
+
+            var settings = Subject.Detect(_indexerSettings);
+
+            settings.ShouldBeEquivalentTo(new TorrentRssIndexerParserSettings
+            {
+                UseEZTVFormat = false,
+                UseEnclosureUrl = false,
+                UseEnclosureLength = false,
+                ParseSizeInDescription = true,
+                ParseSeedersInDescription = false,
+                SizeElementName = null
+            });
+        }
+
+        [Test]
         [Ignore("Cannot reliably reject unparseable titles")]
         public void should_reject_rss_settings_for_AwesomeHD()
         {

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -420,6 +420,10 @@
       <Link>sqlite3.dll</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Files\Indexers\TorrentRss\AlphaRatio.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Files\Indexers\TorrentRss\LimeTorrents.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -77,8 +77,8 @@ namespace NzbDrone.Core.Indexers
         {
             try
             {
-                var content = indexerResponse.Content;
-                content = ReplaceEntities.Replace(content, ReplaceEntity);
+                var content = XmlCleaner.ReplaceEntities(indexerResponse.Content);
+                content = XmlCleaner.ReplaceUnicode(content);
 
                 using (var xmlTextReader = XmlReader.Create(new StringReader(content), new XmlReaderSettings { DtdProcessing = DtdProcessing.Ignore, IgnoreComments = true }))
                 {
@@ -94,19 +94,6 @@ namespace NzbDrone.Core.Indexers
                 ex.Data.Add("ContentSample", contentSample);
 
                 throw;
-            }
-        }
-
-        protected virtual string ReplaceEntity(Match match)
-        {
-            try
-            {
-                var character = WebUtility.HtmlDecode(match.Value);
-                return string.Concat("&#", (int)character[0], ";");
-            }
-            catch
-            {
-                return match.Value;
             }
         }
 

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using NLog;
@@ -191,7 +192,10 @@ namespace NzbDrone.Core.Indexers.TorrentRss
 
         private bool IsEZTVFeed(IndexerResponse response)
         {
-            using (var xmlTextReader = XmlReader.Create(new StringReader(response.Content), new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse, ValidationType = ValidationType.None, IgnoreComments = true, XmlResolver = null }))
+            var content = XmlCleaner.ReplaceEntities(response.Content);
+            content = XmlCleaner.ReplaceUnicode(content);
+
+            using (var xmlTextReader = XmlReader.Create(new StringReader(content), new XmlReaderSettings { DtdProcessing = DtdProcessing.Parse, ValidationType = ValidationType.None, IgnoreComments = true, XmlResolver = null }))
             {
                 var document = XDocument.Load(xmlTextReader);
 

--- a/src/NzbDrone.Core/Indexers/XmlCleaner.cs
+++ b/src/NzbDrone.Core/Indexers/XmlCleaner.cs
@@ -1,0 +1,36 @@
+﻿using System.Globalization;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace NzbDrone.Core.Indexers
+{
+    public static class XmlCleaner
+    {
+
+        private static readonly Regex ReplaceEntitiesRegex = new Regex("&[a-z]+;", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ReplaceUnicodeRegex = new Regex(@"[^\x09\x0A\x0D\x20-\xD7FF\xE000-\xFFFD\x10000-x10FFFF]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        public static string ReplaceEntities(string content)
+        {
+            return ReplaceEntitiesRegex.Replace(content, ReplaceEntity);
+        }
+
+        public static string ReplaceUnicode(string content)
+        {
+            return ReplaceUnicodeRegex.Replace(content, string.Empty);
+        }
+
+        private static string ReplaceEntity(Match match)
+        {
+            try
+            {
+                var character = WebUtility.HtmlDecode(match.Value);
+                return string.Concat("&#", (int)character[0], ";");
+            }
+            catch
+            {
+                return match.Value;
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -653,6 +653,7 @@
     <Compile Include="Indexers\Rarbg\RarbgSettings.cs" />
     <Compile Include="Indexers\Rarbg\RarbgParser.cs" />
     <Compile Include="Indexers\Rarbg\RarbgTokenProvider.cs" />
+    <Compile Include="Indexers\XmlCleaner.cs" />
     <Compile Include="Indexers\RssIndexerRequestGenerator.cs" />
     <Compile Include="Indexers\RssParser.cs" />
     <Compile Include="Indexers\RssSyncCommand.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I started this a couple weeks ago, but found a way around the RSS feed that was throwing the issues when checking for the appropriate feed. This furthers the cleanup of invalid characters for even shittier RSS feeds (look at that AlphaRatio mess of a feed), but could be useful on a feed that isn't a complete mess. I've added an AlphaRatio test that include unicode characters that will be stripped out, even though it has an abomination of a title.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #1518

