### PR TITLE
Scene numbering override

### DIFF
--- a/src/NzbDrone.Api/Series/SeriesResource.cs
+++ b/src/NzbDrone.Api/Series/SeriesResource.cs
@@ -58,6 +58,7 @@ namespace NzbDrone.Api.Series
         public bool Monitored { get; set; }
 
         public bool UseSceneNumbering { get; set; }
+        public bool IgnoreSceneNumbering { get; set; }
         public int Runtime { get; set; }
         public int TvdbId { get; set; }
         public int TvRageId { get; set; }
@@ -131,6 +132,7 @@ namespace NzbDrone.Api.Series
                 Monitored = model.Monitored,
 
                 UseSceneNumbering = model.UseSceneNumbering,
+                IgnoreSceneNumbering = model.IgnoreSceneNumbering,
                 Runtime = model.Runtime,
                 TvdbId = model.TvdbId,
                 TvRageId = model.TvRageId,
@@ -185,6 +187,7 @@ namespace NzbDrone.Api.Series
                 Monitored = resource.Monitored,
 
                 UseSceneNumbering = resource.UseSceneNumbering,
+                IgnoreSceneNumbering = resource.IgnoreSceneNumbering,
                 Runtime = resource.Runtime,
                 TvdbId = resource.TvdbId,
                 TvRageId = resource.TvRageId,

--- a/src/NzbDrone.Core/DataAugmentation/Xem/XemService.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Xem/XemService.cs
@@ -223,7 +223,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
                 return;
             }
 
-            if (!_cache.Find(message.Series.TvdbId.ToString()) && !message.Series.UseSceneNumbering)
+            if (!_cache.Find(message.Series.TvdbId.ToString()) && !message.Series.ActuallyUseSceneNumbering)
             {
                 _logger.Debug("Scene numbering is not available for {0} [{1}]", message.Series.Title, message.Series.TvdbId);
                 return;

--- a/src/NzbDrone.Core/Datastore/Migration/115_add_scene_number_override_flag.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/115_add_scene_number_override_flag.cs
@@ -1,0 +1,15 @@
+﻿using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(115)]
+    public class add_scene_number_override_flag : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series").AddColumn("IgnoreSceneNumbering").AsBoolean().Nullable();
+            Execute.Sql("UPDATE Series SET IgnoreSceneNumbering = 0");
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     List<Episode> seasonEpisodes;
 
                     var seasonSearchCriteria = searchCriteria as SeasonSearchCriteria;
-                    if (seasonSearchCriteria != null && !seasonSearchCriteria.Series.UseSceneNumbering && seasonSearchCriteria.Episodes.Any(v => v.Id == episode.Id))
+                    if (seasonSearchCriteria != null && !seasonSearchCriteria.Series.ActuallyUseSceneNumbering && seasonSearchCriteria.Episodes.Any(v => v.Id == episode.Id))
                     {
                         seasonEpisodes = (searchCriteria as SeasonSearchCriteria).Episodes;
                     }

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -66,12 +66,15 @@ namespace NzbDrone.Core.IndexerSearch
 
                 return SearchDaily(series, episode, userInvokedSearch);
             }
-            if (series.SeriesType == SeriesTypes.Anime)
+
+            // The anime type just does absolute searching, so don't use it if we're not using scene numbering.
+            if (series.SeriesType == SeriesTypes.Anime && series.ActuallyUseSceneNumbering)
             {
                 return SearchAnime(series, episode, userInvokedSearch);
             }
 
