### PR TITLE
Mono internals does not properly copy/move symlinks

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -200,6 +200,11 @@ namespace NzbDrone.Common.Disk
                 throw new IOException(string.Format("Source and destination can't be the same {0}", source));
             }
 
+            CopyFileInternal(source, destination, overwrite);
+        }
+
+        protected virtual void CopyFileInternal(string source, string destination, bool overwrite = false)
+        {
             File.Copy(source, destination, overwrite);
         }
 
@@ -219,6 +224,11 @@ namespace NzbDrone.Common.Disk
             }
 
             RemoveReadOnly(source);
+            MoveFileInternal(source, destination);
+        }
+
+        protected virtual void MoveFileInternal(string source, string destination)
+        {
             File.Move(source, destination);
         }
 

--- a/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
+++ b/src/NzbDrone.Mono.Test/DiskProviderTests/DiskProviderFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using FluentAssertions;
 using Mono.Unix;
 using NUnit.Framework;
 using NzbDrone.Common.Test.DiskTests;
@@ -34,6 +36,56 @@ namespace NzbDrone.Mono.Test.DiskProviderTests
             {
                 entry.FileAccessPermissions &= ~(FileAccessPermissions.UserWrite | FileAccessPermissions.GroupWrite | FileAccessPermissions.OtherWrite);
             }
+        }
+
+        [Test]
+        public void should_move_symlink()
+        {
+            var tempFolder = GetTempFilePath();
+            Directory.CreateDirectory(tempFolder);
+
+            var file = Path.Combine(tempFolder, "target.txt");
+            var source = Path.Combine(tempFolder, "symlink_source.txt");
+            var destination = Path.Combine(tempFolder, "symlink_destination.txt");
+
+            File.WriteAllText(file, "Some content");
+
+            new UnixSymbolicLinkInfo(source).CreateSymbolicLinkTo(file);
+
+            Subject.MoveFile(source, destination);
+
+            File.Exists(file).Should().BeTrue();
+            File.Exists(source).Should().BeFalse();
+            File.Exists(destination).Should().BeTrue();
+            UnixFileSystemInfo.GetFileSystemEntry(destination).IsSymbolicLink.Should().BeTrue();
+
+            File.ReadAllText(destination).Should().Be("Some content");
+        }
+
+        [Test]
+        public void should_copy_symlink()
+        {
+            var tempFolder = GetTempFilePath();
+            Directory.CreateDirectory(tempFolder);
+
+            var file = Path.Combine(tempFolder, "target.txt");
+            var source = Path.Combine(tempFolder, "symlink_source.txt");
+            var destination = Path.Combine(tempFolder, "symlink_destination.txt");
+
+            File.WriteAllText(file, "Some content");
+
+            new UnixSymbolicLinkInfo(source).CreateSymbolicLinkTo(file);
+
+            Subject.CopyFile(source, destination);
+
+            File.Exists(file).Should().BeTrue();
+            File.Exists(source).Should().BeTrue();
+            File.Exists(destination).Should().BeTrue();
+            UnixFileSystemInfo.GetFileSystemEntry(source).IsSymbolicLink.Should().BeTrue();
+            UnixFileSystemInfo.GetFileSystemEntry(destination).IsSymbolicLink.Should().BeTrue();
+
+            File.ReadAllText(source).Should().Be("Some content");
+            File.ReadAllText(destination).Should().Be("Some content");
         }
     }
 }


### PR DESCRIPTION
Based on the IRC chat with Ingram.

Mono doesn't properly move/copy symlinks if they're not on the same filesystem. And instead copies the content.
This PR patches that logic in the DiskProvider. It should also properly handle relative symlinks.

I've also added a check in TryCreateHardlink so that it doesn't try hardlink a symlink, I don't think that would actually ever hardlink but better safe than sorry.

This should make some scenarios work better for the Move/hardlink/symlink issue that's been lingering.
