### PR TITLE
New: Setting SceneName and ReleaseGroup for EpisodeFiles via API

### DIFF
--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileListResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileListResource.cs
@@ -9,5 +9,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
         public List<int> EpisodeFileIds { get; set; }
         public Language Language { get; set; }
         public QualityModel Quality { get; set; }
+        public string SceneName { get; set; }
+        public string ReleaseGroup { get; set; }
     }
 }

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -94,8 +94,14 @@ namespace Sonarr.Api.V3.EpisodeFiles
         {
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
-            episodeFile.SceneName = episodeFileResource.SceneName;
-            episodeFile.ReleaseGroup = episodeFileResource.ReleaseGroup;
+            if (episodeFileResource.SceneName != null)
+            {
+                episodeFile.SceneName = episodeFileResource.SceneName;
+            }
+            if (episodeFileResource.ReleaseGroup != null)
+            {
+                episodeFile.ReleaseGroup = episodeFileResource.ReleaseGroup;
+            }
             _mediaFileService.Update(episodeFile);
         }
 

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -94,6 +94,8 @@ namespace Sonarr.Api.V3.EpisodeFiles
         {
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
+            episodeFile.SceneName = episodeFileResource.SceneName;
+            episodeFile.ReleaseGroup = episodeFileResource.ReleaseGroup;
             _mediaFileService.Update(episodeFile);
         }
 
@@ -112,6 +114,16 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 if (resource.Quality != null)
                 {
                     episodeFile.Quality = resource.Quality;
+                }
+
+                if (resource.SceneName != null)
+                {
+                    episodeFile.SceneName = resource.SceneName;
+                }
+
+                if (resource.ReleaseGroup != null)
+                {
+                    episodeFile.ReleaseGroup = resource.ReleaseGroup;
                 }
             }
 

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -9,7 +9,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
-using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.SceneChecker;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
 using Sonarr.Http;
@@ -96,7 +96,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
 
-            if (episodeFileResource.SceneName != null && SceneChecker.IsSceneTitle(episodeFileResource.SceneName))
+            if (episodeFileResource.SceneName != null && IsSceneTitle(episodeFileResource.SceneName))
             {
                 episodeFile.SceneName = episodeFileResource.SceneName;
             }
@@ -126,7 +126,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                     episodeFile.Quality = resource.Quality;
                 }
 
-                if (resource.SceneName != null && SceneChecker.IsSceneTitle(resource.SceneName))
+                if (resource.SceneName != null && IsSceneTitle(resource.SceneName))
                 {
                     episodeFile.SceneName = resource.SceneName;
                 }

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -94,14 +94,17 @@ namespace Sonarr.Api.V3.EpisodeFiles
         {
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
+
             if (episodeFileResource.SceneName != null)
             {
                 episodeFile.SceneName = episodeFileResource.SceneName;
             }
+
             if (episodeFileResource.ReleaseGroup != null)
             {
                 episodeFile.ReleaseGroup = episodeFileResource.ReleaseGroup;
             }
+
             _mediaFileService.Update(episodeFile);
         }
 

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -9,7 +9,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
-using NzbDrone.Core.Parser.SceneChecker;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
 using Sonarr.Http;
@@ -96,7 +96,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
 
-            if (episodeFileResource.SceneName != null && IsSceneTitle(episodeFileResource.SceneName))
+            if (episodeFileResource.SceneName != null && SceneChecker.IsSceneTitle(episodeFileResource.SceneName))
             {
                 episodeFile.SceneName = episodeFileResource.SceneName;
             }
@@ -126,7 +126,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                     episodeFile.Quality = resource.Quality;
                 }
 
-                if (resource.SceneName != null && IsSceneTitle(resource.SceneName))
+                if (resource.SceneName != null && SceneChecker.IsSceneTitle(resource.SceneName))
                 {
                     episodeFile.SceneName = resource.SceneName;
                 }

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileModule.cs
@@ -9,6 +9,7 @@ using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
 using Sonarr.Http;
@@ -95,7 +96,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
             var episodeFile = _mediaFileService.Get(episodeFileResource.Id);
             episodeFile.Quality = episodeFileResource.Quality;
 
-            if (episodeFileResource.SceneName != null)
+            if (episodeFileResource.SceneName != null && SceneChecker.IsSceneTitle(episodeFileResource.SceneName))
             {
                 episodeFile.SceneName = episodeFileResource.SceneName;
             }
@@ -125,7 +126,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                     episodeFile.Quality = resource.Quality;
                 }
 
-                if (resource.SceneName != null)
+                if (resource.SceneName != null && SceneChecker.IsSceneTitle(resource.SceneName))
                 {
                     episodeFile.SceneName = resource.SceneName;
                 }

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -18,6 +18,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
         public long Size { get; set; }
         public DateTime DateAdded { get; set; }
         public string SceneName { get; set; }
+        public string ReleaseGroup { get; set; }
         public Language Language { get; set; }
         public QualityModel Quality { get; set; }
         public MediaInfoResource MediaInfo { get; set; }
@@ -43,6 +44,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Size = model.Size,
                 DateAdded = model.DateAdded,
                 SceneName = model.SceneName,
+                ReleaseGroup = model.ReleaseGroup,
                 Language = model.Language,
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName)
@@ -66,6 +68,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Size = model.Size,
                 DateAdded = model.DateAdded,
                 SceneName = model.SceneName,
+                ReleaseGroup = model.ReleaseGroup,
                 Language = model.Language,
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),


### PR DESCRIPTION
Include releasegroup in the API output
allow sceneName and releaseGroup to be modified via PUT request

#### Database Migration
NO

#### Description
Allow releaseGroup to be read via episodeFile API request similar to how movieFile functions on Radarr

Allow both releaseGroup and sceneName to be modified by the API

Uses here would be primarily for post processing scripts to include this information if its lost or missing from Sonarr. My primary use case is that I have a script that rewraps MKV files in and MP4 container. After this file extension change the information about the sceneName and releaseGroup is lost and it makes finding subtitles and other release specific things more difficult. This would allow that information to be restored after a rescan is completed.

I have created a similar pull request for Radarr for sceneName though Radarr already supports reading and writing to the releaseGroup property.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

