### PR TITLE
Fixed: Typo in Lost Connection modal

### DIFF
--- a/frontend/src/App/ConnectionLostModal.js
+++ b/frontend/src/App/ConnectionLostModal.js
@@ -22,7 +22,7 @@ function ConnectionLostModal(props) {
     >
       <ModalContent onModalClose={onModalClose}>
         <ModalHeader>
-          Connnection Lost
+          Connection Lost
         </ModalHeader>
 
         <ModalBody>


### PR DESCRIPTION
Modal header had too many n's in Connection Lost

#### Database Migration
NO

#### Description
Fixing a typo that I noticed today
