### PR TITLE
Fixed: Typo in the Week Column Header example

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -19,7 +19,7 @@ export const firstDayOfWeekOptions = [
 export const weekColumnOptions = [
   { key: 'ddd M/D', value: 'Tue 3/25' },
   { key: 'ddd MM/DD', value: 'Tue 03/25' },
-  { key: 'ddd D/M', value: 'Tue 25/03' },
+  { key: 'ddd D/M', value: 'Tue 25/3' },
   { key: 'ddd DD/MM', value: 'Tue 25/03' }
 ];
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In the Calendar Options dialog, fix a small typo in one of the date examples in the `Week Column Header`.
