### PR TITLE
Redirect calls missing URL Base

### DIFF
--- a/src/NzbDrone.Api/Extensions/Pipelines/UrlBasePipeline.cs
+++ b/src/NzbDrone.Api/Extensions/Pipelines/UrlBasePipeline.cs
@@ -20,15 +20,24 @@ namespace NzbDrone.Api.Extensions.Pipelines
 
         public void Register(IPipelines pipelines)
         {
-            pipelines.BeforeRequest.AddItemToStartOfPipeline((Func<NancyContext, Response>) Handle);
+            if (_urlBase.IsNotNullOrWhiteSpace())
+            {
+                pipelines.BeforeRequest.AddItemToStartOfPipeline((Func<NancyContext, Response>) Handle);
+            }
         }
 
         private Response Handle(NancyContext context)
         {
+            var basePath = context.Request.Url.BasePath;
 
-            if (_urlBase.IsNotNullOrWhiteSpace() && _urlBase != context.Request.Url.BasePath)
+            if (basePath.IsNullOrWhiteSpace())
             {
                 return new RedirectResponse($"{_urlBase}{context.Request.Path}{context.Request.Url.Query}");
+            }
+
+            if (_urlBase != basePath)
+            {
+                return new NotFoundResponse();
             }
 
             return null;

--- a/src/NzbDrone.Api/Extensions/Pipelines/UrlBasePipeline.cs
+++ b/src/NzbDrone.Api/Extensions/Pipelines/UrlBasePipeline.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Nancy;
+using Nancy.Bootstrapper;
+using Nancy.Responses;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
+
+namespace NzbDrone.Api.Extensions.Pipelines
+{
+    public class UrlBasePipeline : IRegisterNancyPipeline
+    {
+        private readonly string _urlBase;
+
+        public UrlBasePipeline(IConfigFileProvider configFileProvider)
+        {
+            _urlBase = configFileProvider.UrlBase;
+        }
+
+        public int Order => 99;
+
+        public void Register(IPipelines pipelines)
+        {
+            pipelines.BeforeRequest.AddItemToStartOfPipeline((Func<NancyContext, Response>) Handle);
+        }
+
+        private Response Handle(NancyContext context)
+        {
+
+            if (_urlBase.IsNotNullOrWhiteSpace() && _urlBase != context.Request.Url.BasePath)
+            {
+                return new RedirectResponse($"{_urlBase}{context.Request.Path}{context.Request.Url.Query}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NzbDrone.Api/Frontend/StaticResourceModule.cs
+++ b/src/NzbDrone.Api/Frontend/StaticResourceModule.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nancy.Responses;
@@ -36,20 +36,6 @@ namespace NzbDrone.Api.Frontend
                 path.StartsWith("/signalr", StringComparison.CurrentCultureIgnoreCase))
             {
                 return new NotFoundResponse();
-            }
-
-            //Redirect to the subfolder if the request went to the base URL
-            if (path.Equals("/"))
-            {
-                var urlBase = _configFileProvider.UrlBase;
-
-                if (!string.IsNullOrEmpty(urlBase))
-                {
-                    if (Request.Url.BasePath != urlBase)
-                    {
-                        return new RedirectResponse(urlBase  + "/");
-                    }
-                }
             }
 
             var mapper = _requestMappers.SingleOrDefault(m => m.CanHandle(path));

--- a/src/NzbDrone.Api/NzbDrone.Api.csproj
+++ b/src/NzbDrone.Api/NzbDrone.Api.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Commands\CommandResource.cs" />
     <Compile Include="Extensions\AccessControlHeaders.cs" />
     <Compile Include="Extensions\Pipelines\CorsPipeline.cs" />
+    <Compile Include="Extensions\Pipelines\UrlBasePipeline.cs" />
     <Compile Include="Extensions\Pipelines\RequestLoggingPipeline.cs" />
     <Compile Include="Frontend\Mappers\LoginHtmlMapper.cs" />
     <Compile Include="Frontend\Mappers\RobotsTxtMapper.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently if a user has set a URL Base of `/sonarr` and then hits `localhost:8989` they're redirected to the login page at `localhost:8989/sonarr/login?returnUrl=/` and when they login they get redirected back to the login page because the cookie is stored on `/sonarr` not `/`. This hook needs to execute before the forms auth login hook.