### PR TITLE
Downgrade event-stream

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-prefix=""

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
-save-prefix ""
+save-exact true
+registry "https://registry.yarnpkg.com"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,11 +2834,10 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     es5-ext "~0.10.14"
 
 event-stream@^3.3.4:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
   dependencies:
     duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
     from "^0.1.7"
     map-stream "0.0.7"
     pause-stream "^0.0.11"
@@ -3176,10 +3175,6 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
-
-flatmap-stream@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.0.tgz#ed54e01422cd29281800914fcb968d58b685d5f1"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
#### Database Migration
NO

#### Description

event-stream@3.3.6 has backdoor in it: 

https://snyk.io/blog/a-post-mortem-of-the-malicious-event-stream-backdoor/
https://github.com/dominictarr/event-stream/issues/115
https://github.com/dominictarr/event-stream/issues/116

Since npm has already unpublished event-stream@3.3.6 and flatmap-stream, running `yarn` on a fresh copy of Sonarr would result in 404 error.

Removed `.npmrc` file because (AFAIK) the current workflow uses yarn

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
