### PR TITLE
Phantom search improvements

### DIFF
--- a/frontend/src/Episode/SceneInfo.js
+++ b/frontend/src/Episode/SceneInfo.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
+import padNumber from 'Utilities/Number/padNumber';
 import styles from './SceneInfo.css';
 
 function SceneInfo(props) {
@@ -60,6 +61,10 @@ function SceneInfo(props) {
                         key={alternateTitle.title}
                       >
                         {alternateTitle.title}
+                        {
+                          alternateTitle.sceneSeasonNumber !== -1 &&
+                            <span> (S{padNumber(alternateTitle.sceneSeasonNumber, 2)})</span>
+                        }
                       </div>
                     );
                   })

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -262,6 +262,42 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
+        public void should_fallback_to_title()
+        {
+            _capabilities.SupportedTvSearchParameters = new[] { "q", "title", "tvdbid", "rid", "season", "ep" };
+            _capabilities.SupportsAggregateIdSearch = true;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            results.Tiers.Should().Be(2);
+
+            var pageTier2 = results.GetTier(1).First().First();
+
+            pageTier2.Url.Query.Should().NotContain("tvdbid=20");
+            pageTier2.Url.Query.Should().NotContain("rid=10");
+            pageTier2.Url.Query.Should().NotContain("q=");
+            pageTier2.Url.Query.Should().Contain("title=Monkey%20Island");
+        }
+
+        [Test]
+        public void should_url_encode_title()
+        {
+            _capabilities.SupportedTvSearchParameters = new[] { "q", "title", "tvdbid", "rid", "season", "ep" };
+            _capabilities.SupportsAggregateIdSearch = true;
+
+            _singleEpisodeSearchCriteria.SceneTitles[0] = "Elith & Little";
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            results.Tiers.Should().Be(2);
+
+            var pageTier2 = results.GetTier(1).First().First();
+
+            pageTier2.Url.Query.Should().NotContain("tvdbid=20");
+            pageTier2.Url.Query.Should().NotContain("rid=10");
+            pageTier2.Url.Query.Should().NotContain("q=");
+            pageTier2.Url.Query.Should().Contain("title=Elith%20%26%20Little");
+        }
+
+        [Test]
         public void should_fallback_to_q()
         {
             _capabilities.SupportedTvSearchParameters = new[] { "q", "tvdbid", "rid", "season", "ep" };

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
@@ -55,6 +55,10 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Mocker.GetMock<ISeriesService>()
                   .Setup(s => s.FindByTitle(It.IsAny<string>()))
                   .Returns(_series);
+
+            Mocker.GetMock<ISceneMappingService>()
+                  .Setup(v => v.GetTvdbSeasonNumber(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                  .Returns<string, string, int>((s, r, i) => i);
         }
 
         private void GivenDailySeries()
@@ -324,8 +328,8 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             const int tvdbSeasonNumber = 5;
 
             Mocker.GetMock<ISceneMappingService>()
-                  .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, It.IsAny<string>()))
-                  .Returns(new SceneMapping { SeasonNumber = tvdbSeasonNumber, SceneSeasonNumber = _parsedEpisodeInfo.SeasonNumber });
+                  .Setup(v => v.GetTvdbSeasonNumber(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                  .Returns<string, string, int>((s, r, i) => tvdbSeasonNumber);
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
 

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -51,6 +51,10 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 SeasonNumber = _episodes.First().SeasonNumber,
                 Episodes = _episodes
             };
+
+            Mocker.GetMock<ISceneMappingService>()
+                  .Setup(v => v.GetTvdbSeasonNumber(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                  .Returns<string, string, int>((s, r, i) => i);
         }
 
         private void GivenMatchBySeriesTitle()

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                         else if (remoteEpisode.Episodes.Empty())
                         {
-                            decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse episodes from release name"));
+                            decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to identify correct episode(s) using release name and scene mappings"));
                         }
                         else
                         {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
@@ -1,4 +1,5 @@
 using NLog;
+using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
@@ -7,10 +8,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
     public class SeasonMatchSpecification : IDecisionEngineSpecification
     {
         private readonly Logger _logger;
+        private readonly ISceneMappingService _sceneMappingService;
 
-        public SeasonMatchSpecification(Logger logger)
+        public SeasonMatchSpecification(ISceneMappingService sceneMappingService, Logger logger)
         {
             _logger = logger;
+            _sceneMappingService = sceneMappingService;
         }
 
         public SpecificationPriority Priority => SpecificationPriority.Default;
@@ -26,7 +29,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
             var singleEpisodeSpec = searchCriteria as SeasonSearchCriteria;
             if (singleEpisodeSpec == null) return Decision.Accept();
 
-            if (singleEpisodeSpec.SeasonNumber != remoteEpisode.ParsedEpisodeInfo.SeasonNumber)
+            var seasonNumber = _sceneMappingService.GetTvdbSeasonNumber(remoteEpisode.ParsedEpisodeInfo.SeriesTitle,
+                                                                        remoteEpisode.ParsedEpisodeInfo.ReleaseTitle,
+                                                                        remoteEpisode.ParsedEpisodeInfo.SeasonNumber);
+
+            if (singleEpisodeSpec.SeasonNumber != seasonNumber)
             {
                 _logger.Debug("Season number does not match searched season number, skipping.");
                 return Decision.Reject("Wrong season");

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch.Definitions
@@ -15,6 +16,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
         public Series Series { get; set; }
         public List<string> SceneTitles { get; set; }
+        public List<SceneMapping> SceneMappings { get; set; }
         public List<Episode> Episodes { get; set; }
         public virtual bool MonitoredEpisodesOnly { get; set; }
         public virtual bool UserInvokedSearch { get; set; }

--- a/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/NzbSearchService.cs
@@ -280,6 +280,9 @@ namespace NzbDrone.Core.IndexerSearch
             spec.SceneTitles = _sceneMapping.GetSceneNames(series.TvdbId,
                                                            episodes.Select(e => e.SeasonNumber).Distinct().ToList(),
                                                            episodes.Select(e => e.SceneSeasonNumber ?? e.SeasonNumber).Distinct().ToList());
+            spec.SceneMappings = _sceneMapping.GetSceneMappings(series.TvdbId,
+                                                           episodes.Select(e => e.SeasonNumber).Distinct().ToList());
+
 
             if (!spec.SceneTitles.Contains(series.Title))
             {

--- a/src/NzbDrone.Core/Indexers/IndexerPageableRequestChain.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerPageableRequestChain.cs
@@ -32,6 +32,13 @@ namespace NzbDrone.Core.Indexers
             _chains.Last().Add(new IndexerPageableRequest(request));
         }
 
+        public void AddToTier(int tierIndex, IEnumerable<IndexerRequest> request)
+        {
+            if (request == null) return;
+
+            _chains[tierIndex].Add(new IndexerPageableRequest(request));
+        }
+
         public void AddTier(IEnumerable<IndexerRequest> request)
         {
             AddTier();

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -402,13 +402,9 @@ namespace NzbDrone.Core.Parser
 
             if (sceneSource)
             {
-                var sceneMapping = _sceneMappingService.FindSceneMapping(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle);
-
-                if (sceneMapping != null && sceneMapping.SeasonNumber.HasValue && sceneMapping.SeasonNumber.Value >= 0 &&
-                    sceneMapping.SceneSeasonNumber == seasonNumber)
-                {
-                    seasonNumber = sceneMapping.SeasonNumber.Value;
-                }
+                seasonNumber = _sceneMappingService.GetTvdbSeasonNumber(parsedEpisodeInfo.SeriesTitle,
+                                                                        parsedEpisodeInfo.ReleaseTitle,
+                                                                        parsedEpisodeInfo.SeasonNumber);
             }
 
             if (parsedEpisodeInfo.EpisodeNumbers == null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Mixed a few changes together

- nzedb can return a newznab api error result when downloading .nzb, detect that and produce readable error
- Newznab/Torznab will now _also_ search by title and mapped season number for SceneMappings where both SeasonNumber and SceneSeasonNumber is specified. Examples are Spartacus and Cosmos.
  Parser will no longer produce Wrong season in that scenario either
  This means that such episodes are now also searchable, rather than only parseable on rss
- Display the SceneSeasonNumber on the UI when specified
- Bonus feature for Jackett: If they specify `title` as supported query parameter, we'll use that instead of `q` for single/season/daily searches with the original series title (or scene title), rather than the newznab cleaned one. I didn't discuss this with them yet, but they'll probably be happy since it allows them handling apostrophe themselves.

Example: Searching Cosmos 2x01 results in the following queries:
```
/api?t=tvsearch&...&tvdbid=260586&rid=29336&tvmazeid=1128&season=2&ep=1
 - Yielded one result, so fallback to regular title search is not triggered

/api?t=tvsearch&...&q=Cosmos Possible Worlds&season=1&ep=1
 - Yielded a dozen results

/api?t=tvsearch&...&q=Cosmos - Otros mundos&season=1&ep=1 
 - Yield no results, probably in foreign language category, if any
```

We should probably add a language token to the naming exceptions...
