### PR TITLE
Fixed: Prevent bulk add failure on single validation error for Lists

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddSeriesService>()
-                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t=>t.Count == 0)));
+                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t=>t.Count == 0), It.IsAny<bool>()));
         }
 
         [TestCase(MonitorTypes.None, false)]
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddSeriesService>()
-                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 1 && t.First().Monitored == expectedSeriesMonitored)));
+                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 1 && t.First().Monitored == expectedSeriesMonitored), It.IsAny<bool>()));
         }
 
         [Test]
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             Subject.Execute(new ImportListSyncCommand());
 
             Mocker.GetMock<IAddSeriesService>()
-                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 0)));
+                  .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 0), It.IsAny<bool>()));
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.ImportLists
                 }
             }
 
-            _addSeriesService.AddSeries(seriesToAdd);
+            _addSeriesService.AddSeries(seriesToAdd, true);
 
             var message = string.Format("Import List Sync Completed. Items found: {0}, Series added: {1}", reports.Count, seriesToAdd.Count);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prevents a single validation error from killing the entire list import. 

#### Todos
- [ ] Tests

- Fixes #3959 