### PR TITLE
Change default port of uTorrent and qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public QBittorrentSettings()
         {
             Host = "localhost";
-            Port = 9091;
+            Port = 8080;
             TvCategory = "tv-sonarr";
         }
 

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         public UTorrentSettings()
         {
             Host = "localhost";
-            Port = 9091;
+            Port = 8080;
             TvCategory = "tv-sonarr";
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Changes the default port set when setting up uTorrent or qBittorrent as a download client.

* uTorrent sets `8080` as the alternative port WebUI port by default.
* qBittorrent uses `8080` as the default port.
