### PR TITLE
Improve Kodi Metadata provider handling of scene nfo files

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Roksbox/FindMetadataFileFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Roksbox/FindMetadataFileFixture.cs
@@ -8,7 +8,7 @@ using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
 
-namespace NzbDrone.Core.Test.Metadata.Consumers.Roksbox
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Roksbox
 {
     [TestFixture]
     public class FindMetadataFileFixture : CoreTest<RoksboxMetadata>

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Wdtv/FindMetadataFileFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Wdtv/FindMetadataFileFixture.cs
@@ -8,7 +8,7 @@ using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
 
-namespace NzbDrone.Core.Test.Metadata.Consumers.Wdtv
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Wdtv
 {
     [TestFixture]
     public class FindMetadataFileFixture : CoreTest<WdtvMetadata>

--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/FindMetadataFileFixture.cs
@@ -1,0 +1,65 @@
+﻿using System.IO;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc
+{
+    [TestFixture]
+    public class FindMetadataFileFixture : CoreTest<XbmcMetadata>
+    {
+        private Series _series;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew()
+                                     .With(s => s.Path = @"C:\Test\TV\The.Series".AsOsAgnostic())
+                                     .Build();
+        }
+
+        [Test]
+        public void should_return_null_if_filename_is_not_handled()
+        {
+            var path = Path.Combine(_series.Path, "file.jpg");
+
+            Subject.FindMetadataFile(_series, path).Should().BeNull();
+        }
+
+        [Test]
+        public void should_return_metadata_for_xbmc_nfo()
+        {
+            var path = Path.Combine(_series.Path, "the.series.s01e01.episode.nfo");
+
+            Mocker.GetMock<IDetectXbmcNfo>()
+                  .Setup(v => v.IsXbmcNfoFile(path))
+                  .Returns(true);
+
+            Subject.FindMetadataFile(_series, path).Type.Should().Be(MetadataType.EpisodeMetadata);
+
+            Mocker.GetMock<IDetectXbmcNfo>()
+                  .Verify(v => v.IsXbmcNfoFile(It.IsAny<string>()), Times.Once());
+        }
+
+        [Test]
+        public void should_return_null_for_scene_nfo()
+        {
+            var path = Path.Combine(_series.Path, "the.series.s01e01.episode.nfo");
+
+            Mocker.GetMock<IDetectXbmcNfo>()
+                  .Setup(v => v.IsXbmcNfoFile(path))
+                  .Returns(false);
+
+            Subject.FindMetadataFile(_series, path).Should().BeNull();
+
+            Mocker.GetMock<IDetectXbmcNfo>()
+                  .Verify(v => v.IsXbmcNfoFile(It.IsAny<string>()), Times.Once());
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -220,6 +220,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Compile Include="Download\TrackedDownloads\TrackedDownloadServiceFixture.cs" />
+    <Compile Include="Extras\Metadata\Consumers\Xbmc\FindMetadataFileFixture.cs" />
     <Compile Include="FluentTest.cs" />
     <Compile Include="Framework\CoreTest.cs" />
     <Compile Include="Framework\DbTest.cs" />
@@ -340,8 +341,8 @@
     <Compile Include="Messaging\Commands\CommandEqualityComparerFixture.cs" />
     <Compile Include="Messaging\Commands\CommandExecutorFixture.cs" />
     <Compile Include="Messaging\Events\EventAggregatorFixture.cs" />
-    <Compile Include="Metadata\Consumers\Roksbox\FindMetadataFileFixture.cs" />
-    <Compile Include="Metadata\Consumers\Wdtv\FindMetadataFileFixture.cs" />
+    <Compile Include="Extras\Metadata\Consumers\Roksbox\FindMetadataFileFixture.cs" />
+    <Compile Include="Extras\Metadata\Consumers\Wdtv\FindMetadataFileFixture.cs" />
     <Compile Include="NotificationTests\PlexClientServiceTest.cs" />
     <Compile Include="NotificationTests\ProwlProviderTest.cs" />
     <Compile Include="NotificationTests\Xbmc\Http\ActivePlayersFixture.cs" />

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
@@ -49,8 +49,6 @@ namespace NzbDrone.Core.Extras.Files
             _logger = logger;
         }
 
-        public virtual bool PermanentlyDelete => false;
-
         public List<TExtraFile> GetFilesBySeries(int seriesId)
         {
             return _repository.GetFilesBySeries(seriesId);
@@ -122,17 +120,9 @@ namespace NzbDrone.Core.Extras.Files
 
                     if (_diskProvider.FileExists(path))
                     {
-                        if (PermanentlyDelete)
-                        {
-                            _diskProvider.DeleteFile(path);
-                        }
-
-                        else
-                        {
-                            // Send extra files to the recycling bin so they can be recovered if necessary
-                            var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
-                            _recycleBinProvider.DeleteFile(path, subfolder);
-                        }
+                        // Send to the recycling bin so they can be recovered if necessary
+                        var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
+                        _recycleBinProvider.DeleteFile(path, subfolder);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NzbDrone.Common.Disk;
+
+namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
+{
+    public interface IDetectXbmcNfo
+    {
+        bool IsXbmcNfoFile(string path);
+    }
+
+    public class XbmcNfoDetector : IDetectXbmcNfo
+    {
+        private readonly IDiskProvider _diskProvider;
+
+        private readonly Regex _regex = new Regex("<(movie|tvshow|episodedetails|artist|album|musicvideo)>", RegexOptions.Compiled);
+
+        public XbmcNfoDetector(IDiskProvider diskProvider)
+        {
+            _diskProvider = diskProvider;
+        }
+
+        public bool IsXbmcNfoFile(string path)
+        {
+            // Lets make sure we're not reading huge files.
+            if (_diskProvider.GetFileSize(path) > 10.Megabytes())
+            {
+                return false;
+            }
+
+            // Check if it contains some of the kodi/xbmc xml tags
+            var content = _diskProvider.ReadAllText(path);
+
+            return _regex.IsMatch(content);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Extras/Metadata/Files/MetadataFileService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Files/MetadataFileService.cs
@@ -16,7 +16,5 @@ namespace NzbDrone.Core.Extras.Metadata.Files
             : base(repository, seriesService, diskProvider, recycleBinProvider, logger)
         {
         }
-
-        public override bool PermanentlyDelete => true;
     }
 }

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Extras.Metadata
     {
         private readonly IMetadataFactory _metadataFactory;
         private readonly ICleanMetadataService _cleanMetadataService;
+        private readonly IRecycleBinProvider _recycleBinProvider;
         private readonly IDiskTransferService _diskTransferService;
         private readonly IDiskProvider _diskProvider;
         private readonly IHttpClient _httpClient;
@@ -29,6 +30,7 @@ namespace NzbDrone.Core.Extras.Metadata
         public MetadataService(IConfigService configService,
                                IDiskProvider diskProvider,
                                IDiskTransferService diskTransferService,
+                               IRecycleBinProvider recycleBinProvider,
                                IMetadataFactory metadataFactory,
                                ICleanMetadataService cleanMetadataService,
                                IHttpClient httpClient,
@@ -39,6 +41,7 @@ namespace NzbDrone.Core.Extras.Metadata
         {
             _metadataFactory = metadataFactory;
             _cleanMetadataService = cleanMetadataService;
+            _recycleBinProvider = recycleBinProvider;
             _diskTransferService = diskTransferService;
             _diskProvider = diskProvider;
             _httpClient = httpClient;
@@ -443,11 +446,11 @@ namespace NzbDrone.Core.Extras.Metadata
 
                 _logger.Debug("Removing duplicate Metadata file: {0}", path);
 
-                _diskProvider.DeleteFile(path);
+                var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
+                _recycleBinProvider.DeleteFile(path, subfolder);
                 _metadataFileService.Delete(file.Id);
             }
 
-            
             return matchingMetadataFiles.First();
         }
     }

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraFileRenamer.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraFileRenamer.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Extras.Others
+{
+    public interface IOtherExtraFileRenamer
+    {
+        void RenameOtherExtraFile(Series series, string path);
+    }
+
+    public class OtherExtraFileRenamer : IOtherExtraFileRenamer
+    {
+        private readonly Logger _logger;
+        private readonly IDiskProvider _diskProvider;
+        private readonly IRecycleBinProvider _recycleBinProvider;
+        private readonly ISeriesService _seriesService;
+        private readonly IOtherExtraFileService _otherExtraFileService;
+
+        public OtherExtraFileRenamer(IOtherExtraFileService otherExtraFileService,
+                                     ISeriesService seriesService,
+                                     IRecycleBinProvider recycleBinProvider,
+                                     IDiskProvider diskProvider,
+                                     Logger logger)
+        {
+            _logger = logger;
+            _diskProvider = diskProvider;
+            _recycleBinProvider = recycleBinProvider;
+            _seriesService = seriesService;
+            _otherExtraFileService = otherExtraFileService;
+        }
+
+        public void RenameOtherExtraFile(Series series, string path)
+        {
+            if (!_diskProvider.FileExists(path))
+            {
+                return;
+            }
+
+            var relativePath = series.Path.GetRelativePath(path);
+
+            var otherExtraFile = _otherExtraFileService.FindByPath(relativePath);
+            if (otherExtraFile != null)
+            {
+                var newPath = path + "-orig";
+
+                // Recycle an existing -orig file.
+                RemoveOtherExtraFile(series, newPath);
+
+                // Rename the file to .*-orig
+                _diskProvider.MoveFile(path, newPath);
+                otherExtraFile.RelativePath = relativePath + "-orig";
+                otherExtraFile.Extension += "-orig";
+                _otherExtraFileService.Upsert(otherExtraFile);
+            }
+        }
+
+        private void RemoveOtherExtraFile(Series series, string path)
+        {
+            if (!_diskProvider.FileExists(path))
+            {
+                return;
+            }
+
+            var relativePath = series.Path.GetRelativePath(path);
+
+            var otherExtraFile = _otherExtraFileService.FindByPath(relativePath);
+            if (otherExtraFile != null)
+            {
+                var subfolder = Path.GetDirectoryName(relativePath);
+                _recycleBinProvider.DeleteFile(path, subfolder);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
@@ -65,12 +65,6 @@ namespace NzbDrone.Core.Extras.Others
 
         public override ExtraFile Import(Series series, EpisodeFile episodeFile, string path, string extension, bool readOnly)
         {
-            // If the extension is .nfo we need to change it to .nfo-orig
-            if (Path.GetExtension(path).Equals(".nfo", StringComparison.OrdinalIgnoreCase))
-            {
-                extension += "-orig";
-            }
-
             var extraFile = ImportFile(series, episodeFile, path, readOnly, extension, null);
 
             _otherExtraFileService.Upsert(extraFile);

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
                     if (newDownload)
                     {
-                        _extraService.ImportExtraFiles(localEpisode, episodeFile, copyOnly);
+                        _extraService.ImportEpisode(localEpisode, episodeFile, copyOnly);
                     }
 
                     _eventAggregator.PublishEvent(new EpisodeImportedEvent(localEpisode, episodeFile, oldFiles, newDownload, downloadClientItem));

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -554,6 +554,7 @@
     <Compile Include="Extras\IImportExistingExtraFiles.cs" />
     <Compile Include="Extras\ImportExistingExtraFileFilterResult.cs" />
     <Compile Include="Extras\ImportExistingExtraFilesBase.cs" />
+    <Compile Include="Extras\Metadata\Consumers\Xbmc\XbmcNfoDetector.cs" />
     <Compile Include="Extras\Metadata\Files\MetadataFile.cs" />
     <Compile Include="Extras\Metadata\Files\MetadataFileRepository.cs" />
     <Compile Include="Extras\Metadata\Files\MetadataFileService.cs" />
@@ -562,6 +563,7 @@
     <Compile Include="Extras\Others\OtherExtraFileService.cs" />
     <Compile Include="Extras\Others\OtherExtraFile.cs" />
     <Compile Include="Extras\Others\OtherExtraService.cs" />
+    <Compile Include="Extras\Others\OtherExtraFileRenamer.cs" />
     <Compile Include="Extras\Subtitles\ExistingSubtitleImporter.cs" />
     <Compile Include="Extras\Subtitles\SubtitleFileRepository.cs" />
     <Compile Include="Extras\Subtitles\SubtitleFileService.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Recycle Metadata files on episode removal, instead of permanently deleting them.
- Import nfo 'other' files as 'nfo' instead of 'nfo-orig'.
- On import existing the Kodi metadata provider will check if the .nfo is xml, and only mark if as EpisodeMetadata if that's the case. (leaving it to OtherFiles to pick up the scene nfo)
- On Kodi metadata generation, the existing .nfo OtherFile will be renamed to .nfo-orig.

- Bonus: Kodi metadata generation refresh will preserve 'watched' flag if possible, but not on episode upgrades.

The end result is that if kodi metadata is disabled, scene .nfo files will be treated as scene nfo and kept intact.

#### Issues Fixed or Closed by this PR

* closes #2398
* closes #932

#### Related but not solved:
* ref #991