### PR TITLE
Manual Import regression and improve handling of folders

### DIFF
--- a/src/NzbDrone.Api/ManualImport/ManualImportResource.cs
+++ b/src/NzbDrone.Api/ManualImport/ManualImportResource.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Api.ManualImport
     {
         public string Path { get; set; }
         public string RelativePath { get; set; }
+        public string FolderName { get; set; }
         public string Name { get; set; }
         public long Size { get; set; }
         public SeriesResource Series { get; set; }
@@ -36,6 +37,7 @@ namespace NzbDrone.Api.ManualImport
 
                 Path = model.Path,
                 RelativePath = model.RelativePath,
+                FolderName = model.FolderName,
                 Name = model.Name,
                 Size = model.Size,
                 Series = model.Series.ToResource(),

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportFile.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
     public class ManualImportFile
     {
         public string Path { get; set; }
+        public string FolderName { get; set; }
         public int SeriesId { get; set; }
         public List<int> EpisodeIds { get; set; }
         public QualityModel Quality { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
     {
         public string Path { get; set; }
         public string RelativePath { get; set; }
+        public string FolderName { get; set; }
         public string Name { get; set; }
         public long Size { get; set; }
         public Series Series { get; set; }

--- a/src/UI/ManualImport/ManualImportLayout.js
+++ b/src/UI/ManualImport/ManualImportLayout.js
@@ -211,6 +211,7 @@ module.exports = Marionette.Layout.extend({
             files : _.map(selected, function (file) {
                 return {
                     path       : file.get('path'),
+                    folderName : file.get('folderName'),
                     seriesId   : file.get('series').id,
                     episodeIds : _.map(file.get('episodes'), 'id'),
                     quality    : file.get('quality'),


### PR DESCRIPTION
Mainly fixing the Augmentation erroneously overriding the user selected values.

But I also addressed how it handles folders:
If the root folder doesn't contain a parse-able series, it used to simply fetch all files recursively and process them individually, preventing it from using folder information.
Instead it now processes direct files as individual files, and recurses into folders.

This allows you to point Manual Import at a `myFolder` like `myFolder/Series.Title.S01/1x02.Episode.1080p.mkv` and still have it process properly.
