### PR TITLE
Added qBittorent state 'moving'

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -201,7 +201,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                     default: // new status in API? default to downloading
                         item.Message = "Unknown download state: " + torrent.State;
-                        _logger.Warn(item.Message);
+                        _logger.Info(item.Message);
                         item.Status = DownloadItemStatus.Downloading;
                         break;
                 }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -194,8 +194,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         }
                         break;
 
+                    case "moving": // torrent is being moved from a folder
                     case "downloading": // torrent is being downloaded and data is being transfered
+                        item.Status = DownloadItemStatus.Downloading;
+                        break;
+
                     default: // new status in API? default to downloading
+                        item.Message = "Unknown download state: " + torrent.State;
+                        _logger.Warn(item.Message);
                         item.Status = DownloadItemStatus.Downloading;
                         break;
                 }


### PR DESCRIPTION
#### Database Migration

NO

#### Description

The state 'moving' wasn't being recording in Radarr, so it would show up as a warning.

![image](https://user-images.githubusercontent.com/12074633/67707134-551bc180-f990-11e9-8ea7-5238638234d9.png)