### PR TITLE
Use msbuild, xbuild is deprecated and does not work anymore

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,9 +103,9 @@ BuildWithMSBuild()
 BuildWithXbuild()
 {
     export MONO_IOMAP=case
-    CheckExitCode xbuild /t:Clean $slnFile
+    CheckExitCode msbuild /t:Clean $slnFile
     mono $nuget restore $slnFile
-    CheckExitCode xbuild /p:Configuration=Release /p:Platform=x86 /t:Build /p:AllowedReferenceRelatedFileExtensions=.pdb $slnFile
+    CheckExitCode msbuild /p:Configuration=Release /p:Platform=x86 /t:Build /p:AllowedReferenceRelatedFileExtensions=.pdb $slnFile
 }
 
 LintUI()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I tried to build on Linux and ran into this error:

> The default XML namespace of the project must be the MSBuild XML namespace. If the project is authored in the MSBuild 2003 format, please add xmlns="http://schemas.microsoft.com/developer/msbuild/2003" to the element. If the project has been authored in the old 1.0 or 1.2 format, please convert it to MSBuild 2003 format. 

This was fixed by replacing the deprecated xbuild with msbuild.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR
fixes issue #2553
* 
