### PR TITLE
New: Activity Queue: Rename Timeleft column to Time Left

### DIFF
--- a/frontend/src/Store/Actions/queueActions.js
+++ b/frontend/src/Store/Actions/queueActions.js
@@ -130,7 +130,7 @@ export const defaultState = {
       },
       {
         name: 'estimatedCompletionTime',
-        label: 'Timeleft',
+        label: 'Time Left',
         isSortable: true,
         isVisible: true
       },


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Changes the `Timeleft` column to `Time Left`, as `Timeleft` is not a word.

#### Issues Fixed or Closed by this PR

* Related to #1010 but I assume that's no longer relevant. Was changed in 95da301 but appears to not have made it.
