### PR TITLE
Deluge torrents that don't have a hash are skipped

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -100,6 +100,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             foreach (var torrent in torrents)
             {
+                if (torrent.Hash == null) continue;
                 var item = new DownloadClientItem();
                 item.DownloadId = torrent.Hash.ToUpper();
                 item.Title = torrent.Name;


### PR DESCRIPTION
#### Database Migration
NO

#### Description

In some cases torrents in Deluge may not have a hash (ex: https://torguard.net/checkmytorrentipaddress.php). This causes Sonarr to fail when loading the torrents from Deluge with error message: 'Unable to communicate with deluge. Object reference not set to an instance of an object'. This commit simply causes Sonarr to skip over the torrent with the missing hash and continue loading torrents that do have hashes.

#### Todos
- [ ] Tests
Tested against Deluge with torrent from https://torguard.net/checkmytorrentipaddress.php
- [ ] Documentation
No documentation changes are needed

#### Issues Fixed or Closed by this PR

* #2566
