### PR TITLE
Fixed: Indicate unchecking Replace Illegal Characters will remove them

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/Naming.js
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.js
@@ -226,7 +226,7 @@ class Naming extends Component {
                 <FormInputGroup
                   type={inputTypes.CHECK}
                   name="replaceIllegalCharacters"
-                  helpText="Replace or Remove illegal characters"
+                  helpText="Replace illegal characters. If unchecked, Sonarr will simply remove them instead"
                   onChange={onInputChange}
                   {...settings.replaceIllegalCharacters}
                 />

--- a/frontend/src/Settings/MediaManagement/Naming/Naming.js
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.js
@@ -226,7 +226,7 @@ class Naming extends Component {
                 <FormInputGroup
                   type={inputTypes.CHECK}
                   name="replaceIllegalCharacters"
-                  helpText="Replace illegal characters. If unchecked, Sonarr will simply remove them instead"
+                  helpText="Replace illegal characters. If unchecked, Sonarr will remove them instead"
                   onChange={onInputChange}
                   {...settings.replaceIllegalCharacters}
                 />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The prior help text made it seem like the setting would be required to both replace or remove illegal characters; however, it seems to be specifically meant for replacing those characters. If unchecked, then will Sonarr removes those characters rather than replacing them. I tried to clarify it in the help text, though if there's clearer language, that would be even better.

The current language is very confusing and misleading though.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* 
