### PR TITLE
Add origin, source, container, and codec to title when determining release restriction matches

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -30,10 +30,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger.Debug("Checking if release meets restrictions: {0}", subject);
 
             var title = subject.Release.Title;
-            var origin = subject.Relase.Origin ?? "";
-            var source = subject.Relase.Source ?? "";
-            var container = subject.Relase.Container ?? "";
-            var codec = subject.Relase.Codec ?? "";
+            var origin = subject.Release.Origin ?? "";
+            var source = subject.Release.Source ?? "";
+            var container = subject.Release.Container ?? "";
+            var codec = subject.Release.Codec ?? "";
 
             title += origin + source + container + codec;           var title = subject.Release.Title;
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -30,6 +30,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger.Debug("Checking if release meets restrictions: {0}", subject);
 
             var title = subject.Release.Title;
+            var origin = subject.Relase.Origin ?? "";
+            var source = subject.Relase.Source ?? "";
+            var container = subject.Relase.Container ?? "";
+            var codec = subject.Relase.Codec ?? "";
+
+            title += origin + source + container + codec;           var title = subject.Release.Title;
+
             var restrictions = _restrictionService.AllForTags(subject.Series.Tags);
 
             var required = restrictions.Where(r => r.Required.IsNotNullOrWhiteSpace());


### PR DESCRIPTION
restriction matches

#### Database Migration
NO

#### Description
Right now release restrictions only check a release's title for "must contain" or "must not contain" matches. I added some optional release fields (may or may not be set by the indexer) that will be included when searching for a match to a restriction.

A good use case for this will be if an indexer specifies a scene release in its origin rather than requiring it in the filename (title) of the episode. With this change, a user can now reliable say "must not contain 'scene'" provided their indexer of choice has this info. 

#### Todos
- [ ] Tests
- [ ] Documentation (may require indexer specific documentation?)


#### Issues Fixed or Closed by this PR

* 

As a side note, I've never coded in C# and relied on stack overflow for how to check null property values and concatenate strings. Please forgive me if it's incorrect. 
