### PR TITLE
Consider all scene SxxE00 releases Specials as well.

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                   .Returns(remoteEpisode);
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.ParseSpecialEpisodeTitle(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), null))
+                  .Setup(s => s.ParseSpecialEpisodeTitle(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), null))
                   .Returns(remoteEpisode.ParsedEpisodeInfo);
 
             var client = new DownloadClientDefinition()

--- a/src/NzbDrone.Core.Test/ParserTests/IsPossibleSpecialEpisodeFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/IsPossibleSpecialEpisodeFixture.cs
@@ -39,5 +39,12 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             Parser.Parser.ParseTitle(title).IsPossibleSpecialEpisode.Should().BeTrue();
         }
+
+
+        [TestCase("Dr.S11E00.A.Chrismas.Carol.Special.720p.HDTV-FieldOfView")]
+        public void IsPossibleSpecialEpisode_should_be_true_if_e00_special(string title)
+        {
+            Parser.Parser.ParseTitle(title).IsPossibleSpecialEpisode.Should().BeTrue();
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/IsPossibleSpecialEpisodeFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/IsPossibleSpecialEpisodeFixture.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
 
-        [TestCase("Dr.S11E00.A.Chrismas.Carol.Special.720p.HDTV-FieldOfView")]
+        [TestCase("Dr.S11E00.A.Christmas.Carol.Special.720p.HDTV-FieldOfView")]
         public void IsPossibleSpecialEpisode_should_be_true_if_e00_special(string title)
         {
             Parser.Parser.ParseTitle(title).IsPossibleSpecialEpisode.Should().BeTrue();

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeServiceTests/FindEpisodeByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeServiceTests/FindEpisodeByTitleFixture.cs
@@ -67,5 +67,31 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
                    .Should()
                    .BeNull();
         }
+
+        [Test]
+        public void should_handle_e00_specials()
+        {
+            const string expectedTitle = "Inside The Walking Dead: Walker University";
+            GivenEpisodesWithTitles("Inside The Walking Dead", expectedTitle, "Inside The Walking Dead Walker University 2");
+
+            Subject.FindEpisodeByTitle(1, 1, "The.Walking.Dead.S04E00.Inside.The.Walking.Dead.Walker.University.720p.HDTV.x264-W4F")
+                   .Title
+                   .Should()
+                   .Be(expectedTitle);
+        }
+
+        [TestCase("Dead.Man.Walking.S04E00.Inside.The.Walking.Dead.Walker.University.720p.HDTV.x264-W4F", "Inside The Walking Dead: Walker University", new[] { "Inside The Walking Dead", "Inside The Walking Dead Walker University 2" })]
+        [TestCase("Who.1999.S11E00.Twice.Upon.A.Time.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb", "Twice Upon A Time", new[] { "Last Christmas" })]
+        [TestCase("Who.1999.S11E00.Twice.Upon.A.Time.Christmas.Special.720p.HDTV.x264-FoV", "Twice Upon A Time", new[] { "Last Christmas" })]
+        [TestCase("Who.1999.S10E00.Christmas.Special.The.Return.Of.Doctor.Mysterio.1080p.BluRay.x264-OUIJA", "The Return Of Doctor Mysterio", new[] { "Doctor Mysterio" })]
+        public void should_handle_special(string releaseTitle, string expectedTitle, string[] rejectedTitles)
+        {
+            GivenEpisodesWithTitles(rejectedTitles.Concat(new[] { expectedTitle }).ToArray());
+
+            var episode = Subject.FindEpisodeByTitle(1, 0, releaseTitle);
+
+            episode.Should().NotBeNull();
+            episode.Title.Should().Be(expectedTitle);
+        }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.DecisionEngine
 
                     if (parsedEpisodeInfo == null || parsedEpisodeInfo.IsPossibleSpecialEpisode)
                     {
-                        var specialEpisodeInfo = _parsingService.ParseSpecialEpisodeTitle(report.Title, report.TvdbId, report.TvRageId, searchCriteria);
+                        var specialEpisodeInfo = _parsingService.ParseSpecialEpisodeTitle(parsedEpisodeInfo, report.Title, report.TvdbId, report.TvRageId, searchCriteria);
 
                         if (specialEpisodeInfo != null)
                         {

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     {
                         // Try parsing the original source title and if that fails, try parsing it as a special
                         // TODO: Pass the TVDB ID and TVRage IDs in as well so we have a better chance for finding the item
-                        parsedEpisodeInfo = Parser.Parser.ParseTitle(firstHistoryItem.SourceTitle) ?? _parsingService.ParseSpecialEpisodeTitle(firstHistoryItem.SourceTitle, 0, 0);
+                        parsedEpisodeInfo = Parser.Parser.ParseTitle(firstHistoryItem.SourceTitle) ?? _parsingService.ParseSpecialEpisodeTitle(parsedEpisodeInfo, firstHistoryItem.SourceTitle, 0, 0);
 
                         if (parsedEpisodeInfo != null)
                         {

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -57,11 +57,11 @@ namespace NzbDrone.Core.Parser.Model
         {
             get
             {
-                // if we don't have eny episode numbers we are likely a special episode and need to do a search by episode title
+                // if we don't have any episode numbers we are likely a special episode and need to do a search by episode title
                 return (AirDate.IsNullOrWhiteSpace() &&
                        SeriesTitle.IsNullOrWhiteSpace() &&
-                       (EpisodeNumbers.Length == 0 || SeasonNumber == 0) ||
-                       !SeriesTitle.IsNullOrWhiteSpace() && Special);
+                       (EpisodeNumbers.Length == 0 || SeasonNumber == 0) || !SeriesTitle.IsNullOrWhiteSpace() && Special) ||
+                       EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
             }
 
             //This prevents manually downloading a release from blowing up in mono

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -68,6 +68,18 @@ namespace NzbDrone.Core.Parser.Model
             //TODO: Is there a better way?
             private set {}
         }
+        public bool IsPossibleSceneSeasonSpecial
+        {
+            get
+            {
+                // SxxE00 episodes
+                return SeasonNumber != 0 && EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
+            }
+
+            //This prevents manually downloading a release from blowing up in mono
+            //TODO: Is there a better way?
+            private set { }
+        }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -213,6 +213,16 @@ namespace NzbDrone.Core.Parser
                           RegexOptions.IgnoreCase | RegexOptions.Compiled)
             };
 
+
+        private static readonly Regex[] SpecialEpisodeTitleRegex = new Regex[]
+            {
+                new Regex(@"\.S\d+E00\.(?<episodetitle>.+?)(?:\.(?:720p|1080p|HDTV|WEB|WEBRip|WEB-DL)\.|$)",
+                          RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+                new Regex(@"\.S\d+\.Special\.(?<episodetitle>.+?)(?:\.(?:720p|1080p|HDTV|WEB|WEBRip|WEB-DL)\.|$)",
+                          RegexOptions.IgnoreCase | RegexOptions.Compiled)
+            };
+
         private static readonly Regex[] RejectHashedReleasesRegex = new Regex[]
             {
                 // Generic match for md5 and mixed-case hashes.
@@ -456,7 +466,19 @@ namespace NzbDrone.Core.Parser
 
         public static string NormalizeEpisodeTitle(string title)
         {
-            title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
+            var match = SpecialEpisodeTitleRegex
+                .Select(v => v.Match(title))
+                .Where(v => v.Success)
+                .FirstOrDefault();
+
+            if (match != null)
+            {
+                title = match.Groups["episodetitle"].Value;
+            }
+
+            // Disabled, Until we run into specific testcases for the removal of these words.
+            //title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
+
             title = PunctuationRegex.Replace(title, " ");
             title = DuplicateSpacesRegex.Replace(title, " ");
 

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -60,7 +60,11 @@ namespace NzbDrone.Core.Parser
                 parsedEpisodeInfo = Parser.ParsePath(filename);
             }
 
-            if (parsedEpisodeInfo == null || parsedEpisodeInfo.IsPossibleSpecialEpisode)
+            if (parsedEpisodeInfo != null && parsedEpisodeInfo.IsPossibleSceneSeasonSpecial && GetStandardEpisodes(series, parsedEpisodeInfo, true, null).Any())
+            {
+                // SxxE00 episodes are sometimes mapped via TheXEM, don't use episode title parsing in that case.
+            }
+            else if (parsedEpisodeInfo == null || parsedEpisodeInfo.IsPossibleSpecialEpisode)
             {
                 var title = Path.GetFileNameWithoutExtension(filename);
                 var specialEpisodeInfo = ParseSpecialEpisodeTitle(title, series);

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -102,11 +102,11 @@ namespace NzbDrone.Core.Tv
         {
             return _episodeRepository.GetEpisodes(seriesId, seasonNumber);
         }
-        
-        public Episode FindEpisodeByTitle(int seriesId, int seasonNumber, string releaseTitle) 
+
+        public Episode FindEpisodeByTitle(int seriesId, int seasonNumber, string releaseTitle)
         {
             // TODO: can replace this search mechanism with something smarter/faster/better
-            var normalizedReleaseTitle = Parser.Parser.NormalizeEpisodeTitle(releaseTitle).Replace(".", " ");
+            var normalizedReleaseTitle = Parser.Parser.NormalizeEpisodeTitle(releaseTitle);
             var episodes = _episodeRepository.GetEpisodes(seriesId, seasonNumber);
 
             var matches = episodes.Select(


### PR DESCRIPTION
Pretty old issue about E00 actually being Specials.

@markus101  I'm not sure if there could be bad consequences of this change. So a PR first.

The Sense8 edge-case with episode shift seems to work because it doesn't actually manage to work out which special it is and thus fall back to the normal logic.

Issue https://github.com/Sonarr/Sonarr/issues/1872