### PR TITLE
Deleting Episode Files that no longer exist on disk

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaFileDeletionService/DeleteEpisodeFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaFileDeletionService/DeleteEpisodeFileFixture.cs
@@ -1,0 +1,140 @@
+﻿using System.IO;
+using FizzWare.NBuilder;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.MediaFileDeletionService
+{
+    [TestFixture]
+    public class DeleteEpisodeFileFixture : CoreTest<Core.MediaFiles.MediaFileDeletionService>
+    {
+        private static readonly string RootFolder = @"C:\Test\TV";
+        private Series _series;
+        private EpisodeFile _episodeFile;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew()
+                                     .With(s => s.Path = Path.Combine(RootFolder, "Series Title"))
+                                     .Build();
+
+            _episodeFile = Builder<EpisodeFile>.CreateNew()
+                                               .With(f => f.RelativePath = "Series Title - S01E01")
+                                               .With(f => f.Path = Path.Combine(_series.Path, "Series Title - S01E01"))
+                                               .Build();
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.GetParentFolder(_series.Path))
+                  .Returns(RootFolder);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.GetParentFolder(_episodeFile.Path))
+                  .Returns(_series.Path);
+        }
+
+        private void GivenRootFolderExists()
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.FolderExists(RootFolder))
+                  .Returns(true);
+        }
+
+        private void GivenRootFolderHasFolders()
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.GetDirectories(RootFolder))
+                  .Returns(new[] { _series.Path });
+        }
+
+        private void GivenSeriesFolderExists()
+        {
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.FolderExists(_series.Path))
+                  .Returns(true);
+        }
+
+        [Test]
+        public void should_throw_if_root_folder_does_not_exist()
+        {
+            Assert.Throws<NzbDroneClientException>(() => Subject.DeleteEpisodeFile(_series, _episodeFile));
+        }
+
+        [Test]
+        public void should_should_throw_if_root_folder_is_empty()
+        {
+            GivenRootFolderExists();
+            Assert.Throws<NzbDroneClientException>(() => Subject.DeleteEpisodeFile(_series, _episodeFile));
+        }
+
+        [Test]
+        public void should_delete_from_db_if_series_folder_does_not_exist()
+        {
+            GivenRootFolderExists();
+            GivenRootFolderHasFolders();
+
+            Subject.DeleteEpisodeFile(_series, _episodeFile);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_episodeFile, DeleteMediaFileReason.Manual), Times.Once());
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(_episodeFile.Path, It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_delete_from_db_if_episode_file_does_not_exist()
+        {
+            GivenRootFolderExists();
+            GivenRootFolderHasFolders();
+            GivenSeriesFolderExists();
+
+            Subject.DeleteEpisodeFile(_series, _episodeFile);
+
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_episodeFile, DeleteMediaFileReason.Manual), Times.Once());
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(_episodeFile.Path, It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_delete_from_disk_and_db_if_episode_file_exists()
+        {
+            GivenRootFolderExists();
+            GivenRootFolderHasFolders();
+            GivenSeriesFolderExists();
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.FileExists(_episodeFile.Path))
+                  .Returns(true);
+
+            Subject.DeleteEpisodeFile(_series, _episodeFile);
+
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(_episodeFile.Path, "Series Title"), Times.Once());
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_episodeFile, DeleteMediaFileReason.Manual), Times.Once());
+        }
+
+        [Test]
+        public void should_handle_error_deleting_episode_file()
+        {
+            GivenRootFolderExists();
+            GivenRootFolderHasFolders();
+            GivenSeriesFolderExists();
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(s => s.FileExists(_episodeFile.Path))
+                  .Returns(true);
+
+            Mocker.GetMock<IRecycleBinProvider>()
+                  .Setup(s => s.DeleteFile(_episodeFile.Path, "Series Title"))
+                  .Throws(new IOException());
+
+            Assert.Throws<NzbDroneClientException>(() => Subject.DeleteEpisodeFile(_series, _episodeFile));
+
+            ExceptionVerification.ExpectedErrors(1);
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(_episodeFile.Path, "Series Title"), Times.Once());
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_episodeFile, DeleteMediaFileReason.Manual), Times.Never());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -290,6 +290,7 @@
     <Compile Include="MediaFiles\EpisodeImport\Specifications\NotUnpackingSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\UpgradeSpecificationFixture.cs" />
     <Compile Include="MediaFiles\ImportApprovedEpisodesFixture.cs" />
