### PR TITLE
Improve import process and quality detection

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentQualityFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentQualityFixture.cs
@@ -1,0 +1,211 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Augmenting.Augmenters
+{
+    [TestFixture]
+    public class AugmentQualityFixture : CoreTest<AugmentQuality>
+    {
+        private Series _series;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew()
+                                     .With(e => e.Profile = new Profile { Items = Qualities.QualityFixture.GetDefaultQualities() })
+                                     .Build();
+        }
+
+        private ParsedEpisodeInfo GivenParsedEpisodeInfo(Quality quality, QualityDetectionSource qualityDetectionSource = QualityDetectionSource.Name)
+        {
+            var info = Builder<ParsedEpisodeInfo>.CreateNew()
+                                                .With(p => p.Quality = new QualityModel(quality))
+                                                .Build();
+
+            info.Quality.QualityDetectionSource = qualityDetectionSource;
+
+            return info;
+        }
+
+        private MediaInfoModel GivenMediaInfo(int width)
+        {
+            return Builder<MediaInfoModel>.CreateNew()
+                                          .With(m => m.Width = width)
+                                          .Build();
+        }
+
+        [Test]
+        public void should_return_file_quality_if_other_information_is_not_available()
+        {
+            var expectedQuality = Quality.SDTV;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var localEpisode = new LocalEpisode
+                               {
+                                   FileEpisodeInfo = fileEpisodeInfo,
+                                   Series = _series
+                               };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_folder_quality_when_file_quality_was_determined_by_the_extension()
+        {
+            var expectedQuality = Quality.SDTV;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p, QualityDetectionSource.Extension);
+            var folderEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_folder_quality_when_greater_than_file_quality()
+        {
+            var expectedQuality = Quality.WEBDL720p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p);
+            var folderEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_download_client_item_quality_when_file_quality_was_determined_by_the_extension()
+        {
+            var expectedQuality = Quality.SDTV;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p, QualityDetectionSource.Extension);
+            var downloadClientEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                DownloadClientEpisodeInfo = downloadClientEpisodeInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_download_client_item_quality_when_greater_than_file_quality()
+        {
+            var expectedQuality = Quality.WEBDL720p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p);
+            var downloadClientEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                DownloadClientEpisodeInfo = downloadClientEpisodeInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_download_client_item_quality_over_folder_quality()
+        {
+            var expectedQuality = Quality.WEBDL720p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p, QualityDetectionSource.Extension);
+            var downloadClientEpisodeInfo = GivenParsedEpisodeInfo(expectedQuality);
+            var folderEpisodeInfo = GivenParsedEpisodeInfo(Quality.Bluray720p);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                DownloadClientEpisodeInfo = downloadClientEpisodeInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_media_info_width_to_determine_quality()
+        {
+            var expectedQuality = Quality.HDTV1080p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p);
+            var mediaInfo = GivenMediaInfo(1920);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                MediaInfo = mediaInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_media_info_width_along_with_folder_info_to_determine_quality()
+        {
+            var expectedQuality = Quality.Bluray2160p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p);
+            var folderEpisodeInfo = GivenParsedEpisodeInfo(Quality.Bluray720p);
+            var mediaInfo = GivenMediaInfo(2160);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                MediaInfo = mediaInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        public void should_use_media_info_width_along_with_download_client_info_to_determine_quality()
+        {
+            var expectedQuality = Quality.Bluray2160p;
+            var fileEpisodeInfo = GivenParsedEpisodeInfo(Quality.HDTV720p);
+            var downloadClientEpisodeInfo = GivenParsedEpisodeInfo(Quality.Bluray720p);
+            var mediaInfo = GivenMediaInfo(2160);
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                DownloadClientEpisodeInfo = downloadClientEpisodeInfo,
+                MediaInfo = mediaInfo,
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false);
+
+            localEpisode.Quality.Quality.Should().Be(expectedQuality);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentingServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentingServiceFixture.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Augmenting.Augmenters
+{
+    [TestFixture]
+    public class AugmentingServiceFixture : CoreTest<AugmentingService>
+    {
+        private Series _series;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew().Build();
+
+            var augmenters = new List<Mock<IAugmentLocalEpisode>>
+                             {
+                                 new Mock<IAugmentLocalEpisode>()
+                             };
+
+            Mocker.SetConstant(augmenters.Select(c => c.Object));
+        }
+
+        [Test]
+        public void should_not_use_folder_for_full_season()
+        {
+            var fileEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var folderEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01");
+            var localEpisode = new LocalEpisode
+                               {
+                                   FileEpisodeInfo = fileEpisodeInfo,
+                                   FolderEpisodeInfo = folderEpisodeInfo,
+                                   Path = @"C:\Test\Unsorted TV\Series.Title.S01\Series.Title.S01E01.mkv".AsOsAgnostic(),
+                                   Series = _series
+                               };
+
+            Subject.Augment(localEpisode, false).ParsedEpisodeInfo.Should().Be(fileEpisodeInfo);
+        }
+
+        [Test]
+        public void should_not_use_folder_when_it_contains_more_than_one_valid_video_file()
+        {
+            var fileEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var folderEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01");
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                Path = @"C:\Test\Unsorted TV\Series.Title.S01\Series.Title.S01E01.mkv".AsOsAgnostic(),
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, true).ParsedEpisodeInfo.Should().Be(fileEpisodeInfo);
+        }
+
+        [Test]
+        public void should_not_use_folder_name_if_file_name_is_scene_name()
+        {
+            var fileEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var folderEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                Path = @"C:\Test\Unsorted TV\Series.Title.S01E01\Series.Title.S01E01.720p.HDTV-Sonarr.mkv".AsOsAgnostic(),
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false).ParsedEpisodeInfo.Should().Be(fileEpisodeInfo);
+        }
+
+        [Test]
+        public void should_use_folder_when_only_one_video_file()
+        {
+            var fileEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var folderEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                FolderEpisodeInfo = folderEpisodeInfo,
+                Path = @"C:\Test\Unsorted TV\Series.Title.S01E01\Series.Title.S01E01.mkv".AsOsAgnostic(),
+                Series = _series
+            };
+
+            Subject.Augment(localEpisode, false).ParsedEpisodeInfo.Should().Be(folderEpisodeInfo);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
-using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Qualities;
@@ -15,6 +14,7 @@ using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
 using FizzWare.NBuilder;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
 
 namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
 {
@@ -67,10 +67,6 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
                 Path = @"C:\Test\Unsorted\The.Office.S03E115.DVDRip.XviD-OSiTV.avi"
             };
 
-            Mocker.GetMock<IParsingService>()
-                  .Setup(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()))
-                  .Returns(_localEpisode);
-
             GivenVideoFiles(new List<string> { @"C:\Test\Unsorted\The.Office.S03E115.DVDRip.XviD-OSiTV.avi".AsOsAgnostic() });
         }
 
