### PR TITLE
Fixed: Don't lock command queue if updating is disabled

### DIFF
--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Jobs
                 {
                     new ScheduledTask{ Interval = 1, TypeName = typeof(RefreshMonitoredDownloadsCommand).FullName},
                     new ScheduledTask{ Interval = 5, TypeName = typeof(MessagingCleanupCommand).FullName},
-                    new ScheduledTask{ Interval = 6*60, TypeName = typeof(ApplicationUpdateCommand).FullName},
+                    new ScheduledTask{ Interval = 6*60, TypeName = typeof(ApplicationUpdateCheckCommand).FullName},
                     new ScheduledTask{ Interval = 3*60, TypeName = typeof(UpdateSceneMappingCommand).FullName},
                     new ScheduledTask{ Interval = 6*60, TypeName = typeof(CheckHealthCommand).FullName},
                     new ScheduledTask{ Interval = 12*60, TypeName = typeof(RefreshSeriesCommand).FullName},

--- a/src/NzbDrone.Core/Update/Commands/ApplicationUpdateCheckCommand.cs
+++ b/src/NzbDrone.Core/Update/Commands/ApplicationUpdateCheckCommand.cs
@@ -1,0 +1,11 @@
+using NzbDrone.Core.Messaging.Commands;
+
+namespace NzbDrone.Core.Update.Commands
+{
+    public class ApplicationUpdateCheckCommand : Command
+    {
+        public override bool SendUpdatesToClient => true;
+
+        public override string CompletionMessage => null;
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Splits the update command to ApplicationUpdate and ApplicationUpdateCheck. This will prevent the command queue from being locked down due to the isExclusive ApplicationUpdateCommand if the update command is awaiting something else to finish... especially for cases when we skip updates anyway. 
