### PR TITLE
New: Show rejection message if media info detects the file is an executable

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -211,7 +211,8 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
                       It.IsAny<string>(),
-                      It.IsAny<bool>()))
+                      It.IsAny<bool>(),
+                      null))
                   .Returns(DetectSampleResult.Sample);
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
@@ -281,7 +282,8 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
                       It.IsAny<string>(),
-                      It.IsAny<bool>()))
+                      It.IsAny<bool>(),
+                      null))
                   .Returns(DetectSampleResult.Sample);
 
             Mocker.GetMock<IDiskProvider>()
@@ -390,7 +392,8 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<IDetectSample>()
                   .Setup(s => s.IsSample(It.IsAny<Series>(),
                       It.IsAny<string>(),
-                      It.IsAny<bool>()))
+                      It.IsAny<bool>(),
+                      null))
                   .Returns(DetectSampleResult.Sample);
 
             Mocker.GetMock<IDiskProvider>()

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportDecisionMakerFixture.cs
@@ -15,6 +15,7 @@ using FizzWare.NBuilder;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation;
+using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.Profiles.Languages;
 
@@ -70,7 +71,8 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
                 Quality = _quality,
                 Language = Language.Spanish,
                 Episodes = new List<Episode> { new Episode() },
-                Path = @"C:\Test\Unsorted\The.Office.S03E115.DVDRip.Spanish.XviD-OSiTV.avi"
+                Path = @"C:\Test\Unsorted\The.Office.S03E115.DVDRip.Spanish.XviD-OSiTV.avi",
+                MediaInfo = new MediaInfoModel()
             };
 
             GivenVideoFiles(new List<string> { @"C:\Test\Unsorted\The.Office.S03E115.DVDRip.Spanish.XviD-OSiTV.avi".AsOsAgnostic() });
@@ -184,6 +186,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
             ExceptionVerification.ExpectedErrors(3);
         }
 
+        [Test]
         public void should_not_throw_if_episodes_are_not_found()
         {
             GivenSpecifications(_pass1);

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -26,14 +26,6 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         }
 
         [Test]
-        public void get_runtime()
-        {
-            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", "Media", "H264_sample.mp4");
-
-            Subject.GetRunTime(path).Value.Seconds.Should().Be(10);
-        }
-
-        [Test]
         public void get_info()
         {
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", "Media", "H264_sample.mp4");
@@ -68,6 +60,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             info.VideoHdrFormat.Should().BeEmpty();
             info.VideoHdrFormatCompatibility.Should().BeEmpty();
 
+            info.Format.Should().Be("MPEG-4");
         }
 
         [Test]

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSampleResult.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSampleResult.cs
@@ -4,6 +4,7 @@
     {
         Indeterminate,
         Sample,
-        NotSample
+        NotSample,
+        Executable
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -83,8 +83,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     FolderEpisodeInfo = folderInfo,
                     Path = file,
                     SceneSource = sceneSource,
-                    ExistingFile = series.Path.IsParentPath(file),
-                    OtherVideoFiles = nonSampleVideoFileCount > 1
+                    ExistingFile = series.Path.IsParentPath(file)
                 };
 
                 _augmentMediaInfo.Augment(localEpisode);
@@ -95,6 +94,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             // If not importing from a scene source (series folder for example), then assume all files are not samples
             // to avoid using media info on every file needlessly (especially if Analyse Media Files is disabled).
             var otherFiles = sceneSource && GetNonSampleVideoFileCount(localEpisodes, series, downloadClientItemInfo, folderInfo) > 1;
+
+            // Set 'OtherVideoFiles' to true for each episode if there are other files.
+            localEpisodes.ForEach(l => l.OtherVideoFiles = otherFiles);
 
             decisions.AddRange(localEpisodes.Select(l => GetDecision(l, downloadClientItem, otherFiles)));
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -405,7 +405,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 }
 
                 localEpisode = _augmentMediaInfo.Augment(localEpisode);
-                localEpisode = _aggregationService.Augment(localEpisode, trackedDownload?.DownloadItem, false);
+                localEpisode = _aggregationService.Augment(localEpisode, trackedDownload?.DownloadItem);
 
                 // Apply the user-chosen values.
                 localEpisode.Series = series;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation;
+using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
@@ -36,6 +37,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         private readonly IEpisodeService _episodeService;
         private readonly IImportApprovedEpisodes _importApprovedEpisodes;
         private readonly IAggregationService _aggregationService;
+        private readonly IAugmentMediaInfo _augmentMediaInfo;
         private readonly ITrackedDownloadService _trackedDownloadService;
         private readonly IDownloadedEpisodesImportService _downloadedEpisodesImportService;
         private readonly IEventAggregator _eventAggregator;
@@ -48,6 +50,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                                    ISeriesService seriesService,
                                    IEpisodeService episodeService,
                                    IAggregationService aggregationService,
+                                   IAugmentMediaInfo augmentMediaInfo,
                                    IImportApprovedEpisodes importApprovedEpisodes,
                                    ITrackedDownloadService trackedDownloadService,
                                    IDownloadedEpisodesImportService downloadedEpisodesImportService,
@@ -61,6 +64,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             _seriesService = seriesService;
             _episodeService = episodeService;
             _aggregationService = aggregationService;
