### PR TITLE
remove redundant IE meta tag as we use http header instead

### DIFF
--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Sonarr</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="apple-mobile-web-app-capable" content="yes"/>

--- a/src/UI/login.html
+++ b/src/UI/login.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Sonarr - Login</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since we already use the recommended way of sending down the `X-UA-Compatible` http header we don't need the meta tag as well.

#### Todos
- [ ] Documentation about browser support?