@@ -88,20 +84,31 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
                   .Returns(_videoFiles);
         }
 
+        private void GivenAugmentationSuccess()
+        {
+            Mocker.GetMock<IAugmentingService>()
+                  .Setup(s => s.Augment(It.IsAny<LocalEpisode>(), It.IsAny<bool>()))
+                  .Callback<LocalEpisode, bool>((localEpisode, otherFiles) =>
+                  {
+                      localEpisode.Episodes = _localEpisode.Episodes;
+                  });
+        }
+
         [Test]
         public void should_call_all_specifications()
         {
             var downloadClientItem = Builder<DownloadClientItem>.CreateNew().Build();
+            GivenAugmentationSuccess();
             GivenSpecifications(_pass1, _pass2, _pass3, _fail1, _fail2, _fail3);
 
             Subject.GetImportDecisions(_videoFiles, new Series(), downloadClientItem, null, false);
 
-            _fail1.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
-            _fail2.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
-            _fail3.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
-            _pass1.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
-            _pass2.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
-            _pass3.Verify(c => c.IsSatisfiedBy(_localEpisode, downloadClientItem), Times.Once());
+            _fail1.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
+            _fail2.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
+            _fail3.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
+            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
+            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
+            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<LocalEpisode>(), downloadClientItem), Times.Once());
         }
 
         [Test]
@@ -125,8 +132,9 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
         }
 
         [Test]
-        public void should_return_pass_if_all_specs_pass()
+        public void should_return_approved_if_all_specs_pass()
         {
+            GivenAugmentationSuccess();
             GivenSpecifications(_pass1, _pass2, _pass3);
 
             var result = Subject.GetImportDecisions(_videoFiles, new Series());
@@ -137,6 +145,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
         [Test]
         public void should_have_same_number_of_rejections_as_specs_that_failed()
         {
+            GivenAugmentationSuccess();
             GivenSpecifications(_pass1, _pass2, _pass3, _fail1, _fail2, _fail3);
 
             var result = Subject.GetImportDecisions(_videoFiles, new Series());
@@ -148,8 +157,8 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
         {
             GivenSpecifications(_pass1);
 
-            Mocker.GetMock<IParsingService>()
-                  .Setup(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()))
+            Mocker.GetMock<IAugmentingService>()
+                  .Setup(c => c.Augment(It.IsAny<LocalEpisode>(), It.IsAny<bool>()))
                   .Throws<TestException>();
 
             _videoFiles = new List<string>
@@ -163,75 +172,16 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
 
             Subject.GetImportDecisions(_videoFiles, _series);
 
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()), Times.Exactly(_videoFiles.Count));
+            Mocker.GetMock<IAugmentingService>()
+                  .Verify(c => c.Augment(It.IsAny<LocalEpisode>(), It.IsAny<bool>()), Times.Exactly(_videoFiles.Count));
 
             ExceptionVerification.ExpectedErrors(3);
-        }
-
-        [Test]
-        public void should_use_file_quality_if_folder_quality_is_null()
-        {
-            GivenSpecifications(_pass1, _pass2, _pass3);
-            var expectedQuality = QualityParser.ParseQuality(_videoFiles.Single());
-
-            var result = Subject.GetImportDecisions(_videoFiles, _series);
-
-            result.Single().LocalEpisode.Quality.Should().Be(expectedQuality);
-        }
-
-        [Test]
-        public void should_use_file_quality_if_file_quality_was_determined_by_name()
-        {
-            GivenSpecifications(_pass1, _pass2, _pass3);
-            var expectedQuality = QualityParser.ParseQuality(_videoFiles.Single());
-
-            var result = Subject.GetImportDecisions(_videoFiles, _series, null, new ParsedEpisodeInfo{Quality = new QualityModel(Quality.SDTV)}, true);
-
-            result.Single().LocalEpisode.Quality.Should().Be(expectedQuality);
-        }
-
-        [Test]
-        public void should_use_folder_quality_when_file_quality_was_determined_by_the_extension()
-        {
-            GivenSpecifications(_pass1, _pass2, _pass3);
-            GivenVideoFiles(new string[] { @"C:\Test\Unsorted\The.Office.S03E115.mkv".AsOsAgnostic() });
-
-            _localEpisode.Path = _videoFiles.Single();
-            _localEpisode.Quality.QualitySource = QualitySource.Extension;
-            _localEpisode.Quality.Quality = Quality.HDTV720p;
-
-            var expectedQuality = new QualityModel(Quality.SDTV);
-
-            var result = Subject.GetImportDecisions(_videoFiles, _series, null, new ParsedEpisodeInfo { Quality = expectedQuality }, true);
-
-            result.Single().LocalEpisode.Quality.Should().Be(expectedQuality);
-        }
-
-        [Test]
-        public void should_use_folder_quality_when_greater_than_file_quality()
-        {
-            GivenSpecifications(_pass1, _pass2, _pass3);
-            GivenVideoFiles(new string[] { @"C:\Test\Unsorted\The.Office.S03E115.mkv".AsOsAgnostic() });
-
-            _localEpisode.Path = _videoFiles.Single();
-            _localEpisode.Quality.Quality = Quality.HDTV720p;
-
-            var expectedQuality = new QualityModel(Quality.Bluray720p);
-
-            var result = Subject.GetImportDecisions(_videoFiles, _series, null, new ParsedEpisodeInfo { Quality = expectedQuality }, true);
-
-            result.Single().LocalEpisode.Quality.Should().Be(expectedQuality);
         }
 
         [Test]
         public void should_not_throw_if_episodes_are_not_found()
         {
             GivenSpecifications(_pass1);
-
-            Mocker.GetMock<IParsingService>()
-                  .Setup(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()))
-                  .Returns(new LocalEpisode() { Path = "test" });
 
             _videoFiles = new List<string>
                 {
@@ -244,162 +194,18 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
 
             var decisions = Subject.GetImportDecisions(_videoFiles, _series);
 
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()), Times.Exactly(_videoFiles.Count));
+            Mocker.GetMock<IAugmentingService>()
+                  .Verify(c => c.Augment(It.IsAny<LocalEpisode>(), It.IsAny<bool>()), Times.Exactly(_videoFiles.Count));
 
             decisions.Should().HaveCount(3);
             decisions.First().Rejections.Should().NotBeEmpty();
         }
 
         [Test]
