### PR TITLE
Fixed: Language parsing with space-delimited releases

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -19,6 +19,11 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot.eng.sub")]
         [TestCase("2 Broke Girls - S01E01 - Pilot.English.sub")]
         [TestCase("2 Broke Girls - S01E01 - Pilot.english.sub")]
+        [TestCase("The.Spanish.Princess.S02E08.Peace.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
+        [TestCase("The Spanish Princess S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb")]
+        [TestCase("The.Spanish.Princess.S02E07.1080p.WEB.H264-GGWP")]
+        [TestCase("The.Spanish.Princess.S02E02.1080p.WEB.H264-CAKES")]
+        [TestCase("The.Spanish.Princess.S02E06.Field.of.Cloth.of.Gold.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
         public void should_parse_language_english(string postTitle)
         {
             var result = LanguageParser.ParseLanguage(postTitle);
@@ -223,6 +228,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Russian.Puppets.S01E07.Cold.Action.HDTV.XviD-Droned")]
         [TestCase("Russian.Puppets.S01E07E08.Cold.Action.HDTV.XviD-Droned")]
         [TestCase("Russian.Puppets.S01.1080p.WEBRip.DDP5.1.x264-Drone")]
+        [TestCase("The.Spanish.Princess.S02E08.Peace.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
+        [TestCase("The Spanish Princess S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb")]
         public void should_not_parse_series_or_episode_title(string postTitle)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -19,9 +19,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("2 Broke Girls - S01E01 - Pilot.eng.sub")]
         [TestCase("2 Broke Girls - S01E01 - Pilot.English.sub")]
         [TestCase("2 Broke Girls - S01E01 - Pilot.english.sub")]
-        [TestCase("The.Spanish.Princess.S02E08.Peace.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
         [TestCase("The Spanish Princess S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb")]
-        [TestCase("The.Spanish.Princess.S02E07.1080p.WEB.H264-GGWP")]
         [TestCase("The.Spanish.Princess.S02E02.1080p.WEB.H264-CAKES")]
         [TestCase("The.Spanish.Princess.S02E06.Field.of.Cloth.of.Gold.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
         public void should_parse_language_english(string postTitle)

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly RegexReplace[] CleanSeriesTitleRegex = new[]
             {
-                new RegexReplace(@".*?\.(S\d{2}(?:E\d{2,4})*\..*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+                new RegexReplace(@".*?(?:\.|\s)(S\d{2}(?:E\d{2,4})*(?:\.|\s).*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             };
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly RegexReplace[] CleanSeriesTitleRegex = new[]
             {
-                new RegexReplace(@".*?(?:\.|\s)(S\d{2}(?:E\d{2,4})*(?:\.|\s).*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+                new RegexReplace(@".*?[_. ](S\d{2}(?:E\d{2,4})*[_. ].*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             };
 
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes a missed case for parsing a series' language when spaces are present in the torrent name. My case was `The Spanish Princess` where the torrent name was `The Spanish Princess S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb`

I added the relevant test cases where needed and all appear to pass. However, I'm not sure the greater impact of testing with an or for periods or spaces, but this still works exactly the same.

**Before**
![image](https://user-images.githubusercontent.com/8946502/102168526-7f0dab80-3ee4-11eb-995c-e22ee00fb2af.png)

**After**
![image](https://user-images.githubusercontent.com/8946502/102162990-58e50d00-3ede-11eb-86a5-bb7301cfc860.png)

Happy to review as needed.

#### Issues Fixed or Closed by this PR

* Closes #4056
