### PR TITLE
Health Check - Mount Read-Only

### DIFF
--- a/src/NzbDrone.Common/Disk/DriveInfoMount.cs
+++ b/src/NzbDrone.Common/Disk/DriveInfoMount.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Common.Disk
@@ -8,10 +9,11 @@ namespace NzbDrone.Common.Disk
         private readonly DriveInfo _driveInfo;
         private readonly DriveType _driveType;
 
-        public DriveInfoMount(DriveInfo driveInfo, DriveType driveType = DriveType.Unknown)
+        public DriveInfoMount(DriveInfo driveInfo, DriveType driveType = DriveType.Unknown, Dictionary<string,string> options = null)
         {
             _driveInfo = driveInfo;
             _driveType = driveType;
+            MountOptions = options;
         }
 
         public long AvailableFreeSpace => _driveInfo.AvailableFreeSpace;
@@ -32,6 +34,8 @@ namespace NzbDrone.Common.Disk
         }
 
         public bool IsReady => _driveInfo.IsReady;
+
+        public Dictionary<string, string> MountOptions { get; private set; }
 
         public string Name => _driveInfo.Name;
 

--- a/src/NzbDrone.Common/Disk/DriveInfoMount.cs
+++ b/src/NzbDrone.Common/Disk/DriveInfoMount.cs
@@ -9,11 +9,11 @@ namespace NzbDrone.Common.Disk
         private readonly DriveInfo _driveInfo;
         private readonly DriveType _driveType;
 
-        public DriveInfoMount(DriveInfo driveInfo, DriveType driveType = DriveType.Unknown, Dictionary<string,string> options = null)
+        public DriveInfoMount(DriveInfo driveInfo, DriveType driveType = DriveType.Unknown, MountOptions mountOptions = null)
         {
             _driveInfo = driveInfo;
             _driveType = driveType;
-            MountOptions = options;
+            MountOptions = mountOptions;
         }
 
         public long AvailableFreeSpace => _driveInfo.AvailableFreeSpace;
@@ -35,7 +35,7 @@ namespace NzbDrone.Common.Disk
 
         public bool IsReady => _driveInfo.IsReady;
 
-        public Dictionary<string, string> MountOptions { get; private set; }
+        public MountOptions MountOptions { get; private set; }
 
         public string Name => _driveInfo.Name;
 

--- a/src/NzbDrone.Common/Disk/IMount.cs
+++ b/src/NzbDrone.Common/Disk/IMount.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections.Generic;
 using System.IO;
 
 namespace NzbDrone.Common.Disk
@@ -8,6 +9,7 @@ namespace NzbDrone.Common.Disk
         string DriveFormat { get; }
         DriveType DriveType { get; }
         bool IsReady { get; }
+        Dictionary<string,string> MountOptions { get; }
         string Name { get; }
         string RootDirectory { get; }
         long TotalFreeSpace { get; }

--- a/src/NzbDrone.Common/Disk/IMount.cs
+++ b/src/NzbDrone.Common/Disk/IMount.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Common.Disk
         string DriveFormat { get; }
         DriveType DriveType { get; }
         bool IsReady { get; }
-        Dictionary<string,string> MountOptions { get; }
+        MountOptions MountOptions { get; }
         string Name { get; }
         string RootDirectory { get; }
         long TotalFreeSpace { get; }

--- a/src/NzbDrone.Common/Disk/MountOptions.cs
+++ b/src/NzbDrone.Common/Disk/MountOptions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace NzbDrone.Common.Disk
+{
+    public class MountOptions
+    {
+        private readonly Dictionary<string, string> _options;
+
+        public MountOptions(Dictionary<string, string> options)
+        {
+            _options = options;
+        }
+
+        public bool IsReadOnly => _options.ContainsKey("ro");
+    }
+}

--- a/src/NzbDrone.Common/NzbDrone.Common.csproj
+++ b/src/NzbDrone.Common/NzbDrone.Common.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Disk\FileSystemLookupService.cs" />
     <Compile Include="Disk\DriveInfoMount.cs" />
     <Compile Include="Disk\IMount.cs" />
+    <Compile Include="Disk\MountOptions.cs" />
     <Compile Include="Disk\RelativeFileSystemModel.cs" />
     <Compile Include="Disk\FileSystemModel.cs" />
     <Compile Include="Disk\FileSystemResult.cs" />

