### PR TITLE
Add compatibility w/ Hombrew-installed mono

### DIFF
--- a/osx/Sonarr
+++ b/osx/Sonarr
@@ -9,7 +9,11 @@ APPNAME="Sonarr"
  
 #set up environment
 if [[ -x '/opt/local/bin/mono' ]]; then
+    # Macports and mono-supplied installer path
     export PATH="/opt/local/bin:$PATH"
+elif [[ -x '/usr/local/bin/mono' ]]; then
+    # Homebrew-supplied path to mono
+    export PATH="/usr/local/bin:$PATH"
 fi
 
 export DYLD_FALLBACK_LIBRARY_PATH="$DIR"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
By default, Homebrew installs mono to `/usr/local/bin`. However, when starting Sonarr, it does not appear to have this path as part of its `$PATH`, which results in Sonarr prompting the user to, incorrectly, install Mono via the “official” installer, even though it’s already installed.

Adding this check ensures that the right `$PATH` additions are made for a Homebrew-installed copy of mono.


#### Todos
- [x] Tests
- [x] Documentation


#### Issues Fixed or Closed by this PR

* None