### PR TITLE
Add option for passing a download dir to transmission

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -7,6 +7,7 @@ using NLog;
 using FluentValidation.Results;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Transmission
 {
@@ -18,8 +19,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                             IConfigService configService,
                             IDiskProvider diskProvider,
                             IRemotePathMappingService remotePathMappingService,
+                            IBuildFileNames filenameBuilder,
                             Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, filenameBuilder, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -33,7 +33,6 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             Host = "localhost";
             Port = 9091;
             UrlBase = "/transmission/";
-            PassDownloadDir = true;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             Host = "localhost";
             Port = 9091;
             UrlBase = "/transmission/";
+            PassDownloadDir = true;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -67,6 +68,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         [FieldDefinition(10, Label = "Use SSL", Type = FieldType.Checkbox)]
         public bool UseSsl { get; set; }
+
+        [FieldDefinition(11, Label = "Pass download dir", Type = FieldType.Checkbox, Advanced =true, HelpText = "Pass 'seriesname/season' directory to transmission as download location. Requires valid host mappings. Uses Season Folder Format from Media Management settings.")]
+        public bool PassDownloadDir { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Transmission;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Organizer;
 
 namespace NzbDrone.Core.Download.Clients.Vuze
 {
@@ -19,8 +20,9 @@ namespace NzbDrone.Core.Download.Clients.Vuze
                     IConfigService configService,
                     IDiskProvider diskProvider,
                     IRemotePathMappingService remotePathMappingService,
+                    IBuildFileNames filenameBuilder,
                     Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, filenameBuilder, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -45,7 +45,6 @@ namespace NzbDrone.Core.Download
             _eventAggregator = eventAggregator;
             _seedConfigProvider = seedConfigProvider;
             _logger = logger;
-            // TODO: add
         }
 
         public void DownloadReport(RemoteEpisode remoteEpisode)

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -45,6 +45,7 @@ namespace NzbDrone.Core.Download
             _eventAggregator = eventAggregator;
             _seedConfigProvider = seedConfigProvider;
             _logger = logger;
+            // TODO: add
         }
 
         public void DownloadReport(RemoteEpisode remoteEpisode)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This adds an (advanced) option for transmission to allow downloading directly into the correct directory.
The local series directory will be mapped to remote directory (if such a mapping exists).
The season subdirectory will be generated by filenamebuilder with respect to the configured season folder name pattern.

I need this because i don't want to extract the files i download (.rar support would be helpful, too) and I don't want anyone to move them around after downloading. Just make transmission download them into the correct directories is fine and i guess this could be of use for others aswell.

I am in no way a C# expert, so I'm expecting your feedback, of course.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* This MAY be a solution to issue #738 at least for some people
