### PR TITLE
New: add episode filter during import

### DIFF
--- a/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.css
+++ b/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.css
@@ -1,3 +1,10 @@
+.filterInput {
+  composes: input from '~Components/Form/TextInput.css';
+
+  flex: 0 0 auto;
+  margin-bottom: 20px;
+}
+
 .footer {
   composes: modalFooter from '~Components/Modal/ModalFooter.css';
 

--- a/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.js
+++ b/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.js
@@ -104,6 +104,7 @@ class SelectEpisodeModalContent extends Component {
       filter,
       selectedState
     } = this.state;
+    const filterEpisodeNumber = parseInt(filter);
 
     const errorMessage = getErrorMessage(error, 'Unable to load episodes');
 
@@ -136,7 +137,7 @@ class SelectEpisodeModalContent extends Component {
 
           <TextInput
             className={styles.filterInput}
-            placeholder="Filter episode titles"
+            placeholder="Filter episode title or number"
             name="filter"
             value={filter}
             autoFocus={true}
@@ -158,17 +159,20 @@ class SelectEpisodeModalContent extends Component {
                 <TableBody>
                   {
                     items.map((item) => {
-                      return item.title.toLowerCase().includes(filter) ? (
-                        <SelectEpisodeRow
-                          key={item.id}
-                          id={item.id}
-                          episodeNumber={item.episodeNumber}
-                          title={item.title}
-                          airDate={item.airDate}
-                          isSelected={selectedState[item.id]}
-                          onSelectedChange={this.onSelectedChange}
-                        />
-                      ) : null;
+                      return item.title.toLowerCase().includes(filter) ||
+                        item.episodeNumber === filterEpisodeNumber ?
+                        (
+                          <SelectEpisodeRow
+                            key={item.id}
+                            id={item.id}
+                            episodeNumber={item.episodeNumber}
+                            title={item.title}
+                            airDate={item.airDate}
+                            isSelected={selectedState[item.id]}
+                            onSelectedChange={this.onSelectedChange}
+                          />
+                        ) :
+                        null;
                     })
                   }
                 </TableBody>

--- a/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.js
+++ b/frontend/src/InteractiveImport/Episode/SelectEpisodeModalContent.js
@@ -5,6 +5,7 @@ import getSelectedIds from 'Utilities/Table/getSelectedIds';
 import selectAll from 'Utilities/Table/selectAll';
 import toggleSelected from 'Utilities/Table/toggleSelected';
 import { kinds } from 'Helpers/Props';
+import TextInput from 'Components/Form/TextInput';
 import Button from 'Components/Link/Button';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -46,6 +47,7 @@ class SelectEpisodeModalContent extends Component {
     this.state = {
       allSelected: false,
       allUnselected: false,
+      filter: '',
       lastToggled: null,
       selectedState: {}
     };
@@ -60,6 +62,10 @@ class SelectEpisodeModalContent extends Component {
 
   //
   // Listeners
+
+  onFilterChange = ({ value }) => {
+    this.setState({ filter: value.toLowerCase() });
+  }
 
   onSelectAllChange = ({ value }) => {
     this.setState(selectAll(this.state.selectedState, value));
@@ -95,6 +101,7 @@ class SelectEpisodeModalContent extends Component {
     const {
       allSelected,
       allUnselected,
+      filter,
       selectedState
     } = this.state;
 
@@ -127,6 +134,15 @@ class SelectEpisodeModalContent extends Component {
               <div>{errorMessage}</div>
           }
 
+          <TextInput
+            className={styles.filterInput}
+            placeholder="Filter episode titles"
+            name="filter"
+            value={filter}
+            autoFocus={true}
+            onChange={this.onFilterChange}
+          />
+
           {
             isPopulated && !!items.length &&
               <Table
@@ -142,7 +158,7 @@ class SelectEpisodeModalContent extends Component {
                 <TableBody>
                   {
                     items.map((item) => {
-                      return (
+                      return item.title.toLowerCase().includes(filter) ? (
                         <SelectEpisodeRow
                           key={item.id}
                           id={item.id}
@@ -152,7 +168,7 @@ class SelectEpisodeModalContent extends Component {
                           isSelected={selectedState[item.id]}
                           onSelectedChange={this.onSelectedChange}
                         />
-                      );
+                      ) : null;
                     })
                   }
                 </TableBody>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This replicates the importer's series name filter in the episode selection modal.

Note I do not have access to a Windows box at the moment, so can't really build and test this, but made sure `yarn build` and `yarn lint` were green. I may have a moment to test with a Windows box this weekend.

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #3862