-        public void should_not_use_folder_for_full_season()
-        {
-            var videoFiles = new[]
-                             {
-                                 @"C:\Test\Unsorted\Series.Title.S01\S01E01.mkv".AsOsAgnostic(),
-                                 @"C:\Test\Unsorted\Series.Title.S01\S01E02.mkv".AsOsAgnostic(),
-                                 @"C:\Test\Unsorted\Series.Title.S01\S01E03.mkv".AsOsAgnostic()
-                             };
-
-            GivenSpecifications(_pass1);
-            GivenVideoFiles(videoFiles);
-
-            var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01");
-
-            Subject.GetImportDecisions(_videoFiles, _series, null, folderInfo, true);
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), null, true), Times.Exactly(3));
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.Is<ParsedEpisodeInfo>(p => p != null), true), Times.Never());
-        }
-
-        [Test]
-        public void should_not_use_folder_when_it_contains_more_than_one_valid_video_file()
-        {
-            var videoFiles = new[]
-                             {
-                                 @"C:\Test\Unsorted\Series.Title.S01E01\S01E01.mkv".AsOsAgnostic(),
-                                 @"C:\Test\Unsorted\Series.Title.S01E01\1x01.mkv".AsOsAgnostic()
-                             };
-
-            GivenSpecifications(_pass1);
-            GivenVideoFiles(videoFiles);
-
-            var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
-
-            Subject.GetImportDecisions(_videoFiles, _series, null, folderInfo, true);
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), null, true), Times.Exactly(2));
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.Is<ParsedEpisodeInfo>(p => p != null), true), Times.Never());
-        }
-
-        [Test]
-        public void should_use_folder_when_only_one_video_file()
-        {
-            var videoFiles = new[]
-                             {
-                                 @"C:\Test\Unsorted\Series.Title.S01E01\S01E01.mkv".AsOsAgnostic()
-                             };
-
-            GivenSpecifications(_pass1);
-            GivenVideoFiles(videoFiles);
-
-            var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
-
-            Subject.GetImportDecisions(_videoFiles, _series, null, folderInfo, true);
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), true), Times.Exactly(1));
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), null, true), Times.Never());
-        }
-
-        [Test]
-        public void should_use_folder_when_only_one_video_file_and_a_sample()
-        {
-            var videoFiles = new[]
-                             {
-                                 @"C:\Test\Unsorted\Series.Title.S01E01\S01E01.mkv".AsOsAgnostic(),
-                                 @"C:\Test\Unsorted\Series.Title.S01E01\S01E01.sample.mkv".AsOsAgnostic()
-                             };
-
-            GivenSpecifications(_pass1);
-            GivenVideoFiles(videoFiles.ToList());
-
-            Mocker.GetMock<IDetectSample>()
-                  .Setup(s => s.IsSample(_series, It.IsAny<string>(), It.IsAny<bool>()))
-                  .Returns((Series s, string path, bool special) =>
-                  {
-                      if (path.Contains("sample"))
-                      {
-                          return DetectSampleResult.Sample;
-                      }
-
-                      return DetectSampleResult.NotSample;
-                  });
-
-            var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01E01");
-
-            Subject.GetImportDecisions(_videoFiles, _series, null, folderInfo, true);
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), true), Times.Exactly(2));
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), null, true), Times.Never());
-        }
-
-        [Test]
-        public void should_not_use_folder_name_if_file_name_is_scene_name()
-        {
-            var videoFiles = new[]
-                             {
-                                 @"C:\Test\Unsorted\Series.Title.S01E01.720p.HDTV-LOL\Series.Title.S01E01.720p.HDTV-LOL.mkv".AsOsAgnostic()
-                             };
-
-            GivenSpecifications(_pass1);
-            GivenVideoFiles(videoFiles);
-
-            var folderInfo = Parser.Parser.ParseTitle("Series.Title.S01E01.720p.HDTV-LOL");
-
-            Subject.GetImportDecisions(_videoFiles, _series, null, folderInfo, true);
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), null, true), Times.Exactly(1));
-
-            Mocker.GetMock<IParsingService>()
-                  .Verify(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.Is<ParsedEpisodeInfo>(p => p != null), true), Times.Never());
-        }
-
-        [Test]
-        public void should_not_use_folder_quality_when_it_is_unknown()
-        {
-            GivenSpecifications(_pass1, _pass2, _pass3);
-
-            _series.Profile = new Profile
-                              {
-                                  Items = Qualities.QualityFixture.GetDefaultQualities(Quality.DVD, Quality.Unknown)
-                              };
-
-
-            var folderQuality = new QualityModel(Quality.Unknown);
-
-            var result = Subject.GetImportDecisions(_videoFiles, _series, null, new ParsedEpisodeInfo { Quality = folderQuality}, true);
-
-            result.Single().LocalEpisode.Quality.Should().Be(_quality);
-        }
-
-        [Test]
         public void should_return_a_decision_when_exception_is_caught()
         {
-            Mocker.GetMock<IParsingService>()
-                  .Setup(c => c.GetLocalEpisode(It.IsAny<string>(), It.IsAny<Series>(), It.IsAny<ParsedEpisodeInfo>(), It.IsAny<bool>()))
+            Mocker.GetMock<IAugmentingService>()
+                  .Setup(c => c.Augment(It.IsAny<LocalEpisode>(), It.IsAny<bool>()))
                   .Throws<TestException>();
 
             _videoFiles = new List<string>

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -283,6 +283,8 @@
     <Compile Include="MediaFiles\DownloadedEpisodesCommandServiceFixture.cs" />
     <Compile Include="MediaFiles\DownloadedEpisodesImportServiceFixture.cs" />
     <Compile Include="MediaFiles\EpisodeFileMovingServiceTests\MoveEpisodeFileFixture.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\Augmenters\AugmentingServiceFixture.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\Augmenters\AugmentQualityFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ImportDecisionMakerFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\DetectSampleFixture.cs" />
     <Compile Include="MediaFiles\EpisodeImport\Specifications\FreeSpaceSpecificationFixture.cs" />

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Test.ParserTests
         public void should_parse_quality_from_extension(string title)
         {
             Parser.Parser.ParseTitle(title).Quality.Quality.Should().NotBe(Quality.Unknown);
-            Parser.Parser.ParseTitle(title).Quality.QualitySource.Should().Be(QualitySource.Extension);
+            Parser.Parser.ParseTitle(title).Quality.QualityDetectionSource.Should().Be(QualityDetectionSource.Extension);
         }
 
 

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -272,7 +272,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("White.Van.Man.2011.S02E01.WS.PDTV.x264-REPACK-TLA")]
         public void should_parse_quality_from_name(string title)
         {
-            QualityParser.ParseQuality(title).QualitySource.Should().Be(QualitySource.Name);
+            QualityParser.ParseQuality(title).QualityDetectionSource.Should().Be(QualityDetectionSource.Name);
         }
 
         [TestCase("Revolution.S01E02.Chained.Heat.mkv")]
