### PR TITLE
Fixed: Roksbox no Series images can lead to NullRef

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
             if (image == null)
             {
                 _logger.Trace("Failed to find suitable Series image for series {0}.", series.Title);
-                return null;
+                return new List<ImageFileResult>();
             }
 
             var source = _mediaCoverService.GetCoverPath(series.Id, image.CoverType);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When Series has no images, Roksbox series images handling will return null instead of a blank list, this results in NullRef at `MetadataService.cs` Line 290. Return empty list instead of null like other consumers.

