### PR TITLE
Allow CheckForFinishedDownload and RefreshSeries to be set from the UI

### DIFF
--- a/src/NzbDrone.Api/Config/DownloadClientConfigResource.cs
+++ b/src/NzbDrone.Api/Config/DownloadClientConfigResource.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Api.Config
 
         public bool EnableCompletedDownloadHandling { get; set; }
         public bool RemoveCompletedDownloads { get; set; }
+        public int CheckForFinishedDownloadInterval { get; set; }
 
         public bool AutoRedownloadFailed { get; set; }
         public bool RemoveFailedDownloads { get; set; }
@@ -24,6 +25,7 @@ namespace NzbDrone.Api.Config
 
                 EnableCompletedDownloadHandling = model.EnableCompletedDownloadHandling,
                 RemoveCompletedDownloads = model.RemoveCompletedDownloads,
+                CheckForFinishedDownloadInterval = model.CheckForFinishedDownloadInterval,
 
                 AutoRedownloadFailed = model.AutoRedownloadFailed,
                 RemoveFailedDownloads = model.RemoveFailedDownloads

--- a/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
+++ b/src/NzbDrone.Api/Config/MediaManagementConfigResource.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Api.Config
         public bool CreateEmptySeriesFolders { get; set; }
         public bool DeleteEmptyFolders { get; set; }
         public FileDateType FileDate { get; set; }
+        public int RefreshSeriesInterval { get; set; }
 
         public bool SetPermissionsLinux { get; set; }
         public string FileChmod { get; set; }
@@ -39,6 +40,7 @@ namespace NzbDrone.Api.Config
                 CreateEmptySeriesFolders = model.CreateEmptySeriesFolders,
                 DeleteEmptyFolders = model.DeleteEmptyFolders,
                 FileDate = model.FileDate,
+                RefreshSeriesInterval = model.RefreshSeriesInterval,
 
                 SetPermissionsLinux = model.SetPermissionsLinux,
                 FileChmod = model.FileChmod,

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -176,6 +176,20 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("DownloadClientWorkingFolders", value); }
         }
 
+        public int CheckForFinishedDownloadInterval
+        {
+            get { return GetValueInt("CheckForFinishedDownloadInterval", 1); }
+
+            set { SetValue("CheckForFinishedDownloadInterval", value); }
+        }
+
+        public int RefreshSeriesInterval
+        {
+            get { return GetValueInt("RefreshSeriesInterval", 1); }
+
+            set { SetValue("RefreshSeriesInterval", value); }
+        }
+
         public int DownloadClientHistoryLimit
         {
             get { return GetValueInt("DownloadClientHistoryLimit", 30); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Configuration
         //Download Client
         string DownloadClientWorkingFolders { get; set; }
         int DownloadClientHistoryLimit { get; set; }
+        int CheckForFinishedDownloadInterval { get; set; }
 
         //Completed/Failed Download Handling (Download client)
         bool EnableCompletedDownloadHandling { get; set; }
@@ -38,6 +39,7 @@ namespace NzbDrone.Core.Configuration
         string ExtraFileExtensions { get; set; }
         RescanAfterRefreshType RescanAfterRefresh { get; set; }
         EpisodeTitleRequiredType EpisodeTitleRequired { get; set; }
+        int RefreshSeriesInterval { get; set; }
 
 
         //Permissions (Media Management)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow CheckForFinishedDownloadInterval and RefreshSeriesInterval to be set from the UI. I use Sonarr with synology. Refreshing every 12 hours and checking for completed downloads every 30 seconds or a minute is excessive IMO considering I use deluge which using libtorrent (a single threaded process). I believe these are good options for people. Perhaps they should be classified as advances settings.

#### Todos
- [ ] Tests
- [ ] UI Integration


#### Issues Fixed or Closed by this PR

* 
