### PR TITLE
Fixed: Refreshing Plex Server series in high volume systems

### DIFF
--- a/src/NzbDrone.Common/Cache/CacheManager.cs
+++ b/src/NzbDrone.Common/Cache/CacheManager.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Common.Cache
     {
         ICached<T> GetCache<T>(Type host);
         ICached<T> GetCache<T>(Type host, string name);
+        ICached<T> GetRollingCache<T>(Type host, string name, TimeSpan defaultLifeTime);
         ICachedDictionary<T> GetCacheDictionary<T>(Type host, string name, Func<IDictionary<string, T>> fetchFunc = null, TimeSpan? lifeTime = null);
         void Clear();
         ICollection<ICached> Caches { get; }
@@ -42,6 +43,14 @@ namespace NzbDrone.Common.Cache
             Ensure.That(name, () => name).IsNotNullOrWhiteSpace();
 
             return (ICached<T>)_cache.Get(host.FullName + "_" + name, () => new Cached<T>());
+        }
+
+        public ICached<T> GetRollingCache<T>(Type host, string name, TimeSpan defaultLifeTime)
+        {
+            Ensure.That(host, () => host).IsNotNull();
+            Ensure.That(name, () => name).IsNotNullOrWhiteSpace();
+
+            return (ICached<T>)_cache.Get(host.FullName + "_" + name, () => new Cached<T>(defaultLifeTime, true));
         }
 
         public ICachedDictionary<T> GetCacheDictionary<T>(Type host, string name, Func<IDictionary<string, T>> fetchFunc = null, TimeSpan? lifeTime = null)

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -199,6 +199,24 @@ namespace NzbDrone.Common.Disk
             File.Delete(path);
         }
 
+        public void CloneFile(string source, string destination, bool overwrite = false)
+        {
+            Ensure.That(source, () => source).IsValidPath();
+            Ensure.That(destination, () => destination).IsValidPath();
+
+            if (source.PathEquals(destination))
+            {
+                throw new IOException(string.Format("Source and destination can't be the same {0}", source));
+            }
+
+            CloneFileInternal(source, destination, overwrite);
+        }
+
+        protected virtual void CloneFileInternal(string source, string destination, bool overwrite = false)
+        {
+            CopyFileInternal(source, destination, overwrite);
+        }
+
         public void CopyFile(string source, string destination, bool overwrite = false)
         {
             Ensure.That(source, () => source).IsValidPath();
@@ -249,7 +267,17 @@ namespace NzbDrone.Common.Disk
             File.Move(source, destination);
         }
 
+        public virtual bool TryRenameFile(string source, string destination)
+        {
+            return false;
+        }
+
         public abstract bool TryCreateHardLink(string source, string destination);
+
+        public virtual bool TryCreateRefLink(string source, string destination)
+        {
+            return false;
+        }
 
         public void DeleteFolder(string path, bool recursive)
         {

--- a/src/NzbDrone.Common/Disk/IDiskProvider.cs
+++ b/src/NzbDrone.Common/Disk/IDiskProvider.cs
@@ -29,10 +29,13 @@ namespace NzbDrone.Common.Disk
         long GetFileSize(string path);
         void CreateFolder(string path);
         void DeleteFile(string path);
+        void CloneFile(string source, string destination, bool overwrite = false);
         void CopyFile(string source, string destination, bool overwrite = false);
         void MoveFile(string source, string destination, bool overwrite = false);
         void MoveFolder(string source, string destination);
+        bool TryRenameFile(string source, string destination);
         bool TryCreateHardLink(string source, string destination);
+        bool TryCreateRefLink(string source, string destination);
         void DeleteFolder(string path, bool recursive);
         string ReadAllText(string filePath);
         void WriteAllText(string filename, string contents);

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs
@@ -80,6 +80,7 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("The Wire S01-05 WS BDRip X264-REWARD-No Rars", "The Wire", 1)]
+        [TestCase("Seinfault.S01-S09.1080p.AMZN.WEB-DL.DDP2.0.H.264-NTb", "Seinfault", 1)]
         public void should_parse_multi_season_release(string postTitle, string title, int firstSeason)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ProviderTests/RecycleBinProviderTests/DeleteDirectoryFixture.cs
