### PR TITLE
Flood: allow to remove downloads when seeding criteria have been met

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/158_cdh_per_downloadclient.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/158_cdh_per_downloadclient.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     removeFailedDownloads = true;
             }
                         
-            using (var updateClientCmd = conn.CreateCommand(tran, $"UPDATE DownloadClients SET RemoveCompletedDownloads = (CASE WHEN Implementation = \"RTorrent\" THEN 0 ELSE ? END), RemoveFailedDownloads = ?"))
+            using (var updateClientCmd = conn.CreateCommand(tran, $"UPDATE DownloadClients SET RemoveCompletedDownloads = (CASE WHEN Implementation IN (\"RTorrent\", \"Flood\") THEN 0 ELSE ? END), RemoveFailedDownloads = ?"))
             {
                 updateClientCmd.AddParameter(removeCompletedDownloads ? 1 : 0);
                 updateClientCmd.AddParameter(removeFailedDownloads ? 1 : 0);

--- a/src/NzbDrone.Core/Download/Clients/Flood/Types/Torrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Types/Torrent.cs
@@ -31,5 +31,9 @@ namespace NzbDrone.Core.Download.Clients.Flood.Types
 
         [JsonProperty(PropertyName = "tags")]
         public List<string> Tags { get; set; }
+
+        // added in Flood 4.5
+        [JsonProperty(PropertyName = "dateFinished")]
+        public long? DateFinished { get; set; }
     }
 }


### PR DESCRIPTION
This change implements the new DownloadSeedConfigProvider for Flood.

See 411be4d0116f0739bb9c71235312d0c5a26dd3a2 and #3632.