### PR TITLE
Better handling when MediaInfo is not available

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -164,11 +164,9 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
-                      It.IsAny<QualityModel>(),
                       It.IsAny<string>(),
-                      It.IsAny<long>(),
                       It.IsAny<bool>()))
-                  .Returns(true);
+                  .Returns(DetectSampleResult.Sample);
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
 
@@ -236,11 +234,9 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
-                      It.IsAny<QualityModel>(),
                       It.IsAny<string>(),
-                      It.IsAny<long>(),
                       It.IsAny<bool>()))
-                  .Returns(true);
+                  .Returns(DetectSampleResult.Sample);
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetFiles(It.IsAny<string>(), SearchOption.AllDirectories))
@@ -347,11 +343,9 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
-                      It.IsAny<QualityModel>(),
                       It.IsAny<string>(),
-                      It.IsAny<long>(),
                       It.IsAny<bool>()))
-                  .Returns(true);
+                  .Returns(DetectSampleResult.Sample);
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetFileSize(It.IsAny<string>()))

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
@@ -333,8 +333,16 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
             GivenVideoFiles(videoFiles.ToList());
 
             Mocker.GetMock<IDetectSample>()
-                  .Setup(s => s.IsSample(_series, It.IsAny<QualityModel>(), It.Is<string>(c => c.Contains("sample")), It.IsAny<long>(), It.IsAny<bool>()))
-                  .Returns(true);
+                  .Setup(s => s.IsSample(_series, It.IsAny<string>(), It.IsAny<bool>()))
+                  .Returns((Series s, string path, bool special) =>
+                  {
+                      if (path.Contains("sample"))
+                      {
+                          return DetectSampleResult.Sample;
+                      }
+
+                      return DetectSampleResult.NotSample;
+                  });
 
             var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
 

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -30,10 +30,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         {
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", "Media", "H264_sample.mp4");
 
-            Subject.GetRunTime(path).Seconds.Should().Be(10);
-
+            Subject.GetRunTime(path).Value.Seconds.Should().Be(10);
         }
-
 
         [Test]
         public void get_info()
@@ -86,7 +84,6 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.VideoCodec.Should().Be("AVC");
             info.VideoFps.Should().Be(24);
             info.Width.Should().Be(480);
-
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -283,7 +283,7 @@
     <Compile Include="MediaFiles\DownloadedEpisodesImportServiceFixture.cs" />
     <Compile Include="MediaFiles\EpisodeFileMovingServiceTests\MoveEpisodeFileFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ImportDecisionMakerFixture.cs" />
-    <Compile Include="MediaFiles\EpisodeImport\SampleServiceFixture.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\DetectSampleFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FreeSpaceSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FullSeasonSpecificationFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\SameFileSpecificationFixture.cs" />

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -113,10 +113,7 @@ namespace NzbDrone.Core.MediaFiles
                     return false;
                 }
 
