### PR TITLE
Optional ignoreCase parameter for XElementExtension.TryGetValue

### DIFF
--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.Indexers
 
         protected virtual DateTime GetPublishDate(XElement item)
         {
-            var dateString = item.TryGetValue("pubDate");
+            var dateString = item.TryGetValue("pubDate", ignoreCase: true);
 
             if (dateString.IsNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/Indexers/XElementExtensions.cs
+++ b/src/NzbDrone.Core/Indexers/XElementExtensions.cs
@@ -84,9 +84,21 @@ namespace NzbDrone.Core.Indexers
             return long.Parse(item.TryGetValue("length"));
         }
 
-        public static string TryGetValue(this XElement item, string elementName, string defaultValue = "")
+        public static string TryGetValue(this XElement item, string elementName, string defaultValue = "", bool ignoreCase = false)
         {
             var element = item.Element(elementName);
+
+            if (ignoreCase && element == null)
+            {
+                foreach (XElement elem in item.Elements())
+                {
+                    if (String.Equals(elem.Name.LocalName, elementName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        element = elem;
+                        break;
+                    }
+                }
+            }
 
             return element != null ? element.Value : defaultValue;
         }


### PR DESCRIPTION
Covering cases where an XML tag could possibly have a different character casing as described in issue #2120 