### PR TITLE
Added errorcode 160 - Permission denied on FileStation

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
@@ -47,6 +47,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
 
             FileStationMessages = new Dictionary<int, string>
             {
+                { 160, "Permission denied. Give your user access to FileStation."},
                 { 400, "Invalid parameter of file operation" },
                 { 401, "Unknown error of file operation" },
                 { 402, "System is too busy" },


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If the user account used to access to DSM doesn't have privileges to use FileStation we get 160 as errorcode. This adds the description to let the user know what is happening

#### Issues Fixed or Closed by this PR
#1758 1758
