### PR TITLE
Fix inconsistent naming of qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 {
                     case "error": // some error occurred, applies to paused torrents
                         item.Status = DownloadItemStatus.Failed;
-                        item.Message = "QBittorrent is reporting an error";
+                        item.Message = "qBittorrent is reporting an error";
                         break;
 
                     case "pausedDL": // torrent is paused and has NOT finished downloading
@@ -222,7 +222,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 var config = _proxy.GetConfig(Settings);
                 if (config.MaxRatioEnabled && config.RemoveOnMaxRatio)
                 {
-                    return new NzbDroneValidationFailure(String.Empty, "QBittorrent is configured to remove torrents when they reach their Share Ratio Limit")
+                    return new NzbDroneValidationFailure(String.Empty, "qBittorrent is configured to remove torrents when they reach their Share Ratio Limit")
                     {
                         DetailedDescription = "Sonarr will be unable to perform Completed Download Handling as configured. You can fix this in qBittorrent ('Tools -> Options...' in the menu) by changing 'Options -> BitTorrent -> Share Ratio Limiting' from 'Remove them' to 'Pause them'."
                     };

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             }
             catch(DownloadClientException ex)
             {
-                // if setCategory fails due to method not being found, then try older setLabel command for qbittorent < v.3.3.5
+                // if setCategory fails due to method not being found, then try older setLabel command for qBittorrent < v.3.3.5
                 if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.NotFound)
                 {
                     var setLabelRequest = BuildRequest(settings).Resource("/command/setLabel")
@@ -197,12 +197,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
                 else
                 {
-                    throw new DownloadClientException("Failed to connect to qBitTorrent, check your settings.", ex);
+                    throw new DownloadClientException("Failed to connect to qBittorrent, check your settings.", ex);
                 }
             }
             catch (WebException ex)
             {
-                throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
             }
 
             return response.Content;
@@ -239,23 +239,23 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     _logger.Debug("qbitTorrent authentication failed.");
                     if (ex.Response.StatusCode == HttpStatusCode.Forbidden)
                     {
-                        throw new DownloadClientAuthenticationException("Failed to authenticate with qbitTorrent.", ex);
+                        throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);
                     }
 
-                    throw new DownloadClientException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                    throw new DownloadClientException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
                 catch (WebException ex)
                 {
-                    throw new DownloadClientUnavailableException("Failed to connect to qBitTorrent, please check your settings.", ex);
+                    throw new DownloadClientUnavailableException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
 
                 if (response.Content != "Ok.") // returns "Fails." on bad login
                 {
                     _logger.Debug("qbitTorrent authentication failed.");
-                    throw new DownloadClientAuthenticationException("Failed to authenticate with qbitTorrent.");
+                    throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.");
                 }
 
-                _logger.Debug("qbitTorrent authentication succeeded.");
+                _logger.Debug("qBittorrent authentication succeeded.");
 
                 cookies = response.GetCookies();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I noticed that the naming of "qBittorrent" in exception/log messages is a little inconsistent. This updates all the references to the correct name of the application. 
