### PR TITLE
DownloadStation - Revert Session name

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             requestBuilder.AddQueryParam("account", settings.Username);
             requestBuilder.AddQueryParam("passwd", settings.Password);
             requestBuilder.AddQueryParam("format", "sid");
-            requestBuilder.AddQueryParam("session", Guid.NewGuid().ToString());
+            requestBuilder.AddQueryParam("session", "DownloadStation");
 
             var authResponse = ProcessRequest<DiskStationAuthResponse>(requestBuilder, "login", DiskStationApi.Auth, settings);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As it seems guid is causing some troubles i think we should get back to "DownloadStation" for the session name. Just tried here with filestation api and it's working fine.

#### Todos


#### Issues Fixed or Closed by this PR

* #1786, #1784
