### PR TITLE
New: Add name field to release profiles

### DIFF
--- a/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
@@ -29,6 +29,7 @@ function EditReleaseProfileModalContent(props) {
 
   const {
     id,
+    name,
     enabled,
     required,
     ignored,
@@ -46,6 +47,20 @@ function EditReleaseProfileModalContent(props) {
 
       <ModalBody>
         <Form {...otherProps}>
+
+          <FormGroup>
+            <FormLabel>Name</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.TEXT}
+              name="name"
+              {...name}
+              placeholder="Optional name"
+              canEdit={true}
+              onChange={onInputChange}
+            />
+          </FormGroup>
+
           <FormGroup>
             <FormLabel>Enable Profile</FormLabel>
 

--- a/frontend/src/Settings/Profiles/Release/ReleaseProfile.css
+++ b/frontend/src/Settings/Profiles/Release/ReleaseProfile.css
@@ -9,3 +9,11 @@
   flex-wrap: wrap;
   margin-top: 5px;
 }
+
+.name {
+  @add-mixin truncate;
+
+  margin-bottom: 20px;
+  font-weight: 300;
+  font-size: 24px;
+}

--- a/frontend/src/Settings/Profiles/Release/ReleaseProfile.js
+++ b/frontend/src/Settings/Profiles/Release/ReleaseProfile.js
@@ -56,6 +56,7 @@ class ReleaseProfile extends Component {
   render() {
     const {
       id,
+      name,
       enabled,
       required,
       ignored,
@@ -79,6 +80,14 @@ class ReleaseProfile extends Component {
         overlayContent={true}
         onPress={this.onEditReleaseProfilePress}
       >
+        {
+          name ?
+            <div className={styles.name}>
+              {name}
+            </div> :
+            null
+        }
+
         <div>
           {
             split(required).map((item) => {
@@ -184,6 +193,7 @@ class ReleaseProfile extends Component {
 
 ReleaseProfile.propTypes = {
   id: PropTypes.number.isRequired,
+  name: PropTypes.string,
   enabled: PropTypes.bool.isRequired,
   required: PropTypes.string.isRequired,
   ignored: PropTypes.string.isRequired,

--- a/src/NzbDrone.Core/Datastore/Migration/154_add_name_release_profile.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/154_add_name_release_profile.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(154)]
+    public class add_name_release_profile : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("ReleaseProfiles").AddColumn("Name").AsString().Nullable().WithDefaultValue(null);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Profiles/Releases/ReleaseProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Releases/ReleaseProfile.cs
@@ -5,6 +5,7 @@ namespace NzbDrone.Core.Profiles.Releases
 {
     public class ReleaseProfile : ModelBase
     {
+        public string Name { get; set; }
         public bool Enabled { get; set; }
         public string Required { get; set; }
         public string Ignored { get; set; }

--- a/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileResource.cs
+++ b/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileResource.cs
@@ -7,6 +7,7 @@ namespace Sonarr.Api.V3.Profiles.Release
 {
     public class ReleaseProfileResource : RestResource
     {
+        public string Name { get; set; }
         public bool Enabled { get; set; }
         public string Required { get; set; }
         public string Ignored { get; set; }
@@ -30,7 +31,7 @@ namespace Sonarr.Api.V3.Profiles.Release
             return new ReleaseProfileResource
             {
                 Id = model.Id,
-
+                Name = model.Name,
                 Enabled = model.Enabled,
                 Required = model.Required,
                 Ignored = model.Ignored,
@@ -48,7 +49,7 @@ namespace Sonarr.Api.V3.Profiles.Release
             return new ReleaseProfile
             {
                 Id = resource.Id,
-
+                Name = resource.Name,
                 Enabled = resource.Enabled,
                 Required = resource.Required,
                 Ignored = resource.Ignored,


### PR DESCRIPTION
This adds a new, non-functional field to release profiles for a friendly
name. This name may be used, for example, by scripts invoking the API to
look for specifically named profiles in order to find their ID, which is
required to perform further operations on it. Additionally it adds an
additional organization tool for users to manage their release profiles.

#### Database Migration
YES

#### Description
See above
