### PR TITLE
New: Replace SmtpClient with Mailkit

### DIFF
--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -31,9 +31,6 @@ namespace NzbDrone.Core.Notifications.Email
         [FieldDefinition(1, Label = "Port")]
         public int Port { get; set; }
 
-        [FieldDefinition(2, Label = "SSL", Type = FieldType.Checkbox)]
-        public bool Ssl { get; set; }
-
         [FieldDefinition(3, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="FluentValidation" Version="8.4.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0007" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="MailKit" Version="2.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NLog" Version="4.6.6" />
     <PackageReference Include="OAuth" Version="1.0.3" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Replaces obsolete SmtpClient implementation with Mailkit which correctly handles all modern protocols. Client is setup to use the default `MailKit.Security.SecureSocketOptions.Auto` options. This means if 465 port is specified SSL is used automatically, otherwise mailkit will use StartTLS if available. Tested with both cases on Radarr side. 

Picked from https://github.com/Radarr/Radarr/pull/4638/commits/f69cf134d158cc1ec4ce17daf802823b4792cd54

#### Issues Fixed or Closed by this PR

* Fixes #4213 
