### PR TITLE
Fixed: Parse standalone UHD as 4K if no other resolution info is present

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -298,6 +298,9 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[Coalgirls]_Durarara!!_01_(1920x1080_Blu-ray_FLAC)_[8370CB8F].mkv", false)]
         [TestCase("Planet.Earth.S01E11.Ocean.Deep.1080p.HD-DVD.DD.VC1-TRB", false)]
         [TestCase("Spirited Away(2001) Bluray FHD Hi10P.mkv", false)]
+        [TestCase("V for Vendetta 2005 1080p UHD BluRay DD+7.1 x264-LoRD.mkv", false)]
+        [TestCase("Rise.Of.The.Planet.Of.The.Apes.2011.1080p.UHD.BluRay.DD5.1.HDR.x265-CtrlHD.mkv", false)]
+        [TestCase("Rise.Of.The.Planet.Of.The.Apes.2011.UHD.BluRay.DD5.1.HDR.x265-CtrlHD/ctrlhd-rotpota-1080p.mkv", false)]
         public void should_parse_bluray1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.Bluray1080p, proper);
@@ -316,6 +319,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("House.of.Cards.US.s05e13.4K.UHD.Bluray", false)]
         [TestCase("House.of.Cards.US.s05e13.UHD.4K.Bluray", false)]
         [TestCase("[DameDesuYo] Backlog Bundle - Part 1 (BD 4K 8bit FLAC)", false)]
+        [TestCase("X-Men.Days.of.Future.Past.2014.2160p.UHD.BluRay.X265-IAMABLE.mkv", false)]
         public void should_parse_bluray2160p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.Bluray2160p, proper);
@@ -324,6 +328,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Yuri!!! on ICE - S01E12[JP BD 2160p Remux][ENG subs]", false)]
         [TestCase("Agents.of.S.H.I.E.L.D.S01E08.The.Well.BluRay.2160p.AVC.DTS-HD.MA.5.1.REMUX-FraMeSToR", false)]
         [TestCase("Miami.Vice.2x11.Nato.Per.La.Truffa.Bluray.Remux.AVC.2160p.AC3.ITA", false)]
+        [TestCase("[Dolby Vision] Game.of.Thrones.S07.MULTi.UHD.BLURAY.REMUX.DV-NoTag", false)]
         public void should_parse_bluray2160p_remux_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.Bluray2160pRemux, proper);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -49,6 +49,10 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ResolutionRegex = new Regex(@"\b(?:(?<R360p>360p)|(?<R480p>480p|640x480|848x480)|(?<R576p>576p)|(?<R720p>720p|1280x720)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|4k[-_. ](?:UHD|HEVC|BD)|(?:UHD|HEVC|BD)[-_. ]4k))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        //Handle cases where no resolution is in the release name; assume if UHD then 4k
+        private static readonly Regex ImpliedResolutionRegex = new Regex(@"\b(?<R2160p>UHD)\b",
+                                                                RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static readonly Regex CodecRegex = new Regex(@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>Xvid)|(?<divx>divx))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -514,13 +518,17 @@ namespace NzbDrone.Core.Parser
         {
             var match = ResolutionRegex.Match(name);
 
-            if (!match.Success) return Resolution.Unknown;
+            var matchimplied = ImpliedResolutionRegex.Match(name);
+
+            if (!match.Success & !matchimplied.Success) return Resolution.Unknown;
             if (match.Groups["R360p"].Success) return Resolution.R360P;
             if (match.Groups["R480p"].Success) return Resolution.R480P;
             if (match.Groups["R576p"].Success) return Resolution.R576p;
             if (match.Groups["R720p"].Success) return Resolution.R720p;
             if (match.Groups["R1080p"].Success) return Resolution.R1080p;
             if (match.Groups["R2160p"].Success) return Resolution.R2160p;
+
+            if (matchimplied.Groups["R2160p"].Success) return Resolution.R2160p;
 
             return Resolution.Unknown;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Title

#### Todos
- [X] Tests
- Wiki Updates-N/A


#### Issues Fixed or Closed by this PR
N/A

Reference: https://www.reddit.com/r/sonarr/comments/kvsr4n/sonarr_think_uhd_release_is_fhd/


