### PR TITLE
Qbittorrent - use content path property instead of save path

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -139,7 +139,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     RemainingSize = (long)(torrent.Size * (1.0 - torrent.Progress)),
                     RemainingTime = GetRemainingTime(torrent),
                     SeedRatio = torrent.Ratio
-                    //OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(torrent.SavePath)),
                 };
 
                 // Avoid removing torrents that haven't reached the global max ratio.

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
@@ -24,6 +24,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [JsonProperty(PropertyName = "save_path")]
         public string SavePath { get; set; } // Torrent save path
 
+        [JsonProperty(PropertyName = "content_path")]
+        public string ContentPath { get; set; } // Content path
+
         public float Ratio { get; set; } // Torrent share ratio
 
         [JsonProperty(PropertyName = "ratio_limit")] // Per torrent seeding ratio limit (-2 = use global, -1 = unlimited)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since qbittorent 4.3.0.1 the save path is not consistent anymore, with new release of qbittorent (not released yet, but is already merged on master) (https://github.com/qbittorrent/qBittorrent/issues/13389#issuecomment-716126144 ) we have a new content_path property that is exactly what we need. This pull request changes to use this new property and it still has the fallback to the old one. Since it is a new property in a method that we already call, just a check to see if it is null should be sufficient to be backwards compatible


#### Issues Fixed or Closed by this PR

* #3968 
