### PR TITLE
Update help text in Connections from Download to Import

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Emby
         [FieldDefinition(4, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Download & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
         [JsonIgnore]

--- a/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexHomeTheaterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexHomeTheaterSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
         [FieldDefinition(5, Label = "GUI Notification", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public new bool Notify { get; set; }
 
-        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Download & Rename?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public new bool UpdateLibrary { get; set; }
 
         [FieldDefinition(7, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
         [FieldDefinition(5, Label = "GUI Notification", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Download & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
         [FieldDefinition(7, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox)]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The help text in some Connections dialogs was changed in v3 from "On Download" to a more accurate "On Import", but the associated "Update Library" text was not changed so it is inconsistent.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
