### PR TITLE
New: Show number of files as tooltip over size on disk

### DIFF
--- a/frontend/src/Components/Tooltip/Tooltip.css
+++ b/frontend/src/Components/Tooltip/Tooltip.css
@@ -14,7 +14,7 @@
   &.inverse {
     background-color: $themeDarkColor;
     box-shadow: 0 5px 10px $popoverShadowInverseColor;
-    color: $white
+    color: $white;
   }
 }
 

--- a/frontend/src/Components/Tooltip/Tooltip.css
+++ b/frontend/src/Components/Tooltip/Tooltip.css
@@ -14,6 +14,7 @@
   &.inverse {
     background-color: $themeDarkColor;
     box-shadow: 0 5px 10px $popoverShadowInverseColor;
+    color: $white
   }
 }
 

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -121,6 +121,7 @@
 
 .path,
 .sizeOnDisk,
+.fileCountMessage,
 .qualityProfileName,
 .network,
 .links,

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -121,8 +121,10 @@
 
 .fileCountMessage {
   font-weight: 300;
-  font-size: 12px;
-  color: $iconButtonHoverLightColor;
+  font-size: 15px;
+  color: #e1e2e3;
+  white-space: nowrap;
+  padding: 5px;
 }
 
 .path,

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -119,9 +119,14 @@
   margin: 5px 10px 5px 0;
 }
 
+.fileCountMessage {
+  font-weight: 300;
+  font-size: 12px;
+  color: $iconButtonHoverLightColor;
+}
+
 .path,
 .sizeOnDisk,
-.fileCountMessage,
 .qualityProfileName,
 .network,
 .links,

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -120,11 +120,10 @@
 }
 
 .fileCountMessage {
+  padding: 5px;
+  white-space: nowrap;
   font-weight: 300;
   font-size: 15px;
-  color: #e1e2e3;
-  white-space: nowrap;
-  padding: 5px;
 }
 
 .path,

--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -451,7 +451,7 @@ class SeriesDetails extends Component {
                       </Label>
                     }
                     tooltip={
-                      <span className={styles.fileCountMessage}>
+                      <span>
                         {episodeFilesCountMessage}
                       </span>
                     }

--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -434,7 +434,6 @@ class SeriesDetails extends Component {
 
                   <Label
                     className={styles.detailsLabel}
-                    title={episodeFilesCountMessage}
                     size={sizes.LARGE}
                   >
                     <Icon
@@ -446,6 +445,20 @@ class SeriesDetails extends Component {
                       {
                         formatBytes(sizeOnDisk || 0)
                       }
+                    </span>
+                  </Label>
+
+                  <Label
+                    className={styles.detailsLabel}
+                    size={sizes.LARGE}
+                  >
+                    <Icon
+                      name={icons.FILE}
+                      size={17}
+                    />
+
+                    <span className={styles.fileCountMessage}>
+                      {episodeFilesCountMessage}
                     </span>
                   </Label>
 

--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -432,35 +432,32 @@ class SeriesDetails extends Component {
                     </span>
                   </Label>
 
-                  <Label
-                    className={styles.detailsLabel}
-                    size={sizes.LARGE}
-                  >
-                    <Icon
-                      name={icons.DRIVE}
-                      size={17}
-                    />
+                  <Tooltip
+                    anchor={
+                      <Label
+                        className={styles.detailsLabel}
+                        size={sizes.LARGE}
+                      >
+                        <Icon
+                          name={icons.DRIVE}
+                          size={17}
+                        />
 
-                    <span className={styles.sizeOnDisk}>
-                      {
-                        formatBytes(sizeOnDisk || 0)
-                      }
-                    </span>
-                  </Label>
-
-                  <Label
-                    className={styles.detailsLabel}
-                    size={sizes.LARGE}
-                  >
-                    <Icon
-                      name={icons.FILE}
-                      size={17}
-                    />
-
-                    <span className={styles.fileCountMessage}>
-                      {episodeFilesCountMessage}
-                    </span>
-                  </Label>
+                        <span className={styles.sizeOnDisk}>
+                          {
+                            formatBytes(sizeOnDisk || 0)
+                          }
+                        </span>
+                      </Label>
+                    }
+                    tooltip={
+                      <span className={styles.fileCountMessage}>
+                        {episodeFilesCountMessage}
+                      </span>
+                    }
+                    kind={kinds.INVERSE}
+                    position={tooltipPositions.BOTTOM}
+                  />
 
                   <Label
                     className={styles.detailsLabel}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds a box on series info to show the number of files
![image](https://user-images.githubusercontent.com/19610103/103795764-4a51c780-503e-11eb-8237-0b21bb6e0f26.png)


#### Issues Fixed or Closed by this PR

* #4203 
