### PR TITLE
New: Persist search settings in add new series

### DIFF
--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.js
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.js
@@ -30,9 +30,7 @@ class AddNewSeriesModalContent extends Component {
     this.state = {
       seriesType: props.initialSeriesType === seriesTypes.STANDARD ?
         props.seriesType.value :
-        props.initialSeriesType,
-      searchForMissingEpisodes: false,
-      searchForCutoffUnmetEpisodes: false
+        props.initialSeriesType
     };
   }
 
@@ -45,14 +43,6 @@ class AddNewSeriesModalContent extends Component {
   //
   // Listeners
 
-  onSearchForMissingEpisodesChange = ({ value }) => {
-    this.setState({ searchForMissingEpisodes: value });
-  }
-
-  onSearchForCutoffUnmetEpisodesChange = ({ value }) => {
-    this.setState({ searchForCutoffUnmetEpisodes: value });
-  }
-
   onQualityProfileIdChange = ({ value }) => {
     this.props.onInputChange({ name: 'qualityProfileId', value: parseInt(value) });
   }
@@ -63,14 +53,10 @@ class AddNewSeriesModalContent extends Component {
 
   onAddSeriesPress = () => {
     const {
-      searchForMissingEpisodes,
-      searchForCutoffUnmetEpisodes,
       seriesType
     } = this.state;
 
     this.props.onAddSeriesPress(
-      searchForMissingEpisodes,
-      searchForCutoffUnmetEpisodes,
       seriesType
     );
   }
@@ -91,6 +77,8 @@ class AddNewSeriesModalContent extends Component {
       languageProfileId,
       seriesType,
       seasonFolder,
+      searchForMissingEpisodes,
+      searchForCutoffUnmetEpisodes,
       folder,
       tags,
       showLanguageProfile,
@@ -100,11 +88,6 @@ class AddNewSeriesModalContent extends Component {
       onInputChange,
       ...otherProps
     } = this.props;
-
-    const {
-      searchForMissingEpisodes,
-      searchForCutoffUnmetEpisodes
-    } = this.state;
 
     return (
       <ModalContent onModalClose={onModalClose}>
@@ -271,8 +254,8 @@ class AddNewSeriesModalContent extends Component {
                 containerClassName={styles.searchInputContainer}
                 className={styles.searchInput}
                 name="searchForMissingEpisodes"
-                value={searchForMissingEpisodes}
-                onChange={this.onSearchForMissingEpisodesChange}
+                onChange={onInputChange}
+                {...searchForMissingEpisodes}
               />
             </label>
 
@@ -285,8 +268,8 @@ class AddNewSeriesModalContent extends Component {
                 containerClassName={styles.searchInputContainer}
                 className={styles.searchInput}
                 name="searchForCutoffUnmetEpisodes"
-                value={searchForCutoffUnmetEpisodes}
-                onChange={this.onSearchForCutoffUnmetEpisodesChange}
+                onChange={onInputChange}
+                {...searchForCutoffUnmetEpisodes}
               />
             </label>
           </div>
@@ -319,6 +302,8 @@ AddNewSeriesModalContent.propTypes = {
   languageProfileId: PropTypes.object,
   seriesType: PropTypes.object.isRequired,
   seasonFolder: PropTypes.object.isRequired,
+  searchForMissingEpisodes: PropTypes.object.isRequired,
+  searchForCutoffUnmetEpisodes: PropTypes.object.isRequired,
   folder: PropTypes.string.isRequired,
   tags: PropTypes.object.isRequired,
   showLanguageProfile: PropTypes.bool.isRequired,

--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContentConnector.js
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContentConnector.js
@@ -55,7 +55,7 @@ class AddNewSeriesModalContentConnector extends Component {
     this.props.setAddSeriesDefault({ [name]: value });
   }
 
-  onAddSeriesPress = (searchForMissingEpisodes, searchForCutoffUnmetEpisodes, seriesType) => {
+  onAddSeriesPress = (seriesType) => {
     const {
       tvdbId,
       rootFolderPath,
@@ -63,6 +63,8 @@ class AddNewSeriesModalContentConnector extends Component {
       qualityProfileId,
       languageProfileId,
       seasonFolder,
+      searchForMissingEpisodes,
+      searchForCutoffUnmetEpisodes,
       tags
     } = this.props;
 
@@ -74,9 +76,9 @@ class AddNewSeriesModalContentConnector extends Component {
       languageProfileId: languageProfileId.value,
       seriesType,
       seasonFolder: seasonFolder.value,
-      tags: tags.value,
-      searchForMissingEpisodes,
-      searchForCutoffUnmetEpisodes
+      searchForMissingEpisodes: searchForMissingEpisodes.value,
+      searchForCutoffUnmetEpisodes: searchForCutoffUnmetEpisodes.value,
+      tags: tags.value
     });
   }
 
@@ -102,6 +104,8 @@ AddNewSeriesModalContentConnector.propTypes = {
   languageProfileId: PropTypes.object,
   seriesType: PropTypes.object.isRequired,
   seasonFolder: PropTypes.object.isRequired,
+  searchForMissingEpisodes: PropTypes.object.isRequired,
+  searchForCutoffUnmetEpisodes: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,
   onModalClose: PropTypes.func.isRequired,
   setAddSeriesDefault: PropTypes.func.isRequired,

--- a/frontend/src/Store/Actions/addSeriesActions.js
+++ b/frontend/src/Store/Actions/addSeriesActions.js
@@ -37,8 +37,8 @@ export const defaultState = {
     languageProfileId: 0,
     seriesType: seriesTypes.STANDARD,
     seasonFolder: true,
-    searchForMissingEpisodes: true,
-    searchForCutoffUnmetEpisodes: true,
+    searchForMissingEpisodes: false,
+    searchForCutoffUnmetEpisodes: false,
     tags: []
   }
 };

--- a/frontend/src/Store/Actions/addSeriesActions.js
+++ b/frontend/src/Store/Actions/addSeriesActions.js
@@ -37,6 +37,8 @@ export const defaultState = {
     languageProfileId: 0,
     seriesType: seriesTypes.STANDARD,
     seasonFolder: true,
+    searchForMissingEpisodes: true,
+    searchForCutoffUnmetEpisodes: true,
     tags: []
   }
 };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Persist `searchForCutoffUnmetEpisodes` and `searchForMissingEpisodes` setting values in local cache.

#### Issues Fixed or Closed by this PR

* #4245
