### PR TITLE
New: Select wanted release origin(s) for BTN

### DIFF
--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -201,6 +201,26 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         private bool AddSeriesSearchParameters(BroadcastheNetTorrentQuery parameters, SearchCriteriaBase searchCriteria)
         {
+            if (Settings.IncludeSceneReleases)
+            {
+                parameters.Origin.Add("Scene");
+            }
+
+            if (Settings.IncludeP2PReleases)
+            {
+                parameters.Origin.Add("P2P");
+            }
+
+            if (Settings.IncludeUserReleases)
+            {
+                parameters.Origin.Add("User");
+            }
+
+            if (Settings.IncludeInternalReleases)
+            {
+                parameters.Origin.Add("Internal");
+            }
+
             if (searchCriteria.Series.TvdbId != 0)
             {
                 parameters.Tvdb = string.Format("{0}", searchCriteria.Series.TvdbId);

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
@@ -23,6 +23,10 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         {
             BaseUrl = "http://api.broadcasthe.net/";
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
+            IncludeSceneReleases = true;
+            IncludeP2PReleases = true;
+            IncludeUserReleases = true;
+            IncludeInternalReleases = true;
         }
 
         [FieldDefinition(0, Label = "API URL", Advanced = true, HelpText = "Do not change this unless you know what you're doing. Since your API key will be sent to that host.")]
@@ -36,6 +40,18 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         [FieldDefinition(3)]
         public SeedCriteriaSettings SeedCriteria { get; } = new SeedCriteriaSettings();
+
+        [FieldDefinition(4, Type = FieldType.Checkbox, Label = "Include Scene Releases", Advanced = true, HelpText = "Include releases with Scene origin in results")]
+        public bool IncludeSceneReleases { get; set; }
+
+        [FieldDefinition(5, Type = FieldType.Checkbox, Label = "Include P2P Releases", Advanced = true, HelpText = "Include releases with P2P origin in results")]
+        public bool IncludeP2PReleases { get; set; }
+
+        [FieldDefinition(6, Type = FieldType.Checkbox, Label = "Include User Releases", Advanced = true, HelpText = "Include releases with User origin in results")]
+        public bool IncludeUserReleases { get; set; }
+
+        [FieldDefinition(6, Type = FieldType.Checkbox, Label = "Include Internal Releases", Advanced = true, HelpText = "Include releases with Internal origin in results")]
+        public bool IncludeInternalReleases { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         [FieldDefinition(6, Type = FieldType.Checkbox, Label = "Include User Releases", Advanced = true, HelpText = "Include releases with User origin in results")]
         public bool IncludeUserReleases { get; set; }
 
-        [FieldDefinition(6, Type = FieldType.Checkbox, Label = "Include Internal Releases", Advanced = true, HelpText = "Include releases with Internal origin in results")]
+        [FieldDefinition(7, Type = FieldType.Checkbox, Label = "Include Internal Releases", Advanced = true, HelpText = "Include releases with Internal origin in results")]
         public bool IncludeInternalReleases { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetTorrentQuery.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetTorrentQuery.cs
@@ -1,9 +1,15 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
     public class BroadcastheNetTorrentQuery
     {
+        public BroadcastheNetTorrentQuery()
+        {
+            Origin = new List<string>();
+        }
+        
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Id { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -21,7 +27,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Resolution { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string Origin { get; set; }
+        public List<string> Origin { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Hash { get; set; }
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]


### PR DESCRIPTION
#### Database Migration
NO(?)

#### Description
This allows selection of wanted origins of releases from BTN. Future plans would probably be to port this ability to other "native" indexers.

#### Todos
- [ ] Tests
- [ ] Documentation
