### PR TITLE
New: OnHealthIssue Notification

### DIFF
--- a/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContent.js
+++ b/frontend/src/Settings/Notifications/Notifications/EditNotificationModalContent.js
@@ -42,10 +42,13 @@ function EditNotificationModalContent(props) {
     onDownload,
     onUpgrade,
     onRename,
+    onHealthIssue,
     supportsOnGrab,
     supportsOnDownload,
     supportsOnUpgrade,
     supportsOnRename,
+    supportsOnHealthIssue,
+    includeHealthWarnings,
     tags,
     fields,
     message
@@ -146,6 +149,35 @@ function EditNotificationModalContent(props) {
                   onChange={onInputChange}
                 />
               </FormGroup>
+
+              <FormGroup>
+                <FormLabel>On Health Issue</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="onHealthIssue"
+                  helpText="Be notified on health check failures"
+                  isDisabled={!supportsOnHealthIssue.value}
+                  {...onHealthIssue}
+                  onChange={onInputChange}
+                />
+              </FormGroup>
+
+              {
+                onHealthIssue.value &&
+                  <FormGroup>
+                    <FormLabel>Include Health Warnings</FormLabel>
+
+                    <FormInputGroup
+                      type={inputTypes.CHECK}
+                      name="includeHealthWarnings"
+                      helpText="Be notified on health warnings in addition to errors"
+                      isDisabled={!supportsOnHealthIssue.value}
+                      {...includeHealthWarnings}
+                      onChange={onInputChange}
+                    />
+                  </FormGroup>
+              }
 
               <FormGroup>
                 <FormLabel>Tags</FormLabel>

--- a/frontend/src/Settings/Notifications/Notifications/Notification.js
+++ b/frontend/src/Settings/Notifications/Notifications/Notification.js
@@ -58,10 +58,12 @@ class Notification extends Component {
       onDownload,
       onUpgrade,
       onRename,
+      onHealthIssue,
       supportsOnGrab,
       supportsOnDownload,
       supportsOnUpgrade,
-      supportsOnRename
+      supportsOnRename,
+      supportsOnHealthIssue
     } = this.props;
 
     return (
@@ -103,7 +105,14 @@ class Notification extends Component {
         }
 
         {
-          !onGrab && !onDownload && !onRename &&
+          supportsOnHealthIssue && onHealthIssue &&
+            <Label kind={kinds.SUCCESS}>
+              On Health Issue
+            </Label>
+        }
+
+        {
+          !onGrab && !onDownload && !onRename && !onHealthIssue &&
             <Label
               kind={kinds.DISABLED}
               outline={true}
@@ -140,10 +149,12 @@ Notification.propTypes = {
   onDownload: PropTypes.bool.isRequired,
   onUpgrade: PropTypes.bool.isRequired,
   onRename: PropTypes.bool.isRequired,
+  onHealthIssue: PropTypes.bool.isRequired,
   supportsOnGrab: PropTypes.bool.isRequired,
   supportsOnDownload: PropTypes.bool.isRequired,
   supportsOnUpgrade: PropTypes.bool.isRequired,
   supportsOnRename: PropTypes.bool.isRequired,
+  supportsOnHealthIssue: PropTypes.bool.isRequired,
   onConfirmDeleteNotification: PropTypes.func.isRequired
 };
 

--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -65,6 +65,11 @@ namespace NzbDrone.Core.Test.NotificationTests
                 TestLogger.Info("OnRename was called");
             }
 
+            public override void OnHealthIssue(NzbDrone.Core.HealthCheck.HealthCheck artist)
+            {
+                TestLogger.Info("OnHealthIssue was called");
+            }
+
         }
 
         class TestNotificationWithNoEvents : NotificationBase<TestSetting>
@@ -102,6 +107,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnDownload.Should().BeTrue();
             notification.SupportsOnUpgrade.Should().BeTrue();
             notification.SupportsOnRename.Should().BeTrue();
+            notification.SupportsOnHealthIssue.Should().BeTrue();
         }
 
 
@@ -114,6 +120,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnDownload.Should().BeFalse();
             notification.SupportsOnUpgrade.Should().BeFalse();
             notification.SupportsOnRename.Should().BeFalse();
+            notification.SupportsOnHealthIssue.Should().BeFalse();
         }
     }
 