@@ -281,7 +281,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[CR] Sailor Moon - 004 [48CE2D0F].avi")]
         public void should_parse_quality_from_extension(string title)
         {
-            QualityParser.ParseQuality(title).QualitySource.Should().Be(QualitySource.Extension);
+            QualityParser.ParseQuality(title).QualityDetectionSource.Should().Be(QualityDetectionSource.Extension);
         }
 
         private void ParseAndVerifyQuality(string title, Quality quality, bool proper)

--- a/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
@@ -6,7 +6,9 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Extras.Files;
 using NzbDrone.Core.Extras.Metadata.Files;
 using NzbDrone.Core.Extras.Subtitles;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Extras.Metadata
@@ -14,18 +16,18 @@ namespace NzbDrone.Core.Extras.Metadata
     public class ExistingMetadataImporter : ImportExistingExtraFilesBase<MetadataFile>
     {
         private readonly IExtraFileService<MetadataFile> _metadataFileService;
-        private readonly IParsingService _parsingService;
+        private readonly IAugmentingService _augmentingService;
         private readonly Logger _logger;
         private readonly List<IMetadata> _consumers;
 
         public ExistingMetadataImporter(IExtraFileService<MetadataFile> metadataFileService,
                                         IEnumerable<IMetadata> consumers,
-                                        IParsingService parsingService,
+                                        IAugmentingService augmentingService,
                                         Logger logger)
         : base(metadataFileService)
         {
             _metadataFileService = metadataFileService;
-            _parsingService = parsingService;
+            _augmentingService = augmentingService;
             _logger = logger;
             _consumers = consumers.ToList();
         }
@@ -60,9 +62,18 @@ namespace NzbDrone.Core.Extras.Metadata
                     if (metadata.Type == MetadataType.EpisodeImage ||
                         metadata.Type == MetadataType.EpisodeMetadata)
                     {
-                        var localEpisode = _parsingService.GetLocalEpisode(possibleMetadataFile, series);
+                        var localEpisode = new LocalEpisode
+                        {
+                            FileEpisodeInfo = Parser.Parser.ParsePath(possibleMetadataFile),
+                            Series = series,
+                            Path = possibleMetadataFile
+                        };
 
-                        if (localEpisode == null)
+                        try
+                        {
+                            _augmentingService.Augment(localEpisode, false);
+                        }
+                        catch (AugmentingFailedException ex)
                         {
                             _logger.Debug("Unable to parse extra file: {0}", possibleMetadataFile);
                             continue;

--- a/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
+++ b/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
@@ -1,10 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Extras.Files;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Extras.Others
@@ -12,16 +16,16 @@ namespace NzbDrone.Core.Extras.Others
     public class ExistingOtherExtraImporter : ImportExistingExtraFilesBase<OtherExtraFile>
     {
         private readonly IExtraFileService<OtherExtraFile> _otherExtraFileService;
-        private readonly IParsingService _parsingService;
+        private readonly IAugmentingService _augmentingService;
         private readonly Logger _logger;
 
         public ExistingOtherExtraImporter(IExtraFileService<OtherExtraFile> otherExtraFileService,
-                                          IParsingService parsingService,
+                                          IAugmentingService augmentingService,
                                           Logger logger)
             : base(otherExtraFileService)
         {
             _otherExtraFileService = otherExtraFileService;
-            _parsingService = parsingService;
+            _augmentingService = augmentingService;
             _logger = logger;
         }
 
@@ -44,9 +48,18 @@ namespace NzbDrone.Core.Extras.Others
                     continue;
                 }
 
-                var localEpisode = _parsingService.GetLocalEpisode(possibleExtraFile, series);
+                var localEpisode = new LocalEpisode
+                                   {
+                                       FileEpisodeInfo = Parser.Parser.ParsePath(possibleExtraFile),
+                                       Series = series,
+                                       Path = possibleExtraFile
+                                   };
 
-                if (localEpisode == null)
+                try
+                {
+                    _augmentingService.Augment(localEpisode, false);
+                }
+                catch (AugmentingFailedException ex)
                 {
                     _logger.Debug("Unable to parse extra file: {0}", possibleExtraFile);
                     continue;

--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Extras.Files;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Extras.Subtitles
@@ -12,16 +14,16 @@ namespace NzbDrone.Core.Extras.Subtitles
     public class ExistingSubtitleImporter : ImportExistingExtraFilesBase<SubtitleFile>
     {
         private readonly IExtraFileService<SubtitleFile> _subtitleFileService;
-        private readonly IParsingService _parsingService;
+        private readonly IAugmentingService _augmentingService;
         private readonly Logger _logger;
 
         public ExistingSubtitleImporter(IExtraFileService<SubtitleFile> subtitleFileService,
-                                        IParsingService parsingService,
+                                        IAugmentingService augmentingService,
                                         Logger logger)
             : base (subtitleFileService)
         {
             _subtitleFileService = subtitleFileService;
-            _parsingService = parsingService;
+            _augmentingService = augmentingService;
             _logger = logger;
         }
 
@@ -40,11 +42,20 @@ namespace NzbDrone.Core.Extras.Subtitles
 
                 if (SubtitleFileExtensions.Extensions.Contains(extension))
                 {
-                    var localEpisode = _parsingService.GetLocalEpisode(possibleSubtitleFile, series);
-
-                    if (localEpisode == null)
+                    var localEpisode = new LocalEpisode
                     {
-                        _logger.Debug("Unable to parse subtitle file: {0}", possibleSubtitleFile);
+                        FileEpisodeInfo = Parser.Parser.ParsePath(possibleSubtitleFile),
+                        Series = series,
+                        Path = possibleSubtitleFile
+                    };
+
+                    try
+                    {
+                        _augmentingService.Augment(localEpisode, false);
+                    }
+                    catch (AugmentingFailedException ex)
+                    {
+                        _logger.Debug("Unable to parse extra file: {0}", possibleSubtitleFile);
                         continue;
                     }
 

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -156,14 +156,7 @@ namespace NzbDrone.Core.MediaFiles
                 return new List<ImportResult>();
             }
 
-            var cleanedUpName = GetCleanedUpFolderName(directoryInfo.Name);
             var folderInfo = Parser.Parser.ParseTitle(directoryInfo.Name);
-
-            if (folderInfo != null)
-            {
-                _logger.Debug("{0} folder quality: {1}", cleanedUpName, folderInfo.Quality);
-            }
-
             var videoFiles = _diskScanService.FilterFiles(directoryInfo.FullName, _diskScanService.GetVideoFiles(directoryInfo.FullName));
 
             if (downloadClientItem == null)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentEpisodes.cs
@@ -1,0 +1,22 @@
+﻿using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters
+{
+    public class AugmentEpisodes : IAugmentLocalEpisode
+    {
+        private readonly IParsingService _parsingService;
+
+        public AugmentEpisodes(IParsingService parsingService)
+        {
+            _parsingService = parsingService;
+        }
+
+        public LocalEpisode Augment(LocalEpisode localEpisode, bool otherFiles)
+        {
+            localEpisode.Episodes = _parsingService.GetEpisodes(localEpisode.ParsedEpisodeInfo, localEpisode.Series, localEpisode.SceneSource);
+
+            return localEpisode;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentQuality.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/AugmentQuality.cs
@@ -1,0 +1,145 @@
+﻿using NLog;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters
+{
+    public class AugmentQuality : IAugmentLocalEpisode
+    {
+        private readonly Logger _logger;
+
+        public AugmentQuality(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public LocalEpisode Augment(LocalEpisode localEpisode, bool otherFiles)
+        {
+            if (localEpisode.FileEpisodeInfo == null)
+            {
+                return localEpisode;
+            }
+
+            var series = localEpisode.Series;
+            var quality = localEpisode.FileEpisodeInfo.Quality;
+            var downloadClientItemQuality = localEpisode.DownloadClientEpisodeInfo?.Quality;
+            var folderQuality = localEpisode.FolderEpisodeInfo?.Quality;
+
+            if (UseOtherQuality(series, quality, downloadClientItemQuality))
+            {
+                _logger.Debug("Using quality: {0} from download client item instead of file quality: {1} ", downloadClientItemQuality, quality);
+                quality = downloadClientItemQuality;
+            }
+            else if (UseOtherQuality(series, quality, folderQuality))
+            {
+                _logger.Debug("Using quality: {0} from folder instead of file quality: {1} ", folderQuality, quality);
+                quality = folderQuality;
+            }
+
+            // Alter the detected quality based on the media info (if available)
+            quality = GetQualityFromMediaInfo(quality, localEpisode.MediaInfo);
+
+            _logger.Debug("Using quality: {0}", quality);
+
+            localEpisode.Quality = quality;
+
+            return localEpisode;
+        }
+
+        private bool UseOtherQuality(Series series, QualityModel fileQuality, QualityModel otherQuality)
+        {
+            if (otherQuality == null)
+            {
+                return false;
+            }
+
+            if (otherQuality.Quality == Quality.Unknown)
+            {
+                return false;
+            }
+
+            if (fileQuality.QualityDetectionSource == QualityDetectionSource.Extension)
+            {
+                return true;
+            }
+
+            if (new QualityModelComparer(series.Profile).Compare(otherQuality, fileQuality) > 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private QualityModel GetQualityFromMediaInfo(QualityModel quality, MediaInfoModel mediaInfo)
+        {
+            if (mediaInfo == null)
+            {
+                return quality;
+            }
+
+            var width = mediaInfo.Width;
+            Quality newQuality = null;
+
+            if (width > 1920)
+            {
+                if (quality.QualitySource == QualitySource.Bluray)
+                {
+                    newQuality = Quality.Bluray2160p;
+                }
+                else if (quality.QualitySource == QualitySource.Web)
+                {
+                    newQuality = Quality.WEBDL2160p;
+                }
+                else if (quality.QualitySource == QualitySource.Television)
+                {
+                    newQuality = Quality.HDTV2160p;
+                }
+            }
+            else if (width > 1280)
+            {
+                if (quality.QualitySource == QualitySource.Bluray)
+                {
+                    newQuality = Quality.Bluray1080p;
+                }
+                else if (quality.QualitySource == QualitySource.Web)
+                {
+                    newQuality = Quality.WEBDL1080p;
+                }
+                else if (quality.QualitySource == QualitySource.Television)
+                {
+                    newQuality = Quality.HDTV1080p;
+                }
+            }
+            else if (width > 854)
+            {
+                if (quality.QualitySource == QualitySource.Bluray)
+                {
+                    newQuality = Quality.Bluray720p;
+                }
+                else if (quality.QualitySource == QualitySource.Web)
+                {
+                    newQuality = Quality.WEBDL720p;
+                }
+                else if (quality.QualitySource == QualitySource.Television)
+                {
+                    newQuality = Quality.HDTV720p;
+                }
+            }
+
+            if (newQuality != null && quality.Quality != newQuality)
+            {
+                _logger.Debug("Quality ({0}) differs from the parsed quality ({1})", newQuality, quality.Quality);
+
+                var newQualityModel = new QualityModel(newQuality, quality.Revision);
+                newQualityModel.QualityDetectionSource = QualityDetectionSource.MediaInfo;
+
+                return newQualityModel;
+            }
+
+            return quality;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/IAugmentLocalEpisode.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/Augmenters/IAugmentLocalEpisode.cs
@@ -1,0 +1,9 @@
+﻿using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters
+{
+    public interface IAugmentLocalEpisode
+    {
+        LocalEpisode Augment(LocalEpisode localEpisode, bool otherFiles);
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/AugmentingFailedException.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/AugmentingFailedException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using NzbDrone.Common.Exceptions;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting
+{
+    public class AugmentingFailedException : NzbDroneException
+    {
+        public AugmentingFailedException(string message, params object[] args) : base(message, args)
+        {
+        }
+
+        public AugmentingFailedException(string message) : base(message)
+        {
+        }
+
+        public AugmentingFailedException(string message, Exception innerException, params object[] args) : base(message, innerException, args)
+        {
+        }
+
+        public AugmentingFailedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/AugmentingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Augmenting/AugmentingService.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting.Augmenters;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting
+{
+    public interface IAugmentingService
+    {
+        LocalEpisode Augment(LocalEpisode localEpisode, bool otherFiles);
+    }
+
+    public class AugmentingService : IAugmentingService
+    {
+        private readonly IEnumerable<IAugmentLocalEpisode> _augmenters;
+        private readonly IParsingService _parsingService;
+        private readonly IDiskProvider _diskProvider;
+        private readonly IVideoFileInfoReader _videoFileInfoReader;
+        private readonly Logger _logger;
+
+        public AugmentingService(IEnumerable<IAugmentLocalEpisode> augmenters,
+                                 IParsingService parsingService,
+                                 IDiskProvider diskProvider,
+                                 IVideoFileInfoReader videoFileInfoReader,
+                                 Logger logger)
+        {
+            _augmenters = augmenters;
+            _parsingService = parsingService;
+            _diskProvider = diskProvider;
+            _videoFileInfoReader = videoFileInfoReader;
+            _logger = logger;
+        }
+
+        public LocalEpisode Augment(LocalEpisode localEpisode, bool otherFiles)
+        {
+            localEpisode.ParsedEpisodeInfo = GetBestEpisodeInfo(localEpisode, otherFiles);
+
+            if (localEpisode.ParsedEpisodeInfo == null)
+            {
+                if (MediaFileExtensions.Extensions.Contains(Path.GetExtension(localEpisode.Path)))
+                {
+                    throw new AugmentingFailedException("Unable to parse episode info from path: {0}", localEpisode.Path);
+                }
+            }
+
+            localEpisode.Size = _diskProvider.GetFileSize(localEpisode.Path);
+            localEpisode.MediaInfo = _videoFileInfoReader.GetMediaInfo(localEpisode.Path);
+
+            foreach (var augmenter in _augmenters)
+            {
+                try
+                {
+                    augmenter.Augment(localEpisode, otherFiles);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, ex.Message);
+                }
+            }
+
+            return localEpisode;
+        }
+
+        private ParsedEpisodeInfo GetBestEpisodeInfo(LocalEpisode localEpisode, bool otherFiles)
+        {
+            var parsedEpisodeInfo = localEpisode.FileEpisodeInfo;
+            var downloadClientEpisodeInfo = localEpisode.DownloadClientEpisodeInfo;
+            var folderEpisodeInfo = localEpisode.FolderEpisodeInfo;
+
+            if (!otherFiles && !SceneChecker.IsSceneTitle(Path.GetFileNameWithoutExtension(localEpisode.Path)))
+            {
+                if (downloadClientEpisodeInfo != null && !downloadClientEpisodeInfo.FullSeason)
+                {
+                    parsedEpisodeInfo = localEpisode.DownloadClientEpisodeInfo;
+                }
+                else if (folderEpisodeInfo != null && !folderEpisodeInfo.FullSeason)
+                {
+                    parsedEpisodeInfo = localEpisode.FolderEpisodeInfo;
+                }
+            }
+
+            if (parsedEpisodeInfo == null || parsedEpisodeInfo.IsPossibleSpecialEpisode)
+            {
+                var title = Path.GetFileNameWithoutExtension(localEpisode.Path);
+                var specialEpisodeInfo = _parsingService.ParseSpecialEpisodeTitle(title, localEpisode.Series);
+
+                return specialEpisodeInfo;
+            }
+
+            return parsedEpisodeInfo;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -44,6 +44,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                 return DetectSampleResult.NotSample;
             }
 
+            // TODO: Use MediaInfo from the import process, no need to re-process the file again here
             var runTime = _videoFileInfoReader.GetRunTime(path);
 
             if (!runTime.HasValue)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -7,12 +7,9 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
-using NzbDrone.Core.Parser;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Augmenting;
 using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
-using NzbDrone.Core.MediaFiles.MediaInfo;
-
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
@@ -25,26 +22,23 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
     public class ImportDecisionMaker : IMakeImportDecision
     {
         private readonly IEnumerable<IImportDecisionEngineSpecification> _specifications;
-        private readonly IParsingService _parsingService;
         private readonly IMediaFileService _mediaFileService;
+        private readonly IAugmentingService _augmentingService;
         private readonly IDiskProvider _diskProvider;
-        private readonly IVideoFileInfoReader _videoFileInfoReader;
         private readonly IDetectSample _detectSample;
         private readonly Logger _logger;
 
         public ImportDecisionMaker(IEnumerable<IImportDecisionEngineSpecification> specifications,
-                                   IParsingService parsingService,
                                    IMediaFileService mediaFileService,
+                                   IAugmentingService augmentingService,
                                    IDiskProvider diskProvider,
-                                   IVideoFileInfoReader videoFileInfoReader,
                                    IDetectSample detectSample,
                                    Logger logger)
         {
             _specifications = specifications;
-            _parsingService = parsingService;
             _mediaFileService = mediaFileService;
+            _augmentingService = augmentingService;
             _diskProvider = diskProvider;
-            _videoFileInfoReader = videoFileInfoReader;
             _detectSample = detectSample;
             _logger = logger;
         }
@@ -60,61 +54,62 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
             _logger.Debug("Analyzing {0}/{1} files.", newFiles.Count, videoFiles.Count());
 
-            var shouldUseFolderName = ShouldUseFolderName(videoFiles, series, folderInfo);
+            ParsedEpisodeInfo downloadClientItemInfo = null;
+
+            if (downloadClientItem != null)
+            {
+                downloadClientItemInfo = Parser.Parser.ParseTitle(downloadClientItem.Title);
+            }
+
+            var nonSampleVideoFileCount = NonSampleVideoFileCount(newFiles, series, downloadClientItemInfo, folderInfo);
+
             var decisions = new List<ImportDecision>();
 
             foreach (var file in newFiles)
             {
-                decisions.AddIfNotNull(GetDecision(file, series, downloadClientItem, folderInfo, sceneSource, shouldUseFolderName));
+                decisions.AddIfNotNull(GetDecision(file, series, downloadClientItem, downloadClientItemInfo, folderInfo, nonSampleVideoFileCount > 1, sceneSource));
             }
 
             return decisions;
         }
 
-        private ImportDecision GetDecision(string file, Series series, DownloadClientItem downloadClientItem, ParsedEpisodeInfo folderInfo, bool sceneSource, bool shouldUseFolderName)
+        private ImportDecision GetDecision(string file, Series series, DownloadClientItem downloadClientItem, ParsedEpisodeInfo downloadClientEpisodeInfo, ParsedEpisodeInfo folderEpisodeInfo, bool otherFiles, bool sceneSource)
         {
             ImportDecision decision = null;
 
+            var fileEpisodeInfo = Parser.Parser.ParsePath(file);
+            var localEpisode = new LocalEpisode
+                               {
+                                   Series = series,
+                                   FileEpisodeInfo = fileEpisodeInfo,
+                                   DownloadClientEpisodeInfo = downloadClientEpisodeInfo,
+                                   FolderEpisodeInfo = folderEpisodeInfo,
+                                   Path = file,
+                                   Size = _diskProvider.GetFileSize(file),
+                                   SceneSource = sceneSource
+                               };
+
             try
             {
-                var localEpisode = _parsingService.GetLocalEpisode(file, series, shouldUseFolderName ? folderInfo : null, sceneSource);
+                _augmentingService.Augment(localEpisode, otherFiles);
 
-                if (localEpisode != null)
+                if (localEpisode.Episodes.Empty())
                 {
-                    localEpisode.Quality = GetQuality(folderInfo, localEpisode.Quality, series);
-                    localEpisode.Size = _diskProvider.GetFileSize(file);
-
-                    _logger.Debug("Size: {0}", localEpisode.Size);
-
-                    //TODO: make it so media info doesn't ruin the import process of a new series
-                    if (sceneSource)
-                    {
-                        localEpisode.MediaInfo = _videoFileInfoReader.GetMediaInfo(file);
-                    }
-
-                    if (localEpisode.Episodes.Empty())
-                    {
-                        decision = new ImportDecision(localEpisode, new Rejection("Invalid season or episode"));
-                    }
-                    else
-                    {
-                        decision = GetDecision(localEpisode, downloadClientItem);
-                    }
+                    decision = new ImportDecision(localEpisode, new Rejection("Invalid season or episode"));
                 }
-
                 else
                 {
-                    localEpisode = new LocalEpisode();
-                    localEpisode.Path = file;
-
-                    decision = new ImportDecision(localEpisode, new Rejection("Unable to parse file"));
+                    decision = GetDecision(localEpisode, downloadClientItem);
                 }
             }
-            catch (Exception e)
+            catch (AugmentingFailedException)
             {
-                _logger.Error(e, "Couldn't import file. {0}", file);
+                decision = new ImportDecision(localEpisode, new Rejection("Unable to parse file"));
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Couldn't import file. {0}", file);
 
-                var localEpisode = new LocalEpisode { Path = file };
                 decision = new ImportDecision(localEpisode, new Rejection("Unexpected error processing file"));
             }
 
@@ -156,70 +151,23 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             return null;
         }
 
-        private bool ShouldUseFolderName(List<string> videoFiles, Series series, ParsedEpisodeInfo folderInfo)
+        private int NonSampleVideoFileCount(List<string> videoFiles, Series series, ParsedEpisodeInfo downloadClientItemInfo, ParsedEpisodeInfo folderInfo)
         {
-            if (folderInfo == null)
-            {
-                return false;
-            }
-
-            if (folderInfo.FullSeason)
-            {
-                return false;
-            }
+            var isPossibleSpecialEpisode = downloadClientItemInfo?.IsPossibleSpecialEpisode ?? false;
+            // If we might already have a special, don't try to get it from the folder info.
+            isPossibleSpecialEpisode = isPossibleSpecialEpisode || (folderInfo?.IsPossibleSpecialEpisode ?? false);
 
             return videoFiles.Count(file =>
             {
-                var sample = _detectSample.IsSample(series, file, folderInfo.IsPossibleSpecialEpisode);
+                var sample = _detectSample.IsSample(series, file, isPossibleSpecialEpisode);
 
                 if (sample == DetectSampleResult.Sample)
                 {
                     return false;
                 }
 
-                if (SceneChecker.IsSceneTitle(Path.GetFileName(file)))
-                {
-                    return false;
-                }
-
                 return true;
-            }) == 1;
-        }
-
-        private QualityModel GetQuality(ParsedEpisodeInfo folderInfo, QualityModel fileQuality, Series series)
-        {
-            if (UseFolderQuality(folderInfo, fileQuality, series))
-            {
-                _logger.Debug("Using quality from folder: {0}", folderInfo.Quality);
-                return folderInfo.Quality;
-            }
-
-            return fileQuality;
-        }
-
-        private bool UseFolderQuality(ParsedEpisodeInfo folderInfo, QualityModel fileQuality, Series series)
-        {
-            if (folderInfo == null)
-            {
-                return false;
-            }
-
-            if (folderInfo.Quality.Quality == Quality.Unknown)
-            {
-                return false;
-            }
-
-            if (fileQuality.QualitySource == QualitySource.Extension)
-            {
-                return true;
-            }
-
-            if (new QualityModelComparer(series.Profile).Compare(folderInfo.Quality, fileQuality) > 0)
-            {
-                return true;
-            }
-
-            return false;
+            });
         }
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -750,7 +750,12 @@
     <Compile Include="MediaFiles\Commands\BackendCommandAttribute.cs" />
     <Compile Include="MediaFiles\Commands\CleanUpRecycleBinCommand.cs" />
     <Compile Include="MediaFiles\Commands\DownloadedEpisodesScanCommand.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\Augmenters\AugmentEpisodes.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\Augmenters\AugmentQuality.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\Augmenters\IAugmentLocalEpisode.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\AugmentingService.cs" />
     <Compile Include="MediaFiles\EpisodeImport\DetectSampleResult.cs" />
+    <Compile Include="MediaFiles\EpisodeImport\Augmenting\AugmentingFailedException.cs" />
     <Compile Include="MediaFiles\EpisodeImport\ImportMode.cs" />
     <Compile Include="MediaFiles\Commands\RenameFilesCommand.cs" />
     <Compile Include="MediaFiles\Commands\RenameSeriesCommand.cs" />
@@ -935,6 +940,7 @@
     <Compile Include="Profiles\Delay\DelayProfileTagInUseValidator.cs" />
     <Compile Include="Profiles\ProfileRepository.cs" />
     <Compile Include="ProgressMessaging\ProgressMessageContext.cs" />
+    <Compile Include="Qualities\QualityDetectionSource.cs" />
     <Compile Include="Qualities\QualitySource.cs" />
     <Compile Include="Qualities\Revision.cs" />
     <Compile Include="RemotePathMappings\RemotePathMapping.cs" />

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Collections.Generic;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
@@ -16,11 +16,15 @@ namespace NzbDrone.Core.Parser.Model
         public string Path { get; set; }
         public long Size { get; set; }
         public ParsedEpisodeInfo ParsedEpisodeInfo { get; set; }
+        public ParsedEpisodeInfo FileEpisodeInfo { get; set; }
+        public ParsedEpisodeInfo DownloadClientEpisodeInfo { get; set; }
+        public ParsedEpisodeInfo FolderEpisodeInfo { get; set; }
         public Series Series { get; set; }
         public List<Episode> Episodes { get; set; }
         public QualityModel Quality { get; set; }
         public MediaInfoModel MediaInfo { get; set; }
         public bool ExistingFile { get; set; }
+        public bool SceneSource { get; set; }
         
         public int SeasonNumber 
         { 

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -304,7 +304,7 @@ namespace NzbDrone.Core.Parser
                 try
                 {
                     result.Quality = MediaFileExtensions.GetQualityForExtension(Path.GetExtension(name));
-                    result.QualitySource = QualitySource.Extension;
+                    result.QualityDetectionSource = QualityDetectionSource.Extension;
                 }
                 catch (ArgumentException)
                 {

--- a/src/NzbDrone.Core/Qualities/QualityDetectionSource.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDetectionSource.cs
@@ -1,0 +1,9 @@
+﻿namespace NzbDrone.Core.Qualities
+{
+    public enum QualityDetectionSource
+    {
+        Name,
+        Extension,
+        MediaInfo
+    }
+}

--- a/src/NzbDrone.Core/Qualities/QualityModel.cs
+++ b/src/NzbDrone.Core/Qualities/QualityModel.cs
@@ -10,7 +10,36 @@ namespace NzbDrone.Core.Qualities
         public Revision Revision { get; set; }
 
         [JsonIgnore]
-        public QualitySource QualitySource { get; set; }
+        public QualityDetectionSource QualityDetectionSource { get; set; }
+
+        [JsonIgnore]
+        public QualitySource QualitySource
+        {
+            get
+            {
+                if (Quality == Quality.Bluray2160p || Quality == Quality.Bluray1080p || Quality == Quality.Bluray720p)
+                {
+                    return QualitySource.Bluray;
+                }
+
+                if (Quality == Quality.WEBDL2160p || Quality == Quality.WEBDL1080p || Quality == Quality.WEBDL720p || Quality == Quality.WEBDL480p)
+                {
+                    return QualitySource.Web;
+                }
+
+                if (Quality == Quality.DVD)
+                {
+                    return QualitySource.DVD;
+                }
+
+                if (Quality == Quality.RAWHD || Quality == Quality.HDTV2160p || Quality == Quality.HDTV1080p || Quality == Quality.HDTV720p || Quality == Quality.SDTV)
+                {
+                    return QualitySource.Television;
+                }
+
+                return QualitySource.Unknown;
+            }
+        }
         
         public QualityModel()
             : this(Quality.Unknown, new Revision())

--- a/src/NzbDrone.Core/Qualities/QualitySource.cs
+++ b/src/NzbDrone.Core/Qualities/QualitySource.cs
@@ -2,8 +2,10 @@
 {
     public enum QualitySource
     {
-        Name,
-        Extension,
-        MediaInfo
+        Unknown = 0,
+        Television = 1,
+        Web = 2,
+        DVD = 3,
+        Bluray = 4
     }
 }


### PR DESCRIPTION
New: Use media info during import to extract resolution for quality

#### Database Migration
NO

#### Description
Removes some of the growth that was added to `ImportDecisionMaker` over the years and allows the quality to use the width from MediaInfo to manipulate the detected quality.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* #448
