### PR TITLE
EpisodeFileEditorLayoutTemplate - Move Delete button to the left

### DIFF
--- a/src/UI/EpisodeFile/Editor/EpisodeFileEditorLayoutTemplate.hbs
+++ b/src/UI/EpisodeFile/Editor/EpisodeFileEditorLayoutTemplate.hbs
@@ -21,7 +21,7 @@
             <div class="x-quality"></div>
         </div>
         <div class="modal-footer">
-            <button class="btn btn-danger x-delete-files">Delete Files</button>
+            <button class="btn btn-danger pull-left x-delete-files">Delete Files</button>
             <button class="btn btn-default" data-dismiss="modal">Close</button>
         </div>
     </div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Move the delete button on the Episode File Editor to the left. The button being on the right, next to the close button makes it seem like it is a 'continue' or 'apply changes' button.

