### PR TITLE
qBittorrent API V2 Implementation

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxy.cs
@@ -73,13 +73,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             if (settings.UseApiV2)
             {
                 request = BuildRequest(settings).Resource("/api/v2/torrents/info")
-                                                .AddQueryParam("category", settings.MovieCategory);
+                                                .AddQueryParam("category", settings.TvCategory);
             }
             else
             {
                 request = BuildRequest(settings).Resource("/query/torrents")
-                                                .AddQueryParam("label", settings.MovieCategory)
-                                                .AddQueryParam("category", settings.MovieCategory);
+                                                .AddQueryParam("label", settings.TvCategory)
+                                                .AddQueryParam("category", settings.TvCategory);
             }
 
             var response = ProcessRequest<List<QBittorrentTorrent>>(request, settings);

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             Host = "localhost";
             Port = 8080;
             TvCategory = "tv-sonarr";
+            UseApiV2 = true;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -52,6 +53,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(8, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Use a secure connection. See Options -> Web UI -> 'Use HTTPS instead of HTTP' in qBittorrent.")]
         public bool UseSsl { get; set; }
 
+        [FieldDefinition(9, Label = "Use API V2", Type = FieldType.Checkbox, HelpText = "Uncheck to use older qBittorrent API (When using qBittorent < v4.0.0).")]
+        public bool UseApiV2 { get; set; }
+        
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
qBittorrent from v4.0 onwards includes a new API (V2). The old API will be removed on the release of v4.2 of qBittorrent (due any day). The current build of Radarr will only work with the original API and therefore the update to qBittorrent will break Radarr.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

#2887 