### PR TITLE
Fixed: Parsing RSS with null values

### DIFF
--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -257,12 +257,11 @@ namespace NzbDrone.Core.Indexers
                                  {
                                      try
                                      {
-                                         var lengthValue = v.Attribute("length")?.Value;
                                          return new RssEnclosure
                                                 {
                                                     Url = v.Attribute("url")?.Value,
                                                     Type = v.Attribute("type")?.Value,
-                                                    Length = string.IsNullOrEmpty(lengthValue) ? default(long) : XmlConvert.ToInt64(lengthValue)
+                                                    Length = v.Attribute("length")?.Value?.ParseInt64() ?? default
                                                 };
                                      }
                                      catch (Exception e)

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -261,7 +261,7 @@ namespace NzbDrone.Core.Indexers
                                                 {
                                                     Url = v.Attribute("url")?.Value,
                                                     Type = v.Attribute("type")?.Value,
-                                                    Length = v.Attribute("length")?.Value?.ParseInt64() ?? default
+                                                    Length = v.Attribute("length")?.Value?.ParseInt64() ?? 0
                                                 };
                                      }
                                      catch (Exception e)

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -257,11 +257,12 @@ namespace NzbDrone.Core.Indexers
                                  {
                                      try
                                      {
+                                         var lengthValue = v.Attribute("length")?.Value;
                                          return new RssEnclosure
                                                 {
-                                                    Url = v.Attribute("url").Value,
-                                                    Type = v.Attribute("type").Value,
-                                                    Length = (long)v.Attribute("length")
+                                                    Url = v.Attribute("url")?.Value,
+                                                    Type = v.Attribute("type")?.Value,
+                                                    Length = string.IsNullOrEmpty(lengthValue) ? default(long) : XmlConvert.ToInt64(lengthValue)
                                                 };
                                      }
                                      catch (Exception e)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Given that [XElement.Attribute()](https://docs.microsoft.com/en-us/dotnet/api/system.xml.linq.xelement.attribute?view=net-5.0) will return a null value when it cannot find the attribute, defensive programing is required.

Given that [XAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.xml.linq.xattribute?view=net-5.0) is a class that has nothing to do with long/Int64, the Value property should be accessed and parsed instead of using a cast.


#### Todos
- [x] Tests - unit tests passing.
- [ ] Wiki Updates - Not applicable? This is my first contribution here.


#### Issues Fixed or Closed by this PR

* https://github.com/lidarr/Lidarr/issues/1730