+    <Compile Include="MediaFiles\MediaFileDeletionService\DeleteEpisodeFileFixture.cs" />
     <Compile Include="MediaFiles\MediaFileRepositoryFixture.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatAudioCodecFixture.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatVideoCodecFixture.cs" />

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Tv;
+using NzbDrone.Core.Tv.Events;
+
+namespace NzbDrone.Core.MediaFiles
+{
+    public interface IDeleteMediaFiles
+    {
+        void DeleteEpisodeFile(Series series, EpisodeFile episodeFile);
+    }
+
+    public class MediaFileDeletionService : IDeleteMediaFiles, IHandleAsync<SeriesDeletedEvent>
+    {
+        private readonly IDiskProvider _diskProvider;
+        private readonly IRecycleBinProvider _recycleBinProvider;
+        private readonly IMediaFileService _mediaFileService;
+        private readonly Logger _logger;
+
+        public MediaFileDeletionService(IDiskProvider diskProvider,
+                                        IRecycleBinProvider recycleBinProvider,
+                                        IMediaFileService mediaFileService,
+                                        Logger logger)
+        {
+            _diskProvider = diskProvider;
+            _recycleBinProvider = recycleBinProvider;
+            _mediaFileService = mediaFileService;
+            _logger = logger;
+        }
+
+        public void DeleteEpisodeFile(Series series, EpisodeFile episodeFile)
+        {
+            var fullPath = Path.Combine(series.Path, episodeFile.RelativePath);
+            var rootFolder = _diskProvider.GetParentFolder(series.Path);
+
+            if (!_diskProvider.FolderExists(rootFolder))
+            {
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Series' root folder ({0}) doesn't exist.", rootFolder);
+            }
+
+            if (_diskProvider.GetDirectories(rootFolder).Empty())
+            {
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Series' root folder ({0}) is empty.", rootFolder);
+            }
+
+            if (_diskProvider.FolderExists(series.Path) && _diskProvider.FileExists(fullPath))
+            {
+                _logger.Info("Deleting episode file: {0}", fullPath);
+
+                var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
+
+                try
+                {
+                    _recycleBinProvider.DeleteFile(fullPath, subfolder);
+                }
+                catch (Exception e)
+                {
+                    _logger.Error(e, "Unable to delete episode file");
+                    throw new NzbDroneClientException(HttpStatusCode.InternalServerError, "Unable to delete episode file");
+                }
+            }
+            
+            // Delete the episode file from the database to clean it up even if the file was already deleted
+            _mediaFileService.Delete(episodeFile, DeleteMediaFileReason.Manual);
+        }
+
+        public void HandleAsync(SeriesDeletedEvent message)
+        {
+            if (message.DeleteFiles)
+            {
+                if (_diskProvider.FolderExists(message.Series.Path))
+                {
+                    _recycleBinProvider.DeleteFolder(message.Series.Path);
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
+++ b/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.MediaFiles
         void Cleanup();
     }
 
-    public class RecycleBinProvider : IHandleAsync<SeriesDeletedEvent>, IExecute<CleanUpRecycleBinCommand>, IRecycleBinProvider
+    public class RecycleBinProvider : IExecute<CleanUpRecycleBinCommand>, IRecycleBinProvider
     {
         private readonly IDiskTransferService _diskTransferService;
         private readonly IDiskProvider _diskProvider;
@@ -190,17 +190,6 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             _logger.Debug("Recycling Bin has been cleaned up.");
-        }
-
-        public void HandleAsync(SeriesDeletedEvent message)
-        {
-            if (message.DeleteFiles)
-            {
-                if (_diskProvider.FolderExists(message.Series.Path))
-                {
-                    DeleteFolder(message.Series.Path);
-                }
-            }
         }
 
         public void Execute(CleanUpRecycleBinCommand message)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -777,6 +777,7 @@
     <Compile Include="MediaFiles\Events\SeriesScannedEvent.cs" />
     <Compile Include="MediaFiles\FileDateType.cs" />
     <Compile Include="MediaFiles\MediaFileAttributeService.cs" />
+    <Compile Include="MediaFiles\MediaFileDeletionService.cs" />
     <Compile Include="MediaFiles\MediaFileExtensions.cs" />
     <Compile Include="MediaFiles\MediaFileRepository.cs" />
     <Compile Include="MediaFiles\MediaFileService.cs">

--- a/src/UI/Cells/DeleteEpisodeFileCell.js
+++ b/src/UI/Cells/DeleteEpisodeFileCell.js
@@ -19,7 +19,7 @@ module.exports = Backgrid.Cell.extend({
         var self = this;
 
         if (window.confirm('Are you sure you want to delete \'{0}\' from disk?'.format(this.model.get('path')))) {
-            this.model.destroy().done(function() {
+            this.model.destroy({ wait: true }).done(function() {
                 vent.trigger(vent.Events.EpisodeFileDeleted, { episodeFile : self.model });
             });
         }

--- a/src/UI/EpisodeFile/Editor/EpisodeFileEditorLayout.js
+++ b/src/UI/EpisodeFile/Editor/EpisodeFileEditorLayout.js
@@ -176,7 +176,7 @@ module.exports = Marionette.Layout.extend({
             if (reqres.hasHandler(reqres.Requests.GetEpisodeFileById)) {
                 var episodeFile = reqres.request(reqres.Requests.GetEpisodeFileById, episodeFileId);
 
-                episodeFile.destroy();
+                episodeFile.destroy({ wait: true });
             }
         });
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This improves the deleting of episode files and a small refactor to deleting episode files after a series is deleted.

There are a few rules (consistent with rescanning a series folder):

- If the root folder for a series is missing or empty the file will not be deleted from the DB
- If only the series folder or the episode file is missing the file will be deleted from the DB
- If the file exists on disk we'll delete it from disk and then the DB


#### Issues Fixed or Closed by this PR

* #1782
