### PR TITLE
Remove pending items if the release is no longer on the indexer.

### DIFF
--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveGrabbedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveGrabbedFixture.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
             _remoteEpisode.Series = _series;
             _remoteEpisode.ParsedEpisodeInfo = _parsedEpisodeInfo;
             _remoteEpisode.Release = _release;
-            
+
             _temporarilyRejected = new DownloadDecision(_remoteEpisode, new Rejection("Temp Rejected", RejectionType.Temporary));
 
             Mocker.GetMock<IPendingReleaseRepository>()

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -70,6 +70,11 @@ namespace NzbDrone.Core.Download
                 _downloadClientStatusService.RecordSuccess(downloadClient.Definition.Id);
                 _indexerStatusService.RecordSuccess(remoteEpisode.Release.IndexerId);
             }
+            catch (ReleaseUnavailableException)
+            {
+                _logger.Trace("Release {0} no longer available on indexer.", remoteEpisode);
+                throw;
+            }
             catch (ReleaseDownloadException ex)
             {
                 var http429 = ex.InnerException as TooManyRequestsException;

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Download
             _httpClient = httpClient;
             _torrentFileInfoReader = torrentFileInfoReader;
         }
-        
+
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
 
         public virtual bool PreferTorrentFile => false;
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Download
             {
                 magnetUrl = torrentInfo.MagnetUrl;
             }
-            
+
             if (PreferTorrentFile)
             {
                 if (torrentUrl.IsNotNullOrWhiteSpace())
@@ -160,6 +160,12 @@ namespace NzbDrone.Core.Download
             }
             catch (HttpException ex)
             {
+                if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    _logger.Error(ex, "Downloading torrent file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, torrentUrl);
+                    throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading torrent failed", ex);
+                }
+
                 if ((int)ex.Response.StatusCode == 429)
                 {
                     _logger.Error("API Grab Limit reached for {0}", torrentUrl);

--- a/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseUnavailableException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Exceptions
+{
+    public class ReleaseUnavailableException : ReleaseDownloadException
+    {
+        public ReleaseUnavailableException(ReleaseInfo release, string message, params object[] args)
+            : base(release, message, args)
+        {
+        }
+
+        public ReleaseUnavailableException(ReleaseInfo release, string message)
+            : base(release, message)
+        {
+        }
+
+        public ReleaseUnavailableException(ReleaseInfo release, string message, Exception innerException, params object[] args)
+            : base(release, message, innerException, args)
+        {
+        }
+
+        public ReleaseUnavailableException(ReleaseInfo release, string message, Exception innerException)
+            : base(release, message, innerException)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -536,6 +536,7 @@
     <Compile Include="Exceptions\BadRequestException.cs" />
     <Compile Include="Exceptions\DownstreamException.cs" />
     <Compile Include="Exceptions\NzbDroneClientException.cs" />
+    <Compile Include="Exceptions\ReleaseUnavailableException.cs" />
     <Compile Include="Exceptions\SeriesNotFoundException.cs" />
     <Compile Include="Exceptions\ReleaseDownloadException.cs" />
     <Compile Include="Exceptions\StatusCodeToExceptions.cs" />


### PR DESCRIPTION
If the indexer returns 404 we throw a ReleaseUnavailableException which causes the release to be put on the Rejected list instead. That should prevent the release from being stuck on the pending queue forever.