### PR TITLE
Fixed: autoCapitalization on mobile viewport

### DIFF
--- a/frontend/src/login.html
+++ b/frontend/src/login.html
@@ -226,6 +226,7 @@
                   required
                   title="User name is required"
                   autoFocus="true"
+                  autoCapitalize="false"
                 />
               </div>
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I found that on mobile, it autocapitalizes the first character of the username in the HTTP authentication form.
I changed the input property to turn this off.
If this was intentional, feel free to deny this PR.