### PR TITLE
BTN: Fix name

### DIFF
--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNet.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNet.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
     public class BroadcastheNet : HttpIndexerBase<BroadcastheNetSettings>
     {
-        public override string Name => "BroadcastheNet";
+        public override string Name => "BroadcasTheNet";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override bool SupportsRss => true;


### PR DESCRIPTION
#### Database Migration
No

#### Description
This changes ``BroadcastheNet`` to ``BroadcasTheNet``, per site.