### PR TITLE
Prevent flatmap vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-clean-css": "3.10.0",
     "gulp-concat": "2.6.1",
     "gulp-declare": "0.3.0",
-    "gulp-livereload": "4.0.0",
+    "gulp-livereload": "4.0.1",
     "gulp-postcss": "8.0.0",
     "gulp-print": "5.0.0",
     "gulp-sourcemaps": "2.6.4",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
gulp-livereload 4.0.0 transitively depends on a range of versions of flatmap-stream some of which are known to be vulnerable. See https://github.com/dominictarr/event-stream/issues/116. While the malicious code doesn't appear to target software like sonarr, particularly in dev it would be nice not to depend on known malicious code (if already cached) or a package that no longer exists (flatmap-stream is now unpublished).

#### Todos
N/A

#### Issues Fixed or Closed by this PR
< none >
