### PR TITLE
New: Manual Import rejection column is sortable

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
@@ -75,6 +75,7 @@ const columns = [
       name: icons.DANGER,
       kind: kinds.DANGER
     }),
+    isSortable: true,
     isVisible: true
   }
 ];
@@ -300,7 +301,7 @@ class InteractiveImportModalContent extends Component {
             isPopulated && !!items.length && !isFetching && !isFetching &&
               <Table
                 columns={columns}
-                horizontalScroll={true}
+                horizontalScroll={false}
                 selectAll={true}
                 allSelected={allSelected}
                 allUnselected={allUnselected}

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
@@ -301,7 +301,7 @@ class InteractiveImportModalContent extends Component {
             isPopulated && !!items.length && !isFetching && !isFetching &&
               <Table
                 columns={columns}
-                horizontalScroll={false}
+                horizontalScroll={true}
                 selectAll={true}
                 allSelected={allSelected}
                 allUnselected={allUnselected}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Manual interactive imports can be time consuming because there's no ability to sort on the reject column. Now the user can click on that column and shift deselect based on that.