### PR TITLE
Show size in mass editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,5 @@ output/*
 
 _start
 
-src/.idea/
-
 #JetBrains
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ output/*
 _start
 
 src/.idea/
+
+#JetBrains Rider
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,5 @@ _start
 
 src/.idea/
 
-#JetBrains Rider
+#JetBrains
 .idea

--- a/frontend/src/Series/Editor/SeriesEditor.js
+++ b/frontend/src/Series/Editor/SeriesEditor.js
@@ -62,6 +62,12 @@ function getColumns(showLanguageProfile) {
       isVisible: true
     },
     {
+      name: 'sizeOnDisk',
+      label: 'Size',
+      isSortable: true,
+      isVisible: true
+    },
+    {
       name: 'tags',
       label: 'Tags',
       isSortable: false,

--- a/frontend/src/Series/Editor/SeriesEditorRow.js
+++ b/frontend/src/Series/Editor/SeriesEditorRow.js
@@ -10,6 +10,7 @@ import TableSelectCell from 'Components/Table/Cells/TableSelectCell';
 import SeriesTitleLink from 'Series/SeriesTitleLink';
 import SeriesStatusCell from 'Series/Index/Table/SeriesStatusCell';
 import styles from './SeriesEditorRow.css';
+import formatBytes from 'Utilities/Number/formatBytes';
 
 class SeriesEditorRow extends Component {
 
@@ -37,6 +38,7 @@ class SeriesEditorRow extends Component {
       seasonFolder,
       path,
       tags,
+      statistics,
       columns,
       isSelected,
       onSelectedChange
@@ -91,6 +93,10 @@ class SeriesEditorRow extends Component {
         </TableRowCell>
 
         <TableRowCell>
+          {formatBytes(statistics.sizeOnDisk)}
+        </TableRowCell>
+
+        <TableRowCell>
           <TagListConnector
             tags={tags}
           />
@@ -114,6 +120,7 @@ SeriesEditorRow.propTypes = {
   tags: PropTypes.arrayOf(PropTypes.number).isRequired,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,
   isSelected: PropTypes.bool,
+  statistics: PropTypes.object.isRequired,
   onSelectedChange: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -140,6 +140,10 @@ export const sortPredicates = {
     }
 
     return result;
+  },
+
+  sizeOnDisk: function(item, direction) {
+    return item.statistics.sizeOnDisk;
   }
 };
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added a size column on the Mass Editor page. Is the column label and column position ok?

![alt text](https://i.imgur.com/8PpwxF3.png", "Logo Title Text 1")

Also noted that the title sorting doesn't appear to be working. 

![image](https://user-images.githubusercontent.com/59439639/71772607-cb6b1000-2f4d-11ea-8b16-36ec59b6efb0.png)

In this case when I'm sorting in ascending order, Chernobyl should be on the bottom. If it's incorrect behaviour, I can fix it in a seperate issue/PR. 

#### Todos
- [X] Tests (Couldn't find any front end test?)
- [X] Documentation 


#### Issues Fixed or Closed by this PR

Fixes #3273
