### PR TITLE
New: Add support for Lilith-Raws release group

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
@@ -40,6 +40,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[喵萌奶茶屋&LoliHouse]玛娜利亚魔法学院/巴哈姆特之怒Manaria Friends - 03 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "巴哈姆特之怒Manaria Friends", "喵萌奶茶屋&LoliHouse", 3)]
         [TestCase("[悠哈璃羽字幕社&拉斯观测组&LoliHouse] 刀剑神域: Alicization / Sword Art Online: Alicization - 17 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Sword Art Online Alicization", "悠哈璃羽字幕社&拉斯观测组&LoliHouse", 17)]
         [TestCase("[ZERO字幕組]嫁給非人類·Jingai-san no Yome[11][BIG5][1080p]", "Jingai-san no Yome", "ZERO字幕組", 11)]
+        [TestCase("[Lilith-Raws] 艾梅洛閣下 II 世事件簿 -魔眼蒐集列車 Grace note- / Lord El-Melloi II Case Files - 04 [BiliBili][WEB-DL][1080p][AVC AAC][CHT][MKV]", "Lord El-Melloi II Case Files", "Lilith-Raws", 4)]
         public void should_parse_unbracketed_chinese_anime_releases(string postTitle, string title, string subgroup, int absoluteEpisodeNumber)
         {
             postTitle = XmlCleaner.ReplaceUnicode(postTitle);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -22,8 +22,8 @@ namespace NzbDrone.Core.Parser
                 // Korean series without season number, replace with S01Exxx and remove airdate
                 new RegexReplace(@"\.E(\d{2,4})\.\d{6}\.(.*-NEXT)$", ".S01E$1.$2", RegexOptions.Compiled),
 
-                // Chinese LoliHouse/ZERO releases don't use the expected brackets, normalize using brackets
-                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
+                // Chinese LoliHouse/ZERO/Lilith-Raws releases don't use the expected brackets, normalize using brackets
+                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
                 
                 // Most Chinese anime releases contain additional brackets/separators for chinese and non-chinese titles, remove junk and replace with normal anime pattern
                 new RegexReplace(@"^\[(?<subgroup>[^\]]+)\](?:\s?★[^\[ -]+\s?)?\[(?:(?<chinesetitle>[^\]]+?)(?:\]\[|[_/·]\s*))?(?<title>[^\]]+?)\](?:\[\d{4}\])?\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\]", "[${subgroup}] ${title} - ${episode} ", RegexOptions.Compiled)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Lilith-Raws is a new Chinese anime release group, and they don't use brackets for series name.

#### Todos
- [x] Tests
- [x] Documentation


#### Issues Fixed or Closed by this PR

* 
