### PR TITLE
Mono 6 patch, updated framework checks to 4.7.2/mono 5.18 and post-install update check

### DIFF
--- a/distribution/debian/control
+++ b/distribution/debian/control
@@ -7,8 +7,8 @@ Vcs-Git: git@github.com:Sonarr/Sonarr.git
 Vcs-Browser: https://github.com/Sonarr/Sonarr
 Build-Depends:  debhelper (>= 9),
                 dh-systemd (>= 1.5),
-                mono-devel (>= 5.4),
-                libmono-cil-dev (>= 5.4),
+                mono-devel (>= 5.18),
+                libmono-cil-dev (>= 5.18),
                 cli-common-dev (>= 0.9+xamarin5)
 
 Package: sonarr
@@ -16,7 +16,7 @@ Architecture: all
 Provides: nzbdrone
 Conflicts: nzbdrone
 Replaces: nzbdrone
-Depends: adduser, libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52) | libmediainfo0 (>= 0.7.52), mono-runtime (>= 5.4), ca-certificates-mono, libmono-system-net-http4.0-cil (>= 4.0.0~alpha1), ${cli:Depends}, ${misc:Depends}
+Depends: adduser, libsqlite3-0 (>= 3.7), libmediainfo0v5 (>= 0.7.52) | libmediainfo0 (>= 0.7.52), mono-runtime (>= 5.18), ca-certificates-mono, libmono-system-net-http4.0-cil (>= 4.0.0~alpha1), ${cli:Depends}, ${misc:Depends}
 Recommends: libmediainfo0v5 (>= 18.03) | libmediainfo0 (>= 18.03)
 Suggests: sqlite3 (>= 3.7), mediainfo (>= 0.7.52)
 Description: Internet PVR

--- a/distribution/debian/postinst
+++ b/distribution/debian/postinst
@@ -95,7 +95,7 @@ chown -R $USER:$GROUP /usr/lib/sonarr
 sed -i "s:User=sonarr:User=$USER:g; s:Group=sonarr:Group=$GROUP:g; s:-data=/var/lib/sonarr:-data=$CONFDIR:g" /lib/systemd/system/sonarr.service
 
 #BEGIN BUILTIN UPDATER
-if [ $1 = "upgrade" ] && [ "$UPDATER" = "BuiltIn" ]; then
+if [ "$UPDATER" = "BuiltIn" ]; then
   # If we upgraded, signal Sonarr to do an update check on startup instead of scheduled.
   touch $CONFDIR/update_required
   chown $USER:$GROUP $CONFDIR/update_required

--- a/distribution/debian/rules
+++ b/distribution/debian/rules
@@ -3,7 +3,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-EXCLUDE_MODULEREFS = crypt32 httpapi
+EXCLUDE_MODULEREFS = crypt32 httpapi __Internal
 
 %:
 	dh $@ --with=systemd --with=cli

--- a/distribution/docker-build/Dockerfile
+++ b/distribution/docker-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial AS builder
 
 ENV DEBIAN_FRONTEND noninteractive 
-ENV MONO_VERSION 5.14
+ENV MONO_VERSION 5.18
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb http://download.mono-project.com/repo/debian stable-xenial/snapshots/$MONO_VERSION main" > /etc/apt/sources.list.d/mono-official-stable.list && \

--- a/docker/tests/mono/sonarr/Dockerfile
+++ b/docker/tests/mono/sonarr/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
 
 RUN apt-get update && apt-get install -y \ 
         libmono-system-runtime4.0-cil \
