### PR TITLE
Transmission Seed Idle Limit handling

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         [Test]
         public void completed_download_should_have_required_properties()
         {
-            PrepareClientToReturnCompletedItem();
+            PrepareClientToReturnCompletedItem(true, ratioLimit: 0.5);
             var item = Subject.GetItems().Single();
             VerifyCompleted(item);
 
@@ -184,7 +184,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
             item.Status.Should().Be(expectedItemStatus);
         }
 
-        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, true)]
+        [TestCase(TransmissionTorrentStatus.Stopped, DownloadItemStatus.Completed, false)]
         [TestCase(TransmissionTorrentStatus.CheckWait, DownloadItemStatus.Downloading, false)]
         [TestCase(TransmissionTorrentStatus.Check, DownloadItemStatus.Downloading, false)]
         [TestCase(TransmissionTorrentStatus.Queued, DownloadItemStatus.Queued, false)]

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -32,6 +32,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         public override IEnumerable<DownloadClientItem> GetItems()
         {
+            var configFunc = new Lazy<TransmissionConfig>(() => _proxy.GetConfig(Settings));
             var torrents = _proxy.GetTorrents(Settings);
 
             var items = new List<DownloadClientItem>();
@@ -98,14 +99,53 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     item.Status = DownloadItemStatus.Downloading;
                 }
 
-                item.CanMoveFiles = item.CanBeRemoved =
-                    torrent.Status == TransmissionTorrentStatus.Stopped &&
-                    item.SeedRatio >= torrent.SeedRatioLimit;
+                item.CanBeRemoved = HasReachedSeedLimit(torrent, item.SeedRatio, configFunc);
+                item.CanMoveFiles = item.CanBeRemoved && torrent.Status == TransmissionTorrentStatus.Stopped;
 
                 items.Add(item);
             }
 
             return items;
