### PR TITLE
Added MediaInfo HDR for issue 2824

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -93,7 +93,8 @@ const mediaInfoTokens = [
   { token: '{MediaInfo Full}', example: 'x264 DTS [EN+DE]' },
   { token: '{MediaInfo VideoCodec}', example: 'x264' },
   { token: '{MediaInfo AudioFormat}', example: 'DTS' },
-  { token: '{MediaInfo AudioChannels}', example: '5.1' }
+  { token: '{MediaInfo AudioChannels}', example: '5.1' },
+  { token: '{MediaInfo HDR}', example: 'HDR' }
 ];
 
 const otherTokens = [

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -94,7 +94,7 @@ const mediaInfoTokens = [
   { token: '{MediaInfo VideoCodec}', example: 'x264' },
   { token: '{MediaInfo AudioFormat}', example: 'DTS' },
   { token: '{MediaInfo AudioChannels}', example: '5.1' },
-  { token: '{MediaInfo HDR}', example: 'HDR' }
+  { token: '{MediaInfo VideoDynamicRange}', example: 'HDR' }
 ];
 
 const otherTokens = [

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeFixture.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
+{
+    [TestFixture]
+    public class FormatVideoDynamicRangeFixture : TestBase
+    {
+        [TestCase(8, "BT.601 NTSC", "BT.709", "SDR")]
+        [TestCase(10, "BT.2020", "PQ", "HDR")]
+        [TestCase(8, "BT.2020", "PQ", "SDR")]
+        [TestCase(10, "BT.601 NTSC", "PQ", "SDR")]
+        [TestCase(10, "BT.2020", "BT.709", "SDR")]
+        [TestCase(10, "BT.2020", "HLG", "HDR")]
+        public void should_format_video_dynamic_range(int bitDepth, string colourPrimaries, string transferCharacteristics, string expectedVideoDynamicRange)
+        {
+            var mediaInfo = new MediaInfoModel
+            {
+                VideoBitDepth = bitDepth,
+                VideoColourPrimaries = colourPrimaries,
+                VideoTransferCharacteristics = transferCharacteristics,
+                SchemaRevision = 5
+            };
+
+            MediaInfoFormatter.FormatVideoDynamicRange(mediaInfo).Should().Be(expectedVideoDynamicRange);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using FluentAssertions;
 using Moq;
@@ -59,7 +60,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.VideoBitrate.Should().Be(193329);
             info.VideoFps.Should().Be(24);
             info.Width.Should().Be(480);
-
+            info.VideoColourPrimaries.Should().Be("BT.601 NTSC");
+            info.VideoTransferCharacteristics.Should().Be("BT.709");
         }
 
         [Test]
@@ -95,6 +97,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.VideoBitrate.Should().Be(193329);
             info.VideoFps.Should().Be(24);
             info.Width.Should().Be(480);
+            info.VideoColourPrimaries.Should().Be("BT.601 NTSC");
+            info.VideoTransferCharacteristics.Should().Be("BT.709");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -327,6 +327,7 @@
     <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatAudioCodecFixture.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatVideoCodecFixture.cs" />
     <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatAudioChannelsFixture.cs" />
+    <Compile Include="MediaFiles\MediaInfo\MediaInfoFormatterTests\FormatVideoDynamicRangeFixture.cs" />
     <Compile Include="Messaging\Commands\CommandQueueManagerFixture.cs" />
     <Compile Include="MetadataSource\SkyHook\SkyHookProxySearchFixture.cs" />
     <Compile Include="MetadataSource\SearchSeriesComparerFixture.cs" />

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -520,6 +520,31 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be("South.Park.S15E06.City.Sushi.X264.DTS.[EN+ES+IT]");
         }
 
+        [TestCase(10, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi.HDR")]
+        [TestCase(9, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi")]
+        [TestCase(10, "BT.601 NTSC", "PQ", "South.Park.S15E06.City.Sushi")]
+        [TestCase(10, "BT.2020", "BT.709", "South.Park.S15E06.City.Sushi")]
+        public void should_include_hdr_for_mediainfo_hdr_with_valid_properties(int bitDepth, string colourPrimaries, string transferCharacteristics, string expectedName)
+        {
+            _namingConfig.StandardEpisodeFormat = "{Series.Title}.S{season:00}E{episode:00}.{Episode.Title}.{MEDIAINFO.HDR}";
+
+            _episodeFile.MediaInfo = new Core.MediaFiles.MediaInfo.MediaInfoModel
+            {
+                VideoCodec = "AVC",
+                AudioFormat = "DTS",
+                AudioChannels = 6,
+                AudioLanguages = "English",
+                Subtitles = "English/Spanish/Italian",
+                VideoBitDepth = bitDepth,
+                VideoColourPrimaries = colourPrimaries,
+                VideoTransferCharacteristics = transferCharacteristics,
+                SchemaRevision = 5
+            };
+
+            Subject.BuildFileName(new List<Episode> {_episode1}, _series, _episodeFile)
+                .Should().Be(expectedName);
+        }
+
         [Test]
         public void should_remove_duplicate_non_word_characters()
         {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -520,15 +520,12 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be("South.Park.S15E06.City.Sushi.X264.DTS.[EN+ES+IT]");
         }
 
-        [TestCase(8, "BT.601 NTSC", "BT.709", "South.Park.S15E06.City.Sushi")]
+        [TestCase(8, "BT.601 NTSC", "BT.709", "South.Park.S15E06.City.Sushi.SDR")]
         [TestCase(10, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi.HDR")]
-        [TestCase(8, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi")]
-        [TestCase(10, "BT.601 NTSC", "PQ", "South.Park.S15E06.City.Sushi")]
-        [TestCase(10, "BT.2020", "BT.709", "South.Park.S15E06.City.Sushi")]
         [TestCase(10, "BT.2020", "HLG", "South.Park.S15E06.City.Sushi.HDR")]
         public void should_include_hdr_for_mediainfo_hdr_with_valid_properties(int bitDepth, string colourPrimaries, string transferCharacteristics, string expectedName)
         {
-            _namingConfig.StandardEpisodeFormat = "{Series.Title}.S{season:00}E{episode:00}.{Episode.Title}.{MEDIAINFO.HDR}";
+            _namingConfig.StandardEpisodeFormat = "{Series.Title}.S{season:00}E{episode:00}.{Episode.Title}.{MediaInfo VideoDynamicRange}";
 
             _episodeFile.MediaInfo = new Core.MediaFiles.MediaInfo.MediaInfoModel
             {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -520,10 +520,12 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be("South.Park.S15E06.City.Sushi.X264.DTS.[EN+ES+IT]");
         }
 
+        [TestCase(8, "BT.601 NTSC", "BT.709", "South.Park.S15E06.City.Sushi")]
         [TestCase(10, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi.HDR")]
-        [TestCase(9, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi")]
+        [TestCase(8, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi")]
         [TestCase(10, "BT.601 NTSC", "PQ", "South.Park.S15E06.City.Sushi")]
         [TestCase(10, "BT.2020", "BT.709", "South.Park.S15E06.City.Sushi")]
+        [TestCase(10, "BT.2020", "HLG", "South.Park.S15E06.City.Sushi.HDR")]
         public void should_include_hdr_for_mediainfo_hdr_with_valid_properties(int bitDepth, string colourPrimaries, string transferCharacteristics, string expectedName)
         {
             _namingConfig.StandardEpisodeFormat = "{Series.Title}.S{season:00}E{episode:00}.{Episode.Title}.{MEDIAINFO.HDR}";

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -440,5 +440,26 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             // Last token is the default.
             return tokens.Last();
         }
+
+        private static readonly string[] ValidHdrTransferFunctions = {"PQ", "HLG"};
+        private const string ValidHdrColourPrimaries = "BT.2020";
+
+        public static string FormatVideoDynamicRange(MediaInfoModel mediaInfo)
+        {
+            var videoDynamicRange = "SDR";
+
+            if (mediaInfo.VideoBitDepth >= 10 &&
+                !string.IsNullOrEmpty(mediaInfo.VideoColourPrimaries) &&
+                !string.IsNullOrEmpty(mediaInfo.VideoTransferCharacteristics))
+            {
+                if (mediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
+                    ValidHdrTransferFunctions.Any(mediaInfo.VideoTransferCharacteristics.Contains))
+                {
+                    videoDynamicRange = "HDR";
+                }
+            }
+
+            return videoDynamicRange;
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string VideoCodecLibrary { get; set; }
         public int VideoBitrate { get; set; }
         public int VideoBitDepth { get; set; }
+        public string VideoColourPrimaries { get; set; }
+        public string VideoTransferCharacteristics { get; set; }
         public int Width { get; set; }
         public int Height { get; set; }
         public string AudioFormat { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly Logger _logger;
 
         public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 3;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 4;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 5;
 
         public VideoFileInfoReader(IDiskProvider diskProvider, Logger logger)
         {
@@ -128,6 +128,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     string videoProfile = mediaInfo.Get(StreamKind.Video, 0, "Format_Profile").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
                     string audioProfile = mediaInfo.Get(StreamKind.Audio, 0, "Format_Profile").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
 
+                    var videoColourPrimaries = mediaInfo.Get(StreamKind.Video, 0, "colour_primaries");
+                    var videoTransferCharacteristics = mediaInfo.Get(StreamKind.Video, 0, "transfer_characteristics");
+
                     int.TryParse(audioChannelsStr, out audioChannels);
                     var mediaInfoModel = new MediaInfoModel
                     {
@@ -138,6 +141,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                         VideoCodecLibrary = mediaInfo.Get(StreamKind.Video, 0, "Encoded_Library"),
                         VideoBitrate = videoBitRate,
                         VideoBitDepth = videoBitDepth,
+                        VideoColourPrimaries = videoColourPrimaries,
+                        VideoTransferCharacteristics = videoTransferCharacteristics,
                         Height = height,
                         Width = width,
                         AudioFormat = mediaInfo.Get(StreamKind.Audio, 0, "Format"),

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -30,6 +30,9 @@ namespace NzbDrone.Core.Organizer
 
     public class FileNameBuilder : IBuildFileNames
     {
+        private static readonly string[] ValidHdrTransferFunctions = {"PQ", "HLG"};
+        private static readonly string ValidHdrColourPrimaries = "BT.2020";
+
         private readonly INamingConfigService _namingConfigService;
         private readonly IQualityDefinitionService _qualityDefinitionService;
         private readonly IPreferredWordService _preferredWordService;
@@ -572,6 +575,20 @@ namespace NzbDrone.Core.Organizer
                                 audioChannels.ToString("F1", CultureInfo.InvariantCulture) :
                                 string.Empty;
 
+            var mediaInfoHdr = string.Empty;
+
+            if (episodeFile.MediaInfo.VideoBitDepth >= 10 &&
+                !string.IsNullOrEmpty(episodeFile.MediaInfo.VideoColourPrimaries) &&
+                !string.IsNullOrEmpty(episodeFile.MediaInfo.VideoTransferCharacteristics))
+            {
+                if (episodeFile.MediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
+                    ValidHdrTransferFunctions.Any(episodeFile.MediaInfo.VideoTransferCharacteristics.Contains))
+                {
+                    mediaInfoHdr = "HDR";
+                }
+            }
+            
+
             tokenHandlers["{MediaInfo Video}"] = m => videoCodec;
             tokenHandlers["{MediaInfo VideoCodec}"] = m => videoCodec;
             tokenHandlers["{MediaInfo VideoBitDepth}"] = m => videoBitDepth;
@@ -580,6 +597,8 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{MediaInfo AudioCodec}"] = m => audioCodec;
             tokenHandlers["{MediaInfo AudioChannels}"] = m => audioChannelsFormatted;
             tokenHandlers["{MediaInfo AudioLanguages}"] = m => mediaInfoAudioLanguages;
+
+            tokenHandlers["{MediaInfo HDR}"] = m => mediaInfoHdr;
 
             tokenHandlers["{MediaInfo SubtitleLanguages}"] = m => mediaInfoSubtitleLanguages;
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -30,9 +30,6 @@ namespace NzbDrone.Core.Organizer
 
     public class FileNameBuilder : IBuildFileNames
     {
-        private static readonly string[] ValidHdrTransferFunctions = {"PQ", "HLG"};
-        private static readonly string ValidHdrColourPrimaries = "BT.2020";
-
         private readonly INamingConfigService _namingConfigService;
         private readonly IQualityDefinitionService _qualityDefinitionService;
         private readonly IPreferredWordService _preferredWordService;
@@ -575,30 +572,18 @@ namespace NzbDrone.Core.Organizer
                                 audioChannels.ToString("F1", CultureInfo.InvariantCulture) :
                                 string.Empty;
 
-            var mediaInfoHdr = string.Empty;
-
-            if (episodeFile.MediaInfo.VideoBitDepth >= 10 &&
-                !string.IsNullOrEmpty(episodeFile.MediaInfo.VideoColourPrimaries) &&
-                !string.IsNullOrEmpty(episodeFile.MediaInfo.VideoTransferCharacteristics))
-            {
-                if (episodeFile.MediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
-                    ValidHdrTransferFunctions.Any(episodeFile.MediaInfo.VideoTransferCharacteristics.Contains))
-                {
-                    mediaInfoHdr = "HDR";
-                }
-            }
+            var mediaInfoDynamicRange = MediaInfoFormatter.FormatVideoDynamicRange(episodeFile.MediaInfo);
             
 
             tokenHandlers["{MediaInfo Video}"] = m => videoCodec;
             tokenHandlers["{MediaInfo VideoCodec}"] = m => videoCodec;
             tokenHandlers["{MediaInfo VideoBitDepth}"] = m => videoBitDepth;
+            tokenHandlers["{MediaInfo VideoDynamicRange}"] = m => mediaInfoDynamicRange;
 
             tokenHandlers["{MediaInfo Audio}"] = m => audioCodec;
             tokenHandlers["{MediaInfo AudioCodec}"] = m => audioCodec;
             tokenHandlers["{MediaInfo AudioChannels}"] = m => audioChannelsFormatted;
             tokenHandlers["{MediaInfo AudioLanguages}"] = m => mediaInfoAudioLanguages;
-
-            tokenHandlers["{MediaInfo HDR}"] = m => mediaInfoHdr;
 
             tokenHandlers["{MediaInfo SubtitleLanguages}"] = m => mediaInfoSubtitleLanguages;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added naming token MediaInfo HDR, taking the implementation from Radarr. I added video colour primaries and video transfer characteristics properties to the MediaInfoModel and added the code to determine if those values constitute HDR.

#### Todos
- [x] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

https://github.com/Sonarr/Sonarr/issues/2824
