### PR TITLE
Add missing error check when adding a magnet link to deluge

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -35,6 +35,11 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         {
             var actualHash = _proxy.AddTorrentFromMagnet(magnetLink, Settings);
 
+            if (actualHash.IsNullOrWhiteSpace())
+            {
+                throw new DownloadClientException("Deluge failed to add magnet " + magenetLink);
+            }
+
             if (!Settings.TvCategory.IsNullOrWhiteSpace())
             {
                 _proxy.SetLabel(actualHash, Settings.TvCategory, Settings);

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             if (actualHash.IsNullOrWhiteSpace())
             {
-                throw new DownloadClientException("Deluge failed to add magnet " + magenetLink);
+                throw new DownloadClientException("Deluge failed to add magnet " + magnetLink);
             }
 
             if (!Settings.TvCategory.IsNullOrWhiteSpace())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add missing error check when adding a magnet link to deluge. The same error check is already present for adding from a file, just not a magnet.
