### PR TITLE
Add default calendar name for iCal

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Ical.Net;
 using Ical.Net.DataTypes;
+using Ical.Net.General;
 using Ical.Net.Interfaces.Serialization;
 using Ical.Net.Serialization;
 using Ical.Net.Serialization.iCalendar.Factory;
@@ -91,6 +92,10 @@ namespace NzbDrone.Api.Calendar
             {
                 ProductId = "-//sonarr.tv//Sonarr//EN"
             };
+
+            var calendarName = "Sonarr TV Schedule";
+            calendar.AddProperty(new CalendarProperty("NAME", calendarName));
+            calendar.AddProperty(new CalendarProperty("X-WR-CALNAME", calendarName));
 
             foreach (var episode in episodes.OrderBy(v => v.AirDateUtc.Value))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Provides a default name for the Sonarr.ics when added as its own calendar to an application that supports iCal. I thought this would be better than using the long URL path which is currently used because nothing else is set.

It appears both the `NAME` and `X-WR-CALNAME` are used for this purpose, they are however both non-standard and not in the RFC, which is why they have to be added as properties.
