### PR TITLE
Preserve 'forced' tag when importing subtitles

### DIFF
--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -87,7 +87,8 @@ namespace NzbDrone.Core.Extras.Subtitles
             if (SubtitleFileExtensions.Extensions.Contains(Path.GetExtension(path)))
             {
                 var language = LanguageParser.ParseSubtitleLanguage(path);
-                var suffix = GetSuffix(language, 1, false);
+                var forced = LanguageParser.ParseForcedFlag(path);
+                var suffix = GetSuffix(language, forced, 1, false);
                 var subtitleFile = ImportFile(series, episodeFile, path, readOnly, extension, suffix);
                 subtitleFile.Language = language;
 
@@ -99,7 +100,7 @@ namespace NzbDrone.Core.Extras.Subtitles
             return null;
         }
 
-        private string GetSuffix(Language language, int copy, bool multipleCopies = false)
+        private string GetSuffix(Language language, bool forced, int copy, bool multipleCopies = false)
         {
             var suffixBuilder = new StringBuilder();
 
@@ -113,6 +114,12 @@ namespace NzbDrone.Core.Extras.Subtitles
             {
                 suffixBuilder.Append(".");
                 suffixBuilder.Append(IsoLanguages.Get(language).TwoLetterCode);
+            }
+
+            if (forced)
+            {
+                suffixBuilder.Append(".");
+                suffixBuilder.Append("forced");
             }
 
             return suffixBuilder.ToString();

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -18,7 +18,9 @@ namespace NzbDrone.Core.Parser
                                                                 RegexOptions.Compiled);
 
 
-        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})([-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex SubtitleForcedRegex = new Regex(".+?[-_. ]forced$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static Language ParseLanguage(string title)
         {
@@ -128,6 +130,22 @@ namespace NzbDrone.Core.Parser
 
             return Language.Unknown;
         }
+
+        public static bool ParseForcedFlag(string fileName)
+        {
+            try
+            {
+                Logger.Debug("Parsing forced flag from subtitle file: {0}", fileName);
+
+                var simpleFilename = Path.GetFileNameWithoutExtension(fileName);
+                var forcedFlagMatch = SubtitleForcedRegex.Match(simpleFilename);
+
+                return forcedFlagMatch.Success;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "Failed parsing forced flag from subtitle file: {0}", fileName);
+            }
 
         private static Language RegexLanguage(string title)
         {

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -146,6 +146,7 @@ namespace NzbDrone.Core.Parser
             {
                 Logger.Debug(ex, "Failed parsing forced flag from subtitle file: {0}", fileName);
             }
+        }
 
         private static Language RegexLanguage(string title)
         {

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})([-_. ]forced)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex SubtitleForcedRegex = new Regex(".+?[-_. ]forced$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex SubtitleForcedRegex = new Regex(".+?[-_. ]forced([-_. ][a-z]{2,3})?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static Language ParseLanguage(string title)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a forced property to `SubtitleService.cs`.

This is the first time with the C family for me, so not sure if I overlooked anything.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
#2570 