-                var size = _diskProvider.GetFileSize(videoFile);
-                var quality = QualityParser.ParseQuality(videoFile);
-
-                if (!_detectSample.IsSample(series, quality, videoFile, size, episodeParseResult.IsPossibleSpecialEpisode))
+                if (_detectSample.IsSample(series, videoFile, episodeParseResult.IsPossibleSpecialEpisode) != DetectSampleResult.Sample)
                 {
                     _logger.Warn("Non-sample file detected: [{0}]", videoFile);
                     return false;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -1,16 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using NLog;
 using NzbDrone.Core.MediaFiles.MediaInfo;
-using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
     public interface IDetectSample
     {
-        bool IsSample(Series series, QualityModel quality, string path, long size, bool isSpecial);
+        DetectSampleResult IsSample(Series series, string path, bool isSpecial);
     }
 
     public class DetectSample : IDetectSample
@@ -18,22 +16,18 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
         private readonly IVideoFileInfoReader _videoFileInfoReader;
         private readonly Logger _logger;
 
-        private static List<Quality> _largeSampleSizeQualities = new List<Quality> { Quality.HDTV1080p, Quality.WEBDL1080p, Quality.Bluray1080p };
-
         public DetectSample(IVideoFileInfoReader videoFileInfoReader, Logger logger)
         {
             _videoFileInfoReader = videoFileInfoReader;
             _logger = logger;
         }
 
-        public static long SampleSizeLimit => 70.Megabytes();
-
-        public bool IsSample(Series series, QualityModel quality, string path, long size, bool isSpecial)
+        public DetectSampleResult IsSample(Series series, string path, bool isSpecial)
         {
             if (isSpecial)
             {
                 _logger.Debug("Special, skipping sample check");
-                return false;
+                return DetectSampleResult.NotSample;
             }
 
             var extension = Path.GetExtension(path);
@@ -41,61 +35,39 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             if (extension != null && extension.Equals(".flv", StringComparison.InvariantCultureIgnoreCase))
             {
                 _logger.Debug("Skipping sample check for .flv file");
-                return false;
+                return DetectSampleResult.NotSample;
             }
 
             if (extension != null && extension.Equals(".strm", StringComparison.InvariantCultureIgnoreCase))
             {
                 _logger.Debug("Skipping sample check for .strm file");
-                return false;
+                return DetectSampleResult.NotSample;
             }
 
-            try
+            var runTime = _videoFileInfoReader.GetRunTime(path);
+
+            if (!runTime.HasValue)
             {
-                var runTime = _videoFileInfoReader.GetRunTime(path);
-                var minimumRuntime = GetMinimumAllowedRuntime(series);
-
-                if (runTime.TotalMinutes.Equals(0))
-                {
-                    _logger.Error("[{0}] has a runtime of 0, is it a valid video file?", path);
-                    return true;
-                }
-
-                if (runTime.TotalSeconds < minimumRuntime)
-                {
-                    _logger.Debug("[{0}] appears to be a sample. Runtime: {1} seconds. Expected at least: {2} seconds", path, runTime, minimumRuntime);
-                    return true;
-                }
+                _logger.Error("Failed to get runtime from the file, make sure mediainfo is available");
+                return DetectSampleResult.Indeterminate;
             }
 
-            catch (DllNotFoundException)
-            {
-                _logger.Debug("Falling back to file size detection");
+            var minimumRuntime = GetMinimumAllowedRuntime(series);
 
-                return CheckSize(size, quality);
+            if (runTime.Value.TotalMinutes.Equals(0))
+            {
+                _logger.Error("[{0}] has a runtime of 0, is it a valid video file?", path);
+                return DetectSampleResult.Sample;
+            }
+
+            if (runTime.Value.TotalSeconds < minimumRuntime)
+            {
+                _logger.Debug("[{0}] appears to be a sample. Runtime: {1} seconds. Expected at least: {2} seconds", path, runTime, minimumRuntime);
+                return DetectSampleResult.Sample;
             }
 
             _logger.Debug("Runtime is over 90 seconds");
-            return false;
-        }
-
-        private bool CheckSize(long size, QualityModel quality)
-        {
-            {
-                if (size < SampleSizeLimit * 2)
-                {
-                    _logger.Debug("1080p file is less than sample limit");
-                    return true;
-                }
-            }
-
-            if (size < SampleSizeLimit)
-            {
-                _logger.Debug("File is less than sample limit");
-                return true;
-            }
-
-            return false;
+            return DetectSampleResult.NotSample;
         }
 
         private int GetMinimumAllowedRuntime(Series series)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSampleResult.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSampleResult.cs
@@ -1,0 +1,9 @@
+﻿namespace NzbDrone.Core.MediaFiles.EpisodeImport
+{
+    public enum DetectSampleResult
+    {
+        Indeterminate,
+        Sample,
+        NotSample
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -170,11 +170,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
             return videoFiles.Count(file =>
             {
-                var size = _diskProvider.GetFileSize(file);
-                var fileQuality = QualityParser.ParseQuality(file);
-                var sample = _detectSample.IsSample(series, GetQuality(folderInfo, fileQuality, series), file, size, folderInfo.IsPossibleSpecialEpisode);
+                var sample = _detectSample.IsSample(series, file, folderInfo.IsPossibleSpecialEpisode);
 
-                if (sample)
+                if (sample == DetectSampleResult.Sample)
                 {
                     return false;
                 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
@@ -26,14 +26,17 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             }
 
             var sample = _detectSample.IsSample(localEpisode.Series,
-                                                localEpisode.Quality,
                                                 localEpisode.Path,
-                                                localEpisode.Size,
                                                 localEpisode.IsSpecial);
 
-            if (sample)
+            if (sample == DetectSampleResult.Sample)
             {
                 return Decision.Reject("Sample");
+            }
+
+            else if (sample == DetectSampleResult.Indeterminate)
+            {
+                return Decision.Reject("Unable to determine if file is a sample");
             }
 
             return Decision.Accept();

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public interface IVideoFileInfoReader
     {
         MediaInfoModel GetMediaInfo(string filename);
-        TimeSpan GetRunTime(string filename);
+        TimeSpan? GetRunTime(string filename);
     }
 
     public class VideoFileInfoReader : IVideoFileInfoReader
@@ -181,16 +181,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return null;
         }
 
-        public TimeSpan GetRunTime(string filename)
+        public TimeSpan? GetRunTime(string filename)
         {
             var info = GetMediaInfo(filename);
 
-            if (info == null)
-            {
-                return new TimeSpan();
-            }
-
-            return info.RunTime;
+            return info?.RunTime;
         }
 
         private TimeSpan GetBestRuntime(int audio, int video, int general)

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -744,6 +744,7 @@
     <Compile Include="MediaFiles\Commands\BackendCommandAttribute.cs" />
     <Compile Include="MediaFiles\Commands\CleanUpRecycleBinCommand.cs" />
     <Compile Include="MediaFiles\Commands\DownloadedEpisodesScanCommand.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\DetectSampleResult.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ImportMode.cs" />
     <Compile Include="MediaFiles\Commands\RenameFilesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameSeriesCommand.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Turns out we haven't fallen back to file size to determine if a file is a sample for a long time (years maybe?), so I've fixed the glitch and also improved what Sonarr logs/reports when getting the mediainfo fails completely.

#### Issues Fixed or Closed by this PR

* #1967
