### PR TITLE
Fixed: Rare scenario where early Radarr version messes up Sonarr database

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/128_rename_quality_profiles_add_upgrade_allowedFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/128_rename_quality_profiles_add_upgrade_allowedFixture.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class rename_quality_profiles_add_upgrade_allowedFixture : MigrationTest<rename_quality_profiles_add_upgrade_allowed>
+    {
+        [Test]
+        public void should_handle_injected_radarr_migration()
+        {
+            var dbBefore = WithTestDb(new MigrationContext(MigrationType, 110));
+
+            // Ensure 111 isn't applied
+            dbBefore.GetDirectDataMapper().Query("INSERT INTO VersionInfo (Version, AppliedOn, Description) VALUES (111, '2018-12-24T18:21:07', 'remove_bitmetv')");
+
+            var dbAfter = WithMigrationTestDb();
+
+            var result = dbAfter.QueryScalar<int>("SELECT COUNT(*) FROM VersionInfo WHERE Description = 'remove_bitmetv'");
+
+            result.Should().Be(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/128_rename_quality_profiles_add_upgrade_allowed.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/128_rename_quality_profiles_add_upgrade_allowed.cs
@@ -1,13 +1,20 @@
 using FluentMigrator;
+using FluentMigrator.Infrastructure;
 using NzbDrone.Core.Datastore.Migration.Framework;
+using System.Data;
+using System.Data.SQLite;
 
 namespace NzbDrone.Core.Datastore.Migration
 {
     [Migration(128)]
     public class rename_quality_profiles_add_upgrade_allowed : NzbDroneMigrationBase
     {
+        private IMigrationContext _capturedContext;
+
         protected override void MainDbUpgrade()
         {
+            FixupMigration111();
+
             Rename.Table("Profiles").To("QualityProfiles");
 
             Alter.Table("QualityProfiles").AddColumn("UpgradeAllowed").AsInt32().Nullable();
@@ -18,6 +25,39 @@ namespace NzbDrone.Core.Datastore.Migration
             Update.Table("LanguageProfiles").Set(new { UpgradeAllowed = true }).AllRows();
 
             Rename.Column("ProfileId").OnTable("Series").To("QualityProfileId");
+        }
+
+        public override void GetUpExpressions(IMigrationContext context)
+        {
+            _capturedContext = context;
+
+            base.GetUpExpressions(context);
+
+            _capturedContext = null;
+        }
+
+        // Early Radarr versions can mess up Sonarr's database if they point to the same config. Fixup the damage.        
+        private void FixupMigration111()
+        {
+            // In order to get the expressions we need to check the database directly
+            using (var connection = new SQLiteConnection(ConnectionString))
+            using (var command = connection.CreateCommand())
+            {
+                connection.Open();
+                command.CommandText = "SELECT Description FROM VersionInfo WHERE Version = 111";
+
+                var description = command.ExecuteScalar() as string;
+                connection.Close();
+
+                if (description == "remove_bitmetv")
+                {
+                    // Get the migration expressions from the 111 migration
+                    var migration111 = new create_language_profiles();
+                    migration111.GetUpExpressions(_capturedContext);
+
+                    Execute.Sql("UPDATE VersionInfo SET Description = 'create_language_profiles fixup' WHERE Version = 111");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Workaround in migration 128 that detects if early Radarr version hijacked the 111 migration, if so then the 111 migration is reapplied.