+        libmono-system-net-http4.0-cil \
         && rm -rf /var/lib/apt/lists/*
 
 COPY startup.sh /startup.sh

--- a/docker/tests/run-all.sh
+++ b/docker/tests/run-all.sh
@@ -2,16 +2,18 @@
 opt_parallel=
 opt_version=
 opt_mode=both
-while getopts 'pv:m:?h' c
+while getopts 'pv:m:r?h' c
 do
   case $c in
     p)   opt_parallel=1 ;;
     v)   opt_version=$OPTARG ;;
     m)   opt_mode=$OPTARG ;;
+    r)   opt_report=1 ;;
     ?|h) printf "Usage: %s [-p] [-v mono-ver] [-m sonarr|complete]\n" $0 
          printf " -p  run parallel\n"
          printf " -v  run specified mono version\n"
          printf " -m  run only mono-'complete' or 'sonarr' package variants\n"
+         printf " -r  only report\n"
          exit 2
   esac
 done
@@ -20,17 +22,22 @@ done
 # make sure that the docker host has enough memory to handle about ~300 MB per container, so 2-3 GB total
 # excess goes to the swap and will slow down the entire system
 
-# Preferred versions
-MONO_VERSIONS="6.8 6.6 6.4 6.0 5.20 5.18"
+MONO_VERSIONS=""
 
 # Future versions
 MONO_VERSIONS="$MONO_VERSIONS 6.10=preview-xenial"
 
+# Semi-Supported versions
+MONO_VERSIONS="$MONO_VERSIONS 6.8 6.6 6.4 6.0"
+
 # Supported versions 
-MONO_VERSIONS="$MONO_VERSIONS 5.16 5.14 5.12 5.10 5.8 5.4"
+MONO_VERSIONS="$MONO_VERSIONS 5.20 5.18"
+
+# Legacy unsupported versions (but appear to work)
+MONO_VERSIONS="$MONO_VERSIONS 5.16 5.14 5.12"
 
 # Legacy unsupported versions
-MONO_VERSIONS="$MONO_VERSIONS 5.0"
+MONO_VERSIONS="$MONO_VERSIONS 5.10 5.8 5.4 5.0"
 #MONO_VERSIONS="$MONO_VERSIONS 4.8=stable-wheezy/snapshots/4.8"
 
 if [ "$opt_version" != "" ]; then
@@ -86,23 +93,29 @@ runOne() {
     echo "Finished Test Docker for mono $MONO_VERSION"
 }
 
-if [ "$opt_parallel" == "1" ]; then
-    for MONO_VERSION_PAIR in $MONO_VERSIONS; do
-        prepOne "$MONO_VERSION_PAIR"
-    done
-fi
+if [ "$opt_report" != "1" ]; then
 
-for MONO_VERSION_PAIR in $MONO_VERSIONS; do
     if [ "$opt_parallel" == "1" ]; then
-        runOne "$MONO_VERSION_PAIR" &
-    else
-        prepOne "$MONO_VERSION_PAIR"
-        runOne "$MONO_VERSION_PAIR"
+        for MONO_VERSION_PAIR in $MONO_VERSIONS; do
+            prepOne "$MONO_VERSION_PAIR"
+        done
     fi
-done
 
-if [ "$opt_parallel" == "1" ]; then
-    echo "Waiting for all runs to finish"
-    wait
-    echo "Finished all runs"
+    for MONO_VERSION_PAIR in $MONO_VERSIONS; do
+        if [ "$opt_parallel" == "1" ]; then
+            runOne "$MONO_VERSION_PAIR" &
+        else
+            prepOne "$MONO_VERSION_PAIR"
+            runOne "$MONO_VERSION_PAIR"
+        fi
+    done
+
+    if [ "$opt_parallel" == "1" ]; then
+        echo "Waiting for all runs to finish"
+        wait
+        echo "Finished all runs"
+    fi
+
 fi
+
+grep "<test-run" ../../_tests_results/**/*.xml | sed -r 's/.*?mono-([0-9.]+(-s)?).*?_([IU]).*?\.xml.*?failed="([0-9]*)".*/\1\t\3:\tfailed \4/g' | sort -V -t.

--- a/setup/sonarr.iss
+++ b/setup/sonarr.iss
@@ -48,8 +48,8 @@ Name: "startupShortcut"; Description: "Create shortcut in Startup folder (Starts
 Name: "none"; Description: "Do not start automatically"; GroupDescription: "Start automatically"; Flags: exclusive unchecked
 
 [Files]
-Source: "..\_output\Sonarr.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\_output\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\_output_windows\Sonarr.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\_output_windows\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
@@ -76,4 +76,27 @@ var
   ResultCode: Integer;
 begin
   Exec(ExpandConstant('{commonappdata}\NzbDrone\bin\NzbDrone.Console.exe'), '/u', '', 0, ewWaitUntilTerminated, ResultCode)
