### PR TITLE
Update BTN API URL to use HTTPS instead of HTTP

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
         {
             var recentFeed = ReadAllText(@"Files/Indexers/BroadcastheNet/RecentFeed.json");
 
-            (Subject.Definition.Settings as BroadcastheNetSettings).BaseUrl = "http://api.broadcasthe.net/";
+            (Subject.Definition.Settings as BroadcastheNetSettings).BaseUrl = "https://api.broadcasthe.net/";
 
             recentFeed = recentFeed.Replace("http:", "https:");
 

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
         public BroadcastheNetSettings()
         {
-            BaseUrl = "http://api.broadcasthe.net/";
+            BaseUrl = "https://api.broadcasthe.net/";
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
It seems overnight the Sonarr <-> BTN API Integration has stopped working giving an error `Invalid torrent file specified —> MonoTorrent.BEncoding.BEncodingException: Could not find what value to decode`

Changing the URL to use the HTTPS URL of the API instead of the HTTP, alleviates the issue. 