### PR TITLE
Use MaterialisingResponse for static resource responses

### DIFF
--- a/src/NzbDrone.Api/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/NzbDrone.Api/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using NLog;
 using Nancy;
@@ -38,7 +38,7 @@ namespace NzbDrone.Api.Frontend.Mappers
             if (_diskProvider.FileExists(filePath, _caseSensitive))
             {
                 var response = new StreamResponse(() => GetContentStream(filePath), MimeTypes.GetMimeType(filePath));
-                return response;
+                return new MaterialisingResponse(response);
             }
 
             _logger.Warn("File {0} not found", filePath);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Wraps responses for static resources in [MaterialisingResponse](https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Responses/MaterialisingResponse.cs) so the response is properly calculated before returning to the client and the logs should the correct response (and `OnError` handling works in the pipeline).

PRed such a simple change because there is a warning on `MaterialisingResponse` and while our responses aren't for giant files I wanted to play it safe.