--- a/src/NzbDrone.Core/Datastore/Migration/135_health_issue_notification.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/135_health_issue_notification.cs
@@ -1,0 +1,15 @@
+﻿using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(135)]
+    public class health_issue_notification : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Notifications").AddColumn("OnHealthIssue").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("IncludeHealthWarnings").AsBoolean().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -67,7 +67,8 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(i => i.SupportsOnGrab)
                   .Ignore(i => i.SupportsOnDownload)
                   .Ignore(i => i.SupportsOnUpgrade)
-                  .Ignore(i => i.SupportsOnRename);
+                  .Ignore(i => i.SupportsOnRename)
+                  .Ignore(i => i.SupportsOnHealthIssue);
 
             Mapper.Entity<MetadataDefinition>().RegisterDefinition("Metadata")
                   .Ignore(d => d.Tags);

--- a/src/NzbDrone.Core/HealthCheck/HealthCheckFailedEvent.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheckFailedEvent.cs
@@ -1,0 +1,14 @@
+﻿using NzbDrone.Common.Messaging;
+
+namespace NzbDrone.Core.HealthCheck
+{
+    public class HealthCheckFailedEvent : IEvent
+    {
+        public HealthCheck HealthCheck { get; private set; }
+
+        public HealthCheckFailedEvent(HealthCheck healthCheck)
+        {
+            HealthCheck = healthCheck;
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/HealthCheckService.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheckService.cs
@@ -80,6 +80,11 @@ namespace NzbDrone.Core.HealthCheck
 
                 else
                 {
+                    if (_healthCheckResults.Find(result.Source.Name) == null)
+                    {
+                        _eventAggregator.PublishEvent(new HealthCheckFailedEvent(result));
+                    }
+
                     _healthCheckResults.Set(result.Source.Name, result);
                 }
             }

--- a/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
+++ b/src/NzbDrone.Core/Notifications/Boxcar/Boxcar.cs
@@ -26,6 +26,11 @@ namespace NzbDrone.Core.Notifications.Boxcar
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE , message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -8,6 +8,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Processes;
+using NzbDrone.Core.HealthCheck;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Validation;
@@ -121,6 +122,19 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
             environmentVariables.Add("Sonarr_Series_ImdbId", series.ImdbId ?? string.Empty);
             environmentVariables.Add("Sonarr_Series_Type", series.SeriesType.ToString());
+
+            ExecuteScript(environmentVariables);
+        }
+
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            var environmentVariables = new StringDictionary();
+
+            environmentVariables.Add("Sonarr_EventType", "HealthIssue");
+            environmentVariables.Add("Sonarr_Health_Issue_Level", nameof(healthCheck.Type));
+            environmentVariables.Add("Sonarr_Health_Issue_Message", healthCheck.Message);
+            environmentVariables.Add("Sonarr_Health_Issue_Type", healthCheck.Source.Name);
+            environmentVariables.Add("Sonarr_Health_Issue_Wiki", healthCheck.WikiUrl.ToString() ?? string.Empty);
 
             ExecuteScript(environmentVariables);
         }

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -69,6 +69,23 @@ namespace NzbDrone.Core.Notifications.Discord
             _proxy.SendPayload(payload, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            var attachments = new List<Embed>
+                              {
+                                  new Embed
+                                  {
+                                      Title = healthCheck.Source.Name,
+                                      Text = healthCheck.Message,
+                                      Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? (int)DiscordColors.Warning : (int)DiscordColors.Success
+                                  }
+                              };
+
+            var payload = CreatePayload("Health Issue", attachments);
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -33,6 +33,10 @@ namespace NzbDrone.Core.Notifications.Email
             _emailService.SendEmail(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, body);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _emailService.SendEmail(Settings, HEALTH_ISSUE_TITLE_BRANDED, message.Message);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -29,6 +29,11 @@ namespace NzbDrone.Core.Notifications.Gotify
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE, healthCheck.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Growl/Growl.cs
+++ b/src/NzbDrone.Core/Notifications/Growl/Growl.cs
@@ -28,7 +28,10 @@ namespace NzbDrone.Core.Notifications.Growl
         {
             _growlService.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, "DOWNLOAD", Settings.Host, Settings.Port, Settings.Password);
         }
