### PR TITLE
Added ability to filter scene mappings by regex via services.

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenAbsoluteNumberingSeries();
 
             _parsedEpisodeInfo.Special = true;
-            
+
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
 
             Mocker.GetMock<IEpisodeService>()
@@ -210,7 +210,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenAbsoluteNumberingSeries();
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(seasonNumber);
 
             Mocker.GetMock<IEpisodeService>()
@@ -234,7 +234,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenAbsoluteNumberingSeries();
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(seasonNumber);
 
             Mocker.GetMock<IEpisodeService>()
@@ -258,7 +258,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenAbsoluteNumberingSeries();
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.GetSceneSeasonNumber(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(seasonNumber);
 
             Mocker.GetMock<IEpisodeService>()
@@ -280,7 +280,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             const int tvdbSeasonNumber = 5;
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(new SceneMapping { SeasonNumber = tvdbSeasonNumber, SceneSeasonNumber = _parsedEpisodeInfo.SeasonNumber });
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
@@ -298,7 +298,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             const int tvdbSeasonNumber = 5;
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(new SceneMapping { SeasonNumber = tvdbSeasonNumber, SceneSeasonNumber = _parsedEpisodeInfo.SeasonNumber + 100 });
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
@@ -330,7 +330,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             const int tvdbSeasonNumber = -1;
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle))
+                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
                   .Returns(new SceneMapping { SeasonNumber = tvdbSeasonNumber, SceneSeasonNumber = _parsedEpisodeInfo.SeasonNumber });
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenMatchByTvRageId();
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(v => v.FindTvdbId(It.IsAny<string>()))
+                  .Setup(v => v.FindTvdbId(It.IsAny<string>(), It.IsAny<string>()))
                   .Returns(10);
 
             var result = Subject.Map(_parsedEpisodeInfo, _series.TvdbId, _series.TvRageId);
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         public void should_use_tvdbid_matching_when_alias_is_found()
         {
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.FindTvdbId(It.IsAny<string>()))
+                  .Setup(s => s.FindTvdbId(It.IsAny<string>(), It.IsAny<string>()))
                   .Returns(_series.TvdbId);
 
             Subject.Map(_parsedEpisodeInfo, _series.TvdbId, _series.TvRageId, _singleEpisodeSearchCriteria);

--- a/src/NzbDrone.Core/DataAugmentation/Scene/InvalidSceneMappingException.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/InvalidSceneMappingException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.DataAugmentation.Scene
+{
+    public class InvalidSceneMappingException : NzbDroneException
+    {
+        public InvalidSceneMappingException(IEnumerable<SceneMapping> mappings)
+            : base(FormatMessage(mappings))
+        {
+
+        }
+
+        private static string FormatMessage(IEnumerable<SceneMapping> mappings)
+        {
+            return string.Format("Scene Mappings contains a conflict for tvdbids {0}, please notify Sonarr developers", mappings.Select(v => v.TvdbId));
+        }
+    }
+}

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMapping.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMapping.cs
@@ -17,6 +17,9 @@ namespace NzbDrone.Core.DataAugmentation.Scene
         public int? SeasonNumber { get; set; }
 
         public int? SceneSeasonNumber { get; set; }
+
+        public string FilterRegex { get; set; }
+
         public string Type { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/112_added_regex_to_scenemapping.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/112_added_regex_to_scenemapping.cs
@@ -1,0 +1,16 @@
+﻿using System.Data;
+using FluentMigrator;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(112)]
+    public class added_regex_to_scenemapping : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("SceneMappings").AddColumn("FilterRegex").AsString().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -140,6 +140,7 @@
     <Compile Include="DataAugmentation\DailySeries\DailySeries.cs" />
     <Compile Include="DataAugmentation\DailySeries\DailySeriesDataProxy.cs" />
     <Compile Include="DataAugmentation\DailySeries\DailySeriesService.cs" />
+    <Compile Include="DataAugmentation\Scene\InvalidSceneMappingException.cs" />
     <Compile Include="DataAugmentation\Scene\ISceneMappingProvider.cs" />
     <Compile Include="DataAugmentation\Scene\SceneMapping.cs" />
     <Compile Include="DataAugmentation\Scene\SceneMappingProxy.cs" />
@@ -249,6 +250,7 @@
     <Compile Include="Datastore\Migration\069_quality_proper.cs" />
     <Compile Include="Datastore\Migration\070_delay_profile.cs" />
     <Compile Include="Datastore\Migration\102_add_language_to_episodeFiles_history_and_blacklist.cs" />