+++ b/src/NzbDrone.Core.Test/ProviderTests/RecycleBinProviderTests/DeleteDirectoryFixture.cs
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Test.ProviderTests.RecycleBinProviderTests
             Mocker.Resolve<RecycleBinProvider>().DeleteFolder(path);
 
             Mocker.GetMock<IDiskTransferService>()
-                  .Verify(v => v.TransferFolder(path, @"C:\Test\Recycle Bin\30 Rock".AsOsAgnostic(), TransferMode.Move, true), Times.Once());
+                  .Verify(v => v.TransferFolder(path, @"C:\Test\Recycle Bin\30 Rock".AsOsAgnostic(), TransferMode.Move), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/ProviderTests/RecycleBinProviderTests/DeleteFileFixture.cs
+++ b/src/NzbDrone.Core.Test/ProviderTests/RecycleBinProviderTests/DeleteFileFixture.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Test.ProviderTests.RecycleBinProviderTests
 
             Mocker.Resolve<RecycleBinProvider>().DeleteFile(path);
 
-            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\S01E01.avi".AsOsAgnostic(), TransferMode.Move, false, true), Times.Once());
+            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\S01E01.avi".AsOsAgnostic(), TransferMode.Move, false), Times.Once());
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.ProviderTests.RecycleBinProviderTests
 
             Mocker.Resolve<RecycleBinProvider>().DeleteFile(path);
 
-            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\S01E01_2.avi".AsOsAgnostic(), TransferMode.Move, false, true), Times.Once());
+            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\S01E01_2.avi".AsOsAgnostic(), TransferMode.Move, false), Times.Once());
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Test.ProviderTests.RecycleBinProviderTests
 
             Mocker.Resolve<RecycleBinProvider>().DeleteFile(path, "30 Rock");
 
-            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\30 Rock\S01E01.avi".AsOsAgnostic(), TransferMode.Move, false, true), Times.Once());
+            Mocker.GetMock<IDiskTransferService>().Verify(v => v.TransferFile(path, @"C:\Test\Recycle Bin\30 Rock\S01E01.avi".AsOsAgnostic(), TransferMode.Move, false), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/TvTests/MoveSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/MoveSeriesServiceFixture.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Test.TvTests
         private void GivenFailedMove()
         {
             Mocker.GetMock<IDiskTransferService>()
-                  .Setup(s => s.TransferFolder(It.IsAny<string>(), It.IsAny<string>(), TransferMode.Move, true))
+                  .Setup(s => s.TransferFolder(It.IsAny<string>(), It.IsAny<string>(), TransferMode.Move))
                   .Throws<IOException>();
         }
 
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.TvTests
             Subject.Execute(_command);
 
             Mocker.GetMock<IDiskTransferService>()
-                  .Verify(v => v.TransferFolder(_command.SourcePath, _command.DestinationPath, TransferMode.Move, It.IsAny<bool>()), Times.Once());
+                  .Verify(v => v.TransferFolder(_command.SourcePath, _command.DestinationPath, TransferMode.Move), Times.Once());
 
             Mocker.GetMock<IBuildFileNames>()
                   .Verify(v => v.GetSeriesFolder(It.IsAny<Series>(), null), Times.Never());
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Test.TvTests
             Subject.Execute(_bulkCommand);
 
             Mocker.GetMock<IDiskTransferService>()
-                  .Verify(v => v.TransferFolder(_bulkCommand.Series.First().SourcePath, expectedPath, TransferMode.Move, It.IsAny<bool>()), Times.Once());
+                  .Verify(v => v.TransferFolder(_bulkCommand.Series.First().SourcePath, expectedPath, TransferMode.Move), Times.Once());
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Test.TvTests
             Subject.Execute(_command);
             
             Mocker.GetMock<IDiskTransferService>()
-                  .Verify(v => v.TransferFolder(_command.SourcePath, _command.DestinationPath, TransferMode.Move, It.IsAny<bool>()), Times.Never());
+                  .Verify(v => v.TransferFolder(_command.SourcePath, _command.DestinationPath, TransferMode.Move), Times.Never());
 
             Mocker.GetMock<IBuildFileNames>()
                   .Verify(v => v.GetSeriesFolder(It.IsAny<Series>(), null), Times.Never());

--- a/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdateServiceFixture.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Test.UpdateTests
             Subject.Execute(new ApplicationUpdateCommand());
 
             Mocker.GetMock<IDiskTransferService>()
-                  .Verify(c => c.TransferFolder(updateClientFolder, _sandboxFolder, TransferMode.Move, false));
+                  .Verify(c => c.TransferFolder(updateClientFolder, _sandboxFolder, TransferMode.Move));
         }
 
         [Test]

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Extras.Files
                 transferMode = _configService.CopyUsingHardlinks ? TransferMode.HardLinkOrCopy : TransferMode.Copy;
             }
 
