### PR TITLE
Hide "Rescan Drone Factory Folder" if no Drone Factory folder is setup

### DIFF
--- a/src/NzbDrone.Automation.Test/NzbDrone.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/NzbDrone.Automation.Test.csproj
@@ -58,16 +58,17 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="WebDriver, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.WebDriver.3.2.0\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.8.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Selenium.Support.3.2.0\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.8.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomationTest.cs" />
     <Compile Include="AutomationTestAttribute.cs" />
+    <Compile Include="WantedPageTest.cs" />
     <Compile Include="MainPagesTest.cs" />
     <Compile Include="PageModel\PageBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NzbDrone.Automation.Test/PageModel/PageBase.cs
+++ b/src/NzbDrone.Automation.Test/PageModel/PageBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
@@ -25,6 +25,11 @@ namespace NzbDrone.Automation.Test.PageModel
         {
             var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(timeout));
             return wait.Until(d => d.FindElement(by));
+        }
+
+        public bool Displayed(By by)
+        {
+            return _driver.FindElement(by).Displayed;
         }
 
         public void WaitForNoSpinner(int timeout = 30)

--- a/src/NzbDrone.Automation.Test/WantedPageTest.cs
+++ b/src/NzbDrone.Automation.Test/WantedPageTest.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Automation.Test.PageModel;
+using OpenQA.Selenium;
+
+namespace NzbDrone.Automation.Test
+{
+    [TestFixture]
+    public class WantedPageTest : AutomationTest
+    {
+        private PageBase page;
+
+        [SetUp]
+        public void Setup()
+        {
+            page = new PageBase(driver);
+        }
+
+        [Test]
+        public void hide_drone_update_by_default()
+        {
+            page.WantedNavIcon.Click();
+            page.WaitForNoSpinner();
+
+            Assert.Throws<NoSuchElementException>(() => page.Displayed(By.ClassName("icon-sonarr-refresh")));
+        }
+
+        [Test]
+        public void show_drone_update_if_drone_folder_set()
+        {
+            page.SettingNavIcon.Click();
+            page.WaitForNoSpinner();
+
+            page.FindByClass("x-download-client-tab").Click();
+            page.FindByClass("x-advanced-settings").Click();
+            page.Find(By.Name("downloadedEpisodesFolder")).SendKeys("C:\\");
+            page.FindByClass("x-save-settings").Click();
+
+            page.WantedNavIcon.Click();
+            page.WaitForNoSpinner();
+
+            page.FindByClass("icon-sonarr-refresh").Should().NotBeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Automation.Test/packages.config
+++ b/src/NzbDrone.Automation.Test/packages.config
@@ -3,6 +3,6 @@
   <package id="FluentAssertions" version="4.19.0" targetFramework="net40" />
   <package id="NLog" version="4.4.12" targetFramework="net40" />
   <package id="NUnit" version="3.6.0" targetFramework="net40" />
-  <package id="Selenium.Support" version="3.2.0" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="3.2.0" targetFramework="net40" />
+  <package id="Selenium.Support" version="3.8.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Hides the "Rescan Drone Factory Folder" on the Wanted page if the user has no Drone Factory folder configured

#### Todos
- [x] Tests
- [n/a] Documentation


#### Issues Fixed or Closed by this PR

* #2009 (up-for-grabs)
