### PR TITLE
Adjusting logo classification to support hidpi

### DIFF
--- a/src/UI/Navbar/NavbarLayoutTemplate.hbs
+++ b/src/UI/Navbar/NavbarLayoutTemplate.hbs
@@ -8,8 +8,8 @@
             </button>
             <a class="navbar-brand" href="{{UrlBase}}/">
                 <!--<img src="{{UrlBase}}/Content/Images/logo.png?v=2" alt="Sonarr">-->
-                <img src="{{UrlBase}}/Content/Images/logos/128.png" class="visible-lg"/>
-                <img src="{{UrlBase}}/Content/Images/logos/64.png" class="visible-md visible-sm"/>
+                <img src="{{UrlBase}}/Content/Images/logos/128.png" class="visible-lg visible-md"/>
+                <img src="{{UrlBase}}/Content/Images/logos/64.png" class="visible-sm"/>
                 <span class="visible-xs">
                     <img src="{{UrlBase}}/Content/Images/logos/32.png"/>
                     <span class="logo-text">sonarr</span>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The bootstrap.js breakpoints don't seem to be applied properly for my hidpi display, I've adjusted the classifications on the logo to fix it. You can see the changes made before and after here:

[imgur](https://imgur.com/a/QgcXi7P)

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* None
