### PR TITLE
Update indexer category parameters for the other nyaa

### DIFF
--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
         public NyaaSettings()
         {
             BaseUrl = "";
-            AdditionalParameters = "&cats=1_37&filter=1";
+            AdditionalParameters = "&cats=1_0&filter=1";
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is an error on version 2.0.0.5344 with nyaa indexers

The current settings cause an error 400 bad request like so : 

`20-11-14 10:12:50.3|Warn|HttpClient|HTTP Error - Res: [GET] https://nyaa.si/?page=rss&cats=1_37&filter=1&term=One+Piece+379: 400.BadRequest
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>400 Bad Request</title>
<h1>Bad Request</h1>
<p>The browser (or proxy) sent a request that this server could not understand.</p>

20-11-14 10:12:50.6|Warn|Nyaa|Nyaa HTTP request failed: [400:BadRequest] [GET] at [https://nyaa.si/?page=rss&cats=1_37&filter=1&term=One+Piece+379]
`

https://nyaa.si/?f=1&c=1_37&term=jujutsu

Updating it to category : 1_0 fix the problem

https://nyaa.si/?f=1&c=1_0&term=jujutsu

#### Issues Fixed by this PR

* 
