### PR TITLE
New: Discord notification upgrade colour

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
@@ -6,6 +6,6 @@ namespace NzbDrone.Core.Notifications.Discord
         Success = 2605644,
         Warning = 16753920,
         Standard = 16761392,
-        Upgrade = 7105644
+        Upgrade = 16711833
     }
 }

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
@@ -6,6 +6,6 @@ namespace NzbDrone.Core.Notifications.Discord
         Success = 2605644,
         Warning = 16753920,
         Standard = 16761392,
-        Upgrade = 2110720
+        Upgrade = 4089856
     }
 }

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordColors.cs
@@ -6,6 +6,6 @@ namespace NzbDrone.Core.Notifications.Discord
         Success = 2605644,
         Warning = 16753920,
         Standard = 16761392,
-        Upgrade = 16711833
+        Upgrade = 2110720
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Made the upgrade notification colour to be more clear than the grey that blends in with Discord's background

#### Todos
- [ ] Tests
- [ ] Documentation


#### Issues Fixed or Closed by this PR

* #4044 
