### PR TITLE
Fix DownloadStation integration in DSM 7

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
         {
             var authInfo = GetApiInfo(DiskStationApi.Auth, settings);
 
-            var requestBuilder = BuildRequest(settings, authInfo, "login", 2);
+            var requestBuilder = BuildRequest(settings, authInfo, "login", 3);
             requestBuilder.AddQueryParam("account", settings.Username);
             requestBuilder.AddQueryParam("passwd", settings.Password);
             requestBuilder.AddQueryParam("format", "sid");

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
         {
             var authInfo = GetApiInfo(DiskStationApi.Auth, settings);
 
-            var requestBuilder = BuildRequest(settings, authInfo, "login", authInfo.MaxVersion >= 7 ? 3 : 2);
+            var requestBuilder = BuildRequest(settings, authInfo, "login", authInfo.MaxVersion >= 7 ? 6 : 2);
             requestBuilder.AddQueryParam("account", settings.Username);
             requestBuilder.AddQueryParam("passwd", settings.Password);
             requestBuilder.AddQueryParam("format", "sid");

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
         {
             var authInfo = GetApiInfo(DiskStationApi.Auth, settings);
 
-            var requestBuilder = BuildRequest(settings, authInfo, "login", 3);
+            var requestBuilder = BuildRequest(settings, authInfo, "login", authInfo.MaxVersion >= 7 ? 3 : 2);
             requestBuilder.AddQueryParam("account", settings.Username);
             requestBuilder.AddQueryParam("passwd", settings.Password);
             requestBuilder.AddQueryParam("format", "sid");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Addresses the issue described in #3943 by incrementing the `SYNO.API.Auth`. I've tested the download-import workflow without any added issues related to API changes made by Synology in DSM 7. This change does not raise any significant incompatibility issues as previously detailed in [my comment](https://github.com/Sonarr/Sonarr/issues/3943#issuecomment-774460487).

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* #3943 
