### PR TITLE
Use PUT method for UpdateSeries

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         public void UpdateSeries(int metadataId, PlexServerSettings settings)
         {
             var resource = $"library/metadata/{metadataId}/refresh";
-            var request = BuildRequest(resource, HttpMethod.GET, settings);
+            var request = BuildRequest(resource, HttpMethod.PUT, settings);
             var response = ProcessRequest(request);
 
             CheckForError(response);


### PR DESCRIPTION
Using get will cause 405 Method not allowed response.   The old proxy used the PUT method.

Additional details here on usage of PUT method.

https://forums.plex.tv/discussion/255218/how-to-refresh-a-single-series-via-url-the-plexweb-client-is-able-to-do-so-so-there-must-be-a-way

#### Database Migration
YES | NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