-            _diskTransferService.TransferFile(path, newFileName, transferMode, true, false);
+            _diskTransferService.TransferFile(path, newFileName, transferMode, true);
 
             return new TExtraFile
             {

--- a/src/NzbDrone.Core/MediaFiles/Events/RenameCompletedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/RenameCompletedEvent.cs
@@ -1,0 +1,9 @@
+﻿using NzbDrone.Common.Messaging;
+
+namespace NzbDrone.Core.MediaFiles.Events
+{
+    public class RenameCompletedEvent : IEvent
+    {
+
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
@@ -154,6 +154,8 @@ namespace NzbDrone.Core.MediaFiles
             _logger.ProgressInfo("Renaming {0} files for {1}", episodeFiles.Count, series.Title);
             RenameFiles(episodeFiles, series);
             _logger.ProgressInfo("Selected episode files renamed for {0}", series.Title);
+
+            _eventAggregator.PublishEvent(new RenameCompletedEvent());
         }
 
         public void Execute(RenameSeriesCommand message)
@@ -168,6 +170,8 @@ namespace NzbDrone.Core.MediaFiles
                 RenameFiles(episodeFiles, series);
                 _logger.ProgressInfo("All episode files renamed for {0}", series.Title);
             }
+
+            _eventAggregator.PublishEvent(new RenameCompletedEvent());
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Notifications
         void OnDownload(DownloadMessage message);
         void OnRename(Series series);
         void OnHealthIssue(HealthCheck.HealthCheck healthCheck);
+        void ProcessQueue();
         bool SupportsOnGrab { get; }
         bool SupportsOnDownload { get; }
         bool SupportsOnUpgrade { get; }

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -49,6 +49,11 @@ namespace NzbDrone.Core.Notifications
 
         }
 
+        public virtual void ProcessQueue()
+        {
+
+        }
+
         public bool SupportsOnGrab => HasConcreteImplementation("OnGrab");
         public bool SupportsOnRename => HasConcreteImplementation("OnRename");
         public bool SupportsOnDownload => HasConcreteImplementation("OnDownload");
@@ -76,6 +81,5 @@ namespace NzbDrone.Core.Notifications
 
             return !method.DeclaringType.IsAbstract;
         }
-
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -17,7 +17,10 @@ namespace NzbDrone.Core.Notifications
         : IHandle<EpisodeGrabbedEvent>,
           IHandle<EpisodeImportedEvent>,
           IHandle<SeriesRenamedEvent>,