--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    public class MountCheck : HealthCheckBase
+    {
+        private readonly IDiskProvider _diskProvider;
+        private readonly ISeriesService _seriesService;
+
+        public MountCheck(IDiskProvider diskProvider, ISeriesService seriesService)
+        {
+            _diskProvider = diskProvider;
+            _seriesService = seriesService;
+        }
+
+        public override HealthCheck Check()
+        {
+            var mounts = _seriesService.GetAllSeries()
+                                       .Select(series => _diskProvider.GetMount(series.Path))
+                                       .DistinctBy(m => m.RootDirectory)
+                                       .Where(m => m.MountOptions != null && m.MountOptions.ContainsKey("ro"))
+                                       .ToList();
+
+            if (mounts.Any())
+            {
+                return new HealthCheck(GetType(), HealthCheckResult.Error, "Mount containing a series path is mounted read-only: " + string.Join(",", mounts.Select(m => m.Name)), "#series-mount-ro");
+            }
+
+            return new HealthCheck(GetType());
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
             var mounts = _seriesService.GetAllSeries()
                                        .Select(series => _diskProvider.GetMount(series.Path))
                                        .DistinctBy(m => m.RootDirectory)
-                                       .Where(m => m.MountOptions != null && m.MountOptions.ContainsKey("ro"))
+                                       .Where(m => m.MountOptions != null && m.MountOptions.IsReadOnly)
                                        .ToList();
 
             if (mounts.Any())

--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
+            // Not best for optimization but due to possible symlinks and junctions, we get mounts based on series path so internals can handle mount resolution.
             var mounts = _seriesService.GetAllSeries()
                                        .Select(series => _diskProvider.GetMount(series.Path))
                                        .DistinctBy(m => m.RootDirectory)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -555,6 +555,7 @@
     <Compile Include="HealthCheck\CheckHealthCommand.cs" />
     <Compile Include="HealthCheck\Checks\AppDataLocationCheck.cs" />
     <Compile Include="HealthCheck\Checks\DownloadClientCheck.cs" />
+    <Compile Include="HealthCheck\Checks\MountCheck.cs" />
     <Compile Include="HealthCheck\Checks\DroneFactoryCheck.cs" />
     <Compile Include="HealthCheck\Checks\ImportMechanismCheck.cs" />
     <Compile Include="HealthCheck\Checks\IndexerRssCheck.cs" />

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -86,13 +86,14 @@ namespace NzbDrone.Mono.Disk
 
         public override List<IMount> GetMounts()
         {
-            var procMounts = _procMountProvider.GetMounts();
-
-            return GetDriveInfoMounts().GroupJoin(procMounts, d => d.RootDirectory.FullName, m => m.RootDirectory, (d, m) => new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat), m.FirstOrDefault()?.MountOptions))
-                                       .Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network || d.DriveType == DriveType.Removable)
-                                       .Concat(procMounts)
-                                       .DistinctBy(v => v.RootDirectory)
-                                       .ToList();
+            return _procMountProvider.GetMounts()
+                                     .Concat(GetDriveInfoMounts()
+                                                 .Select(d => new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat)))
+                                                 .Where(d => d.DriveType == DriveType.Fixed ||
+                                                             d.DriveType == DriveType.Network || d.DriveType ==
+                                                             DriveType.Removable))
+                                     .DistinctBy(v => v.RootDirectory)
+                                     .ToList();
         }
 
         public override long? GetTotalSize(string path)

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -86,13 +86,13 @@ namespace NzbDrone.Mono.Disk
 
         public override List<IMount> GetMounts()
         {
-
             var procMounts = _procMountProvider.GetMounts();
-            return GetDriveInfoMounts().Join(procMounts, d => d.RootDirectory.FullName, m => m.RootDirectory, (d, m) => new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat), m.MountOptions))
-                .Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network || d.DriveType == DriveType.Removable)
-                .Concat(procMounts)
-                .DistinctBy(v => v.RootDirectory)
-                .ToList();
+
+            return GetDriveInfoMounts().GroupJoin(procMounts, d => d.RootDirectory.FullName, m => m.RootDirectory, (d, m) => new DriveInfoMount(d, FindDriveType.Find(d.DriveFormat), m.FirstOrDefault()?.MountOptions))
+                                       .Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network || d.DriveType == DriveType.Removable)
+                                       .Concat(procMounts)
+                                       .DistinctBy(v => v.RootDirectory)
+                                       .ToList();
         }
 
         public override long? GetTotalSize(string path)

--- a/src/NzbDrone.Mono/Disk/ProcMount.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMount.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using Mono.Unix;
 using NzbDrone.Common.Disk;
@@ -16,6 +16,7 @@ namespace NzbDrone.Mono.Disk
             Name = name;
             RootDirectory = mount;
             DriveFormat = type;
+            MountOptions = options;
 
             _unixDriveInfo = new UnixDriveInfo(mount);
         }
@@ -27,6 +28,8 @@ namespace NzbDrone.Mono.Disk
         public DriveType DriveType { get; private set; }
 
         public bool IsReady => _unixDriveInfo.IsReady;
+
+        public Dictionary<string, string> MountOptions { get; private set; }
 
         public string Name { get; private set; }
 

--- a/src/NzbDrone.Mono/Disk/ProcMount.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMount.cs
@@ -10,13 +10,13 @@ namespace NzbDrone.Mono.Disk
     {
         private readonly UnixDriveInfo _unixDriveInfo;
 
-        public ProcMount(DriveType driveType, string name, string mount, string type, Dictionary<string, string> options)
+        public ProcMount(DriveType driveType, string name, string mount, string type, MountOptions mountOptions)
         {
             DriveType = driveType;
             Name = name;
             RootDirectory = mount;
             DriveFormat = type;
-            MountOptions = options;
+            MountOptions = mountOptions;
 
             _unixDriveInfo = new UnixDriveInfo(mount);
         }
@@ -29,7 +29,7 @@ namespace NzbDrone.Mono.Disk
 
         public bool IsReady => _unixDriveInfo.IsReady;
 
-        public Dictionary<string, string> MountOptions { get; private set; }
+        public MountOptions MountOptions { get; private set; }
 
         public string Name { get; private set; }
 

--- a/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Mono.Disk
                 driveType = DriveType.Network;
             }
 
-            return new ProcMount(driveType, name, mount, type, options);
+            return new ProcMount(driveType, name, mount, type, new MountOptions(options));
         }
 
         private Dictionary<string, string> ParseOptions(string options)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a health check to determine if any series targets a mount that is currently read-only.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #1867 
