### PR TITLE
FIX: Updated Import for Discord Notifications to use 'Success' Colour

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Url = $"http://thetvdb.com/?tab=series&id={series.TvdbId}",
                 Description = isUpgrade ? "Episode Upgraded" : "Episode Imported",
                 Title = GetTitle(series, episodes),
-                Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Standard,
+                Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Success,
                 Fields = new List<DiscordField>(),
                 Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
             };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updated Discord.OnDownload to use Success Colour (green)

#### Issues Fixed or Closed by this PR
#4036 
* 
