### PR TITLE
New: Sorting Series List/Mass Editor by Language Profile and Tags

### DIFF
--- a/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.js
+++ b/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.js
@@ -144,6 +144,15 @@ function SeriesIndexSortMenu(props) {
         >
           Size on Disk
         </SortMenuItem>
+
+        <SortMenuItem
+          name="tags"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          Tags
+        </SortMenuItem>
       </MenuContent>
     </SortMenu>
   );

--- a/frontend/src/Store/Actions/seriesEditorActions.js
+++ b/frontend/src/Store/Actions/seriesEditorActions.js
@@ -85,7 +85,7 @@ export const defaultState = {
     {
       name: 'tags',
       label: 'Tags',
-      isSortable: false,
+      isSortable: true,
       isVisible: true
     }
   ],

--- a/frontend/src/Store/Actions/seriesEditorActions.js
+++ b/frontend/src/Store/Actions/seriesEditorActions.js
@@ -55,7 +55,7 @@ export const defaultState = {
     {
       name: 'languageProfileId',
       label: 'Language Profile',
-      isSortable: false,
+      isSortable: true,
       isVisible: true
     },
     {

--- a/frontend/src/Store/Actions/seriesIndexActions.js
+++ b/frontend/src/Store/Actions/seriesIndexActions.js
@@ -171,7 +171,7 @@ export const defaultState = {
     {
       name: 'tags',
       label: 'Tags',
-      isSortable: false,
+      isSortable: true,
       isVisible: false
     },
     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Enable sorting by Language Profile and Tags within the Mass editor page

This looks like this when sorted:
##### Language Ascending
![msedge_1RfQGfi0pZ](https://user-images.githubusercontent.com/19610103/101412165-07cf8a80-38da-11eb-86f9-ab0492537a26.png)

##### Language Descending
![msedge_lmKgzCp15a](https://user-images.githubusercontent.com/19610103/101412146-fd14f580-38d9-11eb-92d9-c783550925cb.png)

##### Tags Ascending 
No Tags comes first
![msedge_iIVkt0T40c](https://user-images.githubusercontent.com/19610103/101412245-2afa3a00-38da-11eb-97da-00cca6955585.png)

##### Tags Descending 
No Tags comes last
![msedge_4JKVoeeaUn](https://user-images.githubusercontent.com/19610103/101412270-35b4cf00-38da-11eb-95ef-b3e3b5f2a4c4.png)


#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* #3854 
