### PR TITLE
Fixed: Cleanup Multiple Compiler Warnings

### DIFF
--- a/src/NzbDrone.Api.Test/NzbDrone.Api.Test.csproj
+++ b/src/NzbDrone.Api.Test/NzbDrone.Api.Test.csproj
@@ -50,10 +50,6 @@
     <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.19.0\lib\net40\FluentAssertions.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-    </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL" />
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>

--- a/src/NzbDrone.Api/NzbDrone.Api.csproj
+++ b/src/NzbDrone.Api/NzbDrone.Api.csproj
@@ -75,9 +75,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Omu.ValueInjecter">
-      <HintPath>..\packages\ValueInjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\NzbDrone.Common\Properties\SharedAssemblyInfo.cs">

--- a/src/NzbDrone.App.Test/NzbDrone.Host.Test.csproj
+++ b/src/NzbDrone.App.Test/NzbDrone.Host.Test.csproj
@@ -51,9 +51,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/src/NzbDrone.Automation.Test/AutomationTest.cs
+++ b/src/NzbDrone.Automation.Test/AutomationTest.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Automation.Test
             LogManager.Configuration.LoggingRules.Add(new LoggingRule("*", NLog.LogLevel.Trace, consoleTarget));
         }
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void SmokeTestSetup()
         {
             driver = new FirefoxDriver();
@@ -56,7 +56,7 @@ namespace NzbDrone.Automation.Test
                 .Select(e => e.Text);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void SmokeTestTearDown()
         {
             _runner.KillAll();

--- a/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/NzbDrone.Common.Test.csproj
@@ -48,9 +48,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/src/NzbDrone.Console/NzbDrone.Console.csproj
+++ b/src/NzbDrone.Console/NzbDrone.Console.csproj
@@ -82,9 +82,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Owin">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>

--- a/src/NzbDrone.Core.Test/Datastore/Converters/Int32ConverterFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Converters/Int32ConverterFixture.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Test.Datastore.Converters
         {
             var i = 5;
 
-            Subject.ToDB(5).Should().Be(5);
+            Subject.ToDB(i).Should().Be(5);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateQualityFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateQualityFixture.cs
@@ -18,8 +18,6 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
         private Mock<IAugmentQuality> _fileExtensionAugmenter;
         private Mock<IAugmentQuality> _nameAugmenter;
 
-        private IEnumerable<IAugmentQuality> _qualityAugmenters;
-
         [SetUp]
         public void Setup()
         {

--- a/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/NzbDrone.Core.Test.csproj
@@ -75,13 +75,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NCrunch.Framework, Version=3.2.0.3, Culture=neutral, PublicKeyToken=01d101bf6f3e0aea, processorArchitecture=MSIL">
-      <HintPath>..\packages\NCrunch.Framework.3.2.0.3\lib\NCrunch.Framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/RequiresEpisodeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/RequiresEpisodeTitleFixture.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
-using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
@@ -14,7 +13,6 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
     {
         private Series _series;
         private Episode _episode;
-        private EpisodeFile _episodeFile;
         private NamingConfig _namingConfig;
 
         [SetUp]

--- a/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Test.TvTests
         private List<Episode> _deletedEpisodes;
         private Tuple<Series, List<Episode>> _gameOfThrones;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void TestFixture()
         {
             UseRealHttp();

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
             }
             catch (DownloadClientAuthenticationException ex)
             {
-                _logger.ErrorException(ex.Message, ex);
+                _logger.Error(ex, ex.Message);
 
                 return new NzbDroneValidationFailure("Password", "Authentication failed");
             }
@@ -176,7 +176,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
             }
             catch (Exception ex)
             {
-                _logger.ErrorException(ex.Message, ex);
+                _logger.Error(ex, ex.Message);
                 return new NzbDroneValidationFailure(String.Empty, "Failed to get the list of torrents: " + ex.Message);
             }
 

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenProxy.cs
@@ -21,7 +21,6 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
     public class HadoukenProxy : IHadoukenProxy
     {
-        private static int _callId;
         private readonly IHttpClient _httpClient;
         private readonly Logger _logger;
 
@@ -147,7 +146,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
             }
             catch(Exception ex)
             {
-                _logger.ErrorException("Failed to map Hadouken torrent data.", ex);
+                _logger.Error(ex, "Failed to map Hadouken torrent data.");
             }
 
             return torrent;

--- a/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Extras.Metadata
                         {
                             _aggregationService.Augment(localEpisode, false);
                         }
-                        catch (AugmentingFailedException ex)
+                        catch (AugmentingFailedException)
                         {
                             _logger.Debug("Unable to parse extra file: {0}", possibleMetadataFile);
                             continue;

--- a/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
+++ b/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Extras.Others
                 {
                     _aggregationService.Augment(localEpisode, false);
                 }
-                catch (AugmentingFailedException ex)
+                catch (AugmentingFailedException)
                 {
                     _logger.Debug("Unable to parse extra file: {0}", possibleExtraFile);
                     continue;

--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                     {
                         _aggregationService.Augment(localEpisode, false);
                     }
-                    catch (AugmentingFailedException ex)
+                    catch (AugmentingFailedException)
                     {
                         _logger.Debug("Unable to parse extra file: {0}", possibleSubtitleFile);
                         continue;

--- a/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Messaging.Commands
                 _logger.Error(ex, "Thread aborted");
                 Thread.ResetAbort();
             }
-            catch (OperationCanceledException ex)
+            catch (OperationCanceledException)
             {
                 _logger.Trace("Stopped one command execution pipeline");
             }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvProxy.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Notifications.Plex.PlexTv
             {
                 throw new NzbDroneClientException(ex.Response.StatusCode, "Unable to connect to plex.tv");
             }
-            catch (WebException ex)
+            catch (WebException)
             {
                 throw new NzbDroneClientException(HttpStatusCode.BadRequest, "Unable to connect to plex.tv");
             }

--- a/src/NzbDrone.Core/Tv/MoveSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/MoveSeriesService.cs
@@ -5,7 +5,6 @@ using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Organizer;
-using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Tv.Commands;
 using NzbDrone.Core.Tv.Events;
 
@@ -17,7 +16,6 @@ namespace NzbDrone.Core.Tv
         private readonly IBuildFileNames _filenameBuilder;
         private readonly IDiskProvider _diskProvider;
         private readonly IDiskTransferService _diskTransferService;
-        private readonly IRootFolderService _rootFolderService;
         private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
 

--- a/src/NzbDrone.Host/NzbDrone.Host.csproj
+++ b/src/NzbDrone.Host/NzbDrone.Host.csproj
@@ -96,9 +96,6 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.5.3\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="NLog.Extensions.Logging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.Extensions.Logging.1.1.0\lib\net462\NLog.Extensions.Logging.dll</HintPath>
-    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>

--- a/src/NzbDrone.Host/Owin/MiddleWare/NzbDroneVersionMiddleWare.cs
+++ b/src/NzbDrone.Host/Owin/MiddleWare/NzbDroneVersionMiddleWare.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Host.Owin.MiddleWare
                 context.Response.Headers.Add(_versionHeader);
                 await Next.Invoke(context);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 Logger.Debug("Unable to set version header");
             }

--- a/src/NzbDrone.Integration.Test/CorsFixture.cs
+++ b/src/NzbDrone.Integration.Test/CorsFixture.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using Sonarr.Http.Extensions;
 using RestSharp;
-using Sonarr.Http.Extensions;
 
 namespace NzbDrone.Integration.Test
 {

--- a/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/NzbDrone.Integration.Test.csproj
@@ -64,9 +64,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nancy, Version=1.4.4.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/NzbDrone.Test.Common.csproj
@@ -60,9 +60,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/src/NzbDrone.Update.Test/NzbDrone.Update.Test.csproj
+++ b/src/NzbDrone.Update.Test/NzbDrone.Update.Test.csproj
@@ -50,9 +50,6 @@
     </Reference>
     <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
-    </Reference>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -23,7 +23,6 @@ namespace Sonarr.Api.V3.EpisodeFiles
     {
         private readonly IMediaFileService _mediaFileService;
         private readonly IDeleteMediaFiles _mediaFileDeletionService;
-        private readonly IRecycleBinProvider _recycleBinProvider;
         private readonly ISeriesService _seriesService;
         private readonly IUpgradableSpecification _upgradableSpecification;
 

--- a/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileModule.cs
+++ b/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileModule.cs
@@ -15,11 +15,11 @@ namespace Sonarr.Api.V3.Profiles.Release
         {
             _releaseProfileService = releaseProfileService;
 
-            GetResourceById = Get;
+            GetResourceById = GetReleaseProfile;
             GetResourceAll = GetAll;
             CreateResource = Create;
             UpdateResource = Update;
-            DeleteResource = Delete;
+            DeleteResource = DeleteReleaseProfile;
 
             SharedValidator.Custom(restriction =>
             {
@@ -32,7 +32,7 @@ namespace Sonarr.Api.V3.Profiles.Release
             });
         }
 
-        private ReleaseProfileResource Get(int id)
+        private ReleaseProfileResource GetReleaseProfile(int id)
         {
             return _releaseProfileService.Get(id).ToResource();
         }
@@ -52,7 +52,7 @@ namespace Sonarr.Api.V3.Profiles.Release
             _releaseProfileService.Update(resource.ToModel());
         }
 
-        private void Delete(int id)
+        private void DeleteReleaseProfile(int id)
         {
             _releaseProfileService.Delete(id);
         }

--- a/src/Sonarr.Api.V3/Tags/TagDetailsModule.cs
+++ b/src/Sonarr.Api.V3/Tags/TagDetailsModule.cs
@@ -13,11 +13,11 @@ namespace Sonarr.Api.V3.Tags
         {
             _tagService = tagService;
 
-            GetResourceById = Get;
+            GetResourceById = GetTagDetails;
             GetResourceAll = GetAll;
         }
 
-        private TagDetailsResource Get(int id)
+        private TagDetailsResource GetTagDetails(int id)
         {
             return _tagService.Details(id).ToResource();
         }

--- a/src/Sonarr.Api.V3/Tags/TagModule.cs
+++ b/src/Sonarr.Api.V3/Tags/TagModule.cs
@@ -17,14 +17,14 @@ namespace Sonarr.Api.V3.Tags
         {
             _tagService = tagService;
 
-            GetResourceById = Get;
+            GetResourceById = GetTag;
             GetResourceAll = GetAll;
             CreateResource = Create;
             UpdateResource = Update;
-            DeleteResource = Delete;
+            DeleteResource = DeleteTag;
         }
 
-        private TagResource Get(int id)
+        private TagResource GetTag(int id)
         {
             return _tagService.GetTag(id).ToResource();
         }
@@ -44,7 +44,7 @@ namespace Sonarr.Api.V3.Tags
             _tagService.Update(resource.ToModel());
         }
 
-        private void Delete(int id)
+        private void DeleteTag(int id)
         {
             _tagService.Delete(id);
         }

--- a/src/Sonarr.Http/Frontend/Mappers/BackupFileMapper.cs
+++ b/src/Sonarr.Http/Frontend/Mappers/BackupFileMapper.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
-using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.Backup;
 
 namespace Sonarr.Http.Frontend.Mappers
@@ -9,7 +8,6 @@ namespace Sonarr.Http.Frontend.Mappers
     public class BackupFileMapper : StaticResourceMapperBase
     {
         private readonly IBackupService _backupService;
-        private readonly IAppFolderInfo _appFolderInfo;
 
         public BackupFileMapper(IBackupService backupService, IDiskProvider diskProvider, Logger logger)
             : base(diskProvider, logger)

--- a/src/Sonarr.Http/TinyIoCNancyBootstrapper.cs
+++ b/src/Sonarr.Http/TinyIoCNancyBootstrapper.cs
@@ -91,7 +91,6 @@ namespace Sonarr.Http
                         break;
                     case Lifetime.PerRequest:
                         throw new InvalidOperationException("Unable to directly register a per request lifetime.");
-                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -118,7 +117,6 @@ namespace Sonarr.Http
                         break;
                     case Lifetime.PerRequest:
                         throw new InvalidOperationException("Unable to directly register a per request lifetime.");
-                        break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR cleans up all compiler warnings save for the IHttpProvider Obsolete warnings.

- Multiple variable not used
- Multiple duplicate dependency references (Moq)
- Multiple instances of `ErrorException` obsolete, Converted to Error
- Multiple `TestFixtureSetUp` obsolete, Converted to `OneTimeSetup`
- Multiple `TestFixtureTearDown` obsolete, Converted to `OneTimeTearDown`
- Few instances of overriding base Nancy.Get/Delete without new keyword. Followed scheme used elsewhere in UI GetXXX, DeleteXXX
- And two instances of unreachable Code (Break after a Throw in a switch)

Let me know if you guys want anything changed or reverted. 

#### Issues Fixed or Closed by this PR
None
* 
