### PR TITLE
Allow torrent removal if finished.

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 item.CanMoveFiles = item.CanBeRemoved =
                     torrent.Status == TransmissionTorrentStatus.Stopped &&
-                    item.SeedRatio >= torrent.SeedRatioLimit;
+                    (item.SeedRatio >= torrent.SeedRatioLimit || torrent.isFinished);
 
                 items.Add(item);
             }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 item.CanMoveFiles = item.CanBeRemoved =
                     torrent.Status == TransmissionTorrentStatus.Stopped &&
-                    (item.SeedRatio >= torrent.SeedRatioLimit || torrent.isFinished);
+                    (item.SeedRatio >= torrent.SeedRatioLimit || item.Status == DownloadItemStatus.Completed);
 
                 items.Add(item);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently, torrents in Transmission need to meet both seeding time AND ratio requirements in order to be considered for deletion.  This presents a problem, because Sonarr relies on Transmission's own internal completion mechanism to stop torrents once the seeding goals are met. This means that if a torrent was seeded for enough time, but didn't meet the ratio, it would be stopped and marked as "finished" in Transmission, but Sonarr would never remove it since the ratio was not met (and never will be due to Transmission stopping it).

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
