### PR TITLE
New: Added priority levels to Join Notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Join/JoinPriority.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinPriority.cs
@@ -1,0 +1,11 @@
+namespace NzbDrone.Core.Notifications.Join
+{
+    public enum JoinPriority
+    {
+        Silent = -2,
+        Quiet = -1,
+        Normal = 0,
+        High = 1,
+        Emergency = 2
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinProxy.cs
@@ -94,6 +94,7 @@ namespace NzbDrone.Core.Notifications.Join
             request.AddParameter("text", message);
             request.AddParameter("icon", "https://cdn.rawgit.com/Sonarr/Sonarr/develop/Logo/256.png"); // Use the Sonarr logo.
             request.AddParameter("smallicon", "https://cdn.rawgit.com/Sonarr/Sonarr/develop/Logo/96-Outline-White.png"); // 96x96px with outline at 88x88px on a transparent background.
+            request.AddParameter("priority", settings.Priority);
 
             var response = client.ExecuteAndValidate(request);
             var res = Json.Deserialize<JoinResponseModel>(response.Content);

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Join
 
         public JoinSettings()
         {
-            Priority = 0;
+            Priority = (int)JoinPriority.Normal;
         }
 
         private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -16,6 +16,12 @@ namespace NzbDrone.Core.Notifications.Join
 
     public class JoinSettings : IProviderConfig
     {
+
+        public JoinSettings()
+        {
+            Priority = 0;
+        }
+
         private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();
 
         [FieldDefinition(0, Label = "API Key", HelpText = "The API Key from your Join account settings (click Join API button).", HelpLink = "https://joinjoaomgcd.appspot.com/")]
@@ -26,6 +32,9 @@ namespace NzbDrone.Core.Notifications.Join
 
         [FieldDefinition(2, Label = "Device Names", HelpText = "Comma separated list of full or partial device names you'd like to send notifications to. If unset, all devices will receive notifications.", HelpLink = "https://joaoapps.com/join/api/")]
         public string DeviceNames { get; set; }
+
+        [FieldDefinition(3, Label = "Notification Priority", Type = FieldType.Select, SelectOptions = typeof(JoinPriority))]
+        public int Priority { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -911,6 +911,7 @@
     <Compile Include="MetadataSource\ISearchForNewSeries.cs" />
     <Compile Include="Notifications\Join\JoinAuthException.cs" />
     <Compile Include="Notifications\Join\JoinInvalidDeviceException.cs" />
+    <Compile Include="Notifications\Join\JoinPriority.cs" />
     <Compile Include="Notifications\Join\JoinResponseModel.cs" />
     <Compile Include="Notifications\Join\Join.cs" />
     <Compile Include="Notifications\Join\JoinException.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
A small change to the Join notification service to allow for various priority levels to be selected. This way you can send join notifications to your phone without it vibrating every time. This functions similarly to the pushover notification service's priority levels. 

#### Issues Fixed or Closed by this PR
None
