### PR TITLE
Daily season search

### DIFF
--- a/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
@@ -51,6 +51,34 @@ namespace NzbDrone.Common.Extensions
             }
         }
 
+        public static Dictionary<TKey, TItem> ToDictionaryIgnoreDuplicates<TItem, TKey>(this IEnumerable<TItem> src, Func<TItem, TKey> keySelector)
+        {
+            var result = new Dictionary<TKey, TItem>();
+            foreach (var item in src)
+            {
+                var key = keySelector(item);
+                if (!result.ContainsKey(key))
+                {
+                    result[key] = item;
+                }
+            }
+            return result;
+        }
+
+        public static Dictionary<TKey, TValue> ToDictionaryIgnoreDuplicates<TItem, TKey, TValue>(this IEnumerable<TItem> src, Func<TItem, TKey> keySelector, Func<TItem, TValue> valueSelector)
+        {
+            var result = new Dictionary<TKey, TValue>();
+            foreach (var item in src)
+            {
+                var key = keySelector(item);
+                if (!result.ContainsKey(key))
+                {
+                    result[key] = valueSelector(item);
+                }
+            }
+            return result;
+        }
+
         public static void AddIfNotNull<TSource>(this List<TSource> source, TSource item)
         {
             if (item == null)

--- a/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
@@ -212,7 +212,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
 
             Subject.ProcessDecisions(decisions);
-            Mocker.GetMock<IPendingReleaseService>().Verify(v => v.Add(It.IsAny<DownloadDecision>(), It.IsAny<PendingReleaseReason>()), Times.Never());
+            Mocker.GetMock<IPendingReleaseService>().Verify(v => v.AddMany(It.IsAny<List<Tuple<DownloadDecision, PendingReleaseReason>>>()), Times.Never());
         }
 
         [Test]
@@ -226,7 +226,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
 
             Subject.ProcessDecisions(decisions);
-            Mocker.GetMock<IPendingReleaseService>().Verify(v => v.Add(It.IsAny<DownloadDecision>(), It.IsAny<PendingReleaseReason>()), Times.Exactly(2));
+            Mocker.GetMock<IPendingReleaseService>().Verify(v => v.AddMany(It.IsAny<List<Tuple<DownloadDecision, PendingReleaseReason>>>()), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -27,8 +27,18 @@ namespace NzbDrone.Core.Datastore
 
         static DbFactory()
         {
+            InitializeEnvironment();
+
             MapRepository.Instance.ReflectionStrategy = new SimpleReflectionStrategy();
             TableMapping.Map();
+        }
+
+        private static void InitializeEnvironment()
+        {
+            // Speed up sqlite3 initialization since we don't use the config file and can't rely on preloading.
+            Environment.SetEnvironmentVariable("No_Expand", "true");
+            Environment.SetEnvironmentVariable("No_SQLiteXmlConfigFile", "true");
+            Environment.SetEnvironmentVariable("No_PreLoadSQLite", "true");
         }
 
         public static void RegisterDatabase(IContainer container)

--- a/src/NzbDrone.Core/Datastore/Migration/120_update_series_episodes_history_indexes.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/120_update_series_episodes_history_indexes.cs
@@ -1,0 +1,24 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(120)]
+    public class update_series_episodes_history_indexes : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Create.Index().OnTable("Series").OnColumn("TvdbId").Ascending();
+            Create.Index().OnTable("Episodes").OnColumn("SeriesId").Ascending()
+                                              .OnColumn("AirDate").Ascending();
+
+            Delete.Index().OnTable("History").OnColumn("EpisodeId");
+            Create.Index().OnTable("History").OnColumn("EpisodeId").Ascending()
+                                             .OnColumn("Date").Descending();
+
+            Delete.Index().OnTable("History").OnColumn("DownloadId");
+            Create.Index().OnTable("History").OnColumn("DownloadId").Ascending()
+                                             .OnColumn("Date").Descending();
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 //Multiply maxSize by Series.Runtime
                 maxSize = maxSize * subject.Series.Runtime * subject.Episodes.Count;
 
