### PR TITLE
Updating SocksWebProxy to fix #1641

### DIFF
--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -46,16 +46,14 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.3\lib\net40\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="Org.Mentalis, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNet4.SocksProxy.1.3.2.0\lib\net40\Org.Mentalis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Org.Mentalis, Version=1.0.0.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNet4.SocksProxy.1.3.4.0\lib\net40\Org.Mentalis.dll</HintPath>
     </Reference>
     <Reference Include="SharpRaven, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpRaven.2.2.0\lib\net40\SharpRaven.dll</HintPath>
     </Reference>
-    <Reference Include="SocksWebProxy, Version=1.3.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNet4.SocksProxy.1.3.2.0\lib\net40\SocksWebProxy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SocksWebProxy, Version=1.3.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNet4.SocksProxy.1.3.4.0\lib\net40\SocksWebProxy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/NzbDrone.Common/packages.config
+++ b/src/NzbDrone.Common/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNet4.SocksProxy" version="1.3.2.0" targetFramework="net40" />
+  <package id="DotNet4.SocksProxy" version="1.3.4.0" targetFramework="net40" />
   <package id="ICSharpCode.SharpZipLib.Patched" version="0.86.5" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="NLog" version="4.4.3" targetFramework="net40" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updating the version of the SocksWebProxy dependency to 1.3.4 to resolve issues around exceptions in the Client.Dispose method, as mentioned in #1641

#### Todos
 - None
#### Issues Fixed or Closed by this PR

* #1641

I reset my branch (proxy-support) from Sonarr/develop, but its showing 3 commits below, not 100% sure why. I hope this is not an issue