### PR TITLE
Fixed: sorting for series "A.P. Bio"

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/SeriesTitleNormalizerFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesTitleNormalizerFixture.cs
@@ -8,7 +8,8 @@ namespace NzbDrone.Core.Test.TvTests
     public class SeriesTitleNormalizerFixture
     {
         [TestCase("A to Z", 281588, "a to z")]
-        [TestCase("A. D. - The Trials & Triumph of the Early Church", 266757, "ad trials triumph early church")]
+        [TestCase("A.D. The Bible Continues", 289260, "ad bible continues")]
+        [TestCase("A.P. Bio", 328534, "ap bio")]
         public void should_use_precomputed_title(string title, int tvdbId, string expected)
         {
             SeriesTitleNormalizer.Normalize(title, tvdbId).Should().Be(expected);

--- a/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
+++ b/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
@@ -8,7 +8,8 @@ namespace NzbDrone.Core.Tv
                                                                      {
                                                                          { 281588, "a to z" },
                                                                          { 266757, "ad trials triumph early church" },
-                                                                         { 289260, "ad bible continues"}
+                                                                         { 289260, "ad bible continues"},
+                                                                         { 328534, "ap bio"}
                                                                      };
 
         public static string Normalize(string title, int tvdbId)

--- a/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
+++ b/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
@@ -7,7 +7,6 @@ namespace NzbDrone.Core.Tv
         private readonly static Dictionary<int, string> PreComputedTitles = new Dictionary<int, string>
                                                                      {
                                                                          { 281588, "a to z" },
-                                                                         { 266757, "ad trials triumph early church" },
                                                                          { 289260, "ad bible continues"},
                                                                          { 328534, "ap bio"}
                                                                      };


### PR DESCRIPTION
https://forums.sonarr.tv/t/a-p-bio-sorting-under-p/17959

- Added sorting for "A.P. Bio"
- Added unit test
- Removed name normalization for series which was deleted on thetvdb