### PR TITLE
Fixed: Replace duplicate slashes from file names when importing

### DIFF
--- a/src/NzbDrone.Common.Test/OsPathFixture.cs
+++ b/src/NzbDrone.Common.Test/OsPathFixture.cs
@@ -186,6 +186,15 @@ namespace NzbDrone.Common.Test
         }
 
         [Test]
+        public void should_fix_double_slashes_unix()
+        {
+            var osPath = new OsPath(@"/just/a//test////to/verify the/slashes/");
+
+            osPath.Kind.Should().Be(OsPathKind.Unix);
+            osPath.FullPath.Should().Be(@"/just/a/test/to/verify the/slashes/");
+        }
+
+        [Test]
         public void should_combine_mixed_slashes()
         {
             var left = new OsPath(@"C:/on/windows/transmission");

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -71,6 +71,11 @@ namespace NzbDrone.Common.Disk
                 case OsPathKind.Windows:
                     return path.Replace('/', '\\');
                 case OsPathKind.Unix:
+                    path = path.Replace('\\', '/');
+                    while (path.Contains("//"))
+                    {
+                        path = path.Replace("//", "/");
+                    }
                     return path.Replace('\\', '/');
             }
 

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Common.Disk
                     {
                         path = path.Replace("//", "/");
                     }
-                    return path.Replace('\\', '/');
+                    return path;
             }
 
             return path;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes the problem with double / characters not parsing correctly.

#### Issues Fixed or Closed by this PR
#3470 
