### PR TITLE
Use pattern matching instead of as expression type checking

### DIFF
--- a/src/Marr.Data/QGen/WhereBuilder.cs
+++ b/src/Marr.Data/QGen/WhereBuilder.cs
@@ -148,8 +148,8 @@ namespace Marr.Data.QGen
             if (right == null) // Value is not directly passed in as a constant
             {
                 var rightMemberExp = (rightExpression as MemberExpression);
-                var parentMemberExpression = rightMemberExp.Expression as MemberExpression;
-                if (parentMemberExpression != null) // Value is passed in as a property on a parent entity
+
+                if (rightMemberExp.Expression is MemberExpression parentMemberExpression) // Value is passed in as a property on a parent entity
                 {
                     string entityName = (rightMemberExp.Expression as MemberExpression).Member.Name;
                     var container = ((rightMemberExp.Expression as MemberExpression).Expression as ConstantExpression).Value;

--- a/src/NzbDrone.Common/EnsureThat/ExpressionExtensions.cs
+++ b/src/NzbDrone.Common/EnsureThat/ExpressionExtensions.cs
@@ -7,9 +7,8 @@ namespace NzbDrone.Common.EnsureThat
         internal static string ToPath(this MemberExpression e)
         {
             var path = "";
-            var parent = e.Expression as MemberExpression;
 
-            if (parent != null)
+            if (e.Expression is MemberExpression parent)
                 path = parent.ToPath() + ".";
 
             return path + e.Member.Name;

--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -160,9 +160,7 @@ namespace NzbDrone.Common.Instrumentation.Sentry
 
         private void OnError(Exception ex)
         {
-            var webException = ex as WebException;
-
-            if (webException != null)
+            if (ex is WebException webException)
             {
                 var response = webException.Response as HttpWebResponse;
                 var statusCode = response?.StatusCode;

--- a/src/NzbDrone.Common/TinyIoC.cs
+++ b/src/NzbDrone.Common/TinyIoC.cs
@@ -2629,9 +2629,7 @@ namespace TinyIoC
 
             public void Dispose()
             {
-                var disposable = _instance as IDisposable;
-
-                if (disposable != null)
+                if (_instance is IDisposable disposable)
                     disposable.Dispose();
             }
         }
@@ -2693,9 +2691,7 @@ namespace TinyIoC
 
             public void Dispose()
             {
-                var disposable = _instance.Target as IDisposable;
-
-                if (disposable != null)
+                if (_instance.Target is IDisposable disposable)
                     disposable.Dispose();
             }
         }
@@ -2763,9 +2759,7 @@ namespace TinyIoC
                 if (this._Current == null)
                     return;
 
-                var disposable = this._Current as IDisposable;
-
-                if (disposable != null)
+                if (this._Current is IDisposable disposable)
                     disposable.Dispose();
             }
         }

--- a/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
@@ -25,8 +25,7 @@ namespace NzbDrone.Core.Test.Framework
             {
                 BeforeMigration = m =>
                 {
-                    var migration = m as TMigration;
-                    if (beforeMigration != null && migration != null)
+                    if (beforeMigration != null && m is TMigration migration)
                     {
                         beforeMigration(migration);
                     }

--- a/src/NzbDrone.Core/Datastore/Migration/147_swap_filechmod_for_folderchmod.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/147_swap_filechmod_for_folderchmod.cs
@@ -21,9 +21,8 @@ namespace NzbDrone.Core.Datastore.Migration
             {
                 getFileChmodCmd.Transaction = tran;
                 getFileChmodCmd.CommandText = @"SELECT Value FROM Config WHERE Key = 'filechmod'";
-                
-                var fileChmod = getFileChmodCmd.ExecuteScalar() as string;
-                if (fileChmod != null)
+
+                if (getFileChmodCmd.ExecuteScalar() is string fileChmod)
                 {
                     if (fileChmod.IsNotNullOrWhiteSpace())
                     {

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -88,8 +88,7 @@ namespace NzbDrone.Core.Download
             }
             catch (ReleaseDownloadException ex)
             {
-                var http429 = ex.InnerException as TooManyRequestsException;
-                if (http429 != null)
+                if (ex.InnerException is TooManyRequestsException http429)
                 {
                     _indexerStatusService.RecordFailure(remoteEpisode.Release.IndexerId, http429.RetryAfter);
                 }

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -123,8 +123,7 @@ namespace NzbDrone.Test.Common.AutoMoq
         {
             foreach (var registeredMock in _registeredMocks)
             {
-                var mock = registeredMock.Value as Mock;
-                if (mock != null)
+                if (registeredMock.Value is Mock mock)
                     mock.VerifyAll();
             }
         }

--- a/src/Sonarr.Http/Validation/EmptyCollectionValidator.cs
+++ b/src/Sonarr.Http/Validation/EmptyCollectionValidator.cs
@@ -15,9 +15,7 @@ namespace Sonarr.Http.Validation
         {
             if (context.PropertyValue == null) return true;
 
-            var collection = context.PropertyValue as IEnumerable<T>;
-
-            return collection != null && collection.Empty();
+            return context.PropertyValue is IEnumerable<T> collection && collection.Empty();
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Convert 'as' expression type check and the following null check into pattern matching" [rule](https://www.jetbrains.com/help/resharper/UsePatternMatching.html) reported by ReSharper.


