### PR TITLE
Send signalr message for episode monitored flag changes

### DIFF
--- a/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.js
@@ -116,7 +116,7 @@ function EditDelayProfileModalContent(props) {
                     type={inputTypes.CHECK}
                     name="bypassIfHighestQuality"
                     {...bypassIfHighestQuality}
-                    helpText="Bypass delay when release has the highest enabled quality in the quality profile"
+                    helpText="Bypass delay when release has the highest enabled quality in the quality profile with the preferred protocol"
                     onChange={onInputChange}
                   />
                 </FormGroup>

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeServiceTests/HandleEpisodeFileDeletedFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeServiceTests/HandleEpisodeFileDeletedFixture.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
             Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.MissingFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
-                .Verify(v => v.Update(It.Is<Episode>(e => e.EpisodeFileId == 0)), Times.Once());
+                .Verify(v => v.ClearFileId(It.IsAny<Episode>(), It.IsAny<bool>()), Times.Once());
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
             Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.MissingFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
-                .Verify(v => v.Update(It.Is<Episode>(e => e.EpisodeFileId == 0)), Times.Exactly(2));
+                .Verify(v => v.ClearFileId(It.IsAny<Episode>(), It.IsAny<bool>()), Times.Exactly(2));
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
             Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.MissingFromDisk));
 
             Mocker.GetMock<IEpisodeRepository>()
-                .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == false)), Times.Once());
+                .Verify(v => v.ClearFileId(It.IsAny<Episode>(), true), Times.Once());
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
             Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.Upgrade));
 
             Mocker.GetMock<IEpisodeRepository>()
-                .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == true)), Times.Once());
+                .Verify(v => v.ClearFileId(It.IsAny<Episode>(), false), Times.Once());
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeServiceTests
             Subject.Handle(new EpisodeFileDeletedEvent(_episodeFile, DeleteMediaFileReason.Upgrade));
 
             Mocker.GetMock<IEpisodeRepository>()
-                .Verify(v => v.Update(It.Is<Episode>(e => e.Monitored == true)), Times.Once());
+                .Verify(v => v.ClearFileId(It.IsAny<Episode>(), false), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -279,24 +279,24 @@ namespace NzbDrone.Core.Datastore
                             .Take(pagingSpec.PageSize);
         }
 
-        protected void ModelCreated(TModel model)
+        protected void ModelCreated(TModel model, bool forcePublish = false)
         {
-            PublishModelEvent(model, ModelAction.Created);
+            PublishModelEvent(model, ModelAction.Created, forcePublish);
         }
 
-        protected void ModelUpdated(TModel model)
+        protected void ModelUpdated(TModel model, bool forcePublish = false)
         {
-            PublishModelEvent(model, ModelAction.Updated);
+            PublishModelEvent(model, ModelAction.Updated, forcePublish);
         }
 
-        protected void ModelDeleted(TModel model)
+        protected void ModelDeleted(TModel model, bool forcePublish = false)
         {
-            PublishModelEvent(model, ModelAction.Deleted);
+            PublishModelEvent(model, ModelAction.Deleted, forcePublish);
         }
 
-        private void PublishModelEvent(TModel model, ModelAction action)
+        private void PublishModelEvent(TModel model, ModelAction action, bool forcePublish)
         {
-            if (PublishModelEvents)
+            if (PublishModelEvents || forcePublish)
             {
                 _eventAggregator.PublishEvent(new ModelEvent<TModel>(model, action));
             }

--- a/src/NzbDrone.Core/Datastore/Events/ModelEvent.cs
+++ b/src/NzbDrone.Core/Datastore/Events/ModelEvent.cs
@@ -2,13 +2,22 @@
 
 namespace NzbDrone.Core.Datastore.Events
 {
-    public class ModelEvent <TModel> : IEvent
+    public class ModelEvent<TModel> : IEvent
+        where TModel : ModelBase
     {
+        public int ModelId { get; set; }
         public TModel Model { get; set; }
         public ModelAction Action { get; set; }
 
+        public ModelEvent(int modelId, ModelAction action)
+        {
+            ModelId = modelId;
+            Action = action;
+        }
+
         public ModelEvent(TModel model, ModelAction action)
         {
+            ModelId = model.Id;
             Model = model;
             Action = action;
         }

--- a/src/NzbDrone.Core/Datastore/Extensions/MappingExtensions.cs
+++ b/src/NzbDrone.Core/Datastore/Extensions/MappingExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Marr.Data;
 using Marr.Data.Mapping;
 using NzbDrone.Common.Reflection;
@@ -58,6 +61,11 @@ namespace NzbDrone.Core.Datastore.Extensions
             }
 
             return false;
+        }
+
+        public static List<TModel> QueryScalar<TModel>(this IDataMapper dataMapper, string sql)
+        {
+            return dataMapper.ExecuteReader(sql, reader => (TModel)Convert.ChangeType(reader.GetValue(0), typeof(TModel))).ToList();
         }
     }
 }

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -220,14 +220,7 @@ namespace NzbDrone.Core.Tv
             foreach (var episode in GetEpisodesByFileId(message.EpisodeFile.Id))
             {
                 _logger.Debug("Detaching episode {0} from file.", episode.Id);
-                episode.EpisodeFileId = 0;
-
-                if (message.Reason != DeleteMediaFileReason.Upgrade && _configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
-                {
-                    episode.Monitored = false;
-                }
-
-                UpdateEpisode(episode);
+                _episodeRepository.ClearFileId(episode, message.Reason != DeleteMediaFileReason.Upgrade && _configService.AutoUnmonitorPreviouslyDownloadedEpisodes);
             }
         }
 
