### PR TITLE
Added Console log level option in configfile, which defaults to Info.

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Configuration
         AuthenticationType AuthenticationMethod { get; }
         bool AnalyticsEnabled { get; }
         string LogLevel { get; }
+        string ConsoleLogLevel { get; }
         string Branch { get; }
         string ApiKey { get; }
         string SslCertHash { get; }
@@ -179,6 +180,7 @@ namespace NzbDrone.Core.Configuration
         public string Branch => GetValue("Branch", "master").ToLowerInvariant();
 
         public string LogLevel => GetValue("LogLevel", "Info");
+        public string ConsoleLogLevel => GetValue("ConsoleLogLevel", null, persist: false);
 
         public string SslCertHash => GetValue("SslCertHash", "");
 

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -20,11 +20,19 @@ namespace NzbDrone.Core.Instrumentation
         public void Reconfigure()
         {
             var minimumLogLevel = LogLevel.FromString(_configFileProvider.LogLevel);
+            LogLevel minimumConsoleLogLevel;
+
+            if (_configFileProvider.ConsoleLogLevel != null)
+                minimumConsoleLogLevel = LogLevel.FromString(_configFileProvider.ConsoleLogLevel);
+            else if (minimumLogLevel > LogLevel.Info)
+                minimumConsoleLogLevel = minimumLogLevel;
+            else
+                minimumConsoleLogLevel = LogLevel.Info;
 
             var rules = LogManager.Configuration.LoggingRules;
 
             //Console
-            SetMinimumLogLevel(rules, "consoleLogger", minimumLogLevel);
+            SetMinimumLogLevel(rules, "consoleLogger", minimumConsoleLogLevel);
 
             //Log Files
             SetMinimumLogLevel(rules, "appFileInfo", minimumLogLevel <= LogLevel.Info ? LogLevel.Info : LogLevel.Off);


### PR DESCRIPTION
#### Description
In a systemd environment, having debug/trace level going to journalctl is really not desirable.
Instead of configuring systemd to pipe the stdout to null, one should be able to set the console log level differently than our own rotating log files.

I wanted to either check for systemd or some environment variable. Or allow a 'consoleloglevel' cmdline param. Since that would maintain full backward compatibility.
But instead I decided to just limit the ConsoleLogLevel to Info unless set explicitly to Debug. This means any instance that previously had Debug output in the console will have only Info now.
The config.xml option`ConsoleLogLevel` is not created by default and not exposed in the UI.

An alternative might be to pipe Trace/Debug/Info to stdout and Warn/Error/Fatal to stderr. But that would be an even more breaking change than the above.