### PR TITLE
DownloadStation: Wrong status in enum

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixtrue.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixtrue.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NUnit.Framework;
+using NzbDrone.Core.Download.Clients.DownloadStation;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
+{
+    [TestFixture]
+    public class DownloadStationsTaskStatusJsonConverterFixtrue
+    {
+        [TestCase("captch_needed", DownloadStationTaskStatus.CaptchaNeeded)]
+        [TestCase("filehosting_waiting", DownloadStationTaskStatus.FileHostingWaiting)]
+        [TestCase("hash_checking", DownloadStationTaskStatus.HashChecking)]
+        [TestCase("error", DownloadStationTaskStatus.Error)]
+        [TestCase("downloading", DownloadStationTaskStatus.Downloading)]
+        public void should_parse_enum_correctly(string value, DownloadStationTaskStatus expected)
+        {
+            var task = @"{Status: '" + value + "'}";
+
+            var item = JsonConvert.DeserializeObject<DownloadStationTask>(task);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/DownloadStationsTaskStatusJsonConverterFixture.cs
@@ -1,14 +1,14 @@
-﻿using System;
+﻿using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using NzbDrone.Core.Download.Clients.DownloadStation;
-using Newtonsoft.Json;
 
 namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 {
     [TestFixture]
-    public class DownloadStationsTaskStatusJsonConverterFixtrue
+    public class DownloadStationsTaskStatusJsonConverterFixture
     {
-        [TestCase("captch_needed", DownloadStationTaskStatus.CaptchaNeeded)]
+        [TestCase("captcha_needed", DownloadStationTaskStatus.CaptchaNeeded)]
         [TestCase("filehosting_waiting", DownloadStationTaskStatus.FileHostingWaiting)]
         [TestCase("hash_checking", DownloadStationTaskStatus.HashChecking)]
         [TestCase("error", DownloadStationTaskStatus.Error)]
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
             var task = @"{Status: '" + value + "'}";
 
             var item = JsonConvert.DeserializeObject<DownloadStationTask>(task);
+
+            item.Status.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -604,11 +604,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.Hash_Checking, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.Captcha_Needed, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.CaptchaNeeded, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
         [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
-        [TestCase(DownloadStationTaskStatus.FileHosting_Waiting, DownloadItemStatus.Queued)]
+        [TestCase(DownloadStationTaskStatus.FileHostingWaiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -604,9 +604,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.Hash_Checking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.Captcha_Needed, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
         [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(DownloadStationTaskStatus.FileHosting_Waiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -413,8 +413,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.Hash_Checking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.Captcha_Needed, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
+        [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
+        [TestCase(DownloadStationTaskStatus.FileHosting_Waiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -413,11 +413,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         [TestCase(DownloadStationTaskStatus.Extracting, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Finished, DownloadItemStatus.Completed)]
         [TestCase(DownloadStationTaskStatus.Finishing, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.Hash_Checking, DownloadItemStatus.Downloading)]
-        [TestCase(DownloadStationTaskStatus.Captcha_Needed, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.HashChecking, DownloadItemStatus.Downloading)]
+        [TestCase(DownloadStationTaskStatus.CaptchaNeeded, DownloadItemStatus.Downloading)]
         [TestCase(DownloadStationTaskStatus.Paused, DownloadItemStatus.Paused)]
         [TestCase(DownloadStationTaskStatus.Seeding, DownloadItemStatus.Completed)]
-        [TestCase(DownloadStationTaskStatus.FileHosting_Waiting, DownloadItemStatus.Queued)]
+        [TestCase(DownloadStationTaskStatus.FileHostingWaiting, DownloadItemStatus.Queued)]
         [TestCase(DownloadStationTaskStatus.Waiting, DownloadItemStatus.Queued)]
         public void GetItems_should_return_item_as_downloadItemStatus(DownloadStationTaskStatus apiStatus, DownloadItemStatus expectedItemStatus)
         {

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -176,7 +176,7 @@
     <Compile Include="Download\DownloadClientTests\Blackhole\UsenetBlackholeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DelugeTests\DelugeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadClientFixtureBase.cs" />
-    <Compile Include="Download\DownloadClientTests\DownloadStationTests\DownloadStationsTaskStatusJsonConverterFixtrue.cs" />
+    <Compile Include="Download\DownloadClientTests\DownloadStationTests\DownloadStationsTaskStatusJsonConverterFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\TorrentDownloadStationFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\SerialNumberProviderFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\SharedFolderResolverFixture.cs" />

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Download\DownloadClientTests\Blackhole\UsenetBlackholeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DelugeTests\DelugeFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadClientFixtureBase.cs" />
+    <Compile Include="Download\DownloadClientTests\DownloadStationTests\DownloadStationsTaskStatusJsonConverterFixtrue.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\TorrentDownloadStationFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\SerialNumberProviderFixture.cs" />
     <Compile Include="Download\DownloadClientTests\DownloadStationTests\SharedFolderResolverFixture.cs" />

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
@@ -46,11 +46,12 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         Paused,
         Finishing,
         Finished,
-        HashChecking,
+        Hash_Checking,
         Seeding,
-        FileHostingWaiting,
+        FileHosting_Waiting,
         Extracting,
-        Error
+        Error,
+        Captcha_Needed
     }
 
     public enum DownloadStationPriority

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using NzbDrone.Core.Download.Clients.DownloadStation.Responses;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation
 {
@@ -23,7 +24,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         [JsonProperty(PropertyName = "status_extra")]
         public Dictionary<string, string> StatusExtra { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(DownloadStationsTaskStatusJsonConverter))]
         public DownloadStationTaskStatus Status { get; set; }
 
         public DownloadStationTaskAdditional Additional { get; set; }
@@ -46,12 +47,12 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         Paused,
         Finishing,
         Finished,
-        Hash_Checking,
+        HashChecking,
         Seeding,
-        FileHosting_Waiting,
+        FileHostingWaiting,
         Extracting,
         Error,
-        Captcha_Needed
+        CaptchaNeeded
     }
 
     public enum DownloadStationPriority

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationTask.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using NzbDrone.Core.Download.Clients.DownloadStation.Responses;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStationsTaskStatusJsonConverter.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DownloadStationsTaskStatusJsonConverter.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
+{
+    public class DownloadStationsTaskStatusJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DownloadStationTaskStatus);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var enumString = reader.Value.ToString().Replace("_", string.Empty);
+
+            DownloadStationTaskStatus output;
+
+            Enum.TryParse<DownloadStationTaskStatus>(enumString, true, out output);
+
+            return output;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -373,6 +373,7 @@
     <Compile Include="Download\Clients\DownloadClientUnavailableException.cs" />
     <Compile Include="Download\Clients\DownloadClientException.cs" />
     <Compile Include="Download\Clients\DownloadStation\Proxies\DownloadStationInfoProxy.cs" />
+    <Compile Include="Download\Clients\DownloadStation\Responses\DownloadStationsTaskStatusJsonConverter.cs" />
     <Compile Include="Download\Clients\DownloadStation\TorrentDownloadStation.cs" />
     <Compile Include="Download\Clients\DownloadStation\Proxies\DownloadStationTaskProxy.cs" />
     <Compile Include="Download\Clients\DownloadStation\DownloadStationSettings.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adding captcha_needed status as it wasn't listed in the docs. Changed the other two statuses to fix their names.

#### Issues Fixed or Closed by this PR

*  #2325
