### PR TITLE
Fixed: Multi-file torrents in Vuze with different folder and file names

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -172,7 +172,8 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 "errorString",
                 "uploadedEver",
                 "downloadedEver",
-                "seedRatioLimit"
+                "seedRatioLimit",
+                "fileCount"
             };
 
             var arguments = new Dictionary<string, object>();

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
@@ -3,31 +3,19 @@
     public class TransmissionTorrent
     {
         public int Id { get; set; }
-
         public string HashString { get; set; }
-
         public string Name { get; set; }
-
         public string DownloadDir { get; set; }
-
         public long TotalSize { get; set; }
-
         public long LeftUntilDone { get; set; }
-
         public bool IsFinished { get; set; }
-
         public int Eta { get; set; }
-
         public TransmissionTorrentStatus Status { get; set; }
-
         public int SecondsDownloading { get; set; }
-
         public string ErrorString { get; set; }
-
         public long DownloadedEver { get; set; }
-
         public long UploadedEver { get; set; }
-
         public long SeedRatioLimit { get; set; }
+        public int FileCount { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Download.Clients.Vuze
             // - A multi-file torrent is downloaded in a job folder and 'outputPath' points to that directory directly.
             // - A single-file torrent is downloaded in the root folder and 'outputPath' poinst to that root folder.
             // We have to make sure the return value points to the job folder OR file.
-            if (outputPath == null || outputPath.FileName == torrent.Name)
+            if (outputPath == null || outputPath.FileName == torrent.Name || torrent.FileCount > 1)
             {
                 _logger.Trace("Vuze output directory: {0}", outputPath);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Better handling of multi-file torrents in Vuze where the folder doesn't match the name.


#### Issues Fixed or Closed by this PR

* #2571
