### PR TITLE
Added title search capability for Anime Search

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -279,6 +279,21 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
+        public void should_fallback_to_title_for_anime_search()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q", "title" };
+            _capabilities.SupportsAggregateIdSearch = true;
+
+            var results = Subject.GetSearchRequests(_animeSearchCriteria);
+            results.Tiers.Should().Be(1);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().NotContain("q=");
+            page.Url.Query.Should().Contain("title=");
+        }
+
+        [Test]
         public void should_url_encode_title()
         {
             _capabilities.SupportedTvSearchParameters = new[] { "q", "title", "tvdbid", "rid", "season", "ep" };
@@ -295,6 +310,23 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             pageTier2.Url.Query.Should().NotContain("rid=10");
             pageTier2.Url.Query.Should().NotContain("q=");
             pageTier2.Url.Query.Should().Contain("title=Elith%20%26%20Little");
+        }
+
+        [Test]
+        public void should_url_encode_title_for_anime()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q", "title" };
+            _capabilities.SupportsAggregateIdSearch = true;
+
+            _animeSearchCriteria.SceneTitles[0] = "Shinryaku!? Ika Musume";
+
+            var results = Subject.GetSearchRequests(_animeSearchCriteria);
+            results.Tiers.Should().Be(1);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().NotContain("q=");
+            page.Url.Query.Should().Contain("title=Shinryaku%21%3F%20Ika%20Musume");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -34,6 +34,17 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
         }
 
+        private bool SupportsTitleSearch
+        {
+            get
+            {
+                var capabilities = _capabilitiesProvider.GetCapabilities(Settings);
+
+                return capabilities.SupportedSearchParameters != null &&
+                       capabilities.SupportedSearchParameters.Contains("title");
+            }
+        }
+
         private bool SupportsTvSearch
         {
             get
@@ -197,7 +208,17 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            if (SupportsSearch)
+            if (SupportsTitleSearch)
+            {
+                foreach (var searchTerm in searchCriteria.SceneTitles)
+                {
+                    pageableRequests.Add(GetPagedRequests(MaxPages, Settings.AnimeCategories, "search",
+                        string.Format("&title={0}+{1:00}",
+                        Uri.EscapeDataString(searchTerm),
+                        searchCriteria.AbsoluteEpisodeNumber)));
+                }
+            }
+            else if (SupportsSearch)
             {
                 foreach (var queryTitle in searchCriteria.QueryTitles)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pull request adds the `title` search capability for Anime Search. See https://github.com/Jackett/Jackett/issues/8246 for the full discussion.

Currently, `title` search capability (no sanitization applied to name) is only made available to TV Search, but I see the need for this to be made available to anime as well, especially when anime uses symbols to denote different types of seasons/series. For instance, `Shinryaku!? Ika Musume` and `Shinryaku! Ika Musume` are each different seasons, but there's no way to distinguish this difference when the resulting query looks the same after sanitization.

If there's a way to distinguish between a specific type of series, Jackett could be smarter in returning results which should reduce the overhead that Sonarr has to take. For example, using Animebytes on Jackett, I could reduce the number of irrelevant results and the time for searching will be reduced on Sonarr's end.

#### Todos
- [x] Tests

#### Issues Fixed or Closed by this PR
None
