### PR TITLE
Handle 303 and 307 redirects in Http Requests

### DIFF
--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -53,7 +53,10 @@ namespace NzbDrone.Common.Http
 
         public bool HasHttpRedirect => StatusCode == HttpStatusCode.Moved ||
                                        StatusCode == HttpStatusCode.MovedPermanently ||
-                                       StatusCode == HttpStatusCode.Found;
+                                       StatusCode == HttpStatusCode.Found ||
+                                       StatusCode == HttpStatusCode.TemporaryRedirect ||
+                                       StatusCode == HttpStatusCode.RedirectMethod ||          
+                                       StatusCode == HttpStatusCode.SeeOther;
 
         public string[] GetCookieHeaders()
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update `HttpResponse` to recognize 303 (SeeOther) and 307 (Temporary Redirect) as valid redirects. This will allow Sonarr to follow these when `AllowAutoRedirect` is set to true in `HttpRequest` and ensure they are properly reported as redirects in `response.HasHttpRedirect`

I can add further `HttpClient` tests using httpbin `redirect-to/` endpoint which allows specifying of a redirect code if wanted.

#### Todos
- [ ] Tests

