### PR TITLE
Made date format options more descriptive

### DIFF
--- a/src/UI/Settings/UI/UiViewTemplate.hbs
+++ b/src/UI/Settings/UI/UiViewTemplate.hbs
@@ -22,10 +22,10 @@
 
             <div class="col-sm-4 col-sm-pull-1">
                 <select name="calendarWeekColumnHeader" class="form-control">
-                    <option value="ddd M/D">Tue 3/5</option>
-                    <option value="ddd MM/DD">Tue 03/05</option>
-                    <option value="ddd D/M">Tue 5/3</option>
-                    <option value="ddd DD/MM">Tue 05/03</option>
+                    <option value="ddd M/D">Tue 3/25</option>
+                    <option value="ddd MM/DD">Tue 03/25</option>
+                    <option value="ddd D/M">Tue 25/3</option>
+                    <option value="ddd DD/MM">Tue 25/03</option>
                 </select>
             </div>
         </div>
@@ -39,12 +39,12 @@
 
             <div class="col-sm-4">
                 <select name="shortDateFormat" class="form-control">
-                    <option value="MMM D YYYY">Mar 5 2014</option>
-                    <option value="DD MMM YYYY">05 Mar 2014</option>
-                    <option value="MM/D/YYYY">03/5/2014</option>
-                    <option value="MM/DD/YYYY">03/05/2014</option>
-                    <option value="DD/MM/YYYY">05/03/2014</option>
-                    <option value="YYYY-MM-DD">2014-03-05</option>
+                    <option value="MMM D YYYY">Mar 25 2014</option>
+                    <option value="DD MMM YYYY">25 Mar 2014</option>
+                    <option value="MM/D/YYYY">03/25/2014</option>
+                    <option value="MM/DD/YYYY">03/25/2014</option>
+                    <option value="DD/MM/YYYY">25/03/2014</option>
+                    <option value="YYYY-MM-DD">2014-03-25</option>
                 </select>
             </div>
         </div>
@@ -54,8 +54,8 @@
 
             <div class="col-sm-4">
                 <select name="longDateFormat" class="form-control">
-                    <option value="dddd, MMMM D YYYY">Tuesday, March 5, 2014</option>
-                    <option value="dddd, D MMMM YYYY">Tuesday, 5 March, 2014</option>
+                    <option value="dddd, MMMM D YYYY">Tuesday, March 25, 2014</option>
+                    <option value="dddd, D MMMM YYYY">Tuesday, 25 March, 2014</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since the day and month numbers were both lower than 12 you couldn't tell which was which.  
I changed the day number to 25 because it very obviously couldn't be a month number and has the added bonus of actually being a tuesday (that was actually a coincidence :D).
