### PR TITLE
qbittorrent: add Origin header for webui CSRF

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -146,6 +146,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port);
             requestBuilder.LogResponseContent = true;
             requestBuilder.NetworkCredential = new NetworkCredential(settings.Username, settings.Password);
+            requestBuilder.SetHeader("Origin", requestBuilder.BaseUrl.ToString());
 
             return requestBuilder;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add Origin header for CSRF enforced by qBitTorrent 3.3.13

Without this header, requests to the qBitTorrent WebUI are rejected with 401. With the header (i.e. `Origin: http://localhost:8080`), the requests succeed as normal.

#### Issues Fixed or Closed by this PR
* Fixes #1956 