### PR TITLE
Flood: explicitly cast DateFinished long? to long

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -163,7 +163,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
                         else if (properties.DateFinished != null && properties.DateFinished > 0)
                         {
                             // Check if seed time reached
-                            if ((DateTimeOffset.Now - DateTimeOffset.FromUnixTimeSeconds(properties.DateFinished)) >= seedConfig.SeedTime)
+                            if ((DateTimeOffset.Now - DateTimeOffset.FromUnixTimeSeconds((long)properties.DateFinished)) >= seedConfig.SeedTime)
                             {
                                 item.CanMoveFiles = item.CanBeRemoved = true;
                             }


### PR DESCRIPTION
This is still somehow required even with `properties.DateFinished != null`. 

Fixes:

Sonarr\src\NzbDrone.Core\Download\Clients\Flood\Flood.cs(166,90,166,113):

error CS1503: Argument 1: cannot convert from 'long?' to 'long'