+end;
+
+function Framework472IsNotInstalled(): Boolean;
+var
+  bSuccess: Boolean;
+  regVersion: Cardinal;
+begin
+  Result := True;
+bSuccess := RegQueryDWordValue(HKLM, 'Software\Microsoft\NET Framework Setup\NDP\v4\Full', 'Release', regVersion);
+  if (True = bSuccess) and (regVersion >= 461808) then begin
+    Result := False;
+  end;
+end;
+
+function InitializeSetup(): Boolean;
+begin
+    if Framework472IsNotInstalled() then begin
+        MsgBox('Sonarr requires Microsoft .NET Framework 4.7.2 or higher.'#13#13
+            'Please use Windows Update to install this version'#13
+            'or download it from https://dotnet.microsoft.com/download/dotnet-framework.', mbInformation, MB_OK);
+        result := false;
+    end else
+        result := true;
 end;

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DotnetVersionCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DotnetVersionCheckFixture.cs
@@ -27,9 +27,6 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Subject.Check().ShouldBeOk();
         }
 
-        [TestCase("4.6.2")]
-        [TestCase("4.7")]
-        [TestCase("4.7.1")]
         public void should_return_notice(string version)
         {
             GivenOutput(version);
@@ -47,6 +44,9 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         [TestCase("4.5")]
         [TestCase("4.5.2")]
         [TestCase("4.6.1")]
+        [TestCase("4.6.2")]
+        [TestCase("4.7")]
+        [TestCase("4.7.1")]
         public void should_return_error(string version)
         {
             GivenOutput(version);
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         }
 
         [Test]
-        public void should_return_ok_for_net462_on_Win1511()
+        public void should_return_nok_for_net462_on_Win1511()
         {
             Mocker.GetMock<IOsInfo>()
                   .SetupGet(v => v.Version)
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             GivenOutput("4.6.2");
 
-            Subject.Check().ShouldBeOk();
+            Subject.Check().ShouldBeError();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/MonoVersionCheckFixture.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
         [TestCase("5.18")]
         [TestCase("5.20")]
+        [TestCase("6.4")]
         public void should_return_ok(string version)
         {
             GivenOutput(version);
@@ -27,7 +28,6 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Subject.Check().ShouldBeOk();
         }
 
-        [TestCase("5.16")]
         public void should_return_notice(string version)
         {
             GivenOutput(version);
@@ -35,8 +35,6 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Subject.Check().ShouldBeNotice();
         }
 
-        [TestCase("5.4")]
-        [TestCase("5.8")]
         public void should_return_warning(string version)
         {
             GivenOutput(version);
@@ -57,6 +55,12 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         [TestCase("4.2")]
         [TestCase("4.4.0")]
         [TestCase("4.4.1")]
+        [TestCase("5.4")]
+        [TestCase("5.8")]
+        [TestCase("5.10")]
+        [TestCase("5.12")]
+        [TestCase("5.14")]
+        [TestCase("5.16")]
         public void should_return_error(string version)
         {
             GivenOutput(version);

--- a/src/NzbDrone.Core/HealthCheck/Checks/DotnetVersionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DotnetVersionCheck.cs
@@ -28,12 +28,6 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
             // Target .Net version, which would allow us to increase our target framework
             var targetVersion = new Version("4.7.2");
-            if (Version.TryParse(_osInfo.Version, out var osVersion) && osVersion < new Version("10.0.14393"))
-            {
-                // Windows 10 LTSB 1511 and before do not support 4.7.x
-                targetVersion = new Version("4.6.2");
-            }
-
             if (dotnetVersion >= targetVersion)
             {
                 _logger.Debug("Dotnet version is {0} or better: {1}", targetVersion, dotnetVersion);
@@ -41,13 +35,28 @@ namespace NzbDrone.Core.HealthCheck.Checks
             }
 
             // Supported .net version but below our desired target
-            var stableVersion = new Version("4.6.2");
+            var stableVersion = new Version("4.7.2");
             if (dotnetVersion >= stableVersion)
             {
                 _logger.Debug("Dotnet version is {0} or better: {1}", stableVersion, dotnetVersion);
                 return new HealthCheck(GetType(), HealthCheckResult.Notice,
                     $"Currently installed .Net Framework {dotnetVersion} is supported but we recommend upgrading to at least {targetVersion}.",
                     "#currently-installed-net-framework-is-supported-but-upgrading-is-recommended");
+            }
+
+            if (Version.TryParse(_osInfo.Version, out var osVersion) && osVersion < new Version("10.0.14393"))
+            {
+                return new HealthCheck(GetType(), HealthCheckResult.Error,
+                    $"Currently installed .Net Framework {dotnetVersion} is no longer supported. However your Operating System cannot be upgraded to {targetVersion}.",
+                    "#currently-installed-net-framework-is-old-and-unsupported");
+            }
+
+            var oldVersion = new Version("4.6.2");
+            if (dotnetVersion >= oldVersion)
+            {
+                return new HealthCheck(GetType(), HealthCheckResult.Error,
+                    $"Currently installed .Net Framework {dotnetVersion} is no longer supported. Please upgrade the .Net Framework to at least {targetVersion}.",
+                    "#currently-installed-net-framework-is-old-and-unsupported");
             }
 
             return new HealthCheck(GetType(), HealthCheckResult.Error,

--- a/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MonoVersionCheck.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
             }
 
             // Stable Mono versions
-            var stableVersion = new Version("5.16");
+            var stableVersion = new Version("5.18");
             if (monoVersion >= stableVersion)
             {
                 _logger.Debug("Mono version is {0} or better: {1}", stableVersion, monoVersion);
@@ -51,15 +51,13 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     $"Currently installed Mono version {monoVersion} is supported but upgrading to {bestVersion} is recommended.",
                     "#currently-installed-mono-version-is-supported-but-upgrading-is-recommended");
             }
-
-            // Old but supported Mono versions, there are known bugs
-            var supportedVersion = new Version("5.4");
-            if (monoVersion >= supportedVersion)
+            
+            var oldVersion = new Version("5.4");
+            if (monoVersion >= oldVersion)
             {
-                _logger.Debug("Mono version is {0} or better: {1}", supportedVersion, monoVersion);
-                return new HealthCheck(GetType(), HealthCheckResult.Warning, 
-                    $"Currently installed Mono version {monoVersion} is supported but has some known issues. Please upgrade Mono to version {bestVersion}.", 
-                    "#currently-installed-mono-version-is-supported-but-upgrading-is-recommended");
+                return new HealthCheck(GetType(), HealthCheckResult.Error,
+                $"Currently installed Mono version {monoVersion} is no longer supported. Please upgrade Mono to version {bestVersion}.",
+                "#currently-installed-mono-version-is-old-and-unsupported");
             }
 
             return new HealthCheck(GetType(), HealthCheckResult.Error, 

--- a/src/NzbDrone.Core/Lifecycle/ApplicationStartingEvent.cs
+++ b/src/NzbDrone.Core/Lifecycle/ApplicationStartingEvent.cs
@@ -1,0 +1,9 @@
+﻿using NzbDrone.Common.Messaging;
+
+namespace NzbDrone.Core.Lifecycle
+{
+    public class ApplicationStartingEvent : IEvent
+    {
+
+    }
+}

--- a/src/NzbDrone.Host/ApplicationServer.cs
+++ b/src/NzbDrone.Host/ApplicationServer.cs
@@ -58,6 +58,14 @@ namespace NzbDrone.Host
 
             _runtimeInfo.IsExiting = false;
             DbFactory.RegisterDatabase(_container);
+
+            _container.Resolve<IEventAggregator>().PublishEvent(new ApplicationStartingEvent());
+
+            if (_runtimeInfo.IsExiting)
+            {
+                return;
+            }
+
             _hostController.StartServer();
 
             if (!_startupContext.Flags.Contains(StartupContext.NO_BROWSER)

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -7,6 +7,7 @@ using Mono.Unix.Native;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 
@@ -16,6 +17,7 @@ namespace NzbDrone.Mono.Disk
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(DiskProvider));
 
+        private readonly Logger _logger;
         private readonly IProcMountProvider _procMountProvider;
         private readonly ISymbolicLinkResolver _symLinkResolver;
 
@@ -23,10 +25,11 @@ namespace NzbDrone.Mono.Disk
         // `unchecked((uint)-1)` and `uint.MaxValue` are the same thing.
         private const uint UNCHANGED_ID = uint.MaxValue;
 
-        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver)
+        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver, Logger logger)
         {
             _procMountProvider = procMountProvider;
             _symLinkResolver = symLinkResolver;
+            _logger = logger;
         }
 
         public override IMount GetMount(string path)
@@ -166,6 +169,10 @@ namespace NzbDrone.Mono.Disk
                     newFile.CreateSymbolicLinkTo(fullPath);
                 }
             }
