### PR TITLE
Phantom debian migration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,14 +2,14 @@
 # editorconfig.org
 root = true
 
-[*.{cs,html,js,hbs}]
+[*.{cs}]
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.less]
+[*.{js,html,js,hbs,less}]
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ UpdateVersionNumber()
         verBuild=`echo "${BUILD_NUMBER}" | cut -d. -f4`
         BUILD_NUMBER=$verMajorMinorRevision.$verBuild
         echo "##teamcity[buildNumber '$BUILD_NUMBER']"
-        sed -i "s/^[[]assembly: Assembly\(File\|Informational\)\?Version[(]\"[0-9.*]\+\"[)]/[assembly: Assembly\1Version(\"$BUILD_NUMBER\")/g" ./src/NzbDrone*/Properties/AssemblyInfo.cs ./src/Sonarr*/Properties/AssemblyInfo.cs ./src/ServiceHelpers/Properties/AssemblyInfo.cs ./src/Common/CommonVersionInfo.cs
+        sed -i "s/^[[]assembly: Assembly\(File\|Informational\)\?Version[(]\"[0-9.*]\+\"[)]/[assembly: Assembly\1Version(\"$BUILD_NUMBER\")/g" ./src/NzbDrone*/Properties/AssemblyInfo.cs ./src/Sonarr*/Properties/AssemblyInfo.cs ./src/ServiceHelpers/*/Properties/AssemblyInfo.cs ./src/Common/CommonVersionInfo.cs
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -42,11 +42,20 @@ ProgressEnd()
 UpdateVersionNumber()
 {
     if [ "$BUILD_NUMBER" != "" ]; then
+        echo "Updating Version Info"
         verMajorMinorRevision=`echo "$buildVersion" | cut -d. -f1,2,3`
-        verBuild=`echo "$BUILD_NUMBER" | cut -d. -f4`
+        verBuild=`echo "${BUILD_NUMBER}" | cut -d. -f4`
         BUILD_NUMBER=$verMajorMinorRevision.$verBuild
         echo "##teamcity[buildNumber '$BUILD_NUMBER']"
-        sed -i "s/^[[]assembly: Assembly\(File\|Informational\)\?Version[(]\"[0-9.*]\+\"[)]/[assembly: Assembly\1Version(\"$BUILD_NUMBER\")/g" ./src/**/Properties/AssemblyInfo.cs ./src/Common/CommonVersionInfo.cs
+        sed -i "s/^[[]assembly: Assembly\(File\|Informational\)\?Version[(]\"[0-9.*]\+\"[)]/[assembly: Assembly\1Version(\"$BUILD_NUMBER\")/g" ./src/NzbDrone*/Properties/AssemblyInfo.cs ./src/Sonarr*/Properties/AssemblyInfo.cs ./src/ServiceHelpers/Properties/AssemblyInfo.cs ./src/Common/CommonVersionInfo.cs
+    fi
+}
+
+CreateReleaseInfo()
+{
+    if [ "$BUILD_NUMBER" != "" ]; then
+        echo "Create Release Info"
+        echo -e "# Do Not Edit\nReleaseVersion=$BUILD_NUMBER\nBranch=${BRANCH:-dev}" > $outputFolder/release_info
     fi
 }
 
@@ -336,6 +345,7 @@ esac
 
 UpdateVersionNumber
 Build
+CreateReleaseInfo
 RunGulp
 PackageMono
 PackageMacOS

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,8 @@ updateFolderMono=$outputFolderLinux/Sonarr.Update
 nuget='tools/nuget/nuget.exe';
 vswhere='tools/vswhere/vswhere.exe';
 
