### PR TITLE
User configurable minimum free disk space

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -169,6 +169,22 @@ class MediaManagement extends Component {
                         isAdvanced={true}
                         size={sizes.MEDIUM}
                       >
+                        <FormLabel>Minimum Free Space (in MB)</FormLabel>
+
+                        <FormInputGroup
+                          type={inputTypes.NUMBER}
+                          name="minimumFreeSpaceWhenImporting"
+                          helpText="Prevent import if it would leave less than this amount of disk space available"
+                          onChange={onInputChange}
+                          {...settings.minimumFreeSpaceWhenImporting}
+                        />
+                      </FormGroup>
+
+                      <FormGroup
+                        advancedSettings={advancedSettings}
+                        isAdvanced={true}
+                        size={sizes.MEDIUM}
+                      >
                         <FormLabel>Use Hardlinks instead of Copy</FormLabel>
 
                         <FormInputGroup

--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -169,10 +169,11 @@ class MediaManagement extends Component {
                         isAdvanced={true}
                         size={sizes.MEDIUM}
                       >
-                        <FormLabel>Minimum Free Space (in MB)</FormLabel>
+                        <FormLabel>Minimum Free Space</FormLabel>
 
                         <FormInputGroup
                           type={inputTypes.NUMBER}
+                          unit='MB'
                           name="minimumFreeSpaceWhenImporting"
                           helpText="Prevent import if it would leave less than this amount of disk space available"
                           onChange={onInputChange}

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
@@ -70,6 +70,9 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         [Test]
         public void should_reject_when_there_isnt_enough_space_for_file_plus_min_free_space()
         {
+            Mocker.GetMock<IConfigService>()
+                .Setup(s => s.MinimumFreeSpaceWhenImporting)
+                .Returns(100);
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(150.Megabytes());
 

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         }
 
         [Test]
-        public void should_reject_when_there_isnt_enough_space_for_file_plus_100mb_padding()
+        public void should_reject_when_there_isnt_enough_space_for_file_plus_min_free_space()
         {
             GivenFileSize(100.Megabytes());
             GivenFreeSpace(150.Megabytes());

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -190,6 +190,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("SkipFreeSpaceCheckWhenImporting", value); }
         }
 
+        public int MinimumFreeSpaceWhenImporting
+        {
+            get { return GetValueInt("MinimumFreeSpaceWhenImporting", 100); }
+
+            set { SetValue("MinimumFreeSpaceWhenImporting", value); }
+        }
+
         public bool CopyUsingHardlinks
         {
             get { return GetValueBoolean("CopyUsingHardlinks", true); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -32,6 +32,7 @@ namespace NzbDrone.Core.Configuration
         bool DeleteEmptyFolders { get; set; }
         FileDateType FileDate { get; set; }
         bool SkipFreeSpaceCheckWhenImporting { get; set; }
+        int MinimumFreeSpaceWhenImporting { get; set; }
         bool CopyUsingHardlinks { get; set; }
         bool EnableMediaInfo { get; set; }
         bool ImportExtraFiles { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                     return Decision.Accept();
                 }
 
-                if (freeSpace < localEpisode.Size + 100.Megabytes())
+                if (freeSpace < localEpisode.Size + _configService.MinimumFreeSpaceWhenImporting.Megabytes())
                 {
                     _logger.Warn("Not enough free space ({0}) to import: {1} ({2})", freeSpace, localEpisode, localEpisode.Size);
                     return Decision.Reject("Not enough free space");

--- a/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
+++ b/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
@@ -12,7 +12,7 @@ namespace Sonarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.FileChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.FolderChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.RecycleBin).IsValidPath().SetValidator(pathExistsValidator).When(c => !string.IsNullOrWhiteSpace(c.RecycleBin));
-            SharedValidator.RuleFor(c => c.MinimumFreeSpaceWhenImporting).GreaterThan(100);
+            SharedValidator.RuleFor(c => c.MinimumFreeSpaceWhenImporting).GreaterThan(99);
         }
 
         protected override MediaManagementConfigResource ToResource(IConfigService model)

--- a/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
+++ b/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
@@ -12,6 +12,7 @@ namespace Sonarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.FileChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.FolderChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.RecycleBin).IsValidPath().SetValidator(pathExistsValidator).When(c => !string.IsNullOrWhiteSpace(c.RecycleBin));
+            SharedValidator.RuleFor(c => c.MinimumFreeSpaceWhenImporting).GreaterThan(100);
         }
 
         protected override MediaManagementConfigResource ToResource(IConfigService model)

--- a/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
+++ b/src/Sonarr.Api.V3/Config/MediaManagementConfigModule.cs
@@ -12,7 +12,7 @@ namespace Sonarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.FileChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.FolderChmod).NotEmpty();
             SharedValidator.RuleFor(c => c.RecycleBin).IsValidPath().SetValidator(pathExistsValidator).When(c => !string.IsNullOrWhiteSpace(c.RecycleBin));
-            SharedValidator.RuleFor(c => c.MinimumFreeSpaceWhenImporting).GreaterThan(99);
+            SharedValidator.RuleFor(c => c.MinimumFreeSpaceWhenImporting).GreaterThanOrEqualTo(100);
         }
 
         protected override MediaManagementConfigResource ToResource(IConfigService model)

--- a/src/Sonarr.Api.V3/Config/MediaManagementConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/MediaManagementConfigResource.cs
@@ -24,6 +24,7 @@ namespace Sonarr.Api.V3.Config
 
         public EpisodeTitleRequiredType EpisodeTitleRequired { get; set; }
         public bool SkipFreeSpaceCheckWhenImporting { get; set; }
+        public int MinimumFreeSpaceWhenImporting { get; set; }
         public bool CopyUsingHardlinks { get; set; }
         public bool ImportExtraFiles { get; set; }
         public string ExtraFileExtensions { get; set; }
@@ -52,6 +53,7 @@ namespace Sonarr.Api.V3.Config
 
                 EpisodeTitleRequired = model.EpisodeTitleRequired,
                 SkipFreeSpaceCheckWhenImporting = model.SkipFreeSpaceCheckWhenImporting,
+                MinimumFreeSpaceWhenImporting = model.MinimumFreeSpaceWhenImporting,
                 CopyUsingHardlinks = model.CopyUsingHardlinks,
                 ImportExtraFiles = model.ImportExtraFiles,
                 ExtraFileExtensions = model.ExtraFileExtensions,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow user to configure the minimum amount of disk space available after import instead of using a fixed 100 megabyte value.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

#3233 