+            _augmentMediaInfo = augmentMediaInfo;
             _importApprovedEpisodes = importApprovedEpisodes;
             _trackedDownloadService = trackedDownloadService;
             _downloadedEpisodesImportService = downloadedEpisodesImportService;
@@ -400,7 +404,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                     localEpisode.SceneSource = !existingFile;
                 }
 
-                localEpisode = _aggregationService.Augment(localEpisode, trackedDownload?.DownloadItem);
+                localEpisode = _augmentMediaInfo.Augment(localEpisode);
+                localEpisode = _aggregationService.Augment(localEpisode, trackedDownload?.DownloadItem, false);
 
                 // Apply the user-chosen values.
                 localEpisode.Series = series;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
@@ -29,14 +29,19 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
             try
             {
-                var sample = _detectSample.IsSample(localEpisode.Series, localEpisode.Path, localEpisode.IsSpecial);
+                var sample = _detectSample.IsSample(localEpisode.Series, localEpisode.Path, localEpisode.IsSpecial, localEpisode.MediaInfo);
 
                 if (sample == DetectSampleResult.Sample)
                 {
                     return Decision.Reject("Sample");
                 }
 
-                else if (sample == DetectSampleResult.Indeterminate)
+                if (sample == DetectSampleResult.Executable)
+                {
+                    return Decision.Reject("Executable file instead of video file");
+                }
+
+                if (sample == DetectSampleResult.Indeterminate)
                 {
                     return Decision.Reject("Unable to determine if file is a sample");
                 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/AugmentMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/AugmentMediaInfo.cs
@@ -1,0 +1,32 @@
+﻿using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.MediaFiles.MediaInfo
+{
+    public interface IAugmentMediaInfo
+    {
+        LocalEpisode Augment(LocalEpisode localEpisode);
+    }
+
+    public class AugmentMediaInfo
+    {
+        private readonly IConfigService _configService;
+        private readonly IVideoFileInfoReader _videoFileInfoReader;
+
+        public AugmentMediaInfo(IConfigService configService, IVideoFileInfoReader videoFileInfoReader)
+        {
+            _configService = configService;
+            _videoFileInfoReader = videoFileInfoReader;
+        }
+
+        public LocalEpisode Augment(LocalEpisode localEpisode)
+        {
+            if (!localEpisode.ExistingFile || _configService.EnableMediaInfo)
+            {
+                localEpisode.MediaInfo = _videoFileInfoReader.GetMediaInfo(localEpisode.Path);
+            }
+
+            return localEpisode;
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/AugmentMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/AugmentMediaInfo.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         LocalEpisode Augment(LocalEpisode localEpisode);
     }
 
-    public class AugmentMediaInfo
+    public class AugmentMediaInfo : IAugmentMediaInfo
     {
         private readonly IConfigService _configService;
         private readonly IVideoFileInfoReader _videoFileInfoReader;

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Globalization;
-using System.Linq;
-using Newtonsoft.Json;
-using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -43,5 +39,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string Subtitles { get; set; }
         public string ScanType { get; set; }
         public int SchemaRevision { get; set; }
+        public string Format { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -10,7 +10,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public interface IVideoFileInfoReader
     {
         MediaInfoModel GetMediaInfo(string filename);
-        TimeSpan? GetRunTime(string filename);
     }
 
     public class VideoFileInfoReader : IVideoFileInfoReader
@@ -26,7 +25,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             _diskProvider = diskProvider;
             _logger = logger;
         }
-
 
         public MediaInfoModel GetMediaInfo(string filename)
         {
@@ -156,6 +154,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     string videoProfile = mediaInfo.Get(StreamKind.Video, 0, "Format_Profile").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
                     string audioProfile = mediaInfo.Get(StreamKind.Audio, 0, "Format_Profile").Split(new string[] { " /" }, StringSplitOptions.None)[0].Trim();
 
+                    var format = mediaInfo.Get(StreamKind.General, 0, "Format").Split(new string[] { "/" }, StringSplitOptions.None)[0].Trim();
+
                     var mediaInfoModel = new MediaInfoModel
                     {
                         ContainerFormat = mediaInfo.Get(StreamKind.General, 0, "Format"),
@@ -189,7 +189,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                         AudioLanguages = audioLanguages,
                         Subtitles = subtitles,
                         ScanType = scanType,
-                        SchemaRevision = CURRENT_MEDIA_INFO_SCHEMA_REVISION
+                        SchemaRevision = CURRENT_MEDIA_INFO_SCHEMA_REVISION,
+                        Format = format
                     };
 
                     return mediaInfoModel;
@@ -213,13 +214,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
 
             return null;
-        }
-
-        public TimeSpan? GetRunTime(string filename)
-        {
-            var info = GetMediaInfo(filename);
-
-            return info?.RunTime;
         }
 
         private TimeSpan GetBestRuntime(int audio, int video, int general)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Uses the format from media info (newly fetched) to determine if the file is an executable and rejects imports with an appropriate message. Also cleans up fetching processing of media info so it's not done up to 3 times, files left over after importing may get processed a second time, but previously it was done twice for every file processed during import.

#### Issues Fixed or Closed by this PR

* Closes #3331