-
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _growlService.SendNotification(HEALTH_ISSUE_TITLE, message.Message, "HEALTHISSUE", Settings.Host, Settings.Port, Settings.Password);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -10,9 +10,11 @@ namespace NzbDrone.Core.Notifications
         void OnGrab(GrabMessage grabMessage);
         void OnDownload(DownloadMessage message);
         void OnRename(Series series);
+        void OnHealthIssue(HealthCheck.HealthCheck healthCheck);
         bool SupportsOnGrab { get; }
         bool SupportsOnDownload { get; }
         bool SupportsOnUpgrade { get; }
         bool SupportsOnRename { get; }
+        bool SupportsOnHealthIssue { get; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -27,6 +27,11 @@ namespace NzbDrone.Core.Notifications.Join
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE_BRANDED, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -47,6 +47,13 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, HEALTH_ISSUE_TITLE_BRANDED, message.Message);
+            }
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -10,9 +10,11 @@ namespace NzbDrone.Core.Notifications
     {
         protected const string EPISODE_GRABBED_TITLE = "Episode Grabbed";
         protected const string EPISODE_DOWNLOADED_TITLE = "Episode Downloaded";
+        protected const string HEALTH_ISSUE_TITLE = "Health Check Failure";
 
         protected const string EPISODE_GRABBED_TITLE_BRANDED = "Sonarr - " + EPISODE_GRABBED_TITLE;
         protected const string EPISODE_DOWNLOADED_TITLE_BRANDED = "Sonarr - " + EPISODE_DOWNLOADED_TITLE;
+        protected const string HEALTH_ISSUE_TITLE_BRANDED = "Sonarr - " + HEALTH_ISSUE_TITLE;
 
         public abstract string Name { get; }
 
@@ -42,10 +44,16 @@ namespace NzbDrone.Core.Notifications
 
         }
 
+        public virtual void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+
+        }
+
         public bool SupportsOnGrab => HasConcreteImplementation("OnGrab");
         public bool SupportsOnRename => HasConcreteImplementation("OnRename");
         public bool SupportsOnDownload => HasConcreteImplementation("OnDownload");
         public bool SupportsOnUpgrade => SupportsOnDownload;
+        public bool SupportsOnHealthIssue => HasConcreteImplementation("OnHealthIssue");
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 

--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -8,11 +8,14 @@ namespace NzbDrone.Core.Notifications
         public bool OnDownload { get; set; }
         public bool OnUpgrade { get; set; }
         public bool OnRename { get; set; }
+        public bool OnHealthIssue { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
         public bool SupportsOnRename { get; set; }
+        public bool SupportsOnHealthIssue { get; set; }
+        public bool IncludeHealthWarnings { get; set; }
 
-        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade);
+        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnHealthIssue;
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.Notifications
         List<INotification> OnDownloadEnabled();
         List<INotification> OnUpgradeEnabled();
         List<INotification> OnRenameEnabled();
+        List<INotification> OnHealthIssueEnabled();
     }
 
     public class NotificationFactory : ProviderFactory<INotification, NotificationDefinition>, INotificationFactory
@@ -42,6 +43,11 @@ namespace NzbDrone.Core.Notifications
             return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnRename).ToList();
         }
 