+            else if (PlatformInfo.GetVersion() > new Version(6, 0) && (!FileExists(destination) || overwrite))
+            {
+                TransferFilePatched(source, destination, overwrite, false);
+            }
             else
             {
                 base.CopyFileInternal(source, destination, overwrite);
@@ -207,9 +214,120 @@ namespace NzbDrone.Mono.Disk
                     throw;
                 }
             }
+            else if (PlatformInfo.GetVersion() > new Version(6, 0) && !FileExists(destination))
+            {
+                TransferFilePatched(source, destination, false, true);
+            }
             else
             {
                 base.MoveFileInternal(source, destination);
+            }
+        }
+        
+        private void TransferFilePatched(string source, string destination, bool overwrite, bool move)
+        {
+            // Mono 6.x throws errors if permissions or timestamps cannot be set
+            // - In 6.0 it'll leave a full length file
+            // - In 6.6 it'll leave a zero length file
+            // Catch the exception and attempt to handle these edgecases
+
+            try
+            {
+                if (move)
+                {
+                    base.MoveFileInternal(source, destination);
+                }
+                else
+                {
+                    base.CopyFileInternal(source, destination, overwrite);
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                var srcInfo = new FileInfo(source);
+                var dstInfo = new FileInfo(destination);
+                var exists = dstInfo.Exists && srcInfo.Exists;
+
+                if (exists && dstInfo.Length == 0 && srcInfo.Length != 0)
+                {
+                    // mono >=6.6 bug: zero length file since chmod happens at the start
+                    _logger.Debug("Mono failed to {2} file likely due to known mono bug, attempting to {2} directly. '{0}' -> '{1}'", source, destination, move ? "move" : "copy");
+
+                    try
+                    {
+                        _logger.Trace("Copying content from {0} to {1} ({2} bytes)", source, destination, srcInfo.Length);
+                        using (var srcStream = new FileStream(source, FileMode.Open, FileAccess.Read))
+                        using (var dstStream = new FileStream(destination, FileMode.Create, FileAccess.Write))
+                        {
+                            srcStream.CopyTo(dstStream);
+                        }
+                    }
+                    catch
+                    {
+                        // If it fails again then bail
+                        throw;
+                    }
+                }
+                else if (exists && dstInfo.Length == srcInfo.Length)
+                {
+                    // mono 6.0, 6.4 bug: full length file since utime and chmod happens at the end
+                    _logger.Debug("Mono failed to {2} file likely due to known mono bug, attempting to {2} directly. '{0}' -> '{1}'", source, destination, move ? "move" : "copy");
+
+                    // Check at least part of the file since UnauthorizedAccess can happen due to legitimate reasons too
+                    var checkLength = (int)Math.Min(64 * 1024, dstInfo.Length);
+                    if (checkLength > 0)
+                    {
+                        var srcData = new byte[checkLength];
+                        var dstData = new byte[checkLength];
+
+                        _logger.Trace("Check last {0} bytes from {1}", checkLength, destination);
+
+                        using (var srcStream = new FileStream(source, FileMode.Open, FileAccess.Read))
+                        using (var dstStream = new FileStream(destination, FileMode.Open, FileAccess.Read))
+                        {
+                            srcStream.Position = srcInfo.Length - checkLength;
+                            dstStream.Position = dstInfo.Length - checkLength;
+
+                            srcStream.Read(srcData, 0, checkLength);
+                            dstStream.Read(dstData, 0, checkLength);
+                        }
+
+                        for (var i = 0; i < checkLength; i++)
+                        {
+                            if (srcData[i] != dstData[i])
+                            {
+                                // Files aren't the same, the UnauthorizedAccess was unrelated
+                                _logger.Trace("Copy was incomplete, rethrowing original error");
+                                throw;
+                            }
+                        }
+
+                        _logger.Trace("Copy was complete, finishing {0} operation", move ? "move" : "copy");
+                    }
+                }
+                else
+                {
+                    // Unrecognized situation, the UnauthorizedAccess was unrelated
+                    throw;
+                }
+
+                if (exists)
+                {
+                    try
+                    {
+                        dstInfo.LastWriteTimeUtc = srcInfo.LastWriteTimeUtc;
+                    }
+                    catch
+                    {
+                        _logger.Debug("Unable to change last modified date for {0}, skipping.", destination);
+                    }
+
+                    if (move)
+                    {
+                        _logger.Trace("Removing source file {0}", source);
+                        File.Delete(source);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Mono 6 workaround for the copy/filesystem issue. untested
- Copied over the framework version checks from the phantom-x64 branch to ensure ppl start moving over
- Increased debian package dependency for mono to 5.18
- Now actually doing something with the `update_required` file that was created by the debian package to force an early update check. (necessary to avoid database schema downgrade issues)

#### Todos
- [ ] Tests