-          IHandle<HealthCheckFailedEvent>
+          IHandle<HealthCheckFailedEvent>,
+          IHandleAsync<DownloadsProcessedEvent>,
+          IHandleAsync<RenameCompletedEvent>,
+          IHandleAsync<HealthCheckCompleteEvent>
     {
         private readonly INotificationFactory _notificationFactory;
         private readonly Logger _logger;
@@ -201,6 +204,36 @@ namespace NzbDrone.Core.Notifications
                 catch (Exception ex)
                 {
                     _logger.Warn(ex, "Unable to send OnHealthIssue notification to: " + notification.Definition.Name);
+                }
+            }
+        }
+
+        public void HandleAsync(DownloadsProcessedEvent message)
+        {
+            ProcessQueue();
+        }
+
+        public void HandleAsync(RenameCompletedEvent message)
+        {
+            ProcessQueue();
+        }
+
+        public void HandleAsync(HealthCheckCompleteEvent message)
+        {
+            ProcessQueue();
+        }
+
+        private void ProcessQueue()
+        {
+            foreach (var notification in _notificationFactory.GetAvailableProviders())
+            {
+                try
+                {
+                    notification.ProcessQueue();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Unable to process notification queue for " + notification.Definition.Name);
                 }
             }
         }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Parser
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 // Multi-season pack
-                new Regex(@"^(?<title>.+?)[-_. ]+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))-(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))",
+                new Regex(@"^(?<title>.+?)[-_. ]+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))-S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 // Partial season pack

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.Update
             }
 
             _logger.Info("Preparing client");
-            _diskTransferService.TransferFolder(_appFolderInfo.GetUpdateClientFolder(), updateSandboxFolder, TransferMode.Move, false);
+            _diskTransferService.TransferFolder(_appFolderInfo.GetUpdateClientFolder(), updateSandboxFolder, TransferMode.Move);
 
             _logger.Info("Starting update client {0}", _appFolderInfo.GetUpdateClientExePath());
             _logger.ProgressInfo("Sonarr will restart shortly.");

--- a/src/NzbDrone.Mono.Test/DiskProviderTests/SymlinkResolverFixture.cs
+++ b/src/NzbDrone.Mono.Test/DiskProviderTests/SymlinkResolverFixture.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Mono.Posix;
+using Mono.Unix;
+using NUnit.Framework;
+using NzbDrone.Mono.Disk;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Mono.Test.DiskProviderTests
+{
+    [TestFixture]
+    [Platform("Mono")]
+    public class SymbolicLinkResolverFixture : TestBase<SymbolicLinkResolver>
+    {
+        public SymbolicLinkResolverFixture()
+        {
+            MonoOnly();
+        }
+
+        [Test]
+        public void should_follow_nested_symlinks()
+        {
+            var rootDir = GetTempFilePath();
+            var tempDir1 = Path.Combine(rootDir, "dir1");
+            var tempDir2 = Path.Combine(rootDir, "dir2");
+            var subDir1 = Path.Combine(tempDir1, "subdir1");
+            var file1 = Path.Combine(tempDir2, "file1");
+            var file2 = Path.Combine(tempDir2, "file2");
+
+            Directory.CreateDirectory(tempDir1);
+            Directory.CreateDirectory(tempDir2);
+            File.WriteAllText(file2, "test");
+
+            new UnixSymbolicLinkInfo(subDir1).CreateSymbolicLinkTo("../dir2");
+            new UnixSymbolicLinkInfo(file1).CreateSymbolicLinkTo("file2");
+
+            var realPath = Subject.GetCompleteRealPath(Path.Combine(subDir1, "file1"));
+
+            realPath.Should().Be(file2);
+        }
+
+        [Test]
+        public void should_throw_on_infinite_loop()
+        {
+            var rootDir = GetTempFilePath();
+            var tempDir1 = Path.Combine(rootDir, "dir1");
+            var subDir1 = Path.Combine(tempDir1, "subdir1");
+            var file1 = Path.Combine(tempDir1, "file1");
+
+            Directory.CreateDirectory(tempDir1);
+
+            new UnixSymbolicLinkInfo(subDir1).CreateSymbolicLinkTo("../../dir1/subdir1/baddir");
+
+            var realPath = Subject.GetCompleteRealPath(file1);
+
+            realPath.Should().Be(file1);
+        }
+    }
+}

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -410,9 +410,21 @@ namespace NzbDrone.Mono.Disk
                 fileInfo.CreateLink(destination);
                 return true;
             }
+            catch (UnixIOException ex)
+            {
+                if (ex.ErrorCode == Errno.EXDEV)
+                {
+                    Logger.Trace("Hardlink '{0}' to '{1}' failed due to cross-device access.", source, destination);
+                }
+                else
+                {
+                    Logger.Debug(ex, "Hardlink '{0}' to '{1}' failed.", source, destination);
+                }
+                return false;
+            }
             catch (Exception ex)
             {
-                Logger.Debug(ex, string.Format("Hardlink '{0}' to '{1}' failed.", source, destination));
+                Logger.Debug(ex, "Hardlink '{0}' to '{1}' failed.", source, destination);
                 return false;
             }
         }

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -20,15 +20,17 @@ namespace NzbDrone.Mono.Disk
         private readonly Logger _logger;
         private readonly IProcMountProvider _procMountProvider;
         private readonly ISymbolicLinkResolver _symLinkResolver;