+        public List<INotification> OnHealthIssueEnabled()
+        {
+            return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnHealthIssue).ToList();
+        }
+
         public override void SetProviderCharacteristics(INotification provider, NotificationDefinition definition)
         {
             base.SetProviderCharacteristics(provider, definition);
@@ -50,6 +56,7 @@ namespace NzbDrone.Core.Notifications
             definition.SupportsOnDownload = provider.SupportsOnDownload;
             definition.SupportsOnUpgrade = provider.SupportsOnUpgrade;
             definition.SupportsOnRename = provider.SupportsOnRename;
+            definition.SupportsOnHealthIssue = provider.SupportsOnHealthIssue;
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClient.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClient.cs
@@ -26,6 +26,10 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
             _plexClientService.Notify(Settings, EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _plexClientService.Notify(Settings, HEALTH_ISSUE_TITLE_BRANDED, message.Message);
+        }
 
         public override ValidationResult Test()
         {

--- a/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
@@ -28,6 +28,11 @@ namespace NzbDrone.Core.Notifications.Prowl
             _prowlService.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck message)
+        {
+            _prowlService.SendNotification(HEALTH_ISSUE_TITLE, message.Message, Settings.ApiKey, (NotificationPriority)Settings.Priority);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
@@ -29,6 +29,11 @@ namespace NzbDrone.Core.Notifications.PushBullet
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE_BRANDED, message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE_BRANDED, healthCheck.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
@@ -26,6 +26,11 @@ namespace NzbDrone.Core.Notifications.Pushover
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE, healthCheck.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -70,6 +70,23 @@ namespace NzbDrone.Core.Notifications.Slack
             _proxy.SendPayload(payload, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            var attachments = new List<Attachment>
+                              {
+                                  new Attachment
+                                  {
+                                      Title = healthCheck.Source.Name,
+                                      Text = healthCheck.Message,
+                                      Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? "warning" : "danger"
+                                  }
+                              };
+
+            var payload = CreatePayload("Health Issue", attachments);
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -26,6 +26,11 @@ namespace NzbDrone.Core.Notifications.Telegram
             _proxy.SendNotification(EPISODE_DOWNLOADED_TITLE, message.Message, Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _proxy.SendNotification(HEALTH_ISSUE_TITLE, healthCheck.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
@@ -29,6 +29,11 @@ namespace NzbDrone.Core.Notifications.Twitter
             _twitterService.SendNotification($"Imported: {message.Message}", Settings);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            _twitterService.SendNotification($"Health Issue: {healthCheck.Message}", Settings);
+        }
+
         public override object RequestAction(string action, IDictionary<string, string> query)
         {
             if (action == "startOAuth")

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -41,13 +41,18 @@ namespace NzbDrone.Core.Notifications.Xbmc
             UpdateAndClean(series);
         }
 
+        public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
+        {
+            Notify(Settings, HEALTH_ISSUE_TITLE_BRANDED, healthCheck.Message);
+        }
+
         public override string Name => "Kodi";
 
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();
 
-            failures.AddIfNotNull(_xbmcService.Test(Settings, "Success! XBMC has been successfully configured!"));
+            failures.AddIfNotNull(_xbmcService.Test(Settings, "Success! Kodi has been successfully configured!"));
 
             return new ValidationResult(failures);
         }
@@ -63,7 +68,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
             }
             catch (SocketException ex)
             {
-                var logMessage = string.Format("Unable to connect to XBMC Host: {0}:{1}", Settings.Host, Settings.Port);
+                var logMessage = string.Format("Unable to connect to Kodi Host: {0}:{1}", Settings.Host, Settings.Port);
                 _logger.Debug(ex, logMessage);
             }
         }
@@ -84,7 +89,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
             }
             catch (SocketException ex)
             {
-                var logMessage = string.Format("Unable to connect to XBMC Host: {0}:{1}", Settings.Host, Settings.Port);
+                var logMessage = string.Format("Unable to connect to Kodi Host: {0}:{1}", Settings.Host, Settings.Port);
                 _logger.Debug(ex, logMessage);
             }
         }