+. ./version.sh
+
 CheckExitCode()
 {
     "$@"
@@ -35,6 +37,17 @@ ProgressEnd()
 {
     echo "##teamcity[progressFinish '$1']"
     echo "##teamcity[blockClosed name='$1']"
+}
+
+UpdateVersionNumber()
+{
+    if [ "$BUILD_NUMBER" != "" ]; then
+        verMajorMinorRevision=`echo "$buildVersion" | cut -d. -f1,2,3`
+        verBuild=`echo "$BUILD_NUMBER" | cut -d. -f4`
+        BUILD_NUMBER=$verMajorMinorRevision.$verBuild
+        echo "##teamcity[buildNumber '$BUILD_NUMBER']"
+        sed -i "s/^[[]assembly: Assembly\(File\|Informational\)\?Version[(]\"[0-9.*]\+\"[)]/[assembly: Assembly\1Version(\"$BUILD_NUMBER\")/g" ./src/**/Properties/AssemblyInfo.cs ./src/Common/CommonVersionInfo.cs
+    fi
 }
 
 CleanFolder()
@@ -321,6 +334,7 @@ case "$(uname -s)" in
         ;;
 esac
 
+UpdateVersionNumber
 Build
 RunGulp
 PackageMono

--- a/build.sh
+++ b/build.sh
@@ -196,6 +196,10 @@ PackageMono()
     echo "Adding CurlSharp.dll.config (for dllmap)"
     cp $sourceFolder/NzbDrone.Common/CurlSharp.dll.config $outputFolderLinux
 
+    echo "Adding unix System.Runtime.InteropServices.RuntimeInformation.dll (for SharpRaven)"
+    cp $sourceFolder/packages/System.Runtime.InteropServices.RuntimeInformation.4.3.0/runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll $outputFolderLinux
+    cp $sourceFolder/packages/System.Runtime.InteropServices.RuntimeInformation.4.3.0/runtimes/unix/lib/netstandard1.1/System.Runtime.InteropServices.RuntimeInformation.dll $outputFolderLinux/Sonarr.Update
+
     echo "Renaming Sonarr.Console.exe to Sonarr.exe"
     rm $outputFolderLinux/Sonarr.exe*
     for file in $outputFolderLinux/Sonarr.Console.exe*; do

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -1,7 +1,11 @@
 fromdos ./debian/*
+cp -r ./debian ./debian_backup
 
 BuildVersion=${dependent_build_number:-3.10.0.999}
 BuildBranch=${dependent_build_branch:-master}
+BootstrapVersion=`echo "$BuildVersion" | cut -d. -f1,2,3`
+BootstrapUpdater="BuiltIn"
+PackageUpdater="apt"
 
 echo Version: "$BuildVersion" Branch: "$BuildBranch"
 
@@ -12,8 +16,25 @@ chmod -R ugo-x,ugo+rwX,go-w ./sonarr_bin/*
 
 echo Updating changelog for $BuildVersion
 sed -i "s:{version}:$BuildVersion:g; s:{branch}:$BuildBranch:g;" debian/changelog
+sed -i "s:{version}:$BuildVersion:g; s:{updater}:$PackageUpdater:g" debian/preinst debian/postinst debian/postrm
+sed -i '/#BEGIN BUILTIN UPDATER/,/#END BUILTIN UPDATER/d' debian/preinst debian/postinst debian/postrm
+echo "# Do Not Edit\nReleaseVersion=$BuildVersion\nBranch=$BuildBranch" > release_info
+echo "# Do Not Edit\nPackageVersion=$BuildVersion\nReleaseVersion=$BuildVersion\nUpdateMethod=$PackageUpdater\nBranch=$BuildBranch" > package_info
 
 echo Running debuild for $BuildVersion
+debuild -b
+
+# Restore debian directory to the original files
+rm -rf ./debian
+mv ./debian_backup ./debian
+
+echo Updating changelog for $BootstrapVersion
+sed -i "s:{version}:$BootstrapVersion:g; s:{branch}:$BuildBranch:g;" debian/changelog
+sed -i "s:{version}:$BuildVersion:g; s:{updater}:$BootstrapUpdater:g" debian/preinst debian/postinst debian/postrm
+sed -i '/#BEGIN BUILTIN UPDATER/d; /#END BUILTIN UPDATER/d' debian/preinst debian/postinst debian/postrm
+echo "# Do Not Edit\nPackageVersion=$BootstrapVersion\nReleaseVersion=$BuildVersion\nUpdateMethod=$BootstrapUpdater\nBranch=$BuildBranch" > package_info
+
+echo Running debuild for $BootstrapVersion
 debuild -b
 
 echo Moving stuff around
@@ -23,6 +44,7 @@ rm ../sonarr_*.build
 
 echo Signing Package
 dpkg-sig -k 884589CE --sign builder "sonarr_${BuildVersion}_all.deb"
+dpkg-sig -k 884589CE --sign builder "sonarr_${BootstrapVersion}_all.deb"
 
 echo running alien
 alien -r -v ./*.deb

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -2,7 +2,8 @@ fromdos ./debian/*
 echo Version: "$dependent_build_number" Branch: "$dependent_build_branch"
 
 rm -r ./sonarr_bin/Sonarr.Update
-chmod -R 664 ./sonarr_bin/*
+rm ./sonarr_bin/System.Runtime.InteropServices.RuntimeInformation.dll
+chmod -R ugo-x,ugo+rwX,go-w ./sonarr_bin/*
 
 echo Updating changelog
 sed -i "s/{version}/$dependent_build_number/g" debian/changelog

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -10,8 +10,6 @@ PackageUpdater="apt"
 echo Version: "$BuildVersion" Branch: "$BuildBranch"
 
 rm -r ./sonarr_bin/Sonarr.Update
-rm ./sonarr_bin/System.Runtime.InteropServices.RuntimeInformation.dll
-rm ./sonarr_bin/UI/*.map ./sonarr_bin/UI/Content/*.map
 chmod -R ugo-x,ugo+rwX,go-w ./sonarr_bin/*
 
 echo Updating changelog for $BuildVersion

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -2,6 +2,7 @@ fromdos ./debian/*
 echo Version: "$dependent_build_number" Branch: "$dependent_build_branch"
 
 rm -r ./sonarr_bin/Sonarr.Update
+chmod -R 664 ./sonarr_bin/*
 
 echo Updating changelog
 sed -i "s/{version}/$dependent_build_number/g" debian/changelog

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -1,15 +1,19 @@
 fromdos ./debian/*
-echo Version: "$dependent_build_number" Branch: "$dependent_build_branch"
+
+BuildVersion=${dependent_build_number:-3.10.0.999}
+BuildBranch=${dependent_build_branch:-master}
+
+echo Version: "$BuildVersion" Branch: "$BuildBranch"
 
 rm -r ./sonarr_bin/Sonarr.Update
 rm ./sonarr_bin/System.Runtime.InteropServices.RuntimeInformation.dll
+rm ./sonarr_bin/UI/*.map ./sonarr_bin/UI/Content/*.map
 chmod -R ugo-x,ugo+rwX,go-w ./sonarr_bin/*
 
-echo Updating changelog
-sed -i "s/{version}/$dependent_build_number/g" debian/changelog
-sed -i "s/{branch}/$dependent_build_branch/g" debian/changelog
+echo Updating changelog for $BuildVersion
+sed -i "s:{version}:$BuildVersion:g; s:{branch}:$BuildBranch:g;" debian/changelog
 
-echo Running debuild
+echo Running debuild for $BuildVersion
 debuild -b
 
 echo Moving stuff around
@@ -18,7 +22,7 @@ mv ../sonarr_*.changes ./
 rm ../sonarr_*.build
 
 echo Signing Package
-dpkg-sig -k 884589CE --sign builder "sonarr_${dependent_build_number}_all.deb"
+dpkg-sig -k 884589CE --sign builder "sonarr_${BuildVersion}_all.deb"
 
 echo running alien
 alien -r -v ./*.deb

--- a/distribution/debian.sh
+++ b/distribution/debian.sh
@@ -18,7 +18,6 @@ echo Updating changelog for $BuildVersion
 sed -i "s:{version}:$BuildVersion:g; s:{branch}:$BuildBranch:g;" debian/changelog
 sed -i "s:{version}:$BuildVersion:g; s:{updater}:$PackageUpdater:g" debian/preinst debian/postinst debian/postrm
 sed -i '/#BEGIN BUILTIN UPDATER/,/#END BUILTIN UPDATER/d' debian/preinst debian/postinst debian/postrm
-echo "# Do Not Edit\nReleaseVersion=$BuildVersion\nBranch=$BuildBranch" > release_info
 echo "# Do Not Edit\nPackageVersion=$BuildVersion\nReleaseVersion=$BuildVersion\nUpdateMethod=$PackageUpdater\nBranch=$BuildBranch" > package_info
 
 echo Running debuild for $BuildVersion

--- a/distribution/debian/.editorconfig
+++ b/distribution/debian/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2

--- a/distribution/debian/.editorconfig
+++ b/distribution/debian/.editorconfig
@@ -2,6 +2,5 @@
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = lf
 indent_style = space
 indent_size = 2

--- a/distribution/debian/config
+++ b/distribution/debian/config
@@ -3,10 +3,12 @@
 . /usr/share/debconf/confmodule
 
 db_beginblock
-db_input medium sonarr/owning_user || true
+db_input high sonarr/owning_user || true
 db_input high sonarr/owning_group || true
-db_input low sonarr/config_directory || true
 db_endblock
+db_go
+
+db_input low sonarr/config_directory || true
 db_go
 
 exit 0

--- a/distribution/debian/config
+++ b/distribution/debian/config
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+. /usr/share/debconf/confmodule
+
+db_beginblock
+db_input medium sonarr/owning_user || true
+db_input high sonarr/owning_group || true
+db_input low sonarr/config_directory || true
+db_endblock
+db_go
+
+exit 0

--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -16,7 +16,6 @@ Architecture: all
 Provides: nzbdrone
 Conflicts: nzbdrone
 Replaces: nzbdrone
-Depends: adduser, libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), mono-runtime (>= 5.4), ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
-Recommends: sqlite3 (>= 3.7), mediainfo (>= 0.7.52), ${shlibs:Recommends}, ${cli:Recommends}, ${misc:Recommends}
-Suggests: ${shlibs:Suggests}, ${cli:Suggests}, ${misc:Suggests}
+Depends: adduser, libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), mono-runtime (>= 5.4), ${cli:Depends}, ${misc:Depends}
+Recommends: sqlite3 (>= 3.7), mediainfo (>= 0.7.52), ${cli:Recommends}
 Description: Internet PVR

--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -13,7 +13,9 @@ Build-Depends:  debhelper (>= 9),
 
 Package: sonarr
 Architecture: all
+Provides: nzbdrone
 Conflicts: nzbdrone
+Replaces: nzbdrone
 Depends: libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
 Recommends: sqlite3 (>= 3.7), mediainfo (>= 0.7.52), ${shlibs:Recommends}, ${cli:Recommends}, ${misc:Recommends}
 Suggests: ${shlibs:Suggests}, ${cli:Suggests}, ${misc:Suggests}

--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -5,6 +5,8 @@ Source: sonarr
 Homepage: https://sonarr.tv
 Vcs-Git: git@github.com:Sonarr/Sonarr.git
 Vcs-Browser: https://github.com/Sonarr/Sonarr
+Build-Depends:  debhelper (>= 9),
+                dh-systemd (>= 1.5)
 
 Package: sonarr
 Architecture: all

--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -9,14 +9,14 @@ Build-Depends:  debhelper (>= 9),
                 dh-systemd (>= 1.5),
                 mono-devel (>= 4.6),
                 libmono-cil-dev (>= 4.6),
-                cli-common-dev (>= 0.9)
+                cli-common-dev (>= 0.5.7)
 
 Package: sonarr
 Architecture: all
 Provides: nzbdrone
 Conflicts: nzbdrone
 Replaces: nzbdrone
-Depends: libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
+Depends: adduser, libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), mono-runtime (>= 5.4), ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
 Recommends: sqlite3 (>= 3.7), mediainfo (>= 0.7.52), ${shlibs:Recommends}, ${cli:Recommends}, ${misc:Recommends}
 Suggests: ${shlibs:Suggests}, ${cli:Suggests}, ${misc:Suggests}
 Description: Internet PVR

--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -6,10 +6,15 @@ Homepage: https://sonarr.tv
 Vcs-Git: git@github.com:Sonarr/Sonarr.git
 Vcs-Browser: https://github.com/Sonarr/Sonarr
 Build-Depends:  debhelper (>= 9),
-                dh-systemd (>= 1.5)
+                dh-systemd (>= 1.5),
+                mono-devel (>= 4.6),
+                libmono-cil-dev (>= 4.6),
+                cli-common-dev (>= 0.9)
 
 Package: sonarr
 Architecture: all
 Conflicts: nzbdrone
-Depends: libmono-cil-dev (>= 4.6), sqlite3 (>= 3.7), mediainfo (>= 0.7.52)
+Depends: libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52), ${shlibs:Depends}, ${cli:Depends}, ${misc:Depends}
+Recommends: sqlite3 (>= 3.7), mediainfo (>= 0.7.52), ${shlibs:Recommends}, ${cli:Recommends}, ${misc:Recommends}
+Suggests: ${shlibs:Suggests}, ${cli:Suggests}, ${misc:Suggests}
 Description: Internet PVR

--- a/distribution/debian/install
+++ b/distribution/debian/install
@@ -1,1 +1,1 @@
-sonarr_bin/* /opt/sonarr/bin
+sonarr_bin/* /usr/lib/sonarr/bin

--- a/distribution/debian/install
+++ b/distribution/debian/install
@@ -1,2 +1,1 @@
 sonarr_bin/* /opt/sonarr
-debian/sonarr.service /lib/systemd/system

--- a/distribution/debian/install
+++ b/distribution/debian/install
@@ -1,1 +1,3 @@
 sonarr_bin/* /usr/lib/sonarr/bin
+release_info /usr/lib/sonarr/bin
+package_info /usr/lib/sonarr

--- a/distribution/debian/install
+++ b/distribution/debian/install
@@ -1,1 +1,1 @@
-sonarr_bin/* /opt/sonarr
+sonarr_bin/* /opt/sonarr/bin

--- a/distribution/debian/install
+++ b/distribution/debian/install
@@ -1,3 +1,2 @@
 sonarr_bin/* /usr/lib/sonarr/bin
-release_info /usr/lib/sonarr/bin
 package_info /usr/lib/sonarr

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -1,7 +1,9 @@
+#!/bin/sh
+set -e
+
 USER="sonarr"
 
 # Add User
-
 if ! getent passwd "$USER" >/dev/null; then
   adduser --quiet --system --shell /bin/bash --home /var/opt/sonarr --group "$USER"
 
@@ -10,24 +12,14 @@ if ! getent passwd "$USER" >/dev/null; then
     usermod -a -G "$USER" "$USER"
   fi
 fi
-  
-# Create home directory
 
+# Create home directory
 if [ ! -d /var/opt/sonarr ]; then
   mkdir -p /var/opt/sonarr
-  chown $USER:$USER /var/opt/sonarr
+  chown -R $USER: /var/opt/sonarr
 fi
 
 # Set permissions on /opt/sonarr
+chown -R $USER: /opt/sonarr
 
-chown -R $USER:$USER /opt/sonarr
-
-# Start Sonarr automatically
-
-if [ -f /proc/1/comm ]; then
-  if [ "`cat /proc/1/comm`" = "systemd" ]; then
-    # Enable and start systemd service
-    systemctl enable sonarr.service
-    systemctl start sonarr.service
-  fi
-fi
+#DEBHELPER#

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -1,10 +1,8 @@
 #!/bin/sh
 set -e
 
-# Source debconf library.
-. /usr/share/debconf/confmodule
 
-SYSTEMD_UNIT=/lib/systemd/system/sonarr.service
+. /usr/share/debconf/confmodule
 db_get sonarr/owning_user
 USER="$RET"
 db_get sonarr/owning_group
@@ -20,15 +18,18 @@ if ! getent passwd "$USER" >/dev/null; then
   adduser --system --no-create-home --ingroup "$GROUP" "$USER"
 fi
 
-# Migrate old data dir (Sonarr v3 alpha)
-if [ -d "/var/opt/sonarr" ] && [ "$CONFDIR" != "/var/opt/sonarr" ]; then
-  if [ ! -f "/var/opt/sonarr/sonarr.db" ] && [ -f "/var/opt/sonarr/.config/Sonarr/sonarr.db" ]; then
-    mv "/var/opt/sonarr/.config/Sonarr" "$CONFDIR"
-    rm -rf "/var/opt/sonarr"
-  else
-    mv "/var/opt/sonarr" "$CONFDIR"
+if [ $1 = "configure" ]; then
+  # Migrate old Sonarr v3 alpha data dir
+  if [ -d "/var/opt/sonarr" ] && [ "$CONFDIR" != "/var/opt/sonarr" ] && [ ! -d "$CONFDIR" ]; then
+    if [ ! -f "/var/opt/sonarr/sonarr.db" ] && [ -f "/var/opt/sonarr/.config/Sonarr/sonarr.db" ]; then
+      mv "/var/opt/sonarr/.config/Sonarr" "$CONFDIR"
+      rm -rf "/var/opt/sonarr"
+    else
+      mv "/var/opt/sonarr" "$CONFDIR"
+    fi
+    chown -R $USER:$GROUP "$CONFDIR"
+    chmod -R 775 "$CONFDIR"
   fi
-  chown -R $USER:$GROUP "$CONFDIR"
 fi
 
 # Create data directory
@@ -41,7 +42,7 @@ fi
 chown -R $USER:$GROUP /usr/lib/sonarr
 
 # Update sonarr.service file
-sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/lib/sonarr:-data=$CONFDIR:g" $SYSTEMD_UNIT
+sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/lib/sonarr:-data=$CONFDIR:g" /lib/systemd/system/sonarr.service
 
 #DEBHELPER#
 

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+BUILD_VERSION={version}
+UPDATER={updater}
 
 . /usr/share/debconf/confmodule
 db_get sonarr/owning_user
@@ -38,11 +40,40 @@ if [ ! -d "$CONFDIR" ]; then
   chown -R $USER:$GROUP "$CONFDIR"
 fi
 
+#BEGIN BUILTIN UPDATER
+# Apply patch if present
+if [ "$UPDATER" = "BuiltIn" ] && [ -f /usr/lib/sonarr/bin_patch/release_info ]; then
+  # It shouldn't be possible to get a wrong bin_patch, but let's check anyway and throw it away if it's wrong
+  currentVersion=`cat /usr/lib/sonarr/bin_patch/release_info | grep 'ReleaseVersion=' | cut -d= -f 2`
+  currentRelease=`echo "$currentVersion" | cut -d. -f1,2,3`
+  currentBuild=`echo "$currentVersion" | cut -d. -f4`
+  targetVersion=$BUILD_VERSION
+  targetRelease=`echo "$targetVersion" | cut -d. -f1,2,3`
+  targetBuild=`echo "$targetVersion" | cut -d. -f4`
+
+  if [ "$currentRelease" = "$targetRelease" ] && [ "$currentBuild" -gt "$targetBuild" ]; then
+    echo "Applying $currentVersion from BuiltIn updater instead of downgrading to $targetVersion"
+    rm -rf /usr/lib/sonarr/bin
+    mv /usr/lib/sonarr/bin_patch /usr/lib/sonarr/bin
+  else
+    rm -rf /usr/lib/sonarr/bin_patch
+  fi
+fi
+#END BUILTIN UPDATER
+
 # Set permissions on /usr/lib/sonarr
 chown -R $USER:$GROUP /usr/lib/sonarr
 
 # Update sonarr.service file
 sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/lib/sonarr:-data=$CONFDIR:g" /lib/systemd/system/sonarr.service
+
+#BEGIN BUILTIN UPDATER
+if [ $1 = "upgrade" ] && [ "$UPDATER" = "BuiltIn" ]; then
+  # If we upgraded, signal Sonarr to do an update check on startup instead of scheduled.
+  touch $CONFDIR/update_required
+  chown $USER:$GROUP $CONFDIR/update_required
+fi
+#END BUILTIN UPDATER
 
 #DEBHELPER#
 

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -32,6 +32,21 @@ if [ $1 = "configure" ]; then
     chown -R $USER:$GROUP "$CONFDIR"
     chmod -R 775 "$CONFDIR"
   fi
+
+  # Migrate old NzbDrone data dir
+  if [ -d "/usr/lib/sonarr/nzbdrone-appdata" ] && [ ! -d "$CONFDIR" ]; then
+    NZBDRONE_DATA=`readlink /usr/lib/sonarr/nzbdrone-appdata`
+    if [ -f "$NZBDRONE_DATA/config.xml" ] && [ -f "$NZBDRONE_DATA/nzbdrone.db" ]; then
+      echo "Found NzbDrone database in $NZBDRONE_DATA, copying to $CONFDIR."
+      mkdir -p "$CONFDIR"
+      cp $NZBDRONE_DATA/config.xml $NZBDRONE_DATA/nzbdrone.db* "$CONFDIR/"
+      chown -R $USER:$GROUP "$CONFDIR"
+      chmod -R 775 "$CONFDIR"
+    else
+      echo "Missing NzbDrone database in $NZBDRONE_DATA, skipping migration."
+    fi
+    rm /usr/lib/sonarr/nzbdrone-appdata
+  fi
 fi
 
 # Create data directory

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -1,25 +1,37 @@
 #!/bin/sh
 set -e
 
-USER="sonarr"
+# Source debconf library.
+. /usr/share/debconf/confmodule
 
-# Add User
+SYSTEMD_UNIT=/lib/systemd/system/sonarr.service
+db_get sonarr/owning_user
+USER="$RET"
+db_get sonarr/owning_group
+GROUP="$RET"
+db_get sonarr/config_directory
+CONFDIR="$RET"
+
+# Add User and Group
+if ! getent group "$GROUP" >/dev/null; then
+  groupadd "$GROUP"
+fi
 if ! getent passwd "$USER" >/dev/null; then
-  adduser --quiet --system --shell /bin/bash --home /var/opt/sonarr --group "$USER"
-
-  if ! getent group "$USER" >/dev/null; then
-    groupadd "$USER"
-    usermod -a -G "$USER" "$USER"
-  fi
+  adduser --system --no-create-home --ingroup "$GROUP" "$USER"
 fi
 
-# Create home directory
-if [ ! -d /var/opt/sonarr ]; then
-  mkdir -p /var/opt/sonarr
-  chown -R $USER: /var/opt/sonarr
+# Create data directory
+if [ ! -d "$CONFDIR" ]; then
+  mkdir -p "$CONFDIR"
+  chown -R $USER:$GROUP "$CONFDIR"
 fi
 
 # Set permissions on /opt/sonarr
-chown -R $USER: /opt/sonarr
+chown -R $USER:$GROUP /opt/sonarr
+
+# Update sonarr.service file
+sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/opt/sonarr:-data=$CONFDIR:g" $SYSTEMD_UNIT
 
 #DEBHELPER#
+
+exit 0

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -20,17 +20,28 @@ if ! getent passwd "$USER" >/dev/null; then
   adduser --system --no-create-home --ingroup "$GROUP" "$USER"
 fi
 
+# Migrate old data dir (Sonarr v3 alpha)
+if [ -d "/var/opt/sonarr" ] && [ "$CONFDIR" != "/var/opt/sonarr" ]; then
+  if [ ! -f "/var/opt/sonarr/sonarr.db" ] && [ -f "/var/opt/sonarr/.config/Sonarr/sonarr.db" ]; then
+    mv "/var/opt/sonarr/.config/Sonarr" "$CONFDIR"
+    rm -rf "/var/opt/sonarr"
+  else
+    mv "/var/opt/sonarr" "$CONFDIR"
+  fi
+  chown -R $USER:$GROUP "$CONFDIR"
+fi
+
 # Create data directory
 if [ ! -d "$CONFDIR" ]; then
   mkdir -p "$CONFDIR"
   chown -R $USER:$GROUP "$CONFDIR"
 fi
 
-# Set permissions on /opt/sonarr
-chown -R $USER:$GROUP /opt/sonarr
+# Set permissions on /usr/lib/sonarr
+chown -R $USER:$GROUP /usr/lib/sonarr
 
 # Update sonarr.service file
-sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/opt/sonarr:-data=$CONFDIR:g" $SYSTEMD_UNIT
+sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/lib/sonarr:-data=$CONFDIR:g" $SYSTEMD_UNIT
 
 #DEBHELPER#
 

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -21,13 +21,25 @@ if ! getent passwd "$USER" >/dev/null; then
 fi
 
 if [ $1 = "configure" ]; then
-  # Migrate old Sonarr v3 alpha data dir
+  # Migrate old Sonarr v3 alpha data dir from /var/opt/sonarr or user home
   if [ -d "/var/opt/sonarr" ] && [ "$CONFDIR" != "/var/opt/sonarr" ] && [ ! -d "$CONFDIR" ]; then
-    if [ ! -f "/var/opt/sonarr/sonarr.db" ] && [ -f "/var/opt/sonarr/.config/Sonarr/sonarr.db" ]; then
-      mv "/var/opt/sonarr/.config/Sonarr" "$CONFDIR"
-      rm -rf "/var/opt/sonarr"
+    varoptRoot="/var/opt/sonarr"
+    varoptAppData="$varoptRoot/.config/Sonarr"
+    sonarrUserHome=`getent passwd $USER | cut -d ':' -f 6`
+    sonarrAppData="$sonarrUserHome/.config/Sonarr"
+    if [ ! -f "$varoptRoot/sonarr.db" ]; then
+      # Handle /var/opt/sonarr/sonarr.db
+      mv "$varoptRoot" "$CONFDIR"
+    elif [ -f "$varoptAppData/sonarr.db" ]; then
+      # Handle /var/opt/sonarr/.config/Sonarr/sonarr.db
+      mv "$varoptAppData" "$CONFDIR"
+      rm -rf "$varoptRoot"
+    elif [ -f "$sonarrAppData/sonarr.db" ]; then
+      # Handle ~/.config/Sonarr/sonarr.db
+      mv "$sonarrAppData" "$CONFDIR"
+      rm -rf "$sonarrAppData"
     else
-      mv "/var/opt/sonarr" "$CONFDIR"
+      mv "$varoptRoot" "$CONFDIR"
     fi
     chown -R $USER:$GROUP "$CONFDIR"
     chmod -R 775 "$CONFDIR"

--- a/distribution/debian/postrm
+++ b/distribution/debian/postrm
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "abort-install" ]; then
+    # preinst was aborted, possibly due to NzbDrone still running.
+    # Nothing to do here
+	:
+fi
+
+# Purge the entire sonarr configuration directory.
+# TODO: Maybe move a minimal backup to tmp?
+if [ "$1" = "purge" ]; then
+	if [ -d "/var/opt/sonarr" ]; then
+		rm -rf /var/opt/sonarr
+	fi
+fi
+
+#DEBHELPER#

--- a/distribution/debian/postrm
+++ b/distribution/debian/postrm
@@ -1,21 +1,26 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "abort-install" ]; then
-    # preinst was aborted, possibly due to NzbDrone still running.
-    # Nothing to do here
-	:
+if [ $1 = "abort-install" ]; then
+  # preinst was aborted, possibly due to NzbDrone still running.
+  # Nothing to do here
+  :
+fi
+
+# The bin directory is expected to be empty, unless the BuiltIn updater added files.
+if [ $1 = "remove" ] && [ -d /usr/lib/sonarr/bin ]; then
+  rm -rf /usr/lib/sonarr/bin
 fi
 
 # Purge the entire sonarr configuration directory.
 # TODO: Maybe move a minimal backup to tmp?
-if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
-	. /usr/share/debconf/confmodule
-	db_get sonarr/config_directory
-	CONFDIR="$RET"
-	if [ -d "$CONFDIR" ]; then
-		rm -rf "$CONFDIR"
-	fi
+if [ $1 = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+  . /usr/share/debconf/confmodule
+  db_get sonarr/config_directory
+  CONFDIR="$RET"
+  if [ -d "$CONFDIR" ]; then
+    rm -rf "$CONFDIR"
+  fi
 fi
 
 #DEBHELPER#

--- a/distribution/debian/postrm
+++ b/distribution/debian/postrm
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+BUILD_VERSION={version}
+UPDATER={updater}
+
 if [ $1 = "abort-install" ]; then
   # preinst was aborted, possibly due to NzbDrone still running.
   # Nothing to do here
@@ -11,6 +14,13 @@ fi
 if [ $1 = "remove" ] && [ -d /usr/lib/sonarr/bin ]; then
   rm -rf /usr/lib/sonarr/bin
 fi
+
+#BEGIN BUILTIN UPDATER
+# Remove any existing patch if still present
+if [ $1 = "remove" ] && [ -d /usr/lib/sonarr/bin_patch ]; then
+  rm -rf /usr/lib/sonarr/bin_patch
+fi
+#END BUILTIN UPDATER
 
 # Purge the entire sonarr configuration directory.
 # TODO: Maybe move a minimal backup to tmp?

--- a/distribution/debian/postrm
+++ b/distribution/debian/postrm
@@ -9,9 +9,12 @@ fi
 
 # Purge the entire sonarr configuration directory.
 # TODO: Maybe move a minimal backup to tmp?
-if [ "$1" = "purge" ]; then
-	if [ -d "/var/opt/sonarr" ]; then
-		rm -rf /var/opt/sonarr
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+	. /usr/share/debconf/confmodule
+	db_get sonarr/config_directory
+	CONFDIR="$RET"
+	if [ -d "$CONFDIR" ]; then
+		rm -rf "$CONFDIR"
 	fi
 fi
 

--- a/distribution/debian/postrm
+++ b/distribution/debian/postrm
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-# In case this system is running systemd, we make systemd reload the unit files
-# to pick up changes.
-if [ -d /run/systemd/system ] ; then
-	systemctl --system daemon-reload >/dev/null || true
-fi
-# End automatically added section

--- a/distribution/debian/preinst
+++ b/distribution/debian/preinst
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+BUILD_VERSION={version}
+UPDATER={updater}
+
 # Deal with existing nzbdrone installs
 #
 # Any existing nzbdrone package would already be in de deconfigured stage, so the binaries are gone.
@@ -18,6 +21,33 @@ if [ $1 = "install" ]; then
         exit 1
     fi
 fi
+
+
+#BEGIN BUILTIN UPDATER
+# Check for supported upgrade paths
+if [ $1 = "upgrade" ] && [ "$UPDATER" = "BuiltIn" ] && [ -f /usr/lib/sonarr/bin/release_info ]; then
+  # If we allow the Built-In updater to upgrade from 3.0.1.123 to 3.0.2.500 and now apt is catching up to 3.0.2.425
+  # then we need to deal with that 500->425 'downgrade'.
+  # We do that by preserving the binaries and using those instead for postinst.
+
+  currentVersion=`cat /usr/lib/sonarr/bin/release_info | grep 'ReleaseVersion=' | cut -d= -f 2`
+  currentRelease=`echo "$currentVersion" | cut -d. -f1,2,3`
+  currentBuild=`echo "$currentVersion" | cut -d. -f4`
+  targetVersion=$BUILD_VERSION
+  targetRelease=`echo "$targetVersion" | cut -d. -f1,2,3`
+  targetBuild=`echo "$targetVersion" | cut -d. -f4`
+
+  if [ -d /usr/lib/sonarr/bin_patch ]; then
+    rm -rf /usr/lib/sonarr/bin_patch
+  fi
+
+  # Check if the existing version is already an upgrade for the included build
+  if [ "$currentRelease" = "$targetRelease" ] && [ "$currentBuild" -gt "$targetBuild" ]; then
+    echo "Preserving $currentVersion from BuiltIn updater instead of downgrading to $targetVersion"
+    cp -r /usr/lib/sonarr/bin /usr/lib/sonarr/bin_patch
+  fi
+fi
+#END BUILTIN UPDATER
 
 #DEBHELPER#
 

--- a/distribution/debian/preinst
+++ b/distribution/debian/preinst
@@ -6,22 +6,44 @@ UPDATER={updater}
 
 # Deal with existing nzbdrone installs
 #
-# Any existing nzbdrone package would already be in de deconfigured stage, so the binaries are gone.
-# However the process might still be running since those are not part of the nzbdrone package.
+# Existing nzbdrone packages do not have startup scripts and the process might still be running.
 # If the user manually installed nzbdrone then the process might still be running too.
-
 if [ $1 = "install" ]; then
-    psNzbDrone=`ps aux | grep mono.*NzbDrone\\\\.exe || true`
-    if [ ! -z "$psNzbDrone" ]; then
-        # TODO: Perform operations to detect auto-migration capabilities.
-        
-        # Return failure, which causes postrm abort-install to be called.
-        echo "ps: $psNzbDrone"
-        echo "Error: An existing Sonarr v2 (NzbDrone) process is running. Remove the NzbDrone auto-startup prior to installing sonarr."
-        exit 1
+  psNzbDrone=`ps ax -o'user,pid,ppid,unit,args' | grep mono.*NzbDrone\\\\.exe || true`
+  if [ ! -z "$psNzbDrone" ]; then
+    # Get the user and optional systemd unit
+    psNzbDroneUser=`echo "$psNzbDrone" | tr -s ' ' | cut -d ' ' -f 1`
+    psNzbDroneUnit=`echo "$psNzbDrone" | tr -s ' ' | cut -d ' ' -f 4`
+    # Get the appdata from the cmdline or get it from the user dir
+    droneAppData=`echo "$psNzbDrone" | tr ' ' '\n' | grep -- "-data=" | cut -d= -f 2`
+    if [ "$droneAppData" = "" ]; then
+      droneUserHome=`getent passwd $psNzbDroneUser | cut -d ':' -f 6`
+      droneAppData="$droneUserHome/.config/NzbDrone"
     fi
-fi
 
+    if [ "$psNzbDroneUnit" != "-" ] && [ -d /run/systemd/system ]; then
+      # The user used a systemd auto-startup for NzbDrone, we can deal with that.
+      echo "NzbDrone systemd startup detected at $psNzbDroneUnit, stopping and disabling..."
+      deb-systemd-invoke stop $psNzbDroneUnit >/dev/null
+      deb-systemd-invoke mask $psNzbDroneUnit >/dev/null
+    else
+      # We don't support auto migration for other startup methods, so bail.
+      # This leaves the sonarr package in an incomplete state.
+      echo "ps: $psNzbDrone"
+      echo "Error: An existing Sonarr v2 (NzbDrone) process is running. Remove the NzbDrone auto-startup prior to installing sonarr."
+      exit 1
+    fi
+
+    # We don't have the debconf configuration yet so we can't migrate the data.
+    # Instead we symlink so postinst knows where it's at.
+    if [ -f "/usr/lib/sonarr/nzbdrone-appdata" ]; then
+      rm "/usr/lib/sonarr/nzbdrone-appdata"
+    else
+      mkdir -p "/usr/lib/sonarr"
+    fi
+    ln -s $droneAppData /usr/lib/sonarr/nzbdrone-appdata
+  fi
+fi
 
 #BEGIN BUILTIN UPDATER
 # Check for supported upgrade paths

--- a/distribution/debian/preinst
+++ b/distribution/debian/preinst
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+# Deal with existing nzbdrone installs
+#
+# Any existing nzbdrone package would already be in de deconfigured stage, so the binaries are gone.
+# However the process might still be running since those are not part of the nzbdrone package.
+# If the user manually installed nzbdrone then the process might still be running too.
+
+if [ $1 = "install" ]; then
+    psNzbDrone=`ps aux | grep mono.*NzbDrone\\\\.exe || true`
+    if [ ! -z "$psNzbDrone" ]; then
+        # TODO: Perform operations to detect auto-migration capabilities.
+        
+        # Return failure, which causes postrm abort-install to be called.
+        echo "ps: $psNzbDrone"
+        echo "Error: An existing Sonarr v2 (NzbDrone) process is running. Remove the NzbDrone auto-startup prior to installing sonarr."
+        exit 1
+    fi
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/distribution/debian/prerm
+++ b/distribution/debian/prerm
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ -f /proc/1/comm ] && [ "`cat /proc/1/comm`" = "systemd" ]; then
-  rm -f /etc/init.d/sonarr
-  systemctl stop sonarr.service
-  systemctl disable sonarr.service
-fi

--- a/distribution/debian/rules
+++ b/distribution/debian/rules
@@ -9,8 +9,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-EXCLUDE_MODULEREFS = crypt32 httpapi ntdll api-ms-win-core-sysinfo-l1-1-0 api-ms-win-core-sysinfo-l1-2-0 \
-					 libcurl3 msbuild
+EXCLUDE_MODULEREFS = crypt32 httpapi
 
 %:
 	dh $@ --with=systemd --with=cli

--- a/distribution/debian/rules
+++ b/distribution/debian/rules
@@ -9,9 +9,20 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+EXCLUDE_MODULEREFS = crypt32 httpapi ntdll api-ms-win-core-sysinfo-l1-1-0 api-ms-win-core-sysinfo-l1-2-0 \
+					 libcurl3 msbuild
+
 %:
-	dh $@ --with=systemd
+	dh $@ --with=systemd --with=cli
 
 # No init script, only systemd
 override_dh_installinit:
 	true
+
+# Sonarr like debug symbols for logging
+override_dh_clistrip:
+
+override_dh_makeclilibs:
+
+override_dh_clideps:
+	dh_clideps -d -r $(patsubst %,--exclude-moduleref=%,$(EXCLUDE_MODULEREFS))

--- a/distribution/debian/rules
+++ b/distribution/debian/rules
@@ -10,4 +10,8 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@ --with=systemd
+
+# No init script, only systemd
+override_dh_installinit:
+	true

--- a/distribution/debian/rules
+++ b/distribution/debian/rules
@@ -9,7 +9,9 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-EXCLUDE_MODULEREFS = crypt32 httpapi
+# Note: System.Native is a dependency of System.Runtime.InteropServices.RuntimeInformation used by SharpRaven,
+#       but SharpRaven doesn't use any functions that need System.Native
+EXCLUDE_MODULEREFS = crypt32 httpapi System.Native
 
 %:
 	dh $@ --with=systemd --with=cli

--- a/distribution/debian/sonarr.clideps-override
+++ b/distribution/debian/sonarr.clideps-override
@@ -1,0 +1,2 @@
+recommends libcurl3
+ignores msbuild

--- a/distribution/debian/sonarr.service
+++ b/distribution/debian/sonarr.service
@@ -5,9 +5,10 @@ After=network.target
 [Service]
 User=sonarr
 Group=sonarr
+UMask=002
 
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/sonarr/bin/Sonarr.exe -nobrowser
+ExecStart=/usr/bin/mono --debug /opt/sonarr/bin/Sonarr.exe -nobrowser -data=/var/opt/sonarr
 TimeoutStopSec=20
 KillMode=process
 Restart=on-failure

--- a/distribution/debian/sonarr.service
+++ b/distribution/debian/sonarr.service
@@ -8,7 +8,7 @@ Group=sonarr
 UMask=002
 
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/sonarr/bin/Sonarr.exe -nobrowser -data=/var/opt/sonarr
+ExecStart=/usr/bin/mono --debug /usr/lib/sonarr/bin/Sonarr.exe -nobrowser -data=/var/lib/sonarr
 TimeoutStopSec=20
 KillMode=process
 Restart=on-failure

--- a/distribution/debian/sonarr.service
+++ b/distribution/debian/sonarr.service
@@ -7,7 +7,7 @@ User=sonarr
 Group=sonarr
 
 Type=simple
-ExecStart=/usr/bin/mono --debug /opt/sonarr/Sonarr.exe -nobrowser
+ExecStart=/usr/bin/mono --debug /opt/sonarr/bin/Sonarr.exe -nobrowser
 TimeoutStopSec=20
 KillMode=process
 Restart=on-failure

--- a/distribution/debian/templates
+++ b/distribution/debian/templates
@@ -1,0 +1,19 @@
+Template: sonarr/owning_user
+Type: string
+Default: sonarr
+Description: Sonarr user:
+    Specify the user that Sonarr must run as. The user will be created if it does not already exist.
+
+Template: sonarr/owning_group
+Type: string
+Default: sonarr
+Description: Sonarr group:
+    Specify the group that Sonarr must run as. The group will be created if it does not already exist.
+    If the user doesn't already exist then this group will be specified as the user's primary group.
+    Any media files created by Sonarr will be writeable by this group.
+
+Template: sonarr/config_directory
+Type: string
+Default: /var/lib/sonarr
+Description: Config directory:
+    Specify the directory where Sonarr stores the internal database and metadata. Media content will be stored elsewhere.

--- a/distribution/debian/templates
+++ b/distribution/debian/templates
@@ -2,14 +2,15 @@ Template: sonarr/owning_user
 Type: string
 Default: sonarr
 Description: Sonarr user:
-  Specify the user that Sonarr must run as. The user will be created if it does not already exist.
+  Specify the user that is used to run Sonarr. The user will be created if it does not already exist.
+  The default 'sonarr' should work fine for most users. You can specify the user group next.
 
 Template: sonarr/owning_group
 Type: string
 Default: sonarr
 Description: Sonarr group:
-  Specify the group that Sonarr must run as. The group will be created if it does not already exist.
-  If the user doesn't already exist then this group will be specified as the user's primary group.
+  Specify the group that is used to run Sonarr. The group will be created if it does not already exist.
+  If the user doesn't already exist then this group will be used as the user's primary group.
   Any media files created by Sonarr will be writeable by this group.
   It's advisable to keep the group the same between download client, Sonarr and media centers.
 

--- a/distribution/debian/templates
+++ b/distribution/debian/templates
@@ -2,18 +2,19 @@ Template: sonarr/owning_user
 Type: string
 Default: sonarr
 Description: Sonarr user:
-    Specify the user that Sonarr must run as. The user will be created if it does not already exist.
+  Specify the user that Sonarr must run as. The user will be created if it does not already exist.
 
 Template: sonarr/owning_group
 Type: string
 Default: sonarr
 Description: Sonarr group:
-    Specify the group that Sonarr must run as. The group will be created if it does not already exist.
-    If the user doesn't already exist then this group will be specified as the user's primary group.
-    Any media files created by Sonarr will be writeable by this group.
+  Specify the group that Sonarr must run as. The group will be created if it does not already exist.
+  If the user doesn't already exist then this group will be specified as the user's primary group.
+  Any media files created by Sonarr will be writeable by this group.
+  It's advisable to keep the group the same between download client, Sonarr and media centers.
 
 Template: sonarr/config_directory
 Type: string
 Default: /var/lib/sonarr
 Description: Config directory:
-    Specify the directory where Sonarr stores the internal database and metadata. Media content will be stored elsewhere.
+  Specify the directory where Sonarr stores the internal database and metadata. Media content will be stored elsewhere.

--- a/frontend/src/Settings/General/BackupSettings.js
+++ b/frontend/src/Settings/General/BackupSettings.js
@@ -49,7 +49,8 @@ function BackupSettings(props) {
         <FormInputGroup
           type={inputTypes.NUMBER}
           name="backupInterval"
-          helpText="Interval in days"
+          unit="days"
+          helpText="Interval between automatic backups"
           onChange={onInputChange}
           {...backupInterval}
         />
@@ -64,7 +65,8 @@ function BackupSettings(props) {
         <FormInputGroup
           type={inputTypes.NUMBER}
           name="backupRetention"
-          helpText="Retention in days. Automatic backups older the retention will be cleaned up automatically"
+          unit="days"
+          helpText="Automatic backups older the retention will be cleaned up automatically"
           onChange={onInputChange}
           {...backupRetention}
         />

--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -99,6 +99,7 @@ class GeneralSettings extends Component {
       isMono,
       isWindows,
       mode,
+      packageUpdateMechanism,
       onInputChange,
       onConfirmResetApiKey,
       ...otherProps
@@ -161,6 +162,7 @@ class GeneralSettings extends Component {
                   advancedSettings={advancedSettings}
                   settings={settings}
                   isMono={isMono}
+                  packageUpdateMechanism={packageUpdateMechanism}
                   onInputChange={onInputChange}
                 />
 
@@ -202,6 +204,7 @@ GeneralSettings.propTypes = {
   isMono: PropTypes.bool.isRequired,
   isWindows: PropTypes.bool.isRequired,
   mode: PropTypes.string.isRequired,
+  packageUpdateMechanism: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,
   onConfirmResetApiKey: PropTypes.func.isRequired,
   onConfirmRestart: PropTypes.func.isRequired

--- a/frontend/src/Settings/General/GeneralSettingsConnector.js
+++ b/frontend/src/Settings/General/GeneralSettingsConnector.js
@@ -27,6 +27,7 @@ function createMapStateToProps() {
         isMono: systemStatus.isMono,
         isWindows: systemStatus.isWindows,
         mode: systemStatus.mode,
+        packageUpdateMechanism: systemStatus.packageUpdateMechanism,
         ...sectionSettings
       };
     }

--- a/frontend/src/Settings/General/UpdateSettings.js
+++ b/frontend/src/Settings/General/UpdateSettings.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import titleCase from 'Utilities/String/titleCase';
 import { inputTypes, sizes } from 'Helpers/Props';
 import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
@@ -11,6 +12,7 @@ function UpdateSettings(props) {
     advancedSettings,
     settings,
     isMono,
+    packageUpdateMechanism,
     onInputChange
   } = props;
 
@@ -29,6 +31,13 @@ function UpdateSettings(props) {
     { key: 'builtIn', value: 'Built-In' },
     { key: 'script', value: 'Script' }
   ];
+
+  if (packageUpdateMechanism !== 'builtIn') {
+    updateOptions.push({
+      key: packageUpdateMechanism,
+      value: titleCase(packageUpdateMechanism)
+    });
+  }
 
   return (
     <FieldSet legend="Updates">
@@ -50,58 +59,58 @@ function UpdateSettings(props) {
 
       {
         isMono &&
-        <div>
-          <FormGroup
-            advancedSettings={advancedSettings}
-            isAdvanced={true}
-            size={sizes.MEDIUM}
-          >
-            <FormLabel>Automatic</FormLabel>
+          <div>
+            <FormGroup
+              advancedSettings={advancedSettings}
+              isAdvanced={true}
+              size={sizes.MEDIUM}
+            >
+              <FormLabel>Automatic</FormLabel>
 
-            <FormInputGroup
-              type={inputTypes.CHECK}
-              name="updateAutomatically"
-              helpText="Automatically download and install updates. You will still be able to install from System: Updates"
-              onChange={onInputChange}
-              {...updateAutomatically}
-            />
-          </FormGroup>
+              <FormInputGroup
+                type={inputTypes.CHECK}
+                name="updateAutomatically"
+                helpText="Automatically download and install updates. You will still be able to install from System: Updates"
+                onChange={onInputChange}
+                {...updateAutomatically}
+              />
+            </FormGroup>
 
-          <FormGroup
-            advancedSettings={advancedSettings}
-            isAdvanced={true}
-          >
-            <FormLabel>Mechanism</FormLabel>
-
-            <FormInputGroup
-              type={inputTypes.SELECT}
-              name="updateMechanism"
-              values={updateOptions}
-              helpText="Use Sonarr's built-in updater or a script"
-              helpLink="https://github.com/Sonarr/Sonarr/wiki/Updating"
-              onChange={onInputChange}
-              {...updateMechanism}
-            />
-          </FormGroup>
-
-          {
-            updateMechanism.value === 'script' &&
             <FormGroup
               advancedSettings={advancedSettings}
               isAdvanced={true}
             >
-              <FormLabel>Script Path</FormLabel>
+              <FormLabel>Mechanism</FormLabel>
 
               <FormInputGroup
-                type={inputTypes.TEXT}
-                name="updateScriptPath"
-                helpText="Path to a custom script that takes an extracted update package and handle the remainder of the update process"
+                type={inputTypes.SELECT}
+                name="updateMechanism"
+                values={updateOptions}
+                helpText="Use Sonarr's built-in updater or a script"
+                helpLink="https://github.com/Sonarr/Sonarr/wiki/Updating"
                 onChange={onInputChange}
-                {...updateScriptPath}
+                {...updateMechanism}
               />
             </FormGroup>
-          }
-        </div>
+
+            {
+              updateMechanism.value === 'script' &&
+              <FormGroup
+                advancedSettings={advancedSettings}
+                isAdvanced={true}
+              >
+                <FormLabel>Script Path</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.TEXT}
+                  name="updateScriptPath"
+                  helpText="Path to a custom script that takes an extracted update package and handle the remainder of the update process"
+                  onChange={onInputChange}
+                  {...updateScriptPath}
+                />
+              </FormGroup>
+            }
+          </div>
       }
     </FieldSet>
   );
@@ -111,6 +120,7 @@ UpdateSettings.propTypes = {
   advancedSettings: PropTypes.bool.isRequired,
   settings: PropTypes.object.isRequired,
   isMono: PropTypes.bool.isRequired,
+  packageUpdateMechanism: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Settings/General/UpdateSettings.js
+++ b/frontend/src/Settings/General/UpdateSettings.js
@@ -27,17 +27,20 @@ function UpdateSettings(props) {
     return null;
   }
 
-  const updateOptions = [
-    { key: 'builtIn', value: 'Built-In' },
-    { key: 'script', value: 'Script' }
-  ];
+  const usingExternalUpdateMechanism = packageUpdateMechanism !== 'builtIn';
 
-  if (packageUpdateMechanism !== 'builtIn') {
+  const updateOptions = [];
+
+  if (usingExternalUpdateMechanism) {
     updateOptions.push({
       key: packageUpdateMechanism,
       value: titleCase(packageUpdateMechanism)
     });
+  } else {
+    updateOptions.push({ key: 'builtIn', value: 'Built-In' });
   }
+
+  updateOptions.push({ key: 'script', value: 'Script' });
 
   return (
     <FieldSet legend="Updates">
@@ -50,9 +53,10 @@ function UpdateSettings(props) {
         <FormInputGroup
           type={inputTypes.TEXT}
           name="branch"
-          helpText="Branch to use to update Sonarr"
+          helpText={usingExternalUpdateMechanism ? 'Branch used by external update mechanism' : 'Branch to use to update Sonarr'}
           helpLink="https://github.com/Sonarr/Sonarr/wiki/Release-Branches"
           onChange={onInputChange}
+          readOnly={usingExternalUpdateMechanism}
           {...branch}
         />
       </FormGroup>

--- a/frontend/src/System/Updates/Updates.css
+++ b/frontend/src/System/Updates/Updates.css
@@ -1,8 +1,4 @@
-.updateAvailable {
-  display: flex;
-}
-
-.upToDate {
+.messageContainer {
   display: flex;
   margin-bottom: 20px;
 }
@@ -12,7 +8,7 @@
   font-size: 30px;
 }
 
-.upToDateMessage {
+.message {
   padding-left: 5px;
   font-size: 18px;
   line-height: 30px;

--- a/frontend/src/System/Updates/Updates.js
+++ b/frontend/src/System/Updates/Updates.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { icons, kinds } from 'Helpers/Props';
 import formatDate from 'Utilities/Date/formatDate';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
@@ -21,15 +21,18 @@ class Updates extends Component {
     const {
       isFetching,
       isPopulated,
-      error,
+      updatesError,
+      generalSettingsError,
       items,
       isInstallingUpdate,
+      updateMechanism,
       shortDateFormat,
       onInstallLatestPress
     } = this.props;
 
-    const hasUpdates = isPopulated && !error && items.length > 0;
-    const noUpdates = isPopulated && !error && !items.length;
+    const hasError = !!(updatesError || generalSettingsError);
+    const hasUpdates = isPopulated && !hasError && items.length > 0;
+    const noUpdates = isPopulated && !hasError && !items.length;
     const hasUpdateToInstall = hasUpdates && _.some(items, { installable: true, latest: true });
     const noUpdateToInstall = hasUpdates && !hasUpdateToInstall;
 
@@ -37,7 +40,7 @@ class Updates extends Component {
       <PageContent title="Updates">
         <PageContentBodyConnector>
           {
-            !isPopulated && !error &&
+            !isPopulated && !hasError &&
               <LoadingIndicator />
           }
 
@@ -48,15 +51,30 @@ class Updates extends Component {
 
           {
             hasUpdateToInstall &&
-              <div className={styles.updateAvailable}>
-                <SpinnerButton
-                  className={styles.updateAvailable}
-                  kind={kinds.PRIMARY}
-                  isSpinning={isInstallingUpdate}
-                  onPress={onInstallLatestPress}
-                >
-                  Install Latest
-                </SpinnerButton>
+              <div className={styles.messageContainer}>
+                {
+                  updateMechanism === 'builtIn' || updateMechanism === 'script' ?
+                    <SpinnerButton
+                      className={styles.updateAvailable}
+                      kind={kinds.PRIMARY}
+                      isSpinning={isInstallingUpdate}
+                      onPress={onInstallLatestPress}
+                    >
+                      Install Latest
+                    </SpinnerButton> :
+
+                    <Fragment>
+                      <Icon
+                        name={icons.WARNING}
+                        kind={kinds.WARNING}
+                        size={30}
+                      />
+
+                      <div className={styles.message}>
+                        Unable to update Sonarr. Sonarr is configured to use an external update mechanism
+                      </div>
+                    </Fragment>
+                }
 
                 {
                   isFetching &&
@@ -70,13 +88,14 @@ class Updates extends Component {
 
           {
             noUpdateToInstall &&
-              <div className={styles.upToDate}>
+              <div className={styles.messageContainer}>
                 <Icon
                   className={styles.upToDateIcon}
                   name={icons.CHECK_CIRCLE}
                   size={30}
                 />
-                <div className={styles.upToDateMessage}>
+
+                <div className={styles.message}>
                   The latest version of Sonarr is already installed
                 </div>
 
@@ -144,9 +163,16 @@ class Updates extends Component {
           }
 
           {
-            !!error &&
+            !!updatesError &&
               <div>
                 Failed to fetch updates
+              </div>
+          }
+
+          {
+            !!generalSettingsError &&
+              <div>
+                Failed to update settings
               </div>
           }
         </PageContentBodyConnector>
@@ -159,9 +185,11 @@ class Updates extends Component {
 Updates.propTypes = {
   isFetching: PropTypes.bool.isRequired,
   isPopulated: PropTypes.bool.isRequired,
-  error: PropTypes.object,
+  updatesError: PropTypes.object,
+  generalSettingsError: PropTypes.object,
   items: PropTypes.array.isRequired,
   isInstallingUpdate: PropTypes.bool.isRequired,
+  updateMechanism: PropTypes.string.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
   onInstallLatestPress: PropTypes.func.isRequired
 };

--- a/frontend/src/System/Updates/Updates.js
+++ b/frontend/src/System/Updates/Updates.js
@@ -36,6 +36,12 @@ class Updates extends Component {
     const hasUpdateToInstall = hasUpdates && _.some(items, { installable: true, latest: true });
     const noUpdateToInstall = hasUpdates && !hasUpdateToInstall;
 
+    const externalUpdaterMessages = {
+      external: 'Unable to update Sonarr directly, Sonarr is configured to use an external update mechanism',
+      apt: 'Unable to update Sonarr directly, use apt to install the update',
+      docker: 'Unable to update Sonarr directly, update the docker container to receive the update'
+    };
+
     return (
       <PageContent title="Updates">
         <PageContentBodyConnector>
@@ -71,7 +77,7 @@ class Updates extends Component {
                       />
 
                       <div className={styles.message}>
-                        Unable to update Sonarr. Sonarr is configured to use an external update mechanism
+                        {externalUpdaterMessages[updateMechanism] || externalUpdaterMessages.external}
                       </div>
                     </Fragment>
                 }

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Configuration
         Version ReleaseVersion { get; }
         string ReleaseBranch { get; }
 
-        bool BuiltInUpdaterAllowed { get; }
+        bool IsExternalUpdateMechanism { get; }
         UpdateMechanism DefaultUpdateMechanism { get; }
         string DefaultBranch { get; }
     }
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Configuration
         public string ReleaseBranch { get; set; }
 
 
-        public bool BuiltInUpdaterAllowed => PackageUpdateMechanism == UpdateMechanism.BuiltIn;
+        public bool IsExternalUpdateMechanism => PackageUpdateMechanism >= UpdateMechanism.External;
         public UpdateMechanism DefaultUpdateMechanism { get; private set; }
         public string DefaultBranch { get; private set; }
     }

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -1,0 +1,118 @@
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Update;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.Configuration
+{
+    public interface IDeploymentInfoProvider
+    {
+        Version PackageVersion { get; }
+        string PackageBranch { get; }
+        UpdateMechanism PackageUpdateMechanism { get; }
+
+        Version ReleaseVersion { get; }
+        string ReleaseBranch { get; }
+
+        bool BuiltInUpdaterAllowed { get; }
+        UpdateMechanism DefaultUpdateMechanism { get; }
+        string DefaultBranch { get; }
+    }
+
+    public class DeploymentInfoProvider : IDeploymentInfoProvider
+    {
+        public DeploymentInfoProvider(IAppFolderInfo appFolderInfo, IDiskProvider diskProvider)
+        {
+            var bin = appFolderInfo.StartUpFolder;
+            var packageInfoPath = Path.Combine(bin, "..", "package_info");
+            var releaseInfoPath = Path.Combine(bin, "release_info");
+
+            PackageUpdateMechanism = UpdateMechanism.BuiltIn;
+            DefaultBranch = "master";
+
+            if (Path.GetFileName(bin) == "bin" && diskProvider.FileExists(packageInfoPath))
+            {
+                var data = diskProvider.ReadAllText(packageInfoPath);
+
+                PackageVersion = ReadVersion(data, "PackageVersion");
+                PackageUpdateMechanism = ReadEnumValue(data, "UpdateMethod", UpdateMechanism.BuiltIn);
+                PackageBranch = ReadValue(data, "Branch", null);
+
+                ReleaseVersion = ReadVersion(data, "ReleaseVersion");
+
+                if (PackageBranch.IsNotNullOrWhiteSpace())
+                {
+                    DefaultBranch = PackageBranch;
+                }
+            }
+
+            if (diskProvider.FileExists(releaseInfoPath))
+            {
+                var data = diskProvider.ReadAllText(releaseInfoPath);
+
+                ReleaseVersion = ReadVersion(data, "ReleaseVersion", ReleaseVersion);
+                ReleaseBranch = ReadValue(data, "Branch", null);
+
+                if (ReleaseBranch.IsNotNullOrWhiteSpace())
+                {
+                    DefaultBranch = ReleaseBranch;
+                }
+            }
+
+            DefaultUpdateMechanism = PackageUpdateMechanism;
+        }
+
+        private static string ReadValue(string fileData, string key, string defaultValue)
+        {
+            var match = Regex.Match(fileData, "^" + key + "=(.*)$", RegexOptions.Multiline);
+            if (match.Success)
+            {
+                return match.Groups[1].Value.Trim();
+            }
+
+            return defaultValue;
+        }
+
+        private static T ReadEnumValue<T>(string fileData, string key, T defaultValue)
+            where T : struct
+        {
+            var value = ReadValue(fileData, key, null);
+            if (value != null && Enum.TryParse<T>(value, true, out var result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        private static Version ReadVersion(string fileData, string key, Version defaultValue = null)
+        {
+            var value = ReadValue(fileData, key, null);
+            if (value != null && Version.TryParse(value, out var result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        public Version PackageVersion { get; private set; }
+        public string PackageBranch { get; private set; }
+        public UpdateMechanism PackageUpdateMechanism { get; private set; }
+
+        public Version ReleaseVersion { get; set; }
+        public string ReleaseBranch { get; set; }
+
+
+        public bool BuiltInUpdaterAllowed => PackageUpdateMechanism == UpdateMechanism.BuiltIn;
+        public UpdateMechanism DefaultUpdateMechanism { get; private set; }
+        public string DefaultBranch { get; private set; }
+    }
+}

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Configuration\ConfigFileProvider.cs" />
     <Compile Include="Configuration\ConfigRepository.cs" />
     <Compile Include="Configuration\ConfigService.cs" />
+    <Compile Include="Configuration\DeploymentInfoProvider.cs" />
     <Compile Include="Configuration\Events\ConfigFileSavedEvent.cs" />
     <Compile Include="Configuration\Events\ConfigSavedEvent.cs" />
     <Compile Include="Configuration\IConfigService.cs" />
@@ -1225,6 +1226,7 @@
     <Compile Include="Tv\SeriesTypes.cs" />
     <Compile Include="Tv\ShouldRefreshSeries.cs" />
     <Compile Include="Update\Commands\ApplicationUpdateCommand.cs" />
+    <Compile Include="Update\ConfigureUpdateMechanism.cs" />
     <Compile Include="Update\InstallUpdateService.cs" />
     <Compile Include="Update\RecentUpdateProvider.cs" />
     <Compile Include="Update\UpdateAbortedException.cs" />

--- a/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
+++ b/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Update
 
             var externalMechanisms = Enum.GetValues(typeof(UpdateMechanism))
                                          .Cast<UpdateMechanism>()
-                                         .Where(v => (int)v >= (int)UpdateMechanism.External)
+                                         .Where(v => v >= UpdateMechanism.External)
                                          .ToArray();
 
             foreach (var externalMechanism in externalMechanisms)

--- a/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
+++ b/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
@@ -1,0 +1,62 @@
+using NLog;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Lifecycle;
+using NzbDrone.Core.Messaging.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.Update
+{
+    public interface IUpdaterConfigProvider
+    {
+
+    }
+
+    public class UpdaterConfigProvider : IUpdaterConfigProvider, IHandle<ApplicationStartedEvent>
+    {
+        private Logger _logger;
+        private IConfigFileProvider _configFileProvider;
+        private IDeploymentInfoProvider _deploymentInfoProvider;
+
+        public UpdaterConfigProvider(IDeploymentInfoProvider deploymentInfoProvider, IConfigFileProvider configFileProvider, Logger logger)
+        {
+            _deploymentInfoProvider = deploymentInfoProvider;
+            _configFileProvider = configFileProvider;
+            _logger = logger;
+        }
+
+        public void Handle(ApplicationStartedEvent message)
+        {
+            var updateMechanism = _configFileProvider.UpdateMechanism;
+            var packageUpdateMechanism = _deploymentInfoProvider.PackageUpdateMechanism;
+
+            var externalMechanisms = Enum.GetValues(typeof(UpdateMechanism))
+                                         .Cast<UpdateMechanism>()
+                                         .Where(v => (int)v >= (int)UpdateMechanism.External)
+                                         .ToArray();
+
+            foreach (var externalMechanism in externalMechanisms)
+            {
+                if (packageUpdateMechanism != externalMechanism && updateMechanism == externalMechanism ||
+                    packageUpdateMechanism == externalMechanism && updateMechanism == UpdateMechanism.BuiltIn)
+                {
+                    _logger.Info("Update mechanism {0} not supported in the current configuration, changing to {1}.", updateMechanism, packageUpdateMechanism);
+                    ChangeUpdateMechanism(packageUpdateMechanism);
+                    break;
+                }
+            }
+        }
+        
+        private void ChangeUpdateMechanism(UpdateMechanism updateMechanism)
+        {
+            var config = new Dictionary<string, object>
+            {
+                [nameof(_configFileProvider.UpdateMechanism)] = updateMechanism
+            };
+            _configFileProvider.SaveConfigDictionary(config);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -220,12 +220,12 @@ namespace NzbDrone.Core.Update
 
 
             // Safety net, ConfigureUpdateMechanism should take care of invalid settings
-            if (_configFileProvider.UpdateMechanism == UpdateMechanism.BuiltIn && !_deploymentInfoProvider.BuiltInUpdaterAllowed)
+            if (_configFileProvider.UpdateMechanism == UpdateMechanism.BuiltIn && _deploymentInfoProvider.IsExternalUpdateMechanism)
             {
                 _logger.ProgressDebug("Built-In updater disabled, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
                 return;
             }
-            else if (_configFileProvider.UpdateMechanism != UpdateMechanism.Script && !_deploymentInfoProvider.BuiltInUpdaterAllowed)
+            else if (_configFileProvider.UpdateMechanism != UpdateMechanism.Script && _deploymentInfoProvider.IsExternalUpdateMechanism)
             {
                 _logger.ProgressDebug("Update available, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
                 return;

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -29,6 +29,7 @@ namespace NzbDrone.Core.Update
         private readonly IProcessProvider _processProvider;
         private readonly IVerifyUpdates _updateVerifier;
         private readonly IStartupContext _startupContext;
+        private readonly IDeploymentInfoProvider _deploymentInfoProvider;
         private readonly IConfigFileProvider _configFileProvider;
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IBackupService _backupService;
@@ -43,6 +44,7 @@ namespace NzbDrone.Core.Update
                                     IProcessProvider processProvider,
                                     IVerifyUpdates updateVerifier,
                                     IStartupContext startupContext,
+                                    IDeploymentInfoProvider deploymentInfoProvider,
                                     IConfigFileProvider configFileProvider,
                                     IRuntimeInfo runtimeInfo,
                                     IBackupService backupService,
@@ -61,6 +63,7 @@ namespace NzbDrone.Core.Update
             _processProvider = processProvider;
             _updateVerifier = updateVerifier;
             _startupContext = startupContext;
+            _deploymentInfoProvider = deploymentInfoProvider;
             _configFileProvider = configFileProvider;
             _runtimeInfo = runtimeInfo;
             _backupService = backupService;
@@ -85,6 +88,12 @@ namespace NzbDrone.Core.Update
                 {
                     throw new UpdateFolderNotWritableException("Cannot install update because UI folder '{0}' is not writable by the user '{1}'.", uiFolder, Environment.UserName);
                 }
+            }
+
+            if (_appFolderInfo.StartUpFolder.EndsWith("_output"))
+            {
+                _logger.ProgressDebug("Running in developer environment, not updating.");
+                return;
             }
 
             var updateSandboxFolder = _appFolderInfo.GetUpdateSandboxFolder();
@@ -206,6 +215,19 @@ namespace NzbDrone.Core.Update
             if (OsInfo.IsNotWindows && !_configFileProvider.UpdateAutomatically && message.Trigger != CommandTrigger.Manual)
             {
                 _logger.ProgressDebug("Auto-update not enabled, not installing available update");
+                return;
+            }
+
+
+            // Safety net, ConfigureUpdateMechanism should take care of invalid settings
+            if (_configFileProvider.UpdateMechanism == UpdateMechanism.BuiltIn && !_deploymentInfoProvider.BuiltInUpdaterAllowed)
+            {
+                _logger.ProgressDebug("Built-In updater disabled, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
+                return;
+            }
+            else if (_configFileProvider.UpdateMechanism != UpdateMechanism.Script && !_deploymentInfoProvider.BuiltInUpdaterAllowed)
+            {
+                _logger.ProgressDebug("Update available, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
                 return;
             }
 

--- a/src/NzbDrone.Core/Update/UpdateMechanism.cs
+++ b/src/NzbDrone.Core/Update/UpdateMechanism.cs
@@ -1,8 +1,11 @@
-﻿namespace NzbDrone.Core.Update
+namespace NzbDrone.Core.Update
 {
     public enum UpdateMechanism
     {
         BuiltIn = 0,
-        Script = 1
+        Script = 1,
+        External = 10,
+        Apt = 11,
+        Docker = 12
     }
 }

--- a/src/Sonarr.Api.V3/System/SystemModule.cs
+++ b/src/Sonarr.Api.V3/System/SystemModule.cs
@@ -20,6 +20,7 @@ namespace Sonarr.Api.V3.System
         private readonly IConfigFileProvider _configFileProvider;
         private readonly IMainDatabase _database;
         private readonly ILifecycleService _lifecycleService;
+        private readonly IDeploymentInfoProvider _deploymentInfoProvider;
 
         public SystemModule(IAppFolderInfo appFolderInfo,
                             IRuntimeInfo runtimeInfo,
@@ -28,7 +29,8 @@ namespace Sonarr.Api.V3.System
                             IRouteCacheProvider routeCacheProvider,
                             IConfigFileProvider configFileProvider,
                             IMainDatabase database,
-                            ILifecycleService lifecycleService)
+                            ILifecycleService lifecycleService,
+                            IDeploymentInfoProvider deploymentInfoProvider)
             : base("system")
         {
             _appFolderInfo = appFolderInfo;
@@ -39,6 +41,7 @@ namespace Sonarr.Api.V3.System
             _configFileProvider = configFileProvider;
             _database = database;
             _lifecycleService = lifecycleService;
+            _deploymentInfoProvider = deploymentInfoProvider;
             Get["/status"] = x => GetStatus();
             Get["/routes"] = x => GetRoutes();
             Post["/shutdown"] = x => Shutdown();
@@ -71,8 +74,9 @@ namespace Sonarr.Api.V3.System
                        UrlBase = _configFileProvider.UrlBase,
                        RuntimeVersion = _platformInfo.Version,
                        RuntimeName = PlatformInfo.Platform,
-                       StartTime = _runtimeInfo.StartTime
-                   }.AsResponse();
+                       StartTime = _runtimeInfo.StartTime,
+                       PackageUpdateMechanism = _deploymentInfoProvider.PackageUpdateMechanism
+            }.AsResponse();
         }
 
         private Response GetRoutes()

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Increment packageVersion when package scripts change
+packageVersion='3.0.1'
+
+# For now we keep the build version and package version the same
+buildVersion=$packageVersion
+


### PR DESCRIPTION
#### Description

Changes:
- Use dh_systemd to deal with systemd control instead of manual scripts.
- Use dh_clideps to detect our dependencies instead of depending on libmono-cil-dev. (Needs testing)
- Moved binaries to ./bin subdir. I have some ideas with regard to the built-in updater and having a subdir will make that easier.
- Moved back from /opt/sonarr to /usr/lib/sonarr based on debian policy.
- Added debconf questions for user, group and config/data dir.

Open items:

- [x] Test clideps
- [x] Simplify adduser. afaik you can use a single line, --system quietly returns if user already exists.
- [x] Consider options for nzbdrone->sonarr update script. Options:
  -  [x] Simplest approach is to simply throw a warning in preinst if nzbdrone is still present.
  -  [x] Other approach would be to detect running sonarr instances and handle a few of the existing auto-start solutions.
  - ...
- [x] Also deal with non-apt nzbdrone installs.
- [x] Deal with apt-get updates overriding built-in updater. Options:
  - Disable built-in updater with apt-get or at least branch selection.
  - Add separate bootstrap package sonarr 3.0.0
  - Use ./bin_{version} during unpack and copy to ./bin during postinst, checking for current version.
  - ...
- [x] Ask on reddit/forums about migration steps.

