### PR TITLE
Multi-episode files didn't trigger the DownloadCompletedEvent

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -111,7 +111,9 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
-            if (importResults.Count(c => c.Result == ImportResultType.Imported) >= Math.Max(1, trackedDownload.RemoteEpisode.Episodes.Count))
+            var importedEpisodes = importResults.Where(c => c.Result == ImportResultType.Imported).SelectMany(c => c.ImportDecision.LocalEpisode.Episodes).ToList();
+
+            if (importedEpisodes.Count() >= Math.Max(1, trackedDownload.RemoteEpisode.Episodes.Count))
             {
                 trackedDownload.State = TrackedDownloadStage.Imported;
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload));


### PR DESCRIPTION
#### Description

DownloadCompletedEvent was only raised if the number of files imports was equal or greater than the number of Episodes in the grab event (based on the release title).
Instead it should've compared the number of episodes in the ImportResult rather than the number of ImportResults.

#### Issues Fixed or Closed by this PR

* #3403
