### PR TITLE
Store Plex Auth Token in DB

### DIFF
--- a/src/NzbDrone.Api/ClientSchema/Field.cs
+++ b/src/NzbDrone.Api/ClientSchema/Field.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Api.ClientSchema
         public object Value { get; set; }
         public string Type { get; set; }
         public bool Advanced { get; set; }
+        public bool Persisted { get; set; }
         public List<SelectOption> SelectOptions { get; set; }
     }
 }

--- a/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
+++ b/src/NzbDrone.Api/ClientSchema/SchemaBuilder.cs
@@ -34,6 +34,7 @@ namespace NzbDrone.Api.ClientSchema
                         HelpLink = fieldAttribute.HelpLink,
                         Order = fieldAttribute.Order,
                         Advanced = fieldAttribute.Advanced,
+                        Persisted = fieldAttribute.Persisted,
                         Type = fieldAttribute.Type.ToString().ToLowerInvariant()
                     };
 

--- a/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
+++ b/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Annotations
         public FieldDefinitionAttribute(int order)
         {
             Order = order;
+            Persisted = true;
         }
 
         public int Order { get; private set; }
@@ -16,6 +17,7 @@ namespace NzbDrone.Core.Annotations
         public string HelpLink { get; set; }
         public FieldType Type { get; set; }
         public bool Advanced { get; set; }
+        public bool Persisted { get; set; }
         public Type SelectOptions { get; set; }
     }
 