@@ -235,7 +228,7 @@ namespace NzbDrone.Core.Tv
         {
             foreach (var episode in message.EpisodeFile.Episodes.Value)
             {
-                _episodeRepository.SetFileId(episode.Id, message.EpisodeFile.Id);
+                _episodeRepository.SetFileId(episode, message.EpisodeFile.Id);
                 _logger.Debug("Linking [{0}] > [{1}]", message.EpisodeFile.RelativePath, episode);
             }
         }

--- a/src/Sonarr.Api.V3/Episodes/EpisodeModule.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeModule.cs
@@ -69,7 +69,9 @@ namespace Sonarr.Api.V3.Episodes
             var resource = Request.Body.FromJson<EpisodeResource>();
             _episodeService.SetEpisodeMonitored(id, resource.Monitored);
 
-            return ResponseWithCode(MapToResource(_episodeService.GetEpisode(id), false, false, false), HttpStatusCode.Accepted);
+            resource = MapToResource(_episodeService.GetEpisode(id), false, false, false);
+
+            return ResponseWithCode(resource, HttpStatusCode.Accepted);
         }
 
         private object SetEpisodesMonitored()
@@ -77,10 +79,18 @@ namespace Sonarr.Api.V3.Episodes
             var includeImages = Request.GetBooleanQueryParameter("includeImages", false);
             var resource = Request.Body.FromJson<EpisodesMonitoredResource>();
 
-            _episodeService.SetMonitored(resource.EpisodeIds, resource.Monitored);
+            if (resource.EpisodeIds.Count == 1)
+            {
+                _episodeService.SetEpisodeMonitored(resource.EpisodeIds.First(), resource.Monitored);
+            }
+            else
+            {
+                _episodeService.SetMonitored(resource.EpisodeIds, resource.Monitored);
+            }
 
-            return ResponseWithCode(MapToResource(_episodeService.GetEpisodes(resource.EpisodeIds), false, false, includeImages)
-                , HttpStatusCode.Accepted);
+            var resources = MapToResource(_episodeService.GetEpisodes(resource.EpisodeIds), false, false, includeImages);
+
+            return ResponseWithCode(resources, HttpStatusCode.Accepted);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Episodes/EpisodeModuleWithSignalR.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeModuleWithSignalR.cs
@@ -56,6 +56,13 @@ namespace Sonarr.Api.V3.Episodes
             var resource = MapToResource(episode, true, true, true);
             return resource;
         }
+        
+        protected override EpisodeResource GetResourceByIdForBroadcast(int id)
+        {
+            var episode = _episodeService.GetEpisode(id);
+            var resource = MapToResource(episode, false, false, false);
+            return resource;
+        }
 
         protected EpisodeResource MapToResource(Episode episode, bool includeSeries, bool includeEpisodeFile, bool includeImages)
         {

--- a/src/Sonarr.Http/SonarrRestModuleWithSignalR.cs
+++ b/src/Sonarr.Http/SonarrRestModuleWithSignalR.cs
@@ -23,6 +23,11 @@ namespace Sonarr.Http
             _signalRBroadcaster = signalRBroadcaster;
         }
 
+        protected virtual TResource GetResourceByIdForBroadcast(int id)
+        {
+            return GetResourceById(id);
+        }
+
         public void Handle(ModelEvent<TModel> message)
         {
             if (!_signalRBroadcaster.IsConnected) return;
@@ -32,7 +37,7 @@ namespace Sonarr.Http
                 BroadcastResourceChange(message.Action);
             }
 
-            BroadcastResourceChange(message.Action, message.Model.Id);
+            BroadcastResourceChange(message.Action, message.ModelId);
         }
 
         protected void BroadcastResourceChange(ModelAction action, int id)
@@ -45,7 +50,7 @@ namespace Sonarr.Http
             }
             else
             {
-                var resource = GetResourceById(id);
+                var resource = GetResourceByIdForBroadcast(id);
                 BroadcastResourceChange(action, resource);
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Changing monitored flags for episodes don't result in a signalr message.
This means that second browser tabs won't update, but also third-party apps using signalr won't get notified (Bazarr specifically).

note that I could do this in EpisodeModule handling the SetMonitored api calls and send broadcasts. However this means we wouldn't send updates for monitored flag changes triggered internally.

Some concerns:

- Added `GetResourceByIdForBroadcast` since I didn't want the series to be included in the notification. I have to check if that causes problems in the UI.
- It sends out 4 notifications for the calendar, episode, cutoff, missing endpoints. Which is a bit excessive.
- I do wonder what other things lack notifications to the UI.