+    <Compile Include="Datastore\Migration\112_added_regex_to_scenemapping.cs" />
     <Compile Include="Datastore\Migration\110_fix_extra_files_config.cs" />
     <Compile Include="Datastore\Migration\109_import_extra_files.cs" />
     <Compile Include="Datastore\Migration\108_fix_extra_file_extension.cs" />

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.Parser.Model
 {
     public class ParsedEpisodeInfo
     {
+        public string ReleaseTitle { get; set; }
         public string SeriesTitle { get; set; }
         public SeriesTitleInfo SeriesTitleInfo { get; set; }
         public QualityModel Quality { get; set; }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -316,9 +316,9 @@ namespace NzbDrone.Core.Parser
                     Logger.Debug("Reversed name detected. Converted to '{0}'", title);
                 }
 
-                var simpleTitle = SimpleTitleRegex.Replace(title, string.Empty);
+                title = RemoveFileExtension(title);
 
-                simpleTitle = RemoveFileExtension(simpleTitle);
+                var simpleTitle = SimpleTitleRegex.Replace(title, string.Empty);
 
                 // TODO: Quick fix stripping [url] - prefixes.
                 simpleTitle = WebsitePrefixRegex.Replace(simpleTitle, string.Empty);
@@ -355,7 +355,7 @@ namespace NzbDrone.Core.Parser
                         Logger.Trace(regex);
                         try
                         {
-                            var result = ParseMatchCollection(match);
+                            var result = ParseMatchCollection(match, title);
 
                             if (result != null)
                             {
@@ -522,7 +522,7 @@ namespace NzbDrone.Core.Parser
             return seriesTitleInfo;
         }
 
-        private static ParsedEpisodeInfo ParseMatchCollection(MatchCollection matchCollection)
+        private static ParsedEpisodeInfo ParseMatchCollection(MatchCollection matchCollection, string title)
         {
             var seriesName = matchCollection[0].Groups["title"].Value.Replace('.', ' ').Replace('_', ' ');
             seriesName = RequestInfoRegex.Replace(seriesName, "").Trim(' ');
@@ -551,6 +551,7 @@ namespace NzbDrone.Core.Parser
 
                 result = new ParsedEpisodeInfo
                 {
+                    ReleaseTitle = title,
                     SeasonNumber = seasons.First(),
                     EpisodeNumbers = new int[0],
                     AbsoluteEpisodeNumbers = new int[0]
@@ -644,6 +645,7 @@ namespace NzbDrone.Core.Parser
 
                 result = new ParsedEpisodeInfo
                 {
+                    ReleaseTitle = title,
                     AirDate = airDate.ToString(Episode.AIR_DATE_FORMAT),
                 };
             }

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -35,21 +35,18 @@ namespace NzbDrone.Core.Tv
     {
         private readonly ISeriesRepository _seriesRepository;
         private readonly IEventAggregator _eventAggregator;
-        private readonly ISceneMappingService _sceneMappingService;
         private readonly IEpisodeService _episodeService;
         private readonly IBuildFileNames _fileNameBuilder;
         private readonly Logger _logger;
 
         public SeriesService(ISeriesRepository seriesRepository,
                              IEventAggregator eventAggregator,
-                             ISceneMappingService sceneMappingService,
                              IEpisodeService episodeService,
                              IBuildFileNames fileNameBuilder,
                              Logger logger)
         {
             _seriesRepository = seriesRepository;
             _eventAggregator = eventAggregator;
-            _sceneMappingService = sceneMappingService;
             _episodeService = episodeService;
             _fileNameBuilder = fileNameBuilder;
             _logger = logger;
@@ -85,13 +82,6 @@ namespace NzbDrone.Core.Tv
 
         public Series FindByTitle(string title)
         {
-            var tvdbId = _sceneMappingService.FindTvdbId(title);
-
-            if (tvdbId.HasValue)
-            {
-                return _seriesRepository.FindByTvdbId(tvdbId.Value);
-            }
-
             return _seriesRepository.FindByTitle(title.CleanSeriesTitle());
         }
 
@@ -107,11 +97,11 @@ namespace NzbDrone.Core.Tv
             }
             if (list.Count == 1)
             {
-                // return the first series if there is only one 
+                // return the first series if there is only one
                 return list.Single();
             }
             // build ordered list of series by position in the search string
-            var query = 
+            var query =
                 list.Select(series => new
                 {
                     position = cleanTitle.IndexOf(series.CleanTitle),
@@ -192,7 +182,7 @@ namespace NzbDrone.Core.Tv
                     _logger.Trace("Not changing path for: {0}", s.Title);
                 }
             }
-            
+
             _seriesRepository.UpdateMany(series);
             _logger.Debug("{0} series updated", series.Count);
 


### PR DESCRIPTION
#### Database Migration
YES: 112

#### Description

- First is adding a FilterRegex field to SceneMapping. If it's not-null then the regex is used against the releaseTitle. In order to make that happen I needed to make sure the releaseTitle was passed through from the various places.
Along the way did some cleanup (SeriesService no longer has a ref to SceneMapping, ParsingService does that.)

- Second is dealing with potential duplicates. Atm I throw if there are conflicting scenemappings. Although one with regex will never conflict with one without regex.
The idea is that if you add a mapping to services that for example maps a scene name without year to a tvdb name with year, that you'll ALSO add the original non-year tvdb series 'mapping' unless the original has no scene releases. That way Sonarr is aware that there's a dupe. This means that a regex is basically mandatory in those cases.
The TODO is to turn this into a DecisionSpec as well, so we don't throw inside the parsing service.

There's a little bit of risk involved since I did change some stuff and might not have updated the title vs seriesTitle vs releaseTitle stuff correctly. So it will need some testing.

This requires a change in services too, but I got that ready, just a small commit to add the field.

_This change incorporates an idea I had for TheXEMv2. What TheXEMv2 is about is mapping multiple scene variants to tvdb by using regex and multi-mapping tables instead of just one 'SceneSeasonNumber' fields. 
The idea was that TheXEM/skyhook would know which potential conflicts exist. skyhook could then product a list of 'global mappings', which map to the correct series and prevents series level conflicts (this sometimes requires numbering so isn't just our scenemapping api, but a filtered thexem). And detailed 'local mappings', which map between multiple scene variants to tvdb numbering for individual series, which would only be loaded if that particular series is actually added._

