### PR TITLE
Fixed: Root Folder Downloads check giving errors when RuTorrent is used

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientInfo.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientInfo.cs
@@ -5,6 +5,11 @@ namespace NzbDrone.Core.Download
 {
     public class DownloadClientInfo
     {
+        public DownloadClientInfo()
+        {
+            OutputRootFolders = new List<OsPath>(); 
+        }
+
         public bool IsLocalhost { get; set; }
         public List<OsPath> OutputRootFolders { get; set; }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes null reference error caused by RuTorrent not providing DownloadClientInfo

PR already opened in Radarr/Lidarr/Readarr
* https://github.com/Radarr/Radarr/pull/6345
* https://github.com/lidarr/Lidarr/pull/2266
* https://github.com/Readarr/Readarr/pull/1051