-            if (episode.SeasonNumber == 0)
+            // S00Eyy is a common pattern so don't use special if we're ignoring scene numbering.
+            if (episode.SeasonNumber == 0 && series.ActuallyUseSceneNumbering)
             {
                 // search for special episodes in season 0 
                 return SearchSpecial(series, new List<Episode> { episode }, userInvokedSearch);
@@ -103,7 +106,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             var downloadDecisions = new List<DownloadDecision>();
 
-            if (series.UseSceneNumbering)
+            if (series.ActuallyUseSceneNumbering)
             {
                 var sceneSeasonGroups = episodes.GroupBy(v =>
                 {
@@ -162,7 +165,7 @@ namespace NzbDrone.Core.IndexerSearch
         {
             var searchSpec = Get<SingleEpisodeSearchCriteria>(series, new List<Episode> { episode }, userInvokedSearch);
 
-            if (series.UseSceneNumbering && episode.SceneSeasonNumber.HasValue && episode.SceneEpisodeNumber.HasValue)
+            if (series.ActuallyUseSceneNumbering && episode.SceneSeasonNumber.HasValue && episode.SceneEpisodeNumber.HasValue)
             {
                 searchSpec.EpisodeNumber = episode.SceneEpisodeNumber.Value;
                 searchSpec.SeasonNumber = episode.SceneSeasonNumber.Value;

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -293,6 +293,7 @@
     </Compile>
     <Compile Include="Datastore\Migration\105_rename_torrent_downloadstation.cs" />
     <Compile Include="Datastore\Migration\111_create_language_profiles.cs" />
+    <Compile Include="Datastore\Migration\115_add_scene_number_override_flag.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationContext.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationController.cs" />
     <Compile Include="Datastore\Migration\Framework\MigrationDbFactory.cs" />

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -430,7 +430,7 @@ namespace NzbDrone.Core.Parser
 
             foreach (var episodeNumber in parsedEpisodeInfo.EpisodeNumbers)
             {
-                if (series.UseSceneNumbering && sceneSource)
+                if (series.ActuallyUseSceneNumbering && sceneSource)
                 {
                     List<Episode> episodes = new List<Episode>();
 

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -36,7 +36,14 @@ namespace NzbDrone.Core.Tv
         public List<MediaCover.MediaCover> Images { get; set; }
         public SeriesTypes SeriesType { get; set; }
         public string Network { get; set; }
-        public bool UseSceneNumbering { get; set; }
+
+        protected bool _UseSceneNumbering;
+        protected bool _IgnoreSceneNumbering = false;
+        public bool UseSceneNumbering {
+            get { return _UseSceneNumbering && !_IgnoreSceneNumbering; }
+            set { _UseSceneNumbering = value; }
+        }
+
         public string TitleSlug { get; set; }
         public string Path { get; set; }
         public int Year { get; set; }

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -37,11 +37,11 @@ namespace NzbDrone.Core.Tv
         public SeriesTypes SeriesType { get; set; }
         public string Network { get; set; }
 
-        protected bool _UseSceneNumbering;
-        protected bool _IgnoreSceneNumbering = false;
-        public bool UseSceneNumbering {
-            get { return _UseSceneNumbering && !_IgnoreSceneNumbering; }
-            set { _UseSceneNumbering = value; }
+        public bool IgnoreSceneNumbering { get; set; }
+        public bool UseSceneNumbering { get; set; }
+        public bool ActuallyUseSceneNumbering
+        {
+            get { return UseSceneNumbering && !IgnoreSceneNumbering; }
         }
 
         public string TitleSlug { get; set; }
@@ -80,6 +80,7 @@ namespace NzbDrone.Core.Tv
             RootFolderPath = otherSeries.RootFolderPath;
             Tags = otherSeries.Tags;
             AddOptions = otherSeries.AddOptions;
+            IgnoreSceneNumbering = otherSeries.IgnoreSceneNumbering;
         }
     }
 }

--- a/src/UI/Series/Edit/EditSeriesViewTemplate.hbs
+++ b/src/UI/Series/Edit/EditSeriesViewTemplate.hbs
@@ -56,6 +56,28 @@
                     </div>
 
                     <div class="form-group">
+                        <label class="col-sm-4 control-label">Ignore Scene Numbering</label>
+
+                        <div class="col-sm-8">
+                            <div class="input-group">
+                                <label class="checkbox toggle well">
+                                    <input type="checkbox" name="ignoreSceneNumbering"/>
+                                    <p>
+                                        <span>Yes</span>
+                                        <span>No</span>
+                                    </p>
+
+                                    <div class="btn btn-primary slide-button"/>
+                                </label>
+
+                                <span class="help-inline-checkbox">
+                                    <i class="icon-sonarr-form-info" title="Should searches ignore any XEM mapping?"/>
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label class="col-sm-4 control-label">Profile</label>
 
                         <div class="col-sm-4">

--- a/src/UI/Series/Editor/SeriesEditorFooterView.js
+++ b/src/UI/Series/Editor/SeriesEditorFooterView.js
@@ -11,13 +11,14 @@ module.exports = Marionette.ItemView.extend({
     template : 'Series/Editor/SeriesEditorFooterViewTemplate',
 
     ui : {
-        monitored           : '.x-monitored',
-        profile             : '.x-profiles',
-        seasonFolder        : '.x-season-folder',
-        rootFolder          : '.x-root-folder',
-        selectedCount       : '.x-selected-count',
-        container           : '.series-editor-footer',
-        actions             : '.x-action'
+        monitored            : '.x-monitored',
+        profile              : '.x-profiles',
+        seasonFolder         : '.x-season-folder',
+        rootFolder           : '.x-root-folder',
+        selectedCount        : '.x-selected-count',
+        container            : '.series-editor-footer',
+        actions              : '.x-action',
+        ignoreSceneNumbering : '.x-ignore-scene'
     },
 
     events : {
@@ -56,6 +57,7 @@ module.exports = Marionette.ItemView.extend({
         var profile = this.ui.profile.val();
         var seasonFolder = this.ui.seasonFolder.val();
         var rootFolder = this.ui.rootFolder.val();
+        var ignoreSceneNumbering = this.ui.ignoreSceneNumbering.val();
 
         _.each(selected, function(model) {
             if (monitored === 'true') {
@@ -78,6 +80,12 @@ module.exports = Marionette.ItemView.extend({
                 var rootFolderPath = RootFolders.get(parseInt(rootFolder, 10));
 
                 model.set('rootFolderPath', rootFolderPath.get('path'));
+            }
+
+            if (ignoreSceneNumbering === 'true') {
+              model.set('ignoreSceneNumbering', true);
+            } else if (ignoreSceneNumbering === 'false') {
+              model.set('ignoreSceneNumbering', false);
             }
 
             model.edited = true;


### PR DESCRIPTION
#### Database Migration
YES

#### Description
There are instances where XEM's episode numbering/mapping is incorrect.  This changeset gives users a way to ignore that mapping when they believe it is appropriate, on a per-season basis.  As a user myself, this is a better option than sitting with my fingers crossed hoping that XEM will fix their mapping or that the uploaders will rename their files to conform with the syntax.

This code adds a new boolean database field to the series table (IgnoreSceneNumbering), a toggle for that setting to the series edit panel of the UI, and two new properties to series -- IgnoreSceneNumbering and ActuallyUseSceneNumbering.  Where appropriate, calls to UseSceneNumbering were replaced with calls to ActuallyUseSceneNumbering.

#### Todos
- [ ] Unit/functional tests.  Manual testing was performed and seemed ok.  I'm not a node.js guy nor a C# guy so getting this much done was a bit of a trial;  I made no attempt to grok any existing test framework in the project.

- [ ] Documentation

#### Issues Fixed or Closed by this PR

* 
