### PR TITLE
Mono: Try copying files with cp --reflink first.

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -190,7 +190,7 @@ namespace NzbDrone.Common.Disk
             File.Delete(path);
         }
 
-        public void CopyFile(string source, string destination, bool overwrite = false)
+        public virtual void CopyFile(string source, string destination, bool overwrite = false)
         {
             Ensure.That(source, () => source).IsValidPath();
             Ensure.That(destination, () => destination).IsValidPath();


### PR DESCRIPTION
#### Database Migration
No.

#### Description
This should save a bunch of space for people on compatible filesystems
(like Btrfs). `cp` with `--reflink=auto` will also just do a normal
copy of the file if reflinks aren't possible, so the fallback to the
base is more of a "just in case" than anything. A short (10s) timeout
is used if the source or destination mounts are network mounts, to avoid
cp hanging with network mounts where the server has gone down.

#### Issues Fixed or Closed by this PR

* Partial fix for #967 -- addresses https://github.com/Sonarr/Sonarr/issues/967#issuecomment-273346468, but not the overall issue.
