### PR TITLE
Fixed: '/series' URL Base breaking UI navigation

### DIFF
--- a/frontend/src/Components/Link/Link.js
+++ b/frontend/src/Components/Link/Link.js
@@ -47,10 +47,6 @@ class Link extends Component {
         el = 'a';
         linkProps.href = to;
         linkProps.target = target || '_self';
-      } else if (to.startsWith(`${window.Sonarr.urlBase}/`)) {
-        el = RouterLink;
-        linkProps.to = to;
-        linkProps.target = target;
       } else {
         el = RouterLink;
         linkProps.to = `${window.Sonarr.urlBase}/${to.replace(/^\//, '')}`;

--- a/frontend/src/Components/Page/Header/PageHeader.js
+++ b/frontend/src/Components/Page/Header/PageHeader.js
@@ -53,7 +53,7 @@ class PageHeader extends Component {
         <div className={styles.logoContainer}>
           <Link
             className={styles.logoLink}
-            to={`${window.Sonarr.urlBase}/`}
+            to={'/'}
           >
             <img
               className={styles.logo}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently if the URL base matches the root path of an existing Sonarr page this causes issues in with opening said page (reported about series assumed for all other similar root paths). 

I have tested each link on each page manually and this appears to be working - the API has not been tested from outside of the Sonarr webpage however this should not cause any issues due to the webpage working. 

The logo in the Page Header was the only link that seemed to cause an issue; in testing setting the "to" value to be '/' still works as expected. 

#### Issues Fixed or Closed by this PR

* #4148 
