### PR TITLE
Add support to detect mergerfs mounts

### DIFF
--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Mono.Disk
                                                                                   {
                                                                                       { "afpfs", DriveType.Network },
                                                                                       { "apfs", DriveType.Fixed },
+                                                                                      { "fuse.mergerfs", DriveType.Fixed },
                                                                                       { "zfs", DriveType.Fixed }
                                                                                   };
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently mergerfs filesystems are not shown on the system page. This pull request adds support for it via the drive FindDriveType exception list (only a guess maybe it's not that) because it does not show up in `/proc/filesystems`.

#### Todos
- [ ] Tests
- [ ] Documentation