--- a/src/NzbDrone.Core/NzbDrone.Core.csproj
+++ b/src/NzbDrone.Core/NzbDrone.Core.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Datastore\Migration\130_episode_last_searched_time.cs" />
     <Compile Include="Datastore\Migration\129_add_relative_original_path_to_episode_file.cs" />
     <Compile Include="Datastore\Migration\128_rename_quality_profiles_add_upgrade_allowed.cs" />
+    <Compile Include="Datastore\Migration\135_health_issue_notification.cs" />
     <Compile Include="Datastore\ModelConflictException.cs" />
     <Compile Include="DecisionEngine\Specifications\AlreadyImportedSpecification.cs" />
     <Compile Include="CustomFilters\CustomFilter.cs" />
@@ -161,6 +162,7 @@
     <Compile Include="Download\Aggregation\Aggregators\AggregatePreferredWordScore.cs" />
     <Compile Include="Download\Aggregation\Aggregators\IAggregateRemoteEpisode.cs" />
     <Compile Include="HealthCheck\Checks\SystemTimeCheck.cs" />
+    <Compile Include="HealthCheck\HealthCheckFailedEvent.cs" />
     <Compile Include="Housekeeping\Housekeepers\EnsureValidLanguageProfileId.cs" />
     <Compile Include="Indexers\SeedConfigProvider.cs" />
     <Compile Include="DataAugmentation\DailySeries\DailySeries.cs" />

--- a/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
+++ b/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
@@ -9,10 +9,13 @@ namespace Sonarr.Api.V3.Notifications
         public bool OnDownload { get; set; }
         public bool OnUpgrade { get; set; }
         public bool OnRename { get; set; }
+        public bool OnHealthIssue { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
         public bool SupportsOnRename { get; set; }
+        public bool SupportsOnHealthIssue { get; set; }
+        public bool IncludeHealthWarnings { get; set; }
         public string TestCommand { get; set; }
     }
 
@@ -28,10 +31,13 @@ namespace Sonarr.Api.V3.Notifications
             resource.OnDownload = definition.OnDownload;
             resource.OnUpgrade = definition.OnUpgrade;
             resource.OnRename = definition.OnRename;
+            resource.OnHealthIssue = definition.OnHealthIssue;
             resource.SupportsOnGrab = definition.SupportsOnGrab;
             resource.SupportsOnDownload = definition.SupportsOnDownload;
             resource.SupportsOnUpgrade = definition.SupportsOnUpgrade;
             resource.SupportsOnRename = definition.SupportsOnRename;
+            resource.SupportsOnHealthIssue = definition.SupportsOnHealthIssue;
+            resource.IncludeHealthWarnings = definition.IncludeHealthWarnings;
 
             return resource;
         }
@@ -46,10 +52,13 @@ namespace Sonarr.Api.V3.Notifications
             definition.OnDownload = resource.OnDownload;
             definition.OnUpgrade = resource.OnUpgrade;
             definition.OnRename = resource.OnRename;
+            definition.OnHealthIssue = resource.OnHealthIssue;
             definition.SupportsOnGrab = resource.SupportsOnGrab;
             definition.SupportsOnDownload = resource.SupportsOnDownload;
             definition.SupportsOnUpgrade = resource.SupportsOnUpgrade;
             definition.SupportsOnRename = resource.SupportsOnRename;
+            definition.SupportsOnHealthIssue = resource.SupportsOnHealthIssue;
+            definition.IncludeHealthWarnings = resource.IncludeHealthWarnings;
 
             return definition;
         }


### PR DESCRIPTION
#### Database Migration
YES (Migration 135: Add OnHealthIssue column to notification table)

#### Description
Adds notification option for onHealthIssue, also adds option for toggle warnings in addition to errors (can remove this if wanted).

Warning are only triggered once, not at every health check task. Once a warning/error is cleared it will get triggered again if it returns. 

Pulled from Lidarr implementation

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
Fixes #1798 
