### PR TITLE
Add airs before info for specials in metadata export

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/131_add_displayseasonnumber_and_displayepisodenumber_to_episodes.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/131_add_displayseasonnumber_and_displayepisodenumber_to_episodes.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(131)]
+    public class add_displayseasonnumber_and_displayepisodenumber_to_episodes : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Episodes").AddColumn("DisplaySeasonNumber").AsInt32().Nullable();
+            Alter.Table("Episodes").AddColumn("DisplayEpisodeNumber").AsInt32().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -255,9 +255,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     details.Add(new XElement("aired", episode.AirDate));
                     details.Add(new XElement("plot", episode.Overview));
 
-                    //If trakt ever gets airs before information for specials we should add set it
-                    details.Add(new XElement("displayseason"));
-                    details.Add(new XElement("displayepisode"));
+                    details.Add(new XElement("displayseason", episode.DisplaySeasonNumber ?? -1));
+                    details.Add(new XElement("displayepisode", episode.DisplayEpisodeNumber ?? (episode.DisplaySeasonNumber != null ? 4096 : -1)));
 
                     if (image == null)
                     {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
@@ -7,6 +7,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public int SeasonNumber { get; set; }
         public int EpisodeNumber { get; set; }
         public int? AbsoluteEpisodeNumber { get; set; }
+        public int? DisplaySeasonNumber { get; set; }
+        public int? DisplayEpisodeNumber { get; set; }
         public string Title { get; set; }
         public string AirDate { get; set; }
         public DateTime? AirDateUtc { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -211,6 +211,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             episode.EpisodeNumber = oracleEpisode.EpisodeNumber;
             episode.AbsoluteEpisodeNumber = oracleEpisode.AbsoluteEpisodeNumber;
             episode.Title = oracleEpisode.Title;
+            episode.DisplaySeasonNumber = oracleEpisode.DisplaySeasonNumber;
+            episode.DisplayEpisodeNumber = oracleEpisode.DisplayEpisodeNumber;
 
             episode.AirDate = oracleEpisode.AirDate;
             episode.AirDateUtc = oracleEpisode.AirDateUtc;

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -1280,6 +1280,7 @@
     <Compile Include="Validation\UrlValidator.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentProxyV2.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentProxySelector.cs" />
+    <Compile Include="Datastore\Migration\131_add_displayseasonnumber_and_displayepisodenumber_to_episodes.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0,Profile=Client">

--- a/src/NzbDrone.Core/Tv/Episode.cs
+++ b/src/NzbDrone.Core/Tv/Episode.cs
@@ -29,6 +29,8 @@ namespace NzbDrone.Core.Tv
         public int? SceneAbsoluteEpisodeNumber { get; set; }
         public int? SceneSeasonNumber { get; set; }
         public int? SceneEpisodeNumber { get; set; }
+        public int? DisplaySeasonNumber { get; set; }
+        public int? DisplayEpisodeNumber { get; set; }
         public bool UnverifiedSceneNumbering { get; set; }
         public Ratings Ratings { get; set; }
         public List<MediaCover.MediaCover> Images { get; set; }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -65,6 +65,8 @@ namespace NzbDrone.Core.Tv
                     episodeToUpdate.SeriesId = series.Id;
                     episodeToUpdate.EpisodeNumber = episode.EpisodeNumber;
                     episodeToUpdate.SeasonNumber = episode.SeasonNumber;
+                    episodeToUpdate.DisplayEpisodeNumber = episode.DisplayEpisodeNumber;
+                    episodeToUpdate.DisplaySeasonNumber = episode.DisplaySeasonNumber;
                     episodeToUpdate.AbsoluteEpisodeNumber = episode.AbsoluteEpisodeNumber;
                     episodeToUpdate.Title = episode.Title ?? "TBA";
                     episodeToUpdate.Overview = episode.Overview;


### PR DESCRIPTION
Same as #3065, but against `phantom-develop` 

#### Database Migration
YES

#### Description
Currently special episodes doesn't have the airs before/after information in the metadata export although once it was planned (based on the comment in the code) and it is provided by TheTVDB.

This pull request implements this feature based on the current export mechanism of Kodi:
 - If airs before/after is not provided it defaults to -1 (this is the default behaviour of Kodi)
 - If the episode has an airs before episode on tvdb it is set to that
 - If the episode has an airs after season on tvdb it is set to the provided season and episode 4096 (this is the default behaviour of Kodi)

To support this feature it is needed to be implemented on the SkyHook tvdb proxy (which is closed source), the new fields are to be added for episodes:
 - `displaySeasonNumber`: The season number 
 - `displayEpisodeNumber`: The episode number if it's an airs before record or null if airs after type

Of course if any of those fields are not present they are handled as null.

#### Todos
- [ ] Implement on server side
- [ ] Tests
- [ ] Documentation