### PR TITLE
Set post-import label for deluge

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         string[] GetAvailablePlugins(DelugeSettings settings);
         string[] GetEnabledPlugins(DelugeSettings settings);
         string[] GetAvailableLabels(DelugeSettings settings);
-        void SetLabel(string hash, string label, DelugeSettings settings);
+        void SetTorrentLabel(string hash, string label, DelugeSettings settings);
         void SetTorrentConfiguration(string hash, string key, object value, DelugeSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, DelugeSettings settings);
         void AddLabel(string label, DelugeSettings settings);
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             ProcessRequest<object>(settings, "label.add", label);
         }
 
-        public void SetLabel(string hash, string label, DelugeSettings settings)
+        public void SetTorrentLabel(string hash, string label, DelugeSettings settings)
         {
             ProcessRequest<object>(settings, "label.set_torrent", hash, label);
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
 
             RuleFor(c => c.TvCategory).Matches("^[-a-z]*$").WithMessage("Allowed characters a-z and -");
+            RuleFor(c => c.TvImportedCategory).Matches("^[-a-z]*$").WithMessage("Allowed characters a-z and -");
         }
     }
 
@@ -43,16 +44,19 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         [FieldDefinition(4, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Sonarr avoids conflicts with unrelated downloads, but it's optional")]
         public string TvCategory { get; set; }
 
-        [FieldDefinition(5, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
+        [FieldDefinition(5, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Sonarr to set after it has imported the download. Leave blank to disable this feature.")]
+        public string TvImportedCategory { get; set; }
+
+        [FieldDefinition(6, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
+        [FieldDefinition(7, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(DelugePriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(7, Label = "Add Paused", Type = FieldType.Checkbox)]
+        [FieldDefinition(8, Label = "Add Paused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }
 
-        [FieldDefinition(8, Label = "Use SSL", Type = FieldType.Checkbox)]
+        [FieldDefinition(9, Label = "Use SSL", Type = FieldType.Checkbox)]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentLabel.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentLabel.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Download.Clients.QBittorrent
+{
+    public class QBittorrentLabel
+    {
+        public string Name { get; set; }
+        public string SavePath { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
@@ -23,6 +23,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         void RemoveTorrent(string hash, Boolean removeData, QBittorrentSettings settings);
         void SetTorrentLabel(string hash, string label, QBittorrentSettings settings);
+        void AddLabel(string label, QBittorrentSettings settings);
+        Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, QBittorrentSettings settings);
         void PauseTorrent(string hash, QBittorrentSettings settings);

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
@@ -190,6 +190,19 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             }
         }
 
+        public void AddLabel(string label, QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/command/addCategory")
+                                                .Post()
+                                                .AddFormParameter("category", label);
+            ProcessRequest(request, settings);
+        }
+
+        public Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings)
+        {
+            throw new NotSupportedException("qBittorrent api v1 does not support getting all torrent categories");
+        }
+
         public void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings)
         {
             // Not supported on api v1

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -110,6 +110,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var request = BuildRequest(settings).Resource("/api/v2/torrents/add")
                                                 .Post()
                                                 .AddFormParameter("urls", torrentUrl);
+
             if (settings.TvCategory.IsNotNullOrWhiteSpace())
             {
                 request.AddFormParameter("category", settings.TvCategory);
@@ -175,6 +176,20 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .AddFormParameter("hashes", hash)
                                                 .AddFormParameter("category", label);
             ProcessRequest(request, settings);
+        }
+
+        public void AddLabel(string label, QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/api/v2/torrents/createCategory")
+                                                .Post()
+                                                .AddFormParameter("category", label);
+            ProcessRequest(request, settings);
+        }
+
+        public Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings)
+        {
+            var request = BuildRequest(settings).Resource("/api/v2/torrents/categories");
+            return Json.Deserialize<Dictionary<string, QBittorrentLabel>>(ProcessRequest(request, settings));
         }
 
         public void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -11,6 +11,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+
+            RuleFor(c => c.TvCategory).Matches("^[^/\\\\](((?!//)[^\\\\])*[^/\\\\])?$").WithMessage("Can not contain '\\', '//', or start/end with '/'");
+            RuleFor(c => c.TvImportedCategory).Matches("^[^/\\\\](((?!//)[^\\\\])*[^/\\\\])?$").WithMessage("Can not contain '\\', '//', or start/end with '/'");
         }
     }
 
@@ -40,16 +43,19 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(4, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Sonarr avoids conflicts with unrelated downloads, but it's optional")]
         public string TvCategory { get; set; }
 
-        [FieldDefinition(5, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
+        [FieldDefinition(5, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Sonarr to set after it has imported the download. Leave blank to disable this feature.")]
+        public string TvImportedCategory { get; set; }
+
+        [FieldDefinition(6, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
+        [FieldDefinition(7, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(QBittorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(7, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
+        [FieldDefinition(8, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
         public int InitialState { get; set; }
 
-        [FieldDefinition(8, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Use a secure connection. See Options -> Web UI -> 'Use HTTPS instead of HTTP' in qBittorrent.")]
+        [FieldDefinition(9, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Use a secure connection. See Options -> Web UI -> 'Use HTTPS instead of HTTP' in qBittorrent.")]
         public bool UseSsl { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -37,6 +37,24 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             _rTorrentDirectoryValidator = rTorrentDirectoryValidator;
         }
 
+        public override void MarkItemAsImported(DownloadClientItem downloadClientItem)
+        {
+            // set post-import category
+            if (Settings.TvImportedCategory.IsNotNullOrWhiteSpace() &&
+                Settings.TvImportedCategory != Settings.TvCategory)
+            {
+                try
+                {
+                    _proxy.SetTorrentLabel(downloadClientItem.DownloadId.ToLower(), Settings.TvImportedCategory, Settings);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Failed to set torrent post-import label \"{0}\" for {1} in rTorrent. Does the label exist?",
+                        Settings.TvImportedCategory, downloadClientItem.Title);
+                }
+            }
+        }
+
         protected override string AddFromMagnetLink(RemoteEpisode remoteEpisode, string hash, string magnetLink)
         {
             var priority = (RTorrentPriority)(remoteEpisode.IsRecentEpisode() ? Settings.RecentTvPriority : Settings.OlderTvPriority);

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         void AddTorrentFromUrl(string torrentUrl, string label, RTorrentPriority priority, string directory, RTorrentSettings settings);
         void AddTorrentFromFile(string fileName, byte[] fileContent, string label, RTorrentPriority priority, string directory, RTorrentSettings settings);
         void RemoveTorrent(string hash, RTorrentSettings settings);
+        void SetTorrentLabel(string hash, string label, RTorrentSettings settings);
         bool HasHashTorrent(string hash, RTorrentSettings settings);
     }
 
@@ -43,6 +44,9 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
         [XmlRpcMethod("d.name")]
         string GetName(string hash);
+
+        [XmlRpcMethod("d.custom1.set")]
+        string SetLabel(string hash, string label);
 
         [XmlRpcMethod("system.client_version")]
         string GetVersion();
@@ -90,20 +94,20 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
             foreach (object[] torrent in ret)
             {
-                var labelDecoded = System.Web.HttpUtility.UrlDecode((string) torrent[3]);
+                var labelDecoded = System.Web.HttpUtility.UrlDecode((string)torrent[3]);
 
                 var item = new RTorrentTorrent();
-                item.Name = (string) torrent[0];
-                item.Hash = (string) torrent[1];
-                item.Path = (string) torrent[2];
+                item.Name = (string)torrent[0];
+                item.Hash = (string)torrent[1];
+                item.Path = (string)torrent[2];
                 item.Category = labelDecoded;
-                item.TotalSize = (long) torrent[4];
-                item.RemainingSize = (long) torrent[5];
-                item.DownRate = (long) torrent[6];
-                item.Ratio = (long) torrent[7];
-                item.IsOpen = Convert.ToBoolean((long) torrent[8]);
-                item.IsActive = Convert.ToBoolean((long) torrent[9]);
-                item.IsFinished = Convert.ToBoolean((long) torrent[10]);
+                item.TotalSize = (long)torrent[4];
+                item.RemainingSize = (long)torrent[5];
+                item.DownRate = (long)torrent[6];
+                item.Ratio = (long)torrent[7];
+                item.IsOpen = Convert.ToBoolean((long)torrent[8]);
+                item.IsActive = Convert.ToBoolean((long)torrent[9]);
+                item.IsFinished = Convert.ToBoolean((long)torrent[10]);
 
                 items.Add(item);
             }
@@ -154,6 +158,19 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             if (response != 0)
             {
                 throw new DownloadClientException("Could not add torrent: {0}.", fileName);
+            }
+        }
+
+        public void SetTorrentLabel(string hash, string label, RTorrentSettings settings)
+        {
+            _logger.Debug("Executing remote method: d.custom1.set");
+
+            var client = BuildClient(settings);
+            var response = ExecuteRequest(() => client.SetLabel(hash, label));
+
+            if (response != label)
+            {
+                throw new DownloadClientException("Could not set label to {1} for torrent: {0}.", hash, label);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -52,16 +52,19 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         [FieldDefinition(6, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Sonarr avoids conflicts with unrelated downloads, but it's optional.")]
         public string TvCategory { get; set; }
 
-        [FieldDefinition(7, Label = "Directory", Type = FieldType.Textbox, Advanced = true, HelpText = "Optional location to put downloads in, leave blank to use the default rTorrent location")]
+        [FieldDefinition(7, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Sonarr to set after it has imported the download. Leave blank to disable this feature.")]
+        public string TvImportedCategory { get; set; }
+
+        [FieldDefinition(8, Label = "Directory", Type = FieldType.Textbox, Advanced = true, HelpText = "Optional location to put downloads in, leave blank to use the default rTorrent location")]
         public string TvDirectory { get; set; }
 
-        [FieldDefinition(8, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
+        [FieldDefinition(9, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
+        [FieldDefinition(10, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(10, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will prevent magnets from downloading before downloading")]
+        [FieldDefinition(11, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will prevent magnets from downloading before downloading")]
         public bool AddStopped { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentProxy.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
         void RemoveTorrent(string hash, bool removeData, UTorrentSettings settings);
         void SetTorrentLabel(string hash, string label, UTorrentSettings settings);
+        void RemoveTorrentLabel(string hash, string label, UTorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, UTorrentSettings settings);
         void SetState(string hash, UTorrentState state, UTorrentSettings settings);
     }
@@ -147,6 +148,20 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
             requestBuilder.AddQueryParam("s", "label")
                           .AddQueryParam("v", label);
+
+            ProcessRequest(requestBuilder, settings);
+        }
+
+        public void RemoveTorrentLabel(string hash, string label, UTorrentSettings settings)
+        {
+            var requestBuilder = BuildRequest(settings)
+                .AddQueryParam("action", "setprops")
+                .AddQueryParam("hash", hash);
+
+            requestBuilder.AddQueryParam("s", "label")
+                          .AddQueryParam("v", label)
+                          .AddQueryParam("s", "label")
+                          .AddQueryParam("v", "");
 
             ProcessRequest(requestBuilder, settings);
         }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -41,13 +41,16 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         [FieldDefinition(4, Label = "Category", Type = FieldType.Textbox, HelpText = "Adding a category specific to Sonarr avoids conflicts with unrelated downloads, but it's optional")]
         public string TvCategory { get; set; }
 
-        [FieldDefinition(5, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
+        [FieldDefinition(5, Label = "Post-Import Category", Type = FieldType.Textbox, Advanced = true, HelpText = "Category for Sonarr to set after it has imported the download. Leave blank to disable this feature.")]
+        public string TvImportedCategory { get; set; }
+
+        [FieldDefinition(6, Label = "Recent Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired within the last 14 days")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
+        [FieldDefinition(7, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(UTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(7, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(UTorrentState), HelpText = "Initial state for torrents added to uTorrent")]
+        [FieldDefinition(8, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(UTorrentState), HelpText = "Initial state for torrents added to uTorrent")]
         public int IntialState { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -127,7 +127,6 @@ namespace NzbDrone.Core.Download
 
                 trackedDownload.Warn(statusMessages);
             }
-
         }
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -147,5 +147,10 @@ namespace NzbDrone.Core.Download
 
             return null;
         }
+
+        public virtual void MarkItemAsImported(DownloadClientItem downloadClientItem)
+        {
+            throw new NotSupportedException(this.Name + " does not support marking items as imported");
+        }
     }
 }

--- a/src/NzbDrone.Core/Download/IDownloadClient.cs
+++ b/src/NzbDrone.Core/Download/IDownloadClient.cs
@@ -13,5 +13,6 @@ namespace NzbDrone.Core.Download
         IEnumerable<DownloadClientItem> GetItems();
         void RemoveItem(string downloadId, bool deleteData);
         DownloadClientInfo GetStatus();
+        void MarkItemAsImported(DownloadClientItem downloadClientItem);
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -152,6 +152,7 @@
     <Compile Include="DecisionEngine\Specifications\UpgradeAllowedSpecification.cs" />
     <Compile Include="Exceptions\DownloadClientRejectedReleaseException.cs" />
     <Compile Include="Exceptions\SearchFailedException.cs" />
+    <Compile Include="Download\Clients\QBittorrent\QBittorrentLabel.cs" />
     <Compile Include="Extras\Metadata\MetadataSectionType.cs" />
     <Compile Include="Download\Aggregation\RemoteEpisodeAggregationService.cs" />
     <Compile Include="Download\Aggregation\Aggregators\AggregatePreferredWordScore.cs" />


### PR DESCRIPTION
#### Database Migration
NO (not sure if anything needs to be done with the database tbh)

#### Description
Allows download clients to set a label after a successful import provided that the SetLabel method is overridden (currently only done for Deluge).


#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #2469 (kind-of... only implemented for deluge currently. Not sure what other download clients have the current supporting code). 

Right now it's only setting the label after a successful auto import post-download. I'm not sure how things work if Sonarr fails to import the release automatically, and the user later manually has to import the donwload or where in the code this happens. 
