### PR TITLE
Declare charset as first meta tag and improve consistency

### DIFF
--- a/src/UI/index.html
+++ b/src/UI/index.html
@@ -1,43 +1,43 @@
 <!doctype html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Sonarr</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="mobile-web-app-capable" content="yes"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
 
     <!-- Chrome, Opera, and Firefox OS -->
-    <meta name="theme-color" content="#272727"/>
+    <meta name="theme-color" content="#272727">
+
     <!-- Windows Phone -->
-    <meta name="msapplication-navbutton-color" content="#272727"/>
+    <meta name="msapplication-navbutton-color" content="#272727">
 
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+    <link href="/Content/bootstrap.css" rel="stylesheet" type="text/css">
+    <link href="/Content/bootstrap.toggle-switch.css" rel="stylesheet" type="text/css">
+    <link href="/Content/messenger.css" rel="stylesheet" type="text/css">
+    <link href="/Content/messenger.flat.css" rel="stylesheet" type="text/css">
+    <link href="/Content/fullcalendar.css" rel="stylesheet" type="text/css">
+    <link href="/Content/theme.css" rel="stylesheet" type="text/css">
+    <link href="/Content/cells.css" rel="stylesheet" type="text/css">
+    <link href="/Content/series.css" rel="stylesheet" type="text/css">
+    <link href="/Content/activity.css" rel="stylesheet" type="text/css">
+    <link href="/Content/logs.css" rel="stylesheet" type="text/css">
+    <link href="/Content/settings.css" rel="stylesheet" type="text/css">
+    <link href="/Content/addSeries.css" rel="stylesheet" type="text/css">
+    <link href="/Content/calendar.css" rel="stylesheet" type="text/css">
+    <link href="/Content/update.css" rel="stylesheet" type="text/css">
+    <link href="/Content/overrides.css" rel="stylesheet" type="text/css">
+    <link href="/Content/info.css" rel="stylesheet" type="text/css">
 
-    <link href="/Content/bootstrap.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/bootstrap.toggle-switch.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/messenger.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/messenger.flat.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/fullcalendar.css" rel='stylesheet' type='text/css'>
-    <link href="/Content/theme.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/cells.css" rel='stylesheet' type='text/css'>
-    <link href="/Content/series.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/activity.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/logs.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/settings.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/addSeries.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/calendar.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/update.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/overrides.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/info.css" rel='stylesheet' type='text/css'/>
-
-    <link rel="apple-touch-icon" href="/Content/Images/touch/57.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="/Content/Images/touch/72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="/Content/Images/touch/114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="/Content/Images/touch/144.png"/>
+    <link rel="apple-touch-icon" href="/Content/Images/touch/57.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/Content/Images/touch/72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/Content/Images/touch/114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/Content/Images/touch/144.png">
     <link rel="mask-icon" href="/Content/Images/safari/logo.svg" color="#35c5f4">
-    <link rel="icon" type="image/ico" href="/Content/Images/favicon.ico"/>
+    <link rel="icon" type="image/ico" href="/Content/Images/favicon.ico">
 
-    <link rel="alternate" type="text/calendar" title="iCalendar feed for Sonarr" href="/feed/calendar/NzbDrone.ics"/>
+    <link rel="alternate" type="text/calendar" title="iCalendar feed for Sonarr" href="/feed/calendar/NzbDrone.ics">
 </head>
 <body>
 <div class="container">

--- a/src/UI/login.html
+++ b/src/UI/login.html
@@ -1,20 +1,20 @@
 <!doctype html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>Sonarr - Login</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 
-    <link href="/Content/bootstrap.css" rel='stylesheet' type='text/css'/>
-    <link href="/Content/theme.css" rel='stylesheet' type='text/css'/>
+    <link href="/Content/bootstrap.css" rel="stylesheet" type="text/css">
+    <link href="/Content/theme.css" rel="stylesheet" type="text/css">
 
-    <link rel="apple-touch-icon" href="/Content/Images/touch/57.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="/Content/Images/touch/72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="/Content/Images/touch/114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="/Content/Images/touch/144.png"/>
-    <link rel="icon" type="image/ico" href="/Content/Images/favicon.ico"/>
+    <link rel="apple-touch-icon" href="/Content/Images/touch/57.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="/Content/Images/touch/72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="/Content/Images/touch/114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="/Content/Images/touch/144.png">
+    <link rel="icon" type="image/ico" href="/Content/Images/favicon.ico">
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This adjusts a few areas of `index.html` and `login.html` of the UI.

* Move charset to be the first meta tag (recommended), also the shorter notation can be used for HTML5
* Fix mixture of `'` and `"` for attributes on CSS link references
* Remove `/>` they are not needed in HTML5