+        private readonly ICreateRefLink _createRefLink;
 
         // Mono supports sending -1 for a uint to indicate that the owner or group should not be set
         // `unchecked((uint)-1)` and `uint.MaxValue` are the same thing.
         private const uint UNCHANGED_ID = uint.MaxValue;
 
-        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver, Logger logger)
+        public DiskProvider(IProcMountProvider procMountProvider, ISymbolicLinkResolver symLinkResolver, ICreateRefLink createRefLink, Logger logger)
         {
             _procMountProvider = procMountProvider;
             _symLinkResolver = symLinkResolver;
+            _createRefLink = createRefLink;
             _logger = logger;
         }
 
@@ -175,6 +177,19 @@ namespace NzbDrone.Mono.Disk
             var mount = GetMount(path);
 
             return mount?.TotalSize;
+        }
+
+        protected override void CloneFileInternal(string source, string destination, bool overwrite)
+        {
+            if (!File.Exists(destination) && !UnixFileSystemInfo.GetFileSystemEntry(source).IsSymbolicLink)
+            {
+                if (_createRefLink.TryCreateRefLink(source, destination))
+                {
+                    return;
+                }
+            }
+
+            CopyFileInternal(source, destination, overwrite);
         }
 
         protected override void CopyFileInternal(string source, string destination, bool overwrite)
@@ -379,6 +394,11 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
+        public override bool TryRenameFile(string source, string destination)
+        {
+            return Syscall.rename(source, destination) == 0;
+        }
+
         public override bool TryCreateHardLink(string source, string destination)
         {
             try
@@ -395,6 +415,11 @@ namespace NzbDrone.Mono.Disk
                 Logger.Debug(ex, string.Format("Hardlink '{0}' to '{1}' failed.", source, destination));
                 return false;
             }
+        }
+
+        public override bool TryCreateRefLink(string source, string destination)
+        {
+            return _createRefLink.TryCreateRefLink(source, destination);
         }
 
         private uint GetUserId(string user)

--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Mono.Disk
                                                                                       { "afpfs", DriveType.Network },
                                                                                       { "apfs", DriveType.Fixed },
                                                                                       { "fuse.mergerfs", DriveType.Fixed },
+                                                                                      { "fuse.glusterfs", DriveType.Network },
                                                                                       { "zfs", DriveType.Fixed }
                                                                                   };
 

