### PR TITLE
 Split isReadOnly up into CanBeRemoved and CanMoveFiles in DownloadClientItem 

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
                 .Returns("CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951".ToLower())
                 .Callback(PrepareClientToReturnQueuedItem);
         }
-        
+
         protected virtual void GivenTorrents(List<DelugeTorrent> torrents)
         {
             if (torrents == null)
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
 
         protected void PrepareClientToReturnQueuedItem()
         {
-            GivenTorrents(new List<DelugeTorrent> 
+            GivenTorrents(new List<DelugeTorrent>
                 {
                     _queued
                 });
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
 
         protected void PrepareClientToReturnDownloadingItem()
         {
-            GivenTorrents(new List<DelugeTorrent> 
+            GivenTorrents(new List<DelugeTorrent>
                 {
                     _downloading
                 });
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
 
         protected void PrepareClientToReturnFailedItem()
         {
-            GivenTorrents(new List<DelugeTorrent> 
+            GivenTorrents(new List<DelugeTorrent>
                 {
                     _failed
                 });
@@ -248,11 +248,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(DelugeTorrentStatus.Paused, DownloadItemStatus.Completed, true)]
-        [TestCase(DelugeTorrentStatus.Checking, DownloadItemStatus.Downloading, true)]
-        [TestCase(DelugeTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(DelugeTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(string apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(DelugeTorrentStatus.Paused, DownloadItemStatus.Completed, false)]
+        [TestCase(DelugeTorrentStatus.Checking, DownloadItemStatus.Downloading, false)]
+        [TestCase(DelugeTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(DelugeTorrentStatus.Seeding, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(string apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.State = apiStatus;
 
@@ -261,11 +261,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]
-        public void GetItems_should_check_share_ratio_for_readonly()
+        public void GetItems_should_check_share_ratio_for_moveFiles_and_remove()
         {
             _completed.State = DelugeTorrentStatus.Paused;
             _completed.IsAutoManaged = true;
@@ -278,7 +279,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(DownloadItemStatus.Completed);
-            item.IsReadOnly.Should().BeFalse();
+            item.CanMoveFiles.Should().BeTrue();
+            item.CanBeRemoved.Should().BeTrue();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -580,7 +580,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Finished, true, true)]
         [TestCase(DownloadStationTaskStatus.Seeding,  true, false)]
         [TestCase(DownloadStationTaskStatus.Waiting, false, false)]
-        public void GetItems_should_return_can_be_moved_and_can_be_deleted_expected(DownloadStationTaskStatus apiStatus, bool canMoveFilesExpected, bool canBeRemovedExpected)
+        public void GetItems_should_return_canBeMoved_and_canBeDeleted_as_expected(DownloadStationTaskStatus apiStatus, bool canMoveFilesExpected, bool canBeRemovedExpected)
         {
             GivenSerialNumber();
             GivenSharedFolder();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -576,11 +576,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             items.Should().OnlyContain(v => !v.OutputPath.IsEmpty);
         }
 
-        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, true)]
-        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, false)]
-        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed, true)]
-        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, true)]
-        public void GetItems_should_return_readonly_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool readOnlyExpected)
+        [TestCase(DownloadStationTaskStatus.Downloading, false, false)]
+        [TestCase(DownloadStationTaskStatus.Finished, true, true)]
+        [TestCase(DownloadStationTaskStatus.Seeding,  true, false)]
+        [TestCase(DownloadStationTaskStatus.Waiting, false, false)]
+        public void GetItems_should_return_can_be_moved_and_can_be_deleted_expected(DownloadStationTaskStatus apiStatus, bool canMoveFilesExpected, bool canBeRemovedExpected)
         {
             GivenSerialNumber();
             GivenSharedFolder();
@@ -592,7 +592,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             var items = Subject.GetItems();
 
             items.Should().HaveCount(1);
-            items.First().IsReadOnly.Should().Be(readOnlyExpected);
+
+            var item = items.First();
+
+            item.CanBeRemoved.Should().Be(canBeRemovedExpected);
+            item.CanMoveFiles.Should().Be(canMoveFilesExpected);
         }
 
         [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading)]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -408,26 +408,6 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             items.Should().OnlyContain(v => !v.OutputPath.IsEmpty);
         }
 
-        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, false)]
-        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, true)]
-        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, false)]
-        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed, false)]
-        public void GetItems_should_return_can_be_removed_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool canBeRemovedExpected)
-        {
-            GivenSerialNumber();
-            GivenSharedFolder();
-
-            _queued.Status = apiStatus;
-
-            GivenTasks(new List<DownloadStationTask>() { _queued });
-
-            var items = Subject.GetItems();
-
-            items.Should().HaveCount(1);
-            items.First().CanBeRemoved.Should().Be(canBeRemovedExpected);
-            items.First().CanMoveFiles.Should().Be(canBeRemovedExpected);
-        }
-
         [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Error, DownloadItemStatus.Failed)]
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -408,10 +408,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             items.Should().OnlyContain(v => !v.OutputPath.IsEmpty);
         }
 
