### PR TITLE
New: Health Check for Downloads to Root Folder

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class DownloadClientRootFolderCheckFixture : CoreTest<DownloadClientRootFolderCheck>
+    {
+        private readonly string _downloadRootPath = @"c:\Test".AsOsAgnostic();
+
+        private DownloadClientInfo _clientStatus;
+        private Mock<IDownloadClient> _downloadClient;
+
+        private static Exception[] DownloadClientExceptions =
+        {
+            new DownloadClientUnavailableException("error"),
+            new DownloadClientAuthenticationException("error"),
+            new DownloadClientException("error")
+        };
+
+        [SetUp]
+        public void Setup()
+        {
+            _clientStatus = new DownloadClientInfo
+            {
+                IsLocalhost = true,
+                OutputRootFolders = new List<OsPath> { new OsPath(_downloadRootPath) }
+            };
+
+            _downloadClient = Mocker.GetMock<IDownloadClient>();
+            _downloadClient.Setup(s => s.Definition)
+                .Returns(new DownloadClientDefinition { Name = "Test" });
+
+            _downloadClient.Setup(s => s.GetStatus())
+                .Returns(_clientStatus);
+
+            Mocker.GetMock<IProvideDownloadClient>()
+                  .Setup(s => s.GetDownloadClients())
+                  .Returns(new IDownloadClient[] { _downloadClient.Object });
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(x => x.FolderExists(It.IsAny<string>()))
+                .Returns(true);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(x => x.FolderWritable(It.IsAny<string>()))
+                  .Returns(true);
+        }
+
+        private void GivenRootFolder(string folder)
+        {
+            Mocker.GetMock<IRootFolderService>()
+                  .Setup(s => s.All())
+                  .Returns(new List<RootFolder> { new RootFolder { Path = folder.AsOsAgnostic() } });
+        }
+
+        [Test]
+        public void should_return_downloads_in_root_folder_if_downloading_to_root_folder()
+        {
+            GivenRootFolder(_downloadRootPath);
+
+            Subject.Check().ShouldBeWarning(wikiFragment: "downloads_in_root_folder");
+        }
+
+        [Test]
+        public void should_return_ok_if_not_downloading_to_root_folder()
+        {
+            string rootFolderPath = "c:\\Test2".AsOsAgnostic();
+
+            GivenRootFolder(rootFolderPath);
+
+            Subject.Check().ShouldBeOk();
+        }
+
+        [Test]
+        [TestCaseSource("DownloadClientExceptions")]
+        public void should_return_ok_if_client_throws_downloadclientexception(Exception ex)
+        {
+            _downloadClient.Setup(s => s.GetStatus())
+                .Throws(ex);
+
+            Subject.Check().ShouldBeOk();
+
+            ExceptionVerification.ExpectedErrors(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/HealthCheckFixtureExtensions.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/HealthCheckFixtureExtensions.cs
@@ -21,13 +21,18 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             }
         }
 
-        public static void ShouldBeWarning(this Core.HealthCheck.HealthCheck result, string message = null)
+        public static void ShouldBeWarning(this Core.HealthCheck.HealthCheck result, string message = null, string wikiFragment = null)
         {
             result.Type.Should().Be(HealthCheckResult.Warning);
 
             if (message.IsNotNullOrWhiteSpace())
             {
                 result.Message.Should().Contain(message);
+            }
+
+            if (wikiFragment.IsNotNullOrWhiteSpace())
+            {
+                result.WikiUrl.Fragment.Should().Be(wikiFragment);
             }
         }
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Datastore.Events;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients;
+using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.RootFolders;
+using NzbDrone.Core.ThingiProvider.Events;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ProviderUpdatedEvent<IDownloadClient>))]
+    [CheckOn(typeof(ProviderDeletedEvent<IDownloadClient>))]
+    [CheckOn(typeof(ModelEvent<RootFolder>))]
+    [CheckOn(typeof(ModelEvent<RemotePathMapping>))]
+
+    public class DownloadClientRootFolderCheck : HealthCheckBase, IProvideHealthCheck
+    {
+        private readonly IProvideDownloadClient _downloadClientProvider;
+        private readonly IRootFolderService _rootFolderService;
+        private readonly Logger _logger;
+
+        public DownloadClientRootFolderCheck(IProvideDownloadClient downloadClientProvider,
+                                      IRootFolderService rootFolderService,
+                                      Logger logger)
+        {
+            _downloadClientProvider = downloadClientProvider;
+            _rootFolderService = rootFolderService;
+            _logger = logger;
+        }
+
+        public override HealthCheck Check()
+        {
+            var clients = _downloadClientProvider.GetDownloadClients();
+            var rootFolders = _rootFolderService.All();
+
+            foreach (var client in clients)
+            {
+                try
+                {
+                    var status = client.GetStatus();
+                    var folders = status.OutputRootFolders;
+
+                    foreach (var folder in folders)
+                    {
+                        if (rootFolders.Any(r => r.Path.PathEquals(folder.FullPath)))
+                        {
+                            return new HealthCheck(GetType(), HealthCheckResult.Warning, string.Format("Download client {0} places downloads in the root folder {1}. You should not download to a root folder.", client.Definition.Name, folder.FullPath), "#downloads_in_root_folder");
+                        }
+                    }
+                }
+                catch (DownloadClientException ex)
+                {
+                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Unknown error occured in DownloadClientRootFolderCheck HealthCheck");
+                }
+            }
+
+            return new HealthCheck(GetType());
+        }
+    }
+}


### PR DESCRIPTION
already implemented within Radarr
(cherry picked from commit 88780f33a4c5032aaa151aaae7090371beb42f33)

#### Database Migration
NO

#### Description
Health check to highlight that Sonarr is downloading to the root folder

#### Todos
- [x] Tests
- [x] Wiki Updates


#### Issues Fixed or Closed by this PR

* #4402 
