### PR TITLE
Only allow one of the two checkboxes around empty folders to be checked at time.

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.js
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.js
@@ -99,6 +99,7 @@ class MediaManagement extends Component {
 
                         <FormInputGroup
                           type={inputTypes.CHECK}
+                          isDisabled={settings.deleteEmptyFolders.value && !settings.createEmptySeriesFolders.value}
                           name="createEmptySeriesFolders"
                           helpText="Create missing series folders during disk scan"
                           onChange={onInputChange}
@@ -115,6 +116,7 @@ class MediaManagement extends Component {
 
                         <FormInputGroup
                           type={inputTypes.CHECK}
+                          isDisabled={settings.createEmptySeriesFolders.value && !settings.deleteEmptyFolders.value}
                           name="deleteEmptyFolders"
                           helpText="Delete empty series and season folders during disk scan and when episode files are deleted"
                           onChange={onInputChange}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Both "Create empty series folders" and "Delete empty folders" can be active at the same time - this will- disable them both from being active. 

![image](https://user-images.githubusercontent.com/19610103/103099861-0b684e80-4608-11eb-8f42-aa678f099bc6.png)


