### PR TITLE
Phantom webpack bundling

### DIFF
--- a/frontend/gulp/build.js
+++ b/frontend/gulp/build.js
@@ -10,8 +10,7 @@ gulp.task('build',
       'webpack',
       'copyHtml',
       'copyFonts',
-      'copyImages',
-      'copyJs'
+      'copyImages'
     )
   )
 );

--- a/frontend/gulp/copy.js
+++ b/frontend/gulp/copy.js
@@ -5,17 +5,6 @@ const cache = require('gulp-cached');
 const livereload = require('gulp-livereload');
 const paths = require('./helpers/paths.js');
 
-gulp.task('copyJs', () => {
-  return gulp.src(
-    [
-      path.join(paths.src.root, 'polyfills.js')
-    ], { base: paths.src.root })
-    .pipe(cache('copyJs'))
-    .pipe(print())
-    .pipe(gulp.dest(paths.dest.root))
-    .pipe(livereload());
-});
-
 gulp.task('copyHtml', () => {
   return gulp.src(paths.src.html, { base: paths.src.root })
     .pipe(cache('copyHtml'))

--- a/frontend/gulp/webpack.js
+++ b/frontend/gulp/webpack.js
@@ -13,6 +13,7 @@ const frontendFolder = path.join(__dirname, '..');
 const srcFolder = path.join(frontendFolder, 'src');
 const isProduction = process.argv.indexOf('--production') > -1;
 const isProfiling = isProduction && process.argv.indexOf('--profile') > -1;
+const inlineWebWorkers = true;
 
 const distFolder = path.resolve(frontendFolder, '..', '_output', uiFolder);
 
@@ -121,7 +122,9 @@ const config = {
         use: {
           loader: 'worker-loader',
           options: {
-            name: '[name].js'
+            name: '[name].js',
+            inline: inlineWebWorkers,
+            fallback: !inlineWebWorkers
           }
         }
       },

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "checkJs": false,
+        "baseUrl": "src",
+        "jsx": "react",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "paths": {
+            "*": [
+                "*"
+            ]
+        }
+    },
+    "include": [
+        "./src/**/*"
+    ],
+    "exclude": [
+    ]
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -79,6 +79,5 @@
   </body>
 
   <script src="/initialize.js" data-no-hash></script>
-  <script src="/polyfills.js"></script>
   <!-- webpack bundles body -->
 </html>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,4 +1,6 @@
-import './preload.js';
+import './preload';
+import './polyfills';
+
 import React from 'react';
 import { render } from 'react-dom';
 import { createBrowserHistory } from 'history';

--- a/src/NzbDrone.Api/Indexers/ReleasePushModule.cs
+++ b/src/NzbDrone.Api/Indexers/ReleasePushModule.cs
@@ -11,7 +11,7 @@ using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Api.Indexers
 {
-    class ReleasePushModule : ReleaseModuleBase
+    public class ReleasePushModule : ReleaseModuleBase
     {
         private readonly IMakeDownloadDecision _downloadDecisionMaker;
         private readonly IProcessDownloadDecisions _downloadDecisionProcessor;

--- a/src/NzbDrone.Api/Profiles/LegacyProfileModule.cs
+++ b/src/NzbDrone.Api/Profiles/LegacyProfileModule.cs
@@ -3,7 +3,7 @@ using Nancy;
 
 namespace NzbDrone.Api.Profiles
 {
-    class LegacyProfileModule : NzbDroneApiModule
+    public class LegacyProfileModule : NzbDroneApiModule
     {
         public LegacyProfileModule()
             : base("qualityprofile")

--- a/src/NzbDrone.Api/Wanted/LegacyMissingModule.cs
+++ b/src/NzbDrone.Api/Wanted/LegacyMissingModule.cs
@@ -3,7 +3,7 @@ using Nancy;
 
 namespace NzbDrone.Api.Wanted
 {
-    class LegacyMissingModule : NzbDroneApiModule
+    public class LegacyMissingModule : NzbDroneApiModule
     {
         public LegacyMissingModule() : base("missing")
         {

--- a/src/NzbDrone.Common/Composition/ContainerBuilderBase.cs
+++ b/src/NzbDrone.Common/Composition/ContainerBuilderBase.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Common.Composition
 
             foreach (var assembly in assemblies)
             {
-                _loadedTypes.AddRange(Assembly.Load(assembly).GetTypes());
+                _loadedTypes.AddRange(Assembly.Load(assembly).GetExportedTypes());
             }
 
             Container = new Container(new TinyIoCContainer(), _loadedTypes);

--- a/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
+++ b/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Common.Reflection
 
         public static List<Type> ImplementationsOf<T>(this Assembly assembly)
         {
-            return assembly.GetTypes().Where(c => typeof(T).IsAssignableFrom(c)).ToList();
+            return assembly.GetExportedTypes().Where(c => typeof(T).IsAssignableFrom(c)).ToList();
         }
 
         public static bool IsSimpleType(this Type type)
@@ -67,7 +67,7 @@ namespace NzbDrone.Common.Reflection
 
         public static Type FindTypeByName(this Assembly assembly, string name)
         {
-            return assembly.GetTypes().SingleOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            return assembly.GetExportedTypes().SingleOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public static bool HasAttribute<TAttribute>(this Type type)

--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -40,6 +40,7 @@ namespace NzbDrone.Core.Datastore
             Environment.SetEnvironmentVariable("No_Expand", "true");
             Environment.SetEnvironmentVariable("No_SQLiteXmlConfigFile", "true");
             Environment.SetEnvironmentVariable("No_PreLoadSQLite", "true");
+            Environment.SetEnvironmentVariable("No_SQLiteFunctions", "true");
         }
 
         public static void RegisterDatabase(IContainer container)

--- a/src/Sonarr.Api.V3/Indexers/ReleasePushModule.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleasePushModule.cs
@@ -12,7 +12,7 @@ using NzbDrone.Core.Parser.Model;
 
 namespace Sonarr.Api.V3.Indexers
 {
-    class ReleasePushModule : ReleaseModuleBase
+    public class ReleasePushModule : ReleaseModuleBase
     {
         private readonly IMakeDownloadDecision _downloadDecisionMaker;
         private readonly IProcessDownloadDecisions _downloadDecisionProcessor;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Cherrypicked some of the monaco-editor stuff that I'd like out of the way.

- Import polyfills in index.js so it gets bundled by webpack and doesn't need to be loaded separately in index.html. So no more unbundled js files.
- Enabled inline webworker again, it seems to work with fuse.worker.
- jsconfig file for some intellisense in VSCode.
- Tweaked our Inversion of Control auto registration logic to avoid it loading dependent assemblies unnecessarily. This helps mostly with the Roslyn assemblies in the separate diagnostic-script pr.

@ta264 The inline webworker seems to work with fuse, but lemme know if you see any problems with this PR. 