### PR TITLE
Increase session expiry time

### DIFF
--- a/src/Sonarr.Http/Authentication/AuthenticationModule.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationModule.cs
@@ -34,7 +34,7 @@ namespace Sonarr.Http.Authentication
 
             if (resource.RememberMe)
             {
-                expiry = DateTime.UtcNow.AddDays(7);
+                expiry = DateTime.UtcNow.AddYears(1);
             }
 
             return this.LoginAndRedirect(user.Identifier, expiry, _configFileProvider.UrlBase + "/");


### PR DESCRIPTION


#### Database Migration
NO

#### Description
Increase the session expiry time.

There's a compelling reason to have a short expiry on sites with
senstive information like a bank, but if I forget to lock my computer
and someone starts messing with sonarr, there is very little damage they
can do.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
