### PR TITLE
Fix name of max NumberInput in QualityDefinition.js

### DIFF
--- a/frontend/src/Settings/Quality/Definition/QualityDefinition.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinition.js
@@ -256,7 +256,7 @@ class QualityDefinition extends Component {
 
                 <NumberInput
                   className={styles.sizeInput}
-                  name={`${id}.min`}
+                  name={`${id}.max`}
                   value={maxSize || MAX}
                   min={minSize + MIN_DISTANCE}
                   max={MAX}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Name of max component shouldn't be same as min component. 

#### Todos
- [x] Tests
- [x] Wiki Updates