--- a/src/NzbDrone.Core/Datastore/Converters/EmbeddedDocumentConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/EmbeddedDocumentConverter.cs
@@ -7,11 +7,19 @@ using Newtonsoft.Json.Converters;
 
 namespace NzbDrone.Core.Datastore.Converters
 {
-    public class EmbeddedDocumentConverter : IConverter
+    public class EmbeddedDocumentConverter : EmbeddedDocumentConverterBase<CamelCasePropertyNamesContractResolver>
+    {
+        public EmbeddedDocumentConverter(params JsonConverter[] converters)
+            : base(converters)
+        {
+        }
+    }
+
+    public class EmbeddedDocumentConverterBase<TContractResolver> : IConverter where TContractResolver : IContractResolver, new()
     {
         private readonly JsonSerializerSettings SerializerSetting;
 
-        public EmbeddedDocumentConverter(params JsonConverter[] converters)
+        public EmbeddedDocumentConverterBase(params JsonConverter[] converters)
         {
             SerializerSetting = new JsonSerializerSettings
             {
@@ -19,7 +27,7 @@ namespace NzbDrone.Core.Datastore.Converters
                 NullValueHandling = NullValueHandling.Ignore,
                 Formatting = Formatting.Indented,
                 DefaultValueHandling = DefaultValueHandling.Include,
-                ContractResolver = new CamelCasePropertyNamesContractResolver()
+                ContractResolver = new TContractResolver()
             };
 
             SerializerSetting.Converters.Add(new StringEnumConverter { CamelCaseText = true });

--- a/src/NzbDrone.Core/Datastore/Converters/ProviderSettingConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/ProviderSettingConverter.cs
@@ -1,12 +1,16 @@
 ﻿using System;
+using System.Reflection;
 using Marr.Data.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using NzbDrone.Common.Reflection;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Datastore.Converters
 {
-    public class ProviderSettingConverter : EmbeddedDocumentConverter
+    public class ProviderSettingConverter : EmbeddedDocumentConverterBase<ProviderContractResolver>
     {
         public override object FromDB(ConverterContext context)
         {
@@ -24,8 +28,6 @@ namespace NzbDrone.Core.Datastore.Converters
 
             var ordinal = context.DataRecord.GetOrdinal("ConfigContract");
             var contract = context.DataRecord.GetString(ordinal);
-
-
             var impType = typeof (IProviderConfig).Assembly.FindTypeByName(contract);
 
             if (impType == null)
@@ -35,6 +37,21 @@ namespace NzbDrone.Core.Datastore.Converters
 
             return Json.Deserialize(stringValue, impType);
         }
+    }
+     
+    public class ProviderContractResolver : CamelCasePropertyNamesContractResolver
+    {
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var property = base.CreateProperty(member, memberSerialization);
+            var fieldAttribute = member.GetAttribute<FieldDefinitionAttribute>(false);
 
+            if (fieldAttribute != null)
+            {
+                property.Ignored = !fieldAttribute.Persisted;
+            }
+
+            return property;
+        }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServer.cs
@@ -2,6 +2,7 @@
 using FluentValidation.Results;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
+using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Plex
 {
@@ -33,6 +34,23 @@ namespace NzbDrone.Core.Notifications.Plex
             {
                 _plexServerService.UpdateLibrary(series, Settings);
             }
+        }
+
+        public override object RequestAction(string action, IDictionary<string, string> query)
+        {
+            if (action == "authenticate")
+            {
+                Settings.Validate().Filter("Username", "Password").ThrowOnError();
+
+                var authToken = _plexServerService.Authenticate(Settings);
+
+                return new
+                       {
+                           authToken
+                       };
+            }
+
+            return new { };
         }
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServerProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServerProxy.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Notifications.Plex
         string Version(PlexServerSettings settings);
         List<PlexPreference> Preferences(PlexServerSettings settings);
         int? GetMetadataId(int sectionId, int tvdbId, string language, PlexServerSettings settings);
+        string Authenticate(PlexServerSettings settings);
     }
 
     public class PlexServerProxy : IPlexServerProxy
@@ -162,7 +163,7 @@ namespace NzbDrone.Core.Notifications.Plex
             return items.First().Id;
         }
 
-        private string Authenticate(PlexServerSettings settings)
+        public string Authenticate(PlexServerSettings settings)
         {
             var request = GetPlexTvRequest("users/sign_in.json", Method.POST);
             var client = GetPlexTvClient(settings.Username, settings.Password); 
@@ -221,6 +222,13 @@ namespace NzbDrone.Core.Notifications.Plex
 
         private string GetAuthenticationToken(PlexServerSettings settings)
         {
+            // TODO: v3 Remove authentication by stored username and password.
+
+            if (settings.AuthToken.IsNotNullOrWhiteSpace())
+            {
+                return settings.AuthToken;
+            }
+
             var token = _authCache.Get(settings.Username + settings.Password, () => Authenticate(settings));
 
             if (token.IsNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Notifications/Plex/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexServerSettings.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Notifications.Plex
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+            RuleFor(c => c.AuthToken).NotEmpty();
         }
     }
 
@@ -30,17 +31,22 @@ namespace NzbDrone.Core.Notifications.Plex
         [FieldDefinition(1, Label = "Port")]
         public int Port { get; set; }
 
-        //TODO: Change username and password to token and get a plex.tv OAuth token properly
-        [FieldDefinition(2, Label = "Username")]
+        [FieldDefinition(2, Label = "Username", Persisted = false)]
         public string Username { get; set; }
 
-        [FieldDefinition(3, Label = "Password", Type = FieldType.Password)]
+        [FieldDefinition(3, Label = "Password", Type = FieldType.Password, Persisted = false)]
         public string Password { get; set; }
 
-        [FieldDefinition(4, Label = "Update Library", Type = FieldType.Checkbox)]
+        [FieldDefinition(4, Label = "AuthToken", Advanced = true)]
+        public string AuthToken { get; set; }
+
+        [FieldDefinition(5, Label = "Get Auth Token", Type = FieldType.Action, Persisted = false)]
+        public string Authenticate { get; set; }
+
+        [FieldDefinition(6, Label = "Update Library", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
-        [FieldDefinition(5, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Plex over HTTPS instead of HTTP")]
+        [FieldDefinition(7, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Plex over HTTPS instead of HTTP")]
         public bool UseSsl { get; set; }
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host);

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Notifications.Twitter
         public TwitterSettings()
         {
             DirectMessage = true;
-            AuthorizeNotification = "step1";
+            AuthorizeNotification = "startOAuth";
         }
 
         [FieldDefinition(0, Label = "Consumer Key", HelpText = "Consumer key from a Twitter application", HelpLink = "https://github.com/Sonarr/Sonarr/wiki/Twitter-Notifications")]
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Notifications.Twitter
         [FieldDefinition(5, Label = "Direct Message", Type = FieldType.Checkbox, HelpText = "Send a direct message instead of a public message")]
         public bool DirectMessage { get; set; }
 
-        [FieldDefinition(6, Label = "Connect to twitter", Type = FieldType.Action)]
+        [FieldDefinition(6, Label = "Connect to twitter", Type = FieldType.Action, Persisted = false)]
         public string AuthorizeNotification { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/UI/Form/FormHelpPartial.hbs
+++ b/src/UI/Form/FormHelpPartial.hbs
@@ -1,4 +1,7 @@
 <span class="col-sm-1 help-inline">
+    {{#unless persisted}}
+        <i class="icon-sonarr-form-info" title="Will not be stored in the database"/>
+    {{/unless}}
     {{#if helpText}}
         <i class="icon-sonarr-form-info" title="{{helpText}}"/>
     {{/if}}

--- a/src/UI/Settings/Notifications/Edit/NotificationEditView.js
+++ b/src/UI/Settings/Notifications/Edit/NotificationEditView.js
@@ -27,7 +27,8 @@ var view = Marionette.ItemView.extend({
     events : {
         'click .x-back'         : '_back',
         'change .x-on-download' : '_onDownloadChanged',
-        'click .AuthorizeNotification' : '_onAuthorizeNotification'
+        'click .AuthorizeNotification' : '_onAuthorizeNotification',
+        'click .Authenticate' : '_onAuthenticate'
     },
 
     _deleteView : DeleteView,
@@ -104,12 +105,27 @@ var view = Marionette.ItemView.extend({
                 self.model.setFieldValue('AccessToken', response.accessToken);
                 self.model.setFieldValue('AccessTokenSecret', response.accessTokenSecret);
             });
-            
+
         promise.always(function() {
                 self.ui.indicator.hide();
             });
     },
-    
+
+    _onAuthenticate : function() {
+        this.ui.indicator.show();
+
+        var self = this;
+
+        var promise = this.model.requestAction('authenticate')
+            .then(function(response) {
+                self.model.setFieldValue('AuthToken', response.authToken);
+            });
+
+        promise.always(function() {
+                self.ui.indicator.hide();
+            });
+    },
+
     _showOAuthWindow : function(oauthUrl) {
         var promise = $.Deferred();
     


### PR DESCRIPTION
#### Database Migration
NO

#### Description
No longer stores the plex username/password in the DB and instead will store an auth token. This will force users updating the Plex Media Server connection to authenticate so the token is stored instead and in v3 we can force remove those settings and rely only on the stored token. Additionally we can investigate using the PIN system to authenticate instead of/addition to username and password.