### PR TITLE
Download Station - Added default destination test when adding client

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -278,7 +278,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 {
                     return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
                     {
-                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT -> Location."
+                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
                     };
                 }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             failures.AddIfNotNull(TestConnection());
             if (failures.Any()) return;
-            failures.AddIfNotNull(TestOutputPath());            
+            failures.AddIfNotNull(TestOutputPath());
             failures.AddIfNotNull(TestGetTorrents());
         }
 
@@ -307,10 +307,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 return null;
             }
-            catch (DownloadClientAuthenticationException dcaEx) // User could not have permission to access to downloadstation
+            catch (DownloadClientAuthenticationException ex) // User could not have permission to access to downloadstation
             {
-                _logger.Error(dcaEx);
-                return new NzbDroneValidationFailure(string.Empty, dcaEx.Message);
+                _logger.Error(ex);
+                return new NzbDroneValidationFailure(string.Empty, ex.Message);
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -295,7 +295,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     {
                         return new NzbDroneValidationFailure(fieldName, $"Shared folder does not exist")
                         {
-                            DetailedDescription = $"The DownloadStation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
+                            DetailedDescription = $"The Diskstation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
                         };
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             failures.AddIfNotNull(TestConnection());
             if (failures.Any()) return;
-            failures.AddIfNotNull(TestOutputPath());
+            failures.AddIfNotNull(TestOutputPath());            
             failures.AddIfNotNull(TestGetTorrents());
         }
 
@@ -272,7 +272,14 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                var downloadDir = GetDownloadDirectory();
+                var downloadDir = GetDefaultDir();
+
+                if (downloadDir == null)
+                {
+                    return new NzbDroneValidationFailure(string.Empty, "No default destination configured. You must manually set it up into download station settings.");
+                }
+
+                downloadDir = GetDownloadDirectory();
 
                 if (downloadDir != null)
                 {
@@ -299,6 +306,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 }
 
                 return null;
+            }
+            catch (DownloadClientAuthenticationException dcaEx) // User could not have permission to access to downloadstation
+            {
+                _logger.Error(dcaEx);
+                return new NzbDroneValidationFailure(string.Empty, dcaEx.Message);
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -276,7 +276,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 if (downloadDir == null)
                 {
-                    return new NzbDroneValidationFailure(string.Empty, "No default destination configured. You must manually set it up into download station settings.");
+                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
+                    {
+                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT -> Location."
+                    };
                 }
 
                 downloadDir = GetDownloadDirectory();

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     {
                         return new NzbDroneValidationFailure(fieldName, $"Shared folder does not exist")
                         {
-                            DetailedDescription = $"The Diskstation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
+                            DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
                         };
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 {
                     return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
                     {
-                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT -> Location."
+                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
                     };
                 }
 
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     {
                         return new NzbDroneValidationFailure(fieldName, $"Shared folder does not exist")
                         {
-                            DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT/HTTP/FTP/NZB -> Location."
+                            DetailedDescription = $"The Diskstation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
                         };
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -194,7 +194,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 if (downloadDir == null)
                 {
-                    return new NzbDroneValidationFailure(string.Empty, "No default destination configured. You must manually set it up into download station settings.");
+                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "No default destination")
+                    {
+                        DetailedDescription = $"You must login into your Diskstation as {Settings.Username} and manually set it up into DownloadStation settings under BT -> Location."
+                    };
                 }
 
                 downloadDir = GetDownloadDirectory();
@@ -210,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     {
                         return new NzbDroneValidationFailure(fieldName, $"Shared folder does not exist")
                         {
-                            DetailedDescription = $"The DownloadStation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
+                            DetailedDescription = $"The Diskstation does not have a Shared Folder with the name '{sharedFolder}', are you sure you specified it correctly?"
                         };
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -190,7 +190,14 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                var downloadDir = GetDownloadDirectory();
+                var downloadDir = GetDefaultDir();
+
+                if (downloadDir == null)
+                {
+                    return new NzbDroneValidationFailure(string.Empty, "No default destination configured. You must manually set it up into download station settings.");
+                }
+
+                downloadDir = GetDownloadDirectory();                
 
                 if (downloadDir != null)
                 {
@@ -217,6 +224,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                 }
 
                 return null;
+            }
+            catch (DownloadClientAuthenticationException dcaEx) // User could not have permission to access to downloadstation
+            {
+                _logger.Error(dcaEx);
+                return new NzbDroneValidationFailure(string.Empty, dcaEx.Message);
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -197,7 +197,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     return new NzbDroneValidationFailure(string.Empty, "No default destination configured. You must manually set it up into download station settings.");
                 }
 
-                downloadDir = GetDownloadDirectory();                
+                downloadDir = GetDownloadDirectory();
 
                 if (downloadDir != null)
                 {
@@ -225,10 +225,10 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 return null;
             }
-            catch (DownloadClientAuthenticationException dcaEx) // User could not have permission to access to downloadstation
+            catch (DownloadClientAuthenticationException ex) // User could not have permission to access to downloadstation
             {
-                _logger.Error(dcaEx);
-                return new NzbDroneValidationFailure(string.Empty, dcaEx.Message);
+                _logger.Error(ex);
+                return new NzbDroneValidationFailure(string.Empty, ex.Message);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
User must set download station default destination up before trying to add the client to sonarr.
Fixed an infinite loop when handling authorization error.
And do not retry if user has not permission to use download station

#### Issues Fixed or Closed by this PR
 #1720
