### PR TITLE
Don't grab upgrades if existing file was deleted and will be unmonitored

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -28,6 +28,8 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         private Mock<IDecisionEngineSpecification> _fail2;
         private Mock<IDecisionEngineSpecification> _fail3;
 
+        private Mock<IDecisionEngineSpecification> _failDelayed1;
+
         [SetUp]
         public void Setup()
         {
@@ -39,13 +41,18 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _fail2 = new Mock<IDecisionEngineSpecification>();
             _fail3 = new Mock<IDecisionEngineSpecification>();
 
+            _failDelayed1 = new Mock<IDecisionEngineSpecification>();
+
             _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
             _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
             _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Accept);
-            
+
             _fail1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail1"));
             _fail2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail2"));
             _fail3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("fail3"));
+
+            _failDelayed1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(Decision.Reject("failDelayed1"));
+            _failDelayed1.SetupGet(c => c.Priority).Returns(SpecificationPriority.Disk);
 
             _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "The.Office.S03E115.DVDRip.XviD-OSiTV" } };
             _remoteEpisode = new RemoteEpisode {
@@ -76,6 +83,25 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _pass1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
             _pass2.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
             _pass3.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
+        }
+
+        [Test]
+        public void should_call_delayed_specifications_if_non_delayed_passed()
+        {
+            GivenSpecifications(_pass1, _failDelayed1);
+
+            Subject.GetRssDecision(_reports).ToList();
+            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
+        }
+
+        [Test]
+        public void should_not_call_delayed_specifications_if_non_delayed_failed()
+        {
+            GivenSpecifications(_fail1, _failDelayed1);
+
+            Subject.GetRssDecision(_reports).ToList();
+
+            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Never());
         }
 
         [Test]
@@ -214,10 +240,10 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             var criteria = new SeasonSearchCriteria { Episodes = episodes.Take(1).ToList(), SeasonNumber = 1 };
 
