### PR TITLE
Improve use of All() and speedup Unmapped Folder matching

### DIFF
--- a/src/NzbDrone.Core.Test/DiskSpace/DiskSpaceServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/DiskSpace/DiskSpaceServiceFixture.cs
@@ -47,11 +47,11 @@ namespace NzbDrone.Core.Test.DiskSpace
             GivenSeries();
         }
 
-        private void GivenSeries(params Series[] series)
+        private void GivenSeries(params string[] seriesPaths)
         {
             Mocker.GetMock<ISeriesService>()
-                  .Setup(v => v.GetAllSeries())
-                  .Returns(series.ToList());
+                  .Setup(v => v.GetAllSeriesPaths())
+                  .Returns(seriesPaths.ToList());
         }
 
         private void GivenExistingFolder(string folder)
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Test.DiskSpace
         [Test]
         public void should_check_diskspace_for_series_folders()
         {
-            GivenSeries(new Series { Path = _seriesFolder });
+            GivenSeries(_seriesFolder);
 
             GivenExistingFolder(_seriesFolder);
 
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Test.DiskSpace
         [Test]
         public void should_check_diskspace_for_same_root_folder_only_once()
         {
-            GivenSeries(new Series { Path = _seriesFolder }, new Series { Path = _seriesFolder2 });
+            GivenSeries(_seriesFolder, _seriesFolder2);
 
             GivenExistingFolder(_seriesFolder);
             GivenExistingFolder(_seriesFolder2);
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.DiskSpace
         [Test]
         public void should_not_check_diskspace_for_missing_series_folders()
         {
-            GivenSeries(new Series { Path = _seriesFolder });
+            GivenSeries(_seriesFolder);
 
             var freeSpace = Subject.GetFreeSpace();
 

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/RootFolderCheckFixture.cs
@@ -20,8 +20,8 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
                                         .ToList();
 
             Mocker.GetMock<ISeriesService>()
-                  .Setup(s => s.GetAllSeries())
-                  .Returns(series);
+                  .Setup(s => s.GetAllSeriesPaths())
+                  .Returns(series.Select(s => s.Path).ToList());
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetParentFolder(series.First().Path))
@@ -36,8 +36,8 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         public void should_not_return_error_when_no_series()
         {
             Mocker.GetMock<ISeriesService>()
-                  .Setup(s => s.GetAllSeries())
-                  .Returns(new List<Series>());
+                  .Setup(s => s.GetAllSeriesPaths())
+                  .Returns(new List<string>());
 
             Subject.Check().ShouldBeOk();
         }

--- a/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/RootFolderTests/RootFolderServiceFixture.cs
@@ -44,6 +44,10 @@ namespace NzbDrone.Core.Test.RootFolderTests
         [TestCase("//server//folder")]
         public void should_be_able_to_add_root_dir(string path)
         {
+            Mocker.GetMock<ISeriesRepository>()
+                  .Setup(s => s.AllSeriesPaths())
+                  .Returns(new List<string>());
+
             var root = new RootFolder { Path = path.AsOsAgnostic() };
 
             Subject.Add(root);
@@ -124,9 +128,9 @@ namespace NzbDrone.Core.Test.RootFolderTests
                   .Setup(s => s.Get(It.IsAny<int>()))
                   .Returns(rootFolder);
 
-            Mocker.GetMock<ISeriesService>()
-                  .Setup(s => s.GetAllSeries())
-                  .Returns(new List<Series>());
+            Mocker.GetMock<ISeriesRepository>()
+                  .Setup(s => s.AllSeriesPaths())
+                  .Returns(new List<string>());
 
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.GetDirectories(rootFolder.Path))

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -42,9 +42,9 @@ namespace NzbDrone.Core.DiskSpace
 
         private IEnumerable<string> GetSeriesRootPaths()
         {
-            return _seriesService.GetAllSeries()
-                .Where(s => _diskProvider.FolderExists(s.Path))
-                .Select(s => _diskProvider.GetPathRoot(s.Path))
+            return _seriesService.GetAllSeriesPaths()
+                .Where(s => _diskProvider.FolderExists(s))
+                .Select(s => _diskProvider.GetPathRoot(s))
                 .Distinct();
         }
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -19,8 +19,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
         public override HealthCheck Check()
         {
             // Not best for optimization but due to possible symlinks and junctions, we get mounts based on series path so internals can handle mount resolution.
-            var mounts = _seriesService.GetAllSeries()
-                                       .Select(series => _diskProvider.GetMount(series.Path))
+            var mounts = _seriesService.GetAllSeriesPaths()
+                                       .Select(s => _diskProvider.GetMount(s))
                                        .Where(m => m != null && m.MountOptions != null && m.MountOptions.IsReadOnly)
                                        .DistinctBy(m => m.RootDirectory)
                                        .ToList();

--- a/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RootFolderCheck.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Linq;
+using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.RootFolders;
@@ -26,9 +28,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
-            var rootFolders = _seriesService.GetAllSeries()
-                                                           .Select(s => _rootFolderService.GetBestRootFolderPath(s.Path))
-                                                           .Distinct();
+            var rootFolders = _seriesService.GetAllSeriesPaths().Select(s => _rootFolderService.GetBestRootFolderPath(s)).Distinct();
 
             var missingRootFolders = rootFolders.Where(s => !_diskProvider.FolderExists(s))
                                                           .ToList();

--- a/src/NzbDrone.Core/Tv/SeriesRepository.cs
+++ b/src/NzbDrone.Core/Tv/SeriesRepository.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Tv
         Series FindByTvdbId(int tvdbId);
         Series FindByTvRageId(int tvRageId);
         Series FindByPath(string path);
+        List<string> AllSeriesPaths();
     }
 
     public class SeriesRepository : BasicRepository<Series>, ISeriesRepository
@@ -76,6 +77,13 @@ namespace NzbDrone.Core.Tv
         {
             return Query.Where(s => s.Path == path)
                         .FirstOrDefault();
+        }
+
+        public List<string> AllSeriesPaths()
+        {
+            var mapper = _database.GetDataMapper();
+
+            return mapper.Query<string>("SELECT Path from Series");
         }
 
         private Series ReturnSingleSeriesOrThrow(List<Series> series)

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Tv
         Series FindByPath(string path);
         void DeleteSeries(int seriesId, bool deleteFiles, bool addImportListExclusion);
         List<Series> GetAllSeries();
+        List<string> GetAllSeriesPaths();
         List<Series> AllForTag(int tagId);
         Series UpdateSeries(Series series, bool updateEpisodesToMatchSeason = true, bool publishUpdatedEvent = true);
         List<Series> UpdateSeries(List<Series> series, bool useExistingRelativeFolder);
@@ -155,6 +156,11 @@ namespace NzbDrone.Core.Tv
         public List<Series> GetAllSeries()
         {
             return _seriesRepository.All().ToList();
+        }
+
+        public List<string> GetAllSeriesPaths()
+        {
+            return _seriesRepository.AllSeriesPaths();
         }
 
         public List<Series> AllForTag(int tagId)

--- a/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Validation.Paths
         {
             if (context.PropertyValue == null) return true;
 
-            return !_seriesService.GetAllSeries().Any(s => context.PropertyValue.ToString().IsParentPath(s.Path));
+            return !_seriesService.GetAllSeriesPaths().Any(s => context.PropertyValue.ToString().IsParentPath(s));
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

- Add `AllSeriesPaths` Method
- Use `AllSeriesPaths` in lieu of `All()` in HealthChecks, Diskspace, RootFolderService
- Only call All() (AllSeriesPaths) once for `AllWithUnmappedFolders` instead of for each folder

#### Todos
- [x] Tests

