### PR TITLE
New: Limit filenames to a maximum of 255 characters

### DIFF
--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -343,6 +343,7 @@
     <Compile Include="MetadataSource\SkyHook\SkyHookProxyFixture.cs" />
     <Compile Include="NotificationTests\NotificationBaseFixture.cs" />
     <Compile Include="NotificationTests\SynologyIndexerFixture.cs" />
+    <Compile Include="OrganizerTests\FileNameBuilderTests\TruncatedEpisodeTitlesFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\ReplaceCharacterFixure.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\RequiresAbsoluteEpisodeNumberFixture.cs" />
     <Compile Include="OrganizerTests\FileNameBuilderTests\RequiresEpisodeTitleFixture.cs" />

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 {
@@ -438,7 +439,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.AnimeEpisodeFormat = "{Series.Title}.{season}x{episode:00}.{absolute:000}\\{Series.Title}.S{season:00}E{episode:00}.{absolute:00}.{Episode.Title}";
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
-                   .Should().Be("South.Park.15x06.100\\South.Park.S15E06.100.City.Sushi");
+                   .Should().Be("South.Park.15x06.100\\South.Park.S15E06.100.City.Sushi".AsOsAgnostic());
         }
 
         [Test]
@@ -448,7 +449,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.AnimeEpisodeFormat = "{Series Title} Season {season:0000} Episode {episode:0000}\\{Series.Title}.S{season:00}E{episode:00}.{absolute:00}.{Episode.Title}";
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
-                   .Should().Be("South Park Season 0015 Episode 0006\\South.Park.S15E06.100.City.Sushi");
+                   .Should().Be("South Park Season 0015 Episode 0006\\South.Park.S15E06.100.City.Sushi".AsOsAgnostic());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedEpisodeTitlesFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedEpisodeTitlesFixture.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class TruncatedEpisodeTitlesFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private List<Episode> _episodes;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .With(s => s.Title = "Series Title")
+                    .Build();
+
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            _episodes = new List<Episode>
+                        {
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Episode Title 1")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 1)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Another Episode Title")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 2)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Yet Another Episode Title")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 3)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Yet Another Episode Title Take 2")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 4)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Yet Another Episode Title Take 3")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 5)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Yet Another Episode Title Take 4")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 6)
+                                            .Build(),
+
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "A Really Really Really Really Long Episode Title")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 7)
+                                            .Build()
+                        };
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+            
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+        }
+
+        private void GivenProper()
+        {
+            _episodeFile.Quality.Revision.Version = 2;
+        }
+
+        [Test]
+        public void should_truncate_with_ellipsis_between_first_and_last_episode_titles()
+        {
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}";
+
+            var result = Subject.BuildFileName(_episodes, _series, _episodeFile);
+            result.Length.Should().BeLessOrEqualTo(255);
+            result.Should().Be("Series Title - S01E01-02-03-04-05-06-07 - Episode Title 1...A Really Really Really Really Long Episode Title HDTV-720p");
+        }
+
+        [Test]
+        public void should_truncate_with_ellipsis_if_only_first_episode_title_fits()
+        {
+            _series.Title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit Maecenas et magna sem Morbi vitae volutpat quam, id porta arcu Orci varius natoque penatibus et magnis dis parturient montes";
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}";
+
+            var result = Subject.BuildFileName(_episodes, _series, _episodeFile);
+            result.Length.Should().BeLessOrEqualTo(255);
+            result.Should().Be("Lorem ipsum dolor sit amet, consectetur adipiscing elit Maecenas et magna sem Morbi vitae volutpat quam, id porta arcu Orci varius natoque penatibus et magnis dis parturient montes - S01E01-02-03-04-05-06-07 - Episode Title 1... HDTV-720p");
+        }
+
+        [Test]
+        public void should_truncate_first_episode_title_with_ellipsis_if_only_partially_fits()
+        {
+            _series.Title = "Lorem ipsum dolor sit amet, consectetur adipiscing elit Maecenas et magna sem Morbi vitae volutpat quam, id porta arcu Orci varius natoque penatibus et magnis dis parturient montes nascetur ridiculus musu Cras vestibulum";
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}";
+
+            var result = Subject.BuildFileName(new List<Episode>{_episodes.First()}, _series, _episodeFile);
+            result.Length.Should().BeLessOrEqualTo(255);
+            result.Should().Be("Lorem ipsum dolor sit amet, consectetur adipiscing elit Maecenas et magna sem Morbi vitae volutpat quam, id porta arcu Orci varius natoque penatibus et magnis dis parturient montes nascetur ridiculus musu Cras vestibulum - S01E01 - Episode Ti... HDTV-720p");
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Limits file name sections to 255 characters (accounting for season or episode folders being part of the episode naming format). 

- If the title is acceptable it is returned as-is
- If there are more than 2 episode titles, attempt to return the first and last titles with an ellipsis between them
- Otherwise try to return the first title
- Finally return a partial title

There is an edge case where only an ellipsis could be returned, but the odds of that seem pretty low.


#### Issues Fixed or Closed by this PR

* #2699
