### PR TITLE
Add ability to filter languages in MediaInfo formatter

### DIFF
--- a/frontend/src/Helpers/Props/icons.js
+++ b/frontend/src/Helpers/Props/icons.js
@@ -24,6 +24,7 @@ import {
 import {
   faArrowCircleLeft as fasArrowCircleLeft,
   faArrowCircleRight as fasArrowCircleRight,
+  faAsterisk as fasAsterisk,
   faBackward as fasBackward,
   faBars as fasBars,
   faBolt as fasBolt,
@@ -138,6 +139,7 @@ export const EXTERNAL_LINK = fasExternalLinkAlt;
 export const FATAL = fasTimesCircle;
 export const FILE = farFile;
 export const FILTER = fasFilter;
+export const FOOTNOTE = fasAsterisk;
 export const FOLDER = farFolder;
 export const FOLDER_OPEN = fasFolderOpen;
 export const GROUP = farObjectGroup;

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.css
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.css
@@ -16,3 +16,21 @@
   margin-left: 10px;
   width: 200px;
 }
+
+.footNote {
+
+  color: $helpTextColor;
+  display: flex;
+
+  .icon {
+    padding: 2px;
+    margin-top: 3px;
+    margin-right: 5px;
+  }
+
+  code {
+    background-color: #f7f7f7;
+    border: 1px solid $borderColor;
+    padding: 0px 1px;
+  }
+}

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { sizes } from 'Helpers/Props';
+import { sizes, icons } from 'Helpers/Props';
 import FieldSet from 'Components/FieldSet';
 import Button from 'Components/Link/Button';
+import Icon from 'Components/Icon';
 import SelectInput from 'Components/Form/SelectInput';
 import TextInput from 'Components/Form/TextInput';
 import Modal from 'Components/Modal/Modal';
@@ -90,12 +91,12 @@ const qualityTokens = [
 
 const mediaInfoTokens = [
   { token: '{MediaInfo Simple}', example: 'x264 DTS' },
-  { token: '{MediaInfo Full}', example: 'x264 DTS [EN+DE]' },
+  { token: '{MediaInfo Full}', example: 'x264 DTS [EN+DE]', footNote: 1 },
 
   { token: '{MediaInfo AudioCodec}', example: 'DTS' },
   { token: '{MediaInfo AudioChannels}', example: '5.1' },
-  { token: '{MediaInfo AudioLanguages}', example: '[EN+DE]' },
-  { token: '{MediaInfo SubtitleLanguages}', example: '[DE]' },
+  { token: '{MediaInfo AudioLanguages}', example: '[EN+DE]', footNote: 1 },
+  { token: '{MediaInfo SubtitleLanguages}', example: '[DE]', footNote: 1 },
 
   { token: '{MediaInfo VideoCodec}', example: 'x264' },
   { token: '{MediaInfo VideoBitDepth}', example: '10' },
@@ -444,7 +445,7 @@ class NamingModal extends Component {
                   <FieldSet legend="Media Info">
                     <div className={styles.groups}>
                       {
-                        mediaInfoTokens.map(({ token, example }) => {
+                        mediaInfoTokens.map(({ token, example, footNote }) => {
                           return (
                             <NamingOption
                               key={token}
@@ -452,6 +453,7 @@ class NamingModal extends Component {
                               value={value}
                               token={token}
                               example={example}
+                              footNote={footNote}
                               tokenSeparator={tokenSeparator}
                               tokenCase={tokenCase}
                               onPress={this.onOptionPress}
@@ -460,6 +462,14 @@ class NamingModal extends Component {
                         }
                         )
                       }
+                    </div>
+
+                    <div className={styles.footNote}>
+                      <Icon className={styles.icon} name={icons.FOOTNOTE} />
+                      <div>
+                        MediaInfo Full/AudioLanguages/SubtitleLanguages support a <code>:EN+DE</code> suffix allowing you to filter the languages included in the filename. Use <code>-DE</code> to exclude specific languages.
+                      Appending <code>+</code> (eg <code>:EN+</code>) will output <code>[EN]</code>/<code>[EN+--]</code>/<code>[--]</code> depending on excluded languages. For example <code>{'{'}MediaInfo Full:EN+DE{'}'}</code>.
+                      </div>
                     </div>
                   </FieldSet>
 

--- a/frontend/src/Settings/MediaManagement/Naming/NamingOption.css
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingOption.css
@@ -37,6 +37,12 @@
   flex: 0 0 50%;
   padding: 6px 16px;
   background-color: #ddd;
+  justify-content: space-between;
+
+  .footNote {
+    color: #aaa;
+    padding: 2px;
+  }
 }
 
 .lower {

--- a/frontend/src/Settings/MediaManagement/Naming/NamingOption.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingOption.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { sizes } from 'Helpers/Props';
+import { sizes, icons } from 'Helpers/Props';
 import Link from 'Components/Link/Link';
+import Icon from 'Components/Icon';
 import styles from './NamingOption.css';
 
 class NamingOption extends Component {
@@ -39,6 +40,7 @@ class NamingOption extends Component {
       token,
       tokenSeparator,
       example,
+      footNote,
       tokenCase,
       isFullFilename,
       size
@@ -60,6 +62,11 @@ class NamingOption extends Component {
 
         <div className={styles.example}>
           {example.replace(/ /g, tokenSeparator)}
+
+          {
+            footNote !== 0 &&
+            <Icon className={styles.footNote} name={icons.FOOTNOTE} />
+          }
         </div>
       </Link>
     );
@@ -69,6 +76,7 @@ class NamingOption extends Component {
 NamingOption.propTypes = {
   token: PropTypes.string.isRequired,
   example: PropTypes.string.isRequired,
+  footNote: PropTypes.number.isRequired,
   tokenSeparator: PropTypes.string.isRequired,
   tokenCase: PropTypes.string.isRequired,
   isFullFilename: PropTypes.bool.isRequired,
@@ -77,6 +85,7 @@ NamingOption.propTypes = {
 };
 
 NamingOption.defaultProps = {
+  footNote: 0,
   size: sizes.SMALL,
   isFullFilename: false
 };

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -796,6 +796,29 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be(expected);
         }
 
+        [TestCase("English/German", "", "[EN+DE]")]
+        [TestCase("English/Dutch/German", "", "[EN+NL+DE]")]
+        [TestCase("English/German", ":DE", "[DE]")]
+        [TestCase("English/Dutch/German", ":EN+NL", "[EN+NL]")]
+        [TestCase("English/Dutch/German", ":NL+EN", "[NL+EN]")]
+        [TestCase("English/Dutch/German", ":-NL", "[EN+DE]")]
+        [TestCase("English/Dutch/German", ":DE+", "[DE+-]")]
+        [TestCase("English/Dutch/German", ":DE+NO.", "[DE].")]
+        [TestCase("English/Dutch/German", ":-EN-", "[NL+DE]-")]
+        public void should_format_subtitle_languages_all(string subtitleLanguages, string format, string expected)
+        {
+            _episodeFile.ReleaseGroup = null;
+
+            GivenMediaInfoModel(subtitles: subtitleLanguages);
+
+
+            _namingConfig.StandardEpisodeFormat = "{MediaInfo SubtitleLanguages" + format +"}End";
+
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be(expected + "End");
+        }
+
         [TestCase(8, "BT.601 NTSC", "BT.709", "South.Park.S15E06.City.Sushi")]
         [TestCase(10, "BT.2020", "PQ", "South.Park.S15E06.City.Sushi.HDR")]
         [TestCase(10, "BT.2020", "HLG", "South.Park.S15E06.City.Sushi.HDR")]

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("vi", "vie", Language.Vietnamese),
                                                                new IsoLanguage("sv", "swe", Language.Swedish),
                                                                new IsoLanguage("no", "nor", Language.Norwegian),
+                                                               new IsoLanguage("nb", "nob", Language.Norwegian), // Norwegian Bokmål
                                                                new IsoLanguage("fi", "fin", Language.Finnish),
                                                                new IsoLanguage("tr", "tur", Language.Turkish),
                                                                new IsoLanguage("pt", "por", Language.Portuguese),
@@ -53,7 +54,7 @@ namespace NzbDrone.Core.Parser
 
         public static IsoLanguage Get(Language language)
         {
-            return All.SingleOrDefault(l => l.Language == language);
+            return All.FirstOrDefault(l => l.Language == language);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Definitely a 1% feature.

@markus101 We talked about this and I think it would still be better to filter by language profile or something, but I feel like there's more edgecases there and harder to implement.
Allow `{MediaInfo SubtitleLanguages:EN+DE}` custom format to influence formatter:
- `:EN+DE` filters out all except EN and DE (the order here determines the output order too)
- `:-DE-NO` filters out DE and NO
- `:EN+DE+` (trailing + ) will replace any unlisted languages with `--`, so a file with `EN+NL+NO` would become `[EN+--]` (not sure about this one)

Formats work for AudioLanguages, AudioLanguagesAll and even Full. For Full it'll eliminates any possible future formatting for the codec/etc stuff that's in Full, but that's not a big issue imo.

Finally I'm also not sure about how to document it.

#### Todos
- [x] Tests
- [ ] Documentation