+        }
+
+        protected bool HasReachedSeedLimit(TransmissionTorrent torrent, double? ratio, Lazy<TransmissionConfig> config)
+        {
+            var isStopped = torrent.Status == TransmissionTorrentStatus.Stopped;
+            var isSeeding = torrent.Status == TransmissionTorrentStatus.Seeding;
+            
+            if (torrent.SeedRatioMode == 1)
+            {
+                if (isStopped && ratio.HasValue && ratio >= torrent.SeedRatioLimit)
+                {
+                    return true;
+                }
+            }
+            else if (torrent.SeedRatioMode == 0)
+            {
+                if (isStopped && config.Value.SeedRatioLimited && ratio >= config.Value.SeedRatioLimit)
+                {
+                    return true;
+                }
+            }
+
+            // Transmission doesn't support SeedTimeLimit, use/abuse seed idle limit, but only if it was set per-torrent.
+            if (torrent.SeedIdleMode == 1)
+            {
+                if ((isStopped || isSeeding) && torrent.SecondsSeeding > torrent.SeedIdleLimit * 60)
+                {
+                    return true;
+                }
+            }
+            else if (torrent.SeedIdleMode == 0)
+            {
+                // The global idle limit is a real idle limit, if it's configured then 'Stopped' is enough.
+                if (isStopped && config.Value.IdleSeedingLimitEnabled)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override void RemoveItem(string downloadId, bool deleteData)
@@ -116,7 +156,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public override DownloadClientInfo GetStatus()
         {
             var config = _proxy.GetConfig(Settings);
-            var destDir = config.GetValueOrDefault("download-dir") as string;
+            var destDir = config.DownloadDir;
 
             if (Settings.TvCategory.IsNotNullOrWhiteSpace())
             {
@@ -184,7 +224,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             if (!Settings.TvCategory.IsNotNullOrWhiteSpace()) return null;
 
             var config = _proxy.GetConfig(Settings);
-            var destDir = (string)config.GetValueOrDefault("download-dir");
+            var destDir = config.DownloadDir;
 
             return $"{destDir.TrimEnd('/')}/{Settings.TvCategory}";
         }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionConfig.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionConfig.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Download.Clients.Transmission
+{
+    public class TransmissionConfig
+    {
+        [JsonProperty("rpc-version")]
+        public string RpcVersion { get; set; }
+        public string Version { get; set; }
+
+        [JsonProperty("download-dir")]
+        public string DownloadDir { get; set; }
+
+        public double SeedRatioLimit { get; set; }
+        public bool SeedRatioLimited { get; set; }
+
+        [JsonProperty("idle-seeding-limit")]
+        public long IdleSeedingLimit { get; set; }
+        [JsonProperty("idle-seeding-limit-enabled")]
+        public bool IdleSeedingLimitEnabled { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         void AddTorrentFromUrl(string torrentUrl, string downloadDirectory, TransmissionSettings settings);
         void AddTorrentFromData(byte[] torrentData, string downloadDirectory, TransmissionSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, TransmissionSettings settings);
-        Dictionary<string, object> GetConfig(TransmissionSettings settings);
+        TransmissionConfig GetConfig(TransmissionSettings settings);
         string GetProtocolVersion(TransmissionSettings settings);
         string GetClientVersion(TransmissionSettings settings);
         void RemoveTorrent(string hash, bool removeData, TransmissionSettings settings);
@@ -101,26 +101,22 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var config = GetConfig(settings);
 
-            var version = config["rpc-version"];
-
-            return version.ToString();
+            return config.RpcVersion;
         }
 
         public string GetClientVersion(TransmissionSettings settings)
         {
             var config = GetConfig(settings);
 
-            var version = config["version"];
-
-            return version.ToString();
+            return config.Version;
         }
 
-        public Dictionary<string, object> GetConfig(TransmissionSettings settings)
+        public TransmissionConfig GetConfig(TransmissionSettings settings)
         {
             // Gets the transmission version.
             var result = GetSessionVariables(settings);
 
-            return result.Arguments;
+            return Json.Deserialize<TransmissionConfig>(result.Arguments.ToJson());
         }
 
         public void RemoveTorrent(string hashString, bool removeData, TransmissionSettings settings)
@@ -164,15 +160,20 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 "hashString", // Unique torrent ID. Use this instead of the client id?
                 "name",
                 "downloadDir",
-                "status",
                 "totalSize",
                 "leftUntilDone",
                 "isFinished",
                 "eta",
+                "status",
+                "secondsDownloading",
+                "secondsSeeding",
                 "errorString",
                 "uploadedEver",
                 "downloadedEver",
                 "seedRatioLimit",
+                "seedRatioMode",
+                "seedIdleLimit",
+                "seedIdleMode",
                 "fileCount"
             };
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
@@ -12,10 +12,14 @@
         public int Eta { get; set; }
         public TransmissionTorrentStatus Status { get; set; }
         public int SecondsDownloading { get; set; }
+        public int SecondsSeeding { get; set; }
         public string ErrorString { get; set; }
         public long DownloadedEver { get; set; }
         public long UploadedEver { get; set; }
-        public long SeedRatioLimit { get; set; }
+        public double SeedRatioLimit { get; set; }
+        public int SeedRatioMode { get; set; }
+        public long SeedIdleLimit { get; set; }
+        public int SeedIdleMode { get; set; }
         public int FileCount { get; set; }
     }
 }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="DecisionEngine\Specifications\RepackSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\MultiSeasonSpecification.cs" />
     <Compile Include="DecisionEngine\Specifications\UpgradeAllowedSpecification.cs" />
+    <Compile Include="Download\Clients\Transmission\TransmissionConfig.cs" />
     <Compile Include="Exceptions\DownloadClientRejectedReleaseException.cs" />
     <Compile Include="Exceptions\SearchFailedException.cs" />
     <Compile Include="Download\Clients\QBittorrent\QBittorrentLabel.cs" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Revises the Transmission Seed Criteria detection.

The torrent will be eligible for removal if:
- If a per-torrent or global ratio is set and reached. And the Torrent status is 'Stopped'.
- If a per-torrent idle-limit is set, and seed time (not idle-time) is larger than that. Torrent status must be 'Stopped' or 'Seeding'.
- If a per-torrent idle-limit is not set, but a global one is. Then if torrent status is 'Stopped'.

The is largely a workaround to transmission not providing the idle-limit and/or not having a seed time limit.
The per-torrent idle-limit is likely set _by_ sonarr and treated as a seed time limit. The global idle limit is not set by sonarr and treated as idle limit, but since it cannot be verified the only criteria is that it must be Stopped.

#### Todos
- [x] Tests
- [x] Documentation


#### Issues Fixed or Closed by this PR

Fixes #2807