-                if (subject.Episodes.Count == 1)
+                if (subject.Episodes.Count == 1 && subject.Series.SeriesType == SeriesTypes.Standard)
                 {
                     Episode episode = subject.Episodes.First();
                     List<Episode> seasonEpisodes;
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     var seasonSearchCriteria = searchCriteria as SeasonSearchCriteria;
                     if (seasonSearchCriteria != null && !seasonSearchCriteria.Series.UseSceneNumbering && seasonSearchCriteria.Episodes.Any(v => v.Id == episode.Id))
                     {
-                        seasonEpisodes = (searchCriteria as SeasonSearchCriteria).Episodes;
+                        seasonEpisodes = seasonSearchCriteria.Episodes;
                     }
                     else
                     {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/DailySeasonSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/DailySeasonSearchCriteria.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace NzbDrone.Core.IndexerSearch.Definitions
+{
+    public class DailySeasonSearchCriteria : SearchCriteriaBase
+    {
+        public int Year { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[{0} : {1}]", Series.Title, Year);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/BitMeTv/BitMeTvRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/BitMeTv/BitMeTvRequestGenerator.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Core.Indexers.BitMeTv
     public class BitMeTvRequestGenerator : IIndexerRequestGenerator
     {
         public BitMeTvSettings Settings { get; set; }
-        
+
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
             var pageableRequests = new IndexerPageableRequestChain();
@@ -28,6 +28,11 @@ namespace NzbDrone.Core.Indexers.BitMeTv
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -127,6 +127,34 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            var parameters = new BroadcastheNetTorrentQuery();
+            if (AddSeriesSearchParameters(parameters, searchCriteria))
+            {
+                parameters.Category = "Episode";
+                parameters.Name = string.Format("{0}%", searchCriteria.Year);
+
+                pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
+
+                pageableRequests.AddTier();
+
+                foreach (var episode in searchCriteria.Episodes)
+                {
+                    parameters = parameters.Clone();
+
+                    parameters.Category = "Episode";
+                    parameters.Name = string.Format("S{0:00}E{1:00}", episode.SeasonNumber, episode.EpisodeNumber);
+
+                    pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
+                }
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/Fanzub/FanzubRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Fanzub/FanzubRequestGenerator.cs
@@ -44,6 +44,11 @@ namespace NzbDrone.Core.Indexers.Fanzub
             return new IndexerPageableRequestChain();
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
@@ -58,6 +58,21 @@ namespace NzbDrone.Core.Indexers.HDBits
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            var query = new TorrentQuery();
+            if (TryAddSearchParameters(query, searchCriteria))
+            {
+                query.Search = string.Format("{0}-", searchCriteria.Year);
+
+                pageableRequests.Add(GetRequest(query));
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(SeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -79,6 +79,16 @@ namespace NzbDrone.Core.Indexers
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
         }
 
+        public override IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria)
+        {
+            if (!SupportsSearch)
+            {
+                return new List<ReleaseInfo>();
+            }
+
+            return FetchReleases(g => g.GetSearchRequests(searchCriteria));
+        }
+
         public override IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria)
         {
             if (!SupportsSearch)

--- a/src/NzbDrone.Core/Indexers/IIndexer.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexer.cs
@@ -10,11 +10,12 @@ namespace NzbDrone.Core.Indexers
         bool SupportsRss { get; }
         bool SupportsSearch { get; }
         DownloadProtocol Protocol { get; }
-        
+
         IList<ReleaseInfo> FetchRecent();
         IList<ReleaseInfo> Fetch(SeasonSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(SingleEpisodeSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
+        IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
     }

--- a/src/NzbDrone.Core/Indexers/IIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexerRequestGenerator.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Indexers
         IndexerPageableRequestChain GetSearchRequests(SingleEpisodeSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(SeasonSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria);
+        IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria);
     }

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsRequestGenerator.cs
@@ -32,6 +32,11 @@ namespace NzbDrone.Core.Indexers.IPTorrents
             return new IndexerPageableRequestChain();
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -65,6 +65,7 @@ namespace NzbDrone.Core.Indexers
         public abstract IList<ReleaseInfo> Fetch(SeasonSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(SingleEpisodeSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
+        public abstract IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -146,6 +146,17 @@ namespace NzbDrone.Core.Indexers.Newznab
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            AddTvIdPageableRequests(pageableRequests, MaxPages, Settings.Categories, searchCriteria,
+                string.Format("&season={0}",
+                searchCriteria.Year));
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -41,6 +41,11 @@ namespace NzbDrone.Core.Indexers.Nyaa
             return new IndexerPageableRequestChain();
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Omgwtfnzbs/OmgwtfnzbsRequestGenerator.cs
@@ -68,6 +68,20 @@ namespace NzbDrone.Core.Indexers.Omgwtfnzbs
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            foreach (var queryTitle in searchCriteria.QueryTitles)
+            {
+                pageableRequests.Add(GetPagedRequests(string.Format("{0}+{1}",
+                    queryTitle,
+                    searchCriteria.Year)));
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgRequestGenerator.cs
@@ -52,6 +52,15 @@ namespace NzbDrone.Core.Indexers.Rarbg
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            pageableRequests.Add(GetPagedRequests("search", searchCriteria.Series.TvdbId, "\"{0}\"", searchCriteria.Year));
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/RssIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/RssIndexerRequestGenerator.cs
@@ -37,6 +37,11 @@ namespace NzbDrone.Core.Indexers
             return new IndexerPageableRequestChain();
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerRequestGenerator.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
     public class TorrentRssIndexerRequestGenerator : IIndexerRequestGenerator
     {
         public TorrentRssIndexerSettings Settings { get; set; }
-        
+
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
             var pageableRequests = new IndexerPageableRequestChain();
@@ -29,6 +29,11 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/Indexers/Torrentleech/TorrentleechRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Torrentleech/TorrentleechRequestGenerator.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Core.Indexers.Torrentleech
     public class TorrentleechRequestGenerator : IIndexerRequestGenerator
     {
         public TorrentleechSettings Settings { get; set; }
-        
+
         public virtual IndexerPageableRequestChain GetRecentRequests()
         {
             var pageableRequests = new IndexerPageableRequestChain();
@@ -28,6 +28,11 @@ namespace NzbDrone.Core.Indexers.Torrentleech
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Datastore\Migration\042_add_download_clients_table.cs" />
     <Compile Include="Datastore\Migration\043_convert_config_to_download_clients.cs" />
     <Compile Include="Datastore\Migration\044_fix_xbmc_episode_metadata.cs" />
+    <Compile Include="Datastore\Migration\120_update_series_episodes_history_indexes.cs" />
     <Compile Include="Datastore\Migration\118_add_history_eventType_index.cs" />
     <Compile Include="Datastore\Migration\045_add_indexes.cs" />
     <Compile Include="Datastore\Migration\046_fix_nzb_su_url.cs" />

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -631,6 +631,7 @@
     <Compile Include="Http\CloudFlare\CloudFlareHttpInterceptor.cs" />
     <Compile Include="Http\HttpProxySettingsProvider.cs" />
     <Compile Include="Http\TorcacheHttpInterceptor.cs" />
+    <Compile Include="IndexerSearch\Definitions\DailySeasonSearchCriteria.cs" />
     <Compile Include="Indexers\BitMeTv\BitMeTv.cs" />
     <Compile Include="Indexers\BitMeTv\BitMeTvSettings.cs" />
     <Compile Include="Indexers\BitMeTv\BitMeTvRequestGenerator.cs" />


### PR DESCRIPTION
#### Database Migration
**YES** 120 - Replace/add db indexes

#### Description
A season search for a daily show used to simply do a 'standard' season search, which only works if the show uses years as seasons.
This change adds a DailySeasonSearchCriteria that groups by the year in the airdate and performs searches for those.

Possible side-effect I just realised is that Jackett might not handle the format.

This PR also includes half a dozen performance improvements:

Test method: With no download client I queried 1 daily show season that caused 1416 releases to be added to the pending queue.Subsequently all indexers were disabled, which causes the RssSync to only evaluate the pending releases.

The following measurements of cumulative improvements. The biggest improvement by far is sqlite initialization env vars.

Original: 47.5 sec total
Sqlite initialisation: 19.9 sec total
Command Progress debounce: 17.1 sec total
PendingRelease refactoring: 13.9 sec total
Database indexes: 12.2 sec total
EventAggregator caching: 10.1 sec total

I had some other more agressive caching changes, but they only saved around 1.2 sec outside of the profiler in release mode.
A bigger improvement was possible using a db transaction to keep the connection open... iirc around 3-4 sec improvment, but it led to other unstable to behavior and simply too risky.

#### Issues Fixed or Closed by this PR

* https://github.com/Sonarr/Sonarr/issues/755