-            var reports = episodes.Select(v => 
-                new ReleaseInfo() 
-                { 
-                    Title = string.Format("{0}.S{1:00}E{2:00}.720p.WEB-DL-DRONE", series.Title, v.SceneSeasonNumber, v.SceneEpisodeNumber) 
+            var reports = episodes.Select(v =>
+                new ReleaseInfo()
+                {
+                    Title = string.Format("{0}.S{1:00}E{2:00}.720p.WEB-DL-DRONE", series.Title, v.SceneSeasonNumber, v.SceneEpisodeNumber)
                 }).ToList();
 
             Mocker.GetMock<IParsingService>()

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DeletedEpisodeFileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DeletedEpisodeFileSpecificationFixture.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.DecisionEngine;
+
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Common.Disk;
+using Moq;
+using NzbDrone.Test.Common;
+using System.IO;
+
+namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
+{
+    [TestFixture]
+    public class DeletedEpisodeFileSpecificationFixture : CoreTest<DeletedEpisodeFileSpecification>
+    {
+        private RemoteEpisode _parseResultMulti;
+        private RemoteEpisode _parseResultSingle;
+        private EpisodeFile _firstFile;
+        private EpisodeFile _secondFile;
+
+        [SetUp]
+        public void Setup()
+        {
+            _firstFile = new EpisodeFile
+            {
+                Id = 1,
+                RelativePath = "My.Series.S01E01.mkv",
+                Quality = new QualityModel(Quality.Bluray1080p, new Revision(version: 1)),
+                DateAdded = DateTime.Now
+            };
+            _secondFile = new EpisodeFile
+            {
+                Id = 2,
+                RelativePath = "My.Series.S01E02.mkv",
+                Quality = new QualityModel(Quality.Bluray1080p, new Revision(version: 1)),
+                DateAdded = DateTime.Now
+            };
+
+            var singleEpisodeList = new List<Episode> { new Episode { EpisodeFile = _firstFile, EpisodeFileId = 1 } };
+            var doubleEpisodeList = new List<Episode> {
+                new Episode { EpisodeFile = _firstFile, EpisodeFileId = 1 },
+                new Episode { EpisodeFile = _secondFile, EpisodeFileId = 2 }
+            };
+
+            var fakeSeries = Builder<Series>.CreateNew()
+                         .With(c => c.Profile = new Profile { Cutoff = Quality.Bluray1080p })
+                         .With(c => c.Path = @"C:\Series\My.Series".AsOsAgnostic())
+                         .Build();
+
+            _parseResultMulti = new RemoteEpisode
+            {
+                Series = fakeSeries,
+                ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = new QualityModel(Quality.DVD, new Revision(version: 2)) },
+                Episodes = doubleEpisodeList
+            };
+
+            _parseResultSingle = new RemoteEpisode
+            {
+                Series = fakeSeries,
+                ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = new QualityModel(Quality.DVD, new Revision(version: 2)) },
+                Episodes = singleEpisodeList
+            };
+
+            GivenUnmonitorDeletedEpisodes(true);
+        }
+
+        private void GivenUnmonitorDeletedEpisodes(bool enabled)
+        {
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(v => v.AutoUnmonitorPreviouslyDownloadedEpisodes)
+                  .Returns(enabled);
+        }
+
+        private void WithExistingFile(EpisodeFile episodeFile)
+        {
+            var path = Path.Combine(@"C:\Series\My.Series".AsOsAgnostic(), episodeFile.RelativePath);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(v => v.FileExists(path))
+                  .Returns(true);
+        }
+
+        [Test]
+        public void should_return_true_when_unmonitor_deleted_episdes_is_off()
+        {
+            GivenUnmonitorDeletedEpisodes(false);
+
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_when_searching()
+        {
+            Subject.IsSatisfiedBy(_parseResultSingle, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_file_exists()
+        {
+            WithExistingFile(_firstFile);
+
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_file_is_missing()
+        {
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_true_if_both_of_multiple_episode_exist()
+        {
+            WithExistingFile(_firstFile);
+            WithExistingFile(_secondFile);
+
+            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_one_of_multiple_episode_is_missing()
+        {
+            WithExistingFile(_firstFile);
+
+            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -159,6 +159,7 @@
     <Compile Include="DecisionEngineTests\MinimumAgeSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\RetentionSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\RssSync\DelaySpecificationFixture.cs" />
+    <Compile Include="DecisionEngineTests\RssSync\DeletedEpisodeFileSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\RssSync\ProperSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\Search\SeriesSpecificationFixture.cs" />
     <Compile Include="DecisionEngineTests\SameEpisodesSpecificationFixture.cs" />

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -122,8 +122,16 @@ namespace NzbDrone.Core.DecisionEngine
 
         private DownloadDecision GetDecisionForReport(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria = null)
         {
-            var reasons = _specifications.Select(c => EvaluateSpec(c, remoteEpisode, searchCriteria))
-                                         .Where(c => c != null);
+            var reasons = new Rejection[0];
+
+            foreach (var specifications in _specifications.GroupBy(v => v.Priority).OrderBy(v => v.Key))
+            {
+                reasons = specifications.Select(c => EvaluateSpec(c, remoteEpisode, searchCriteria))
+                                        .Where(c => c != null)
+                                        .ToArray();
+
+                if (reasons.Any()) break;
+            }
 
             return new DownloadDecision(remoteEpisode, reasons.ToArray());
         }

--- a/src/NzbDrone.Core/DecisionEngine/IDecisionEngineSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/IDecisionEngineSpecification.cs
@@ -7,6 +7,8 @@ namespace NzbDrone.Core.DecisionEngine
     {
         RejectionType Type { get; }
 
+        SpecificationPriority Priority { get; }
+
         Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria);
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/SpecificationPriority.cs
+++ b/src/NzbDrone.Core/DecisionEngine/SpecificationPriority.cs
@@ -1,0 +1,10 @@
+﻿namespace NzbDrone.Core.DecisionEngine
+{
+    public enum SpecificationPriority
+    {
+        Default = 0,
+        Parsing = 0,
+        Database = 0,
+        Disk = 1
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/BlacklistSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/BlacklistSpecification.cs
@@ -16,10 +16,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
-        {          
+        {
             if (_blacklistService.Blacklisted(subject.Series.Id, subject.Release))
             {
                 _logger.Debug("{0} is blacklisted, rejecting.", subject.Release.Title);

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/CutoffSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/CutoffSpecification.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
@@ -29,7 +30,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 }
 
                 _logger.Debug("Comparing file quality with report. Existing file is {0}", file.Quality);
-                
+
                 if (!_qualityUpgradableSpecification.CutoffNotMet(subject.Series.Profile, file.Quality, subject.ParsedEpisodeInfo.Quality))
                 {
                     _logger.Debug("Cutoff already met, rejecting.");

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _episodeService = episodeService;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/LanguageSpecification.cs
@@ -13,12 +13,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
         {
             var wantedLanguage = subject.Series.Profile.Value.Language;
-            
+
             _logger.Debug("Checking if report meets language requirements. {0}", subject.ParsedEpisodeInfo.Language);
 
             if (subject.ParsedEpisodeInfo.Language != wantedLanguage)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Temporary;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
     {
         private readonly Logger _logger;
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public NotSampleSpecification(Logger logger)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Temporary;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
+{
+    public class DeletedEpisodeFileSpecification : IDecisionEngineSpecification
+    {
+        private readonly IDiskProvider _diskProvider;
+        private readonly IConfigService _configService;
+        private readonly Logger _logger;
+
+        public DeletedEpisodeFileSpecification(IDiskProvider diskProvider, IConfigService configService, Logger logger)
+        {
+            _diskProvider = diskProvider;
+            _configService = configService;
+            _logger = logger;
+        }
+
+        public SpecificationPriority Priority => SpecificationPriority.Disk;
+        public RejectionType Type => RejectionType.Temporary;
+
+        public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        {
+            if (!_configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
+            {
+                return Decision.Accept();
+            }
+
+            if (searchCriteria != null)
+            {
+                _logger.Debug("Skipping deleted episodefile check during search");
+                return Decision.Accept();
+            }
+
+            var missingEpisodeFiles = subject.Episodes
+                                             .Where(v => v.EpisodeFileId != 0)
+                                             .Select(v => v.EpisodeFile.Value)
+                                             .DistinctBy(v => v.Id)
+                                             .Where(v => IsEpisodeFileMissing(subject.Series, v))
+                                             .ToArray();
+
+            if (missingEpisodeFiles.Any())
+            {
+                foreach (var missingEpisodeFile in missingEpisodeFiles)
+                {
+                    _logger.Trace("Episode file {0} is missing from disk.", missingEpisodeFile.RelativePath);
+                }
+
+                _logger.Debug("Files for this episode exist in the database but not on disk, will be unmonitored on next diskscan. skipping.");
+                return Decision.Reject("Series is not monitored");
+            }
+
+            return Decision.Accept();
+        }
+
+        private bool IsEpisodeFileMissing(Series series, EpisodeFile episodeFile)
+        {
+            var fullPath = Path.Combine(series.Path, episodeFile.RelativePath);
+
+            return !_diskProvider.FileExists(fullPath);
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
@@ -59,7 +60,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                     {
                         if (recent)
                         {
-                            return Decision.Reject("Recent grab event in history already meets cutoff: {0}", mostRecent.Quality);  
+                            return Decision.Reject("Recent grab event in history already meets cutoff: {0}", mostRecent.Quality);
                         }
 
                         return Decision.Reject("CDH is disabled and grab event in history already meets cutoff: {0}", mostRecent.Quality);

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SameEpisodesGrabSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SameEpisodesGrabSpecification.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/DailyEpisodeMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/DailyEpisodeMatchSpecification.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _episodeService = episodeService;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public Decision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/TorrentSeedingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/TorrentSeedingSpecification.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
+        public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
         public virtual Decision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -315,6 +315,7 @@
     <Compile Include="DecisionEngine\Rejection.cs" />
     <Compile Include="DecisionEngine\RejectionType.cs" />
     <Compile Include="DecisionEngine\SameEpisodesSpecification.cs" />
+    <Compile Include="DecisionEngine\SpecificationPriority.cs" />
     <Compile Include="DecisionEngine\Specifications\AcceptableSizeSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\BlacklistSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\AnimeVersionUpgradeSpecification.cs" />
@@ -330,6 +331,7 @@
     <Compile Include="DecisionEngine\Specifications\RetentionSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\DelaySpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\HistorySpecification.cs" />
+    <Compile Include="DecisionEngine\Specifications\RssSync\DeletedEpisodeFileSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\MonitoredEpisodeSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\RssSync\ProperSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\Search\DailyEpisodeMatchSpecification.cs" />


### PR DESCRIPTION
We want to block upgrades, if the existing file was already deleted. But Sonarr isn't aware of that till the next disk scan.
This PR adds a Specification that will check if the file exists.

For performance reasons this Specification can only run if no other rejections exist. So I refactored the specifications to use a tiered approach. If any rejection exist in the current tier, the the next one won't be evaluated, thus avoiding the disk IO.

I haven't tested it, nor are there any unit tests. First I want to know how happy we are with this approach.