-        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, true)]
-        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, false)]
-        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, true)]
-        public void GetItems_should_return_readonly_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool readOnlyExpected)
+        [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading, false)]
+        [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed, true)]
+        [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued, false)]
+        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_can_be_removed_expected(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus, bool canBeRemovedExpected)
         {
             GivenSerialNumber();
             GivenSharedFolder();
@@ -423,7 +424,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             var items = Subject.GetItems();
 
             items.Should().HaveCount(1);
-            items.First().IsReadOnly.Should().Be(readOnlyExpected);
+            items.First().CanBeRemoved.Should().Be(canBeRemovedExpected);
+            items.First().CanMoveFiles.Should().Be(canBeRemovedExpected);
         }
 
         [TestCase(DownloadStationTaskStatus.Downloading, DownloadItemStatus.Downloading)]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -311,7 +311,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_not_reached()
+        public void should_not_be_removed_if_max_ratio_not_reached()
         {
             GivenMaxRatio(1.0f);
 
@@ -330,11 +330,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_reached_and_not_paused()
+        public void should_not_be_removed_if_max_ratio_reached_and_not_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -353,11 +353,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_read_only_if_max_ratio_is_not_set()
+        public void should_not_be_removed_if_max_ratio_is_not_set()
         {
             GivenMaxRatio(1.0f, false);
 
@@ -376,11 +376,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeTrue();
+            item.CanBeRemoved.Should().BeFalse();
         }
 
         [Test]
-        public void should_not_be_read_only_if_max_ratio_reached_and_paused()
+        public void should_be_removed_if_max_ratio_reached_and_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -399,7 +399,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             GivenTorrents(new List<QBittorrentTorrent> { torrent });
 
             var item = Subject.GetItems().Single();
-            item.IsReadOnly.Should().BeFalse();
+            item.CanBeRemoved.Should().BeTrue();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -311,7 +311,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void should_not_be_removed_if_max_ratio_not_reached()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_not_reached()
         {
             GivenMaxRatio(1.0f);
 
@@ -331,10 +331,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_not_be_removed_if_max_ratio_reached_and_not_paused()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_reached_and_not_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -354,10 +355,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_not_be_removed_if_max_ratio_is_not_set()
+        public void should_not_be_removable_and_should_not_allow_move_files_if_max_ratio_is_not_set()
         {
             GivenMaxRatio(1.0f, false);
 
@@ -377,10 +379,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeFalse();
+            item.CanMoveFiles.Should().BeFalse();
         }
 
         [Test]
-        public void should_be_removed_if_max_ratio_reached_and_paused()
+        public void should_be_removable_and_should_allow_move_files_if_max_ratio_reached_and_paused()
         {
             GivenMaxRatio(1.0f);
 
@@ -400,6 +403,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -172,13 +172,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
-        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.Status = apiStatus;
 
@@ -187,7 +187,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
@@ -292,12 +292,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checking, DownloadItemStatus.Queued, false)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked, DownloadItemStatus.Completed, false)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Started, DownloadItemStatus.Completed, true)]
-        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued | UTorrentTorrentStatus.Paused, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(UTorrentTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checking, DownloadItemStatus.Queued, true)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked, DownloadItemStatus.Completed, true)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Started, DownloadItemStatus.Completed, false)]
+        [TestCase(UTorrentTorrentStatus.Loaded | UTorrentTorrentStatus.Checked | UTorrentTorrentStatus.Queued | UTorrentTorrentStatus.Paused, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(UTorrentTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.Status = apiStatus;
 
@@ -306,7 +306,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -174,13 +174,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
-        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, true)]
-        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, true)]
-        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, true)]
-        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedReadOnly)
+        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, false)]
+        [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.SeedingWait, DownloadItemStatus.Completed, false)]
+        [TestCase(TransmissionTorrentStatus.Seeding, DownloadItemStatus.Completed, false)]
+        public void GetItems_should_return_completed_item_as_downloadItemStatus(TransmissionTorrentStatus apiStatus, DownloadItemStatus expectedItemStatus, bool expectedValue)
         {
             _completed.Status = apiStatus;
 
@@ -189,7 +189,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
             var item = Subject.GetItems().Single();
 
             item.Status.Should().Be(expectedItemStatus);
-            item.IsReadOnly.Should().Be(expectedReadOnly);
+            item.CanBeRemoved.Should().Be(expectedValue);
+            item.CanMoveFiles.Should().Be(expectedValue);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/HistoryTests/HistoryServiceFixture.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Test.HistoryTests
                                    Path = @"C:\Test\Unsorted\Series.s01e01.mkv"
                                };
 
-            Subject.Handle(new EpisodeImportedEvent(localEpisode, episodeFile, true, "sab", "abcd", true));
+            Subject.Handle(new EpisodeImportedEvent(localEpisode, episodeFile, true, "sab", "abcd"));
 
             Mocker.GetMock<IHistoryRepository>()
                 .Verify(v => v.Insert(It.Is<History.History>(h => h.SourceTitle == Path.GetFileNameWithoutExtension(localEpisode.Path))));

--- a/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/ImportApprovedEpisodesFixture.cs
@@ -224,9 +224,9 @@ namespace NzbDrone.Core.Test.MediaFiles
         }
 
         [Test]
-        public void should_copy_readonly_downloads()
+        public void should_copy_when_cannot_move_files_downloads()
         {
-            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true });
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", CanMoveFiles = false});
 
             Mocker.GetMock<IUpgradeMediaFiles>()
                   .Verify(v => v.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), _approvedDecisions.First().LocalEpisode, true), Times.Once());
@@ -235,7 +235,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         [Test]
         public void should_use_override_importmode()
         {
-            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", IsReadOnly = true }, ImportMode.Move);
+            Subject.Import(new List<ImportDecision> { _approvedDecisions.First() }, true, new DownloadClientItem { Title = "30.Rock.S01E01", CanMoveFiles = false }, ImportMode.Move);
 
             Mocker.GetMock<IUpgradeMediaFiles>()
                   .Verify(v => v.UpgradeEpisodeFile(It.IsAny<EpisodeFile>(), _approvedDecisions.First().LocalEpisode, false), Times.Once());

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -103,8 +103,8 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
                     Status = item.Status,
 
-                    CanBeDeleted = !Settings.ReadOnly,
-                    CanBeRemovedFromClient = !Settings.ReadOnly
+                    CanMoveFiles = !Settings.ReadOnly,
+                    CanBeRemoved = !Settings.ReadOnly
                 };
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -103,7 +103,8 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
                     Status = item.Status,
 
-                    IsReadOnly = Settings.ReadOnly
+                    CanBeDeleted = !Settings.ReadOnly,
+                    CanBeRemovedFromClient = !Settings.ReadOnly
                 };
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -68,7 +68,10 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
                     OutputPath = item.OutputPath,
 
-                    Status = item.Status
+                    Status = item.Status,
+
+                    CanBeRemoved = true,
+                    CanMoveFiles = true
                 };
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -123,6 +123,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 else if (torrent.IsFinished && torrent.State != DelugeTorrentStatus.Checking)
                 {
                     item.Status = DownloadItemStatus.Completed;
+                    item.CanBeDeleted = true;
                 }
                 else if (torrent.State == DelugeTorrentStatus.Queued)
                 {
@@ -138,14 +139,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 }
 
                 // Here we detect if Deluge is managing the torrent and whether the seed criteria has been met. This allows drone to delete the torrent as appropriate.
-                if (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused)
-                {
-                    item.IsReadOnly = false;
-                }
-                else
-                {
-                    item.IsReadOnly = true;
-                }
+                item.CanBeRemovedFromClient = (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused);
 
                 items.Add(item);
             }
@@ -178,7 +172,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             {
                 status.OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, destDir) };
             }
-            
+
             return status;
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -123,7 +123,6 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 else if (torrent.IsFinished && torrent.State != DelugeTorrentStatus.Checking)
                 {
                     item.Status = DownloadItemStatus.Completed;
-                    item.CanBeDeleted = true;
                 }
                 else if (torrent.State == DelugeTorrentStatus.Queued)
                 {
@@ -139,7 +138,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 }
 
                 // Here we detect if Deluge is managing the torrent and whether the seed criteria has been met. This allows drone to delete the torrent as appropriate.
-                item.CanBeRemovedFromClient = (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused);
+                item.CanMoveFiles = item.CanBeRemoved = (torrent.IsAutoManaged && torrent.StopAtRatio && torrent.Ratio >= torrent.StopRatio && torrent.State == DelugeTorrentStatus.Paused);
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -90,7 +90,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingTime = GetRemainingTime(torrent),
                     Status = GetStatus(torrent),
                     Message = GetMessage(torrent),
-                    IsReadOnly = !IsFinished(torrent)
+                    CanBeDeleted = IsCompleted(torrent),
+                    CanBeRemovedFromClient = IsFinished(torrent)
                 };
 
                 if (item.Status == DownloadItemStatus.Completed || item.Status == DownloadItemStatus.Failed)
@@ -197,6 +198,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         protected bool IsFinished(DownloadStationTask torrent)
         {
             return torrent.Status == DownloadStationTaskStatus.Finished;
+        }
+
+        protected bool IsCompleted(DownloadStationTask torrent)
+        {
+            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent);
         }
 
         protected string GetMessage(DownloadStationTask torrent)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -202,7 +202,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         protected bool IsCompleted(DownloadStationTask torrent)
         {
-            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent) || (torrent.Size != 0 && GetRemainingSize(torrent) <= 0);
+            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent) ||  (torrent.Status == DownloadStationTaskStatus.Waiting && torrent.Size != 0 && GetRemainingSize(torrent) <= 0);
         }
 
         protected string GetMessage(DownloadStationTask torrent)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -202,7 +202,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
         protected bool IsCompleted(DownloadStationTask torrent)
         {
-            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent);
+            return torrent.Status == DownloadStationTaskStatus.Seeding || IsFinished(torrent) || (torrent.Size != 0 && GetRemainingSize(torrent) <= 0);
         }
 
         protected string GetMessage(DownloadStationTask torrent)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -90,8 +90,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingTime = GetRemainingTime(torrent),
                     Status = GetStatus(torrent),
                     Message = GetMessage(torrent),
-                    CanBeDeleted = IsCompleted(torrent),
-                    CanBeRemovedFromClient = IsFinished(torrent)
+                    CanMoveFiles = IsCompleted(torrent),
+                    CanBeRemoved = IsFinished(torrent)
                 };
 
                 if (item.Status == DownloadItemStatus.Completed || item.Status == DownloadItemStatus.Failed)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -99,9 +99,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingSize = taskRemainingSize,
                     Status = GetStatus(nzb),
                     Message = GetMessage(nzb),
+                    CanBeRemoved = true,
+                    CanMoveFiles = true
                 };
-
-                item.CanBeRemoved = item.CanMoveFiles = IsFinished(nzb);
 
                 if (item.Status != DownloadItemStatus.Paused)
                 {
@@ -290,11 +290,6 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
 
             return null;
-        }
-
-        protected bool IsFinished(DownloadStationTask task)
-        {
-            return task.Status == DownloadStationTaskStatus.Finished;
         }
 
         protected string GetMessage(DownloadStationTask task)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -99,8 +99,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingSize = taskRemainingSize,
                     Status = GetStatus(nzb),
                     Message = GetMessage(nzb),
-                    CanBeRemovedFromClient = IsFinished(nzb),
-                    CanBeDeleted = IsCompleted(nzb)
+                    CanBeRemoved = IsFinished(nzb),
+                    CanMoveFiles = IsFinished(nzb)
                 };
 
                 if (item.Status != DownloadItemStatus.Paused)
@@ -297,11 +297,6 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             return task.Status == DownloadStationTaskStatus.Finished;
         }
 
-        protected bool IsCompleted(DownloadStationTask task)
-        {
-            return task.Status == DownloadStationTaskStatus.Seeding || IsFinished(task);
-        }
-        
         protected string GetMessage(DownloadStationTask task)
         {
             if (task.StatusExtra != null)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -99,9 +99,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingSize = taskRemainingSize,
                     Status = GetStatus(nzb),
                     Message = GetMessage(nzb),
-                    CanBeRemoved = IsFinished(nzb),
-                    CanMoveFiles = IsFinished(nzb)
                 };
+
+                item.CanBeRemoved = item.CanMoveFiles = IsFinished(nzb);
 
                 if (item.Status != DownloadItemStatus.Paused)
                 {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -99,7 +99,8 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                     RemainingSize = taskRemainingSize,
                     Status = GetStatus(nzb),
                     Message = GetMessage(nzb),
-                    IsReadOnly = !IsFinished(nzb)
+                    CanBeRemovedFromClient = IsFinished(nzb),
+                    CanBeDeleted = IsCompleted(nzb)
                 };
 
                 if (item.Status != DownloadItemStatus.Paused)
@@ -296,6 +297,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             return task.Status == DownloadStationTaskStatus.Finished;
         }
 
+        protected bool IsCompleted(DownloadStationTask task)
+        {
+            return task.Status == DownloadStationTaskStatus.Seeding || IsFinished(task);
+        }
+        
         protected string GetMessage(DownloadStationTask task)
         {
             if (task.StatusExtra != null)

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -83,6 +83,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                 else if (torrent.IsFinished && torrent.State != HadoukenTorrentState.CheckingFiles)
                 {
                     item.Status = DownloadItemStatus.Completed;
+                    item.CanBeDeleted = true;
                 }
                 else if (torrent.State == HadoukenTorrentState.QueuedForChecking)
                 {
@@ -97,14 +98,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                if (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused)
-                {
-                    item.IsReadOnly = false;
-                }
-                else
-                {
-                    item.IsReadOnly = true;
-                }
+                item.CanBeRemovedFromClient = (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused);
 
                 items.Add(item);
             }
@@ -170,7 +164,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
                 if (version < new Version("5.1"))
                 {
-                    return new ValidationFailure(string.Empty, "Old Hadouken client with unsupported API, need 5.1 or higher");                    
+                    return new ValidationFailure(string.Empty, "Old Hadouken client with unsupported API, need 5.1 or higher");
                 }
             }
             catch (DownloadClientAuthenticationException ex)

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -83,7 +83,6 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                 else if (torrent.IsFinished && torrent.State != HadoukenTorrentState.CheckingFiles)
                 {
                     item.Status = DownloadItemStatus.Completed;
-                    item.CanBeDeleted = true;
                 }
                 else if (torrent.State == HadoukenTorrentState.QueuedForChecking)
                 {
@@ -98,7 +97,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                item.CanBeRemovedFromClient = (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused);
+                item.CanMoveFiles = item.CanBeRemoved = (torrent.IsFinished && torrent.State == HadoukenTorrentState.Paused);
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -72,7 +72,9 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
                 queueItem.TotalSize = vortexQueueItem.TotalDownloadSize;
                 queueItem.RemainingSize = vortexQueueItem.TotalDownloadSize - vortexQueueItem.DownloadedSize;
                 queueItem.RemainingTime = null;
-                
+                queueItem.CanBeRemoved = true;
+                queueItem.CanMoveFiles = true;
+
                 if (vortexQueueItem.IsPaused)
                 {
                     queueItem.Status = DownloadItemStatus.Paused;
@@ -132,7 +134,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
                 {
                     _proxy.Remove(queueItem.Id, deleteData, Settings);
                 }
-            }            
+            }
         }
 
         protected List<NzbVortexGroup> GetGroups()

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -83,6 +83,8 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
                 queueItem.TotalSize = totalSize;
                 queueItem.Category = item.Category;
                 queueItem.DownloadClient = Definition.Name;
+                queueItem.CanMoveFiles = true;
+                queueItem.CanBeRemoved = true;
 
                 if (globalStatus.DownloadPaused || remainingSize == pausedSize && remainingSize != 0)
                 {

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -77,6 +77,9 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
                     DownloadId = GetDownloadClientId(file),
                     Title = title,
 
+                    CanBeRemoved = true,
+                    CanMoveFiles = true,
+
                     TotalSize = _diskProvider.GetFileSize(file),
 
                     OutputPath = new OsPath(file)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.CanBeRemovedFromClient =!(config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) || torrent.State != "pausedUP";
+                item.CanMoveFiles = item.CanBeRemoved = !(config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) && torrent.State == "pausedUP";
 
                 if (!item.OutputPath.IsEmpty && item.OutputPath.FileName != torrent.Name)
                 {
@@ -133,10 +133,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     case "uploading": // torrent is being seeded and data is being transfered
                     case "stalledUP": // torrent is being seeded, but no connection were made
                     case "queuedUP": // queuing is enabled and torrent is queued for upload
-                        item.CanBeDeleted = true;
-                        item.Status = DownloadItemStatus.Completed;
-                        item.RemainingTime = TimeSpan.Zero; // qBittorrent sends eta=8640000 for completed torrents
-                        break;
                     case "checkingUP": // torrent has finished downloading and is being checked
                         item.Status = DownloadItemStatus.Completed;
                         item.RemainingTime = TimeSpan.Zero; // qBittorrent sends eta=8640000 for completed torrents

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.CanMoveFiles = item.CanBeRemoved = !(config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) && torrent.State == "pausedUP";
+                item.CanMoveFiles = item.CanBeRemoved = (!config.MaxRatioEnabled || config.MaxRatio <= torrent.Ratio) && torrent.State == "pausedUP";
 
                 if (!item.OutputPath.IsEmpty && item.OutputPath.FileName != torrent.Name)
                 {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.IsReadOnly = (config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) || torrent.State != "pausedUP";
+                item.CanBeRemovedFromClient =!(config.MaxRatioEnabled && config.MaxRatio > torrent.Ratio) || torrent.State != "pausedUP";
 
                 if (!item.OutputPath.IsEmpty && item.OutputPath.FileName != torrent.Name)
                 {
@@ -129,10 +129,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Status = DownloadItemStatus.Queued;
                         break;
 
-                    case "pausedUP": // torrent is paused and has finished downloading
+                    case "pausedUP": // torrent is paused and has finished downloading:
                     case "uploading": // torrent is being seeded and data is being transfered
                     case "stalledUP": // torrent is being seeded, but no connection were made
                     case "queuedUP": // queuing is enabled and torrent is queued for upload
+                        item.CanBeDeleted = true;
+                        item.Status = DownloadItemStatus.Completed;
+                        item.RemainingTime = TimeSpan.Zero; // qBittorrent sends eta=8640000 for completed torrents
+                        break;
                     case "checkingUP": // torrent has finished downloading and is being checked
                         item.Status = DownloadItemStatus.Completed;
                         item.RemainingTime = TimeSpan.Zero; // qBittorrent sends eta=8640000 for completed torrents

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -78,6 +78,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                 queueItem.TotalSize = (long)(sabQueueItem.Size * 1024 * 1024);
                 queueItem.RemainingSize = (long)(sabQueueItem.Sizeleft * 1024 * 1024);
                 queueItem.RemainingTime = sabQueueItem.Timeleft;
+                queueItem.CanBeRemoved = true;
+                queueItem.CanMoveFiles = true;
 
                 if (sabQueue.Paused || sabQueueItem.Status == SabnzbdDownloadStatus.Paused)
                 {

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -90,11 +90,13 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                          torrent.Status == TransmissionTorrentStatus.SeedingWait)
                 {
                     item.Status = DownloadItemStatus.Completed;
+                    item.CanBeDeleted = true;
                 }
                 else if (torrent.IsFinished && torrent.Status != TransmissionTorrentStatus.Check &&
                          torrent.Status != TransmissionTorrentStatus.CheckWait)
                 {
                     item.Status = DownloadItemStatus.Completed;
+                    item.CanBeDeleted = true;
                 }
                 else if (torrent.Status == TransmissionTorrentStatus.Queued)
                 {
@@ -105,7 +107,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                item.IsReadOnly = torrent.Status != TransmissionTorrentStatus.Stopped;
+                item.CanBeRemovedFromClient = torrent.Status == TransmissionTorrentStatus.Stopped;
 
                 items.Add(item);
             }
@@ -122,7 +124,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var config = _proxy.GetConfig(Settings);
             var destDir = config.GetValueOrDefault("download-dir") as string;
-            
+
             if (Settings.TvCategory.IsNotNullOrWhiteSpace())
             {
                 destDir = string.Format("{0}/.{1}", destDir, Settings.TvCategory);

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -90,13 +90,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                          torrent.Status == TransmissionTorrentStatus.SeedingWait)
                 {
                     item.Status = DownloadItemStatus.Completed;
-                    item.CanBeDeleted = true;
                 }
                 else if (torrent.IsFinished && torrent.Status != TransmissionTorrentStatus.Check &&
                          torrent.Status != TransmissionTorrentStatus.CheckWait)
                 {
                     item.Status = DownloadItemStatus.Completed;
-                    item.CanBeDeleted = true;
                 }
                 else if (torrent.Status == TransmissionTorrentStatus.Queued)
                 {
@@ -107,7 +105,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                item.CanBeRemovedFromClient = torrent.Status == TransmissionTorrentStatus.Stopped;
+                item.CanMoveFiles = item.CanBeRemoved = torrent.Status == TransmissionTorrentStatus.Stopped;
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -114,12 +114,17 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                         item.RemainingTime = TimeSpan.Zero;
                     }
 
-                    if (torrent.IsFinished) item.Status = DownloadItemStatus.Completed;
+                    if (torrent.IsFinished)
+                    {
+                        item.Status = DownloadItemStatus.Completed;
+                        item.CanBeDeleted = true;
+                    }
                     else if (torrent.IsActive) item.Status = DownloadItemStatus.Downloading;
                     else if (!torrent.IsActive) item.Status = DownloadItemStatus.Paused;
 
                     // No stop ratio data is present, so do not delete
-                    item.IsReadOnly = true;
+                    item.CanBeRemovedFromClient = false;
+
 
                     items.Add(item);
                 }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -107,24 +107,31 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                     item.RemainingSize = torrent.RemainingSize;
                     item.Category = torrent.Category;
 
-                    if (torrent.DownRate > 0) {
+                    if (torrent.DownRate > 0)
+                    {
                         var secondsLeft = torrent.RemainingSize / torrent.DownRate;
                         item.RemainingTime = TimeSpan.FromSeconds(secondsLeft);
-                    } else {
+                    }
+                    else
+                    {
                         item.RemainingTime = TimeSpan.Zero;
                     }
 
                     if (torrent.IsFinished)
                     {
                         item.Status = DownloadItemStatus.Completed;
-                        item.CanBeDeleted = true;
                     }
-                    else if (torrent.IsActive) item.Status = DownloadItemStatus.Downloading;
-                    else if (!torrent.IsActive) item.Status = DownloadItemStatus.Paused;
+                    else if (torrent.IsActive)
+                    {
+                        item.Status = DownloadItemStatus.Downloading;
+                    }
+                    else if (!torrent.IsActive)
+                    {
+                        item.Status = DownloadItemStatus.Paused;
+                    }
 
                     // No stop ratio data is present, so do not delete
-                    item.CanBeRemovedFromClient = false;
-
+                    item.CanMoveFiles = item.CanBeRemoved = false;
 
                     items.Add(item);
                 }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -150,7 +150,6 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                          torrent.Status.HasFlag(UTorrentTorrentStatus.Checked) && torrent.Remaining == 0 && torrent.Progress == 1.0)
                 {
                     item.Status = DownloadItemStatus.Completed;
-                    item.CanBeDeleted = true;
                 }
                 else if (torrent.Status.HasFlag(UTorrentTorrentStatus.Paused))
                 {
@@ -166,7 +165,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                 }
 
                 // 'Started' without 'Queued' is when the torrent is 'forced seeding'
-                item.CanBeRemovedFromClient = !(torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) || torrent.Status.HasFlag(UTorrentTorrentStatus.Started));
+                item.CanMoveFiles = item.CanBeRemoved = (!torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) && !torrent.Status.HasFlag(UTorrentTorrentStatus.Started));
 
                 queueItems.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -150,6 +150,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                          torrent.Status.HasFlag(UTorrentTorrentStatus.Checked) && torrent.Remaining == 0 && torrent.Progress == 1.0)
                 {
                     item.Status = DownloadItemStatus.Completed;
+                    item.CanBeDeleted = true;
                 }
                 else if (torrent.Status.HasFlag(UTorrentTorrentStatus.Paused))
                 {
@@ -165,7 +166,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                 }
 
                 // 'Started' without 'Queued' is when the torrent is 'forced seeding'
-                item.IsReadOnly = torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) || torrent.Status.HasFlag(UTorrentTorrentStatus.Started);
+                item.CanBeRemovedFromClient = !(torrent.Status.HasFlag(UTorrentTorrentStatus.Queued) || torrent.Status.HasFlag(UTorrentTorrentStatus.Started));
 
                 queueItems.Add(item);
             }

--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -21,7 +21,10 @@ namespace NzbDrone.Core.Download
 
         public DownloadItemStatus Status { get; set; }
         public bool IsEncrypted { get; set; }
-        public bool IsReadOnly { get; set; }
+        //public bool IsReadOnly { get; set; }
+
+        public bool CanBeDeleted { get; set; }
+        public bool CanBeRemovedFromClient { get; set; }
 
         public bool Removed { get; set; }
     }

--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -21,10 +21,9 @@ namespace NzbDrone.Core.Download
 
         public DownloadItemStatus Status { get; set; }
         public bool IsEncrypted { get; set; }
-        //public bool IsReadOnly { get; set; }
 
-        public bool CanBeDeleted { get; set; }
-        public bool CanBeRemovedFromClient { get; set; }
+        public bool CanMoveFiles { get; set; }
+        public bool CanBeRemoved { get; set; }
 
         public bool Removed { get; set; }
     }

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download
         {
             if (!_configService.RemoveCompletedDownloads ||
                 message.TrackedDownload.DownloadItem.Removed ||
-                message.TrackedDownload.DownloadItem.IsReadOnly ||
+                !message.TrackedDownload.DownloadItem.CanBeRemovedFromClient ||
                 message.TrackedDownload.DownloadItem.Status == DownloadItemStatus.Downloading)
             {
                 return;
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Download
         {
             var trackedDownload = message.TrackedDownload;
 
-            if (trackedDownload == null || trackedDownload.DownloadItem.IsReadOnly || _configService.RemoveFailedDownloads == false)
+            if (trackedDownload == null || !trackedDownload.DownloadItem.CanBeRemovedFromClient || _configService.RemoveFailedDownloads == false)
             {
                 return;
             }

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download
         {
             if (!_configService.RemoveCompletedDownloads ||
                 message.TrackedDownload.DownloadItem.Removed ||
-                !message.TrackedDownload.DownloadItem.CanBeRemovedFromClient ||
+                !message.TrackedDownload.DownloadItem.CanBeRemoved ||
                 message.TrackedDownload.DownloadItem.Status == DownloadItemStatus.Downloading)
             {
                 return;
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Download
         {
             var trackedDownload = message.TrackedDownload;
 
-            if (trackedDownload == null || !trackedDownload.DownloadItem.CanBeRemovedFromClient || _configService.RemoveFailedDownloads == false)
+            if (trackedDownload == null || !trackedDownload.DownloadItem.CanBeRemoved || _configService.RemoveFailedDownloads == false)
             {
                 return;
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         private void RemoveCompletedDownloads(List<TrackedDownload> trackedDownloads)
         {
-            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.CanBeRemoved && c.State == TrackedDownloadStage.Imported))
+            foreach (var trackedDownload in trackedDownloads.Where(c => c.DownloadItem.CanBeRemoved && c.State == TrackedDownloadStage.Imported))
             {
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         private void RemoveCompletedDownloads(List<TrackedDownload> trackedDownloads)
         {
-            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.CanBeRemovedFromClient && c.State == TrackedDownloadStage.Imported))
+            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.CanBeRemoved && c.State == TrackedDownloadStage.Imported))
             {
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 {
                     var clientTrackedDownloads = ProcessClientDownloads(downloadClient);
 
-                    // Only track completed downloads if 
+                    // Only track completed downloads if
                     trackedDownloads.AddRange(clientTrackedDownloads.Where(DownloadIsTrackable));
                 }
 
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         private void RemoveCompletedDownloads(List<TrackedDownload> trackedDownloads)
         {
-            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.IsReadOnly && c.State == TrackedDownloadStage.Imported))
+            foreach (var trackedDownload in trackedDownloads.Where(c => !c.DownloadItem.CanBeRemovedFromClient && c.State == TrackedDownloadStage.Imported))
             {
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));
             }

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.MediaFiles
             var decisions = _importDecisionMaker.GetImportDecisions(videoFiles.ToList(), series, folderInfo, true);
             var importResults = _importApprovedEpisodes.Import(decisions, true, downloadClientItem, importMode);
 
-            if ((downloadClientItem == null || downloadClientItem.CanBeDeleted) &&
+            if ((downloadClientItem == null || downloadClientItem.CanMoveFiles) &&
                 importResults.Any(i => i.Result == ImportResultType.Imported) &&
                 ShouldDeleteFolder(directoryInfo, series))
             {

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.MediaFiles
             var decisions = _importDecisionMaker.GetImportDecisions(videoFiles.ToList(), series, folderInfo, true);
             var importResults = _importApprovedEpisodes.Import(decisions, true, downloadClientItem, importMode);
 
-            if ((downloadClientItem == null || !downloadClientItem.IsReadOnly) &&
+            if ((downloadClientItem == null || downloadClientItem.CanBeDeleted) &&
                 importResults.Any(i => i.Result == ImportResultType.Imported) &&
                 ShouldDeleteFolder(directoryInfo, series))
             {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     {
                         default:
                         case ImportMode.Auto:
-                            copyOnly = downloadClientItem != null && downloadClientItem.IsReadOnly;
+                            copyOnly = downloadClientItem != null && !downloadClientItem.CanBeDeleted;
                             break;
                         case ImportMode.Move:
                             copyOnly = false;
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
                     if (downloadClientItem != null)
                     {
-                        _eventAggregator.PublishEvent(new EpisodeImportedEvent(localEpisode, episodeFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId, downloadClientItem.IsReadOnly));
+                        _eventAggregator.PublishEvent(new EpisodeImportedEvent(localEpisode, episodeFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId, !downloadClientItem.CanBeDeleted));
                     }
                     else
                     {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     {
                         default:
                         case ImportMode.Auto:
-                            copyOnly = downloadClientItem != null && !downloadClientItem.CanBeDeleted;
+                            copyOnly = downloadClientItem != null && !downloadClientItem.CanMoveFiles;
                             break;
                         case ImportMode.Move:
                             copyOnly = false;
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
                     if (downloadClientItem != null)
                     {
-                        _eventAggregator.PublishEvent(new EpisodeImportedEvent(localEpisode, episodeFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId, !downloadClientItem.CanBeDeleted));
+                        _eventAggregator.PublishEvent(new EpisodeImportedEvent(localEpisode, episodeFile, newDownload, downloadClientItem.DownloadClient, downloadClientItem.DownloadId));//, !downloadClientItem.CanMoveFiles));
                     }
                     else
                     {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -251,7 +251,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 {
                     if (_downloadedEpisodesImportService.ShouldDeleteFolder(
                             new DirectoryInfo(trackedDownload.DownloadItem.OutputPath.FullPath),
-                            trackedDownload.RemoteEpisode.Series) && !trackedDownload.DownloadItem.IsReadOnly)
+                            trackedDownload.RemoteEpisode.Series) && trackedDownload.DownloadItem.CanBeDeleted)
                     {
                         _diskProvider.DeleteFolder(trackedDownload.DownloadItem.OutputPath.FullPath, true);
                     }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -251,7 +251,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 {
                     if (_downloadedEpisodesImportService.ShouldDeleteFolder(
                             new DirectoryInfo(trackedDownload.DownloadItem.OutputPath.FullPath),
-                            trackedDownload.RemoteEpisode.Series) && trackedDownload.DownloadItem.CanBeDeleted)
+                            trackedDownload.RemoteEpisode.Series) && trackedDownload.DownloadItem.CanMoveFiles)
                     {
                         _diskProvider.DeleteFolder(trackedDownload.DownloadItem.OutputPath.FullPath, true);
                     }

--- a/src/NzbDrone.Core/MediaFiles/Events/EpisodeImportedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/EpisodeImportedEvent.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.MediaFiles.Events
         public bool NewDownload { get; private set; }
         public string DownloadClient { get; private set; }
         public string DownloadId { get; private set; }
-        public bool IsReadOnly { get; set; }
+        //public bool IsReadOnly { get; set; }
 
         public EpisodeImportedEvent(LocalEpisode episodeInfo, EpisodeFile importedEpisode, bool newDownload)
         {
@@ -19,14 +19,14 @@ namespace NzbDrone.Core.MediaFiles.Events
             NewDownload = newDownload;
         }
 
-        public EpisodeImportedEvent(LocalEpisode episodeInfo, EpisodeFile importedEpisode, bool newDownload, string downloadClient, string downloadId, bool isReadOnly)
+        public EpisodeImportedEvent(LocalEpisode episodeInfo, EpisodeFile importedEpisode, bool newDownload, string downloadClient, string downloadId)//, bool isReadOnly)
         {
             EpisodeInfo = episodeInfo;
             ImportedEpisode = importedEpisode;
             NewDownload = newDownload;
             DownloadClient = downloadClient;
             DownloadId = downloadId;
-            IsReadOnly = isReadOnly;
+          //  IsReadOnly = isReadOnly;
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR is to separate the logic behind IsReadOnly. This flag is used to indicate when the item can be imported and when can it be removed from the client. It a WIP, so i'm open to suggestions...

#### Todos
- [x] Fix DownloadClient Tests

#### Issues Fixed or Closed by this PR

* #1764 
