### PR TITLE
Fix Parser False Positive Group Matches

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -36,8 +36,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264-RlsGroup","RlsGroup")]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264-RlsGroup","RlsGroup")]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
-        
-       //[TestCase("", "")]
+        //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -32,11 +32,11 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S01E05.The-Aniversary.WEBDL-1080p.mkv", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.HDTV-1080p.mkv", null)]
         [TestCase("Shameless US (2010) S04 (1080p BDRip x265 10bit DTS-HD MA 5 1 - WEM)[TAoE]",null)]
-        [TestCase("The.Expanse.S03E04.2160p.Amazon.WEBRip.DTS-HD.MA.5.1.x264-TrollUHD","TrollUHD")]
-        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264-RlsGroup","RlsGroup")]
-        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264-RlsGroup","RlsGroup")]
-        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
-        [TestCase("SomeShow.S20E13.1080p.Blu-Ray.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
+        [TestCase("The.Expanse.S03E04.2160p.Amazon.WEBRip.DTS-HD.MA.5.1.x264",null)]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264",null)]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264",null)]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-ES.5.1.x264",null)]
+        [TestCase("SomeShow.S20E13.1080p.Blu-Ray.DTS-ES.5.1.x264",null)]
         //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -32,7 +32,12 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S01E05.The-Aniversary.WEBDL-1080p.mkv", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.HDTV-1080p.mkv", null)]
         [TestCase("Shameless US (2010) S04 (1080p BDRip x265 10bit DTS-HD MA 5 1 - WEM)[TAoE]",null)]
-        //[TestCase("", "")]
+        [TestCase("The.Expanse.S03E04.2160p.Amazon.WEBRip.DTS-HD.MA.5.1.x264-TrollUHD","TrollUHD")]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264-RlsGroup","RlsGroup")]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264-RlsGroup","RlsGroup")]
+        [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
+        
+       //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264-RlsGroup","RlsGroup")]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264-RlsGroup","RlsGroup")]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
+        [TestCase("SomeShow.S20E13.1080p.Blu-Ray.DTS-ES.5.1.x264-RlsGroup","RlsGroup")]
         //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -31,6 +31,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Black Monday S01 E01-E02 1080p AMZN WEBRip DDP5.1 x264 monkee", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.WEBDL-1080p.mkv", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.HDTV-1080p.mkv", null)]
+        [TestCase("Shameless US (2010) S04 (1080p BDRip x265 10bit DTS-HD MA 5 1 - WEM)[TAoE]",null)]
         //[TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -384,7 +384,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?!.+?(?:480p|720p|1080p|2160p)))(?<!.*?WEB-DL|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?!.+?(?:480p|720p|1080p|2160p)))(?<!.*?WEB-DL|Blu-Ray|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -384,7 +384,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?!.+?(?:480p|720p|1080p|2160p)))(?<!.*?WEB-DL|480p|720p|1080p|2160p)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?!.+?(?:480p|720p|1080p|2160p)))(?<!.*?WEB-DL|480p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix: Add various DTS- audio formats to exclusion so parser does not detect it as a group
Fix: Add Blu-Ray to exclusion so parser does not detect it as a group

#### Todos
- [x] Tests
- [ ] Documentation

#### Issues Fixed or Closed by this PR

* #3984 


Regex is the bane of my existence, but I think I did this right...testing indicates it did not pick up the -HD of DTS-HD as expected.

It may make sense to split the audio into it's own group?