--- a/src/NzbDrone.Mono/Disk/RefLinkCreator.cs
+++ b/src/NzbDrone.Mono/Disk/RefLinkCreator.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NLog;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Mono.Interop;
+using Mono.Unix.Native;
+using Mono.Unix;
+
+namespace NzbDrone.Mono.Disk
+{
+    public interface ICreateRefLink
+    {
+        bool TryCreateRefLink(string srcPath, string linkPath);
+    }
+
+    public class RefLinkCreator : ICreateRefLink
+    {
+        private readonly Logger _logger;
+        private readonly bool _supported;
+
+        public RefLinkCreator(Logger logger)
+        {
+            _logger = logger;
+
+            // Only support x86_64 because we know the FICLONE value is valid for it
+            _supported = OsInfo.IsLinux && (Syscall.uname(out var results) == 0 && results.machine == "x86_64");
+        }
+
+        public bool TryCreateRefLink(string srcPath, string linkPath)
+        {
+            if (!_supported)
+            {
+                return false;
+            }
+
+            try
+            {
+                using (var srcHandle = NativeMethods.open(srcPath, OpenFlags.O_RDONLY))
+                {
+                    if (srcHandle.IsInvalid)
+                    {
+                        _logger.Trace("Failed to create reflink at '{0}' to '{1}': Couldn't open source file", linkPath, srcPath);
+                        return false;
+                    }
+
+                    using (var linkHandle = NativeMethods.open(linkPath, OpenFlags.O_WRONLY | OpenFlags.O_CREAT | OpenFlags.O_TRUNC))
+                    {
+                        if (linkHandle.IsInvalid)
+                        {
+                            _logger.Trace("Failed to create reflink at '{0}' to '{1}': Couldn't create new link file", linkPath, srcPath);
+                            return false;
+                        }
+
+                        if (NativeMethods.clone_file(linkHandle, srcHandle) == -1)
+                        {
+                            var error = new UnixIOException();
+                            linkHandle.Dispose();
+                            Syscall.unlink(linkPath);
+                            _logger.Trace("Failed to create reflink at '{0}' to '{1}': {2}", linkPath, srcPath, error.Message);
+                            return false;
+                        }
+
+                        _logger.Trace("Created reflink at '{0}' to '{1}'", linkPath, srcPath);
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Syscall.unlink(linkPath);
+                _logger.Trace(ex, "Failed to create reflink at '{0}' to '{1}'", linkPath, srcPath);
+                return false;
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Mono/Disk/SymbolicLinkResolver.cs
+++ b/src/NzbDrone.Mono/Disk/SymbolicLinkResolver.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Drawing;
+using System.Net;
 using System.Text;
 using Mono.Unix;
 using Mono.Unix.Native;
@@ -11,8 +13,6 @@ namespace NzbDrone.Mono.Disk
         string GetCompleteRealPath(string path);
     }
 
-    // Mono's own implementation doesn't handle exceptions very well.
-    // All of this code was copied from mono with minor changes.
     public class SymbolicLinkResolver : ISymbolicLinkResolver
     {
         private readonly Logger _logger;
@@ -28,33 +28,26 @@ namespace NzbDrone.Mono.Disk
 
             try
             {
-                string[] dirs;
-                int lastIndex;
-                GetPathComponents(path, out dirs, out lastIndex);
+                var realPath = path;
+                for (var links = 0; links < 32; links++)
+                {
+                    var wasSymLink = TryFollowFirstSymbolicLink(ref realPath);
+                    if (!wasSymLink)
+                    {
+                        return realPath;
+                    }
+                }
 
-                var realPath = new StringBuilder();
-                if (dirs.Length > 0)
-                {
-                    var dir = UnixPath.IsPathRooted(path) ? "/" : "";
-                    dir += dirs[0];
-                    realPath.Append(GetRealPath(dir));
-                }
-                for (var i = 1; i < lastIndex; ++i)
-                {
-                    realPath.Append("/").Append(dirs[i]);
-                    var realSubPath = GetRealPath(realPath.ToString());
-                    realPath.Remove(0, realPath.Length);
-                    realPath.Append(realSubPath);
-                }
-                return realPath.ToString();
+                var ex = new UnixIOException(Errno.ELOOP);
+                _logger.Warn("Failed to check for symlinks in the path {0}: {1}", path, ex.Message);
+                return path;
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, string.Format("Failed to check for symlinks in the path {0}", path));
+                _logger.Debug(ex, "Failed to check for symlinks in the path {0}", path);
                 return path;
             }
         }
-
 
         private static void GetPathComponents(string path, out string[] components, out int lastIndex)
         {
@@ -87,23 +80,77 @@ namespace NzbDrone.Mono.Disk
             lastIndex = target;
         }
 
-        public string GetRealPath(string path)
+        private bool TryFollowFirstSymbolicLink(ref string path)
         {
-            do
+            string[] dirs;
+            int lastIndex;
+            GetPathComponents(path, out dirs, out lastIndex);
+
+            if (lastIndex == 0)
             {
-                var link = UnixPath.TryReadLink(path);
+                return false;
+            }
 
-                if (link == null)
+            var realPath = "";
+
+            for (var i = 0; i < lastIndex; ++i)
+            {
+                if (i != 0 || UnixPath.IsPathRooted(path))
                 {
-                    var errno = Stdlib.GetLastError();
-                    if (errno != Errno.EINVAL)
-                    {
-                        _logger.Trace("Checking path {0} for symlink returned error {1}, assuming it's not a symlink.", path, errno);
-                    }
-
-                    return path;
+                    realPath = string.Concat(realPath, UnixPath.DirectorySeparatorChar, dirs[i]);
+                }
+                else
+                {
+                    realPath = string.Concat(realPath, dirs[i]);
                 }
 
+                var pathValid = TryFollowSymbolicLink(ref realPath, out var wasSymLink);
+
+                if (!pathValid || wasSymLink)
+                {
+                    // If the path does not exist, or it was a symlink then we need to concat the remaining dir components and start over (or return)
+                    var count = lastIndex - i - 1;
+                    if (count > 0)
+                    {
+                        realPath = string.Concat(realPath, UnixPath.DirectorySeparatorChar, string.Join(UnixPath.DirectorySeparatorChar.ToString(), dirs, i + 1, lastIndex - i - 1));
+                    }
+                    path = realPath;
+                    return pathValid;
+                }
+            }
+
+            return false;
+        }
+
+        private bool TryFollowSymbolicLink(ref string path, out bool wasSymLink)
+        {
+            if (!UnixFileSystemInfo.TryGetFileSystemEntry(path, out var fsentry) || !fsentry.Exists)
+            {
+                wasSymLink = false;
+                return false;
+            }
+
+            if (!fsentry.IsSymbolicLink)
+            {
+                wasSymLink = false;
+                return true;
+            }
+
+            var link = UnixPath.TryReadLink(path);
+
+            if (link == null)
+            {
+                var errno = Stdlib.GetLastError();
+                if (errno != Errno.EINVAL)
+                {
+                    _logger.Trace("Checking path {0} for symlink returned error {1}, assuming it's not a symlink.", path, errno);
+                }
+
+                wasSymLink = true;
+                return false;
+            }
+            else
+            {
                 if (UnixPath.IsPathRooted(link))
                 {
                     path = link;
@@ -113,8 +160,10 @@ namespace NzbDrone.Mono.Disk
                     path = UnixPath.GetDirectoryName(path) + UnixPath.DirectorySeparatorChar + link;
                     path = UnixPath.GetCanonicalPath(path);
                 }
-            } while (true);
-        } 
 
+                wasSymLink = true;
+                return true;
+            }
+        }
     }
 }

--- a/src/NzbDrone.Mono/Interop/NativeMethods.cs
+++ b/src/NzbDrone.Mono/Interop/NativeMethods.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Text;
+using Mono.Unix.Native;
+
+namespace NzbDrone.Mono.Interop
+{
+    internal enum IoctlRequest : uint
+    {
+        // Hardcoded ioctl for FICLONE on a typical linux system
+        // #define FICLONE _IOW(0x94, 9, int)
+        FICLONE = 0x40049409
+    }
+    
+    internal static class NativeMethods
+    {
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int Ioctl(SafeUnixHandle dst_fd, IoctlRequest request, SafeUnixHandle src_fd);
+
+        public static SafeUnixHandle open(string pathname, OpenFlags flags)
+        {
+            return new SafeUnixHandle(Syscall.open(pathname, flags));
+        }
+
+        internal static int clone_file(SafeUnixHandle link_fd, SafeUnixHandle src_fd)
+        {
+            return Ioctl(link_fd, IoctlRequest.FICLONE, src_fd);
+        }
+    }
+}

--- a/src/NzbDrone.Mono/Interop/SafeUnixHandle.cs
+++ b/src/NzbDrone.Mono/Interop/SafeUnixHandle.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using Mono.Unix.Native;
+
+namespace NzbDrone.Mono.Interop
+{
+    [SecurityPermission(SecurityAction.InheritanceDemand, UnmanagedCode = true)]
+    [SecurityPermission(SecurityAction.Demand, UnmanagedCode = true)]
+    internal sealed class SafeUnixHandle : SafeHandle
+    {
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        private SafeUnixHandle()
+            : base(new IntPtr(-1), true)
+        {
+        }
+
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        public SafeUnixHandle(int fd)
+            : base(new IntPtr(-1), true)
+        {
+            handle = new IntPtr(fd);
+        }
+
+        public override bool IsInvalid
+        {
+            get { return this.handle == new IntPtr(-1); }
+        }
+
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        protected override bool ReleaseHandle()
+        {
+            return Syscall.close(this.handle.ToInt32()) != -1;
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Plex Library Update request are put in a queue and a later async event triggers processing that queue.
I think we should make the queue more generic and have a timeout, but that isn't necessary yet.

Also added a Rolling Expiry to Cached to keep track of the queue object.
The whole Cached implementation wasn't actually threadsafe, so I kinda rewrote it to be entirely threadsafe.

There's not that much benefit from refreshing multiple series at once, except that it saves on the sections query.
Ideally we should determine the mapping between series folder and plex, then we can identify the section the series is in more efficiently by simply comparing section/locations.
Perhaps using the series location.
But for now the async behavior (and deduplication) should give sufficient performance gain.