### PR TITLE
Fixed: Trakt BaseURL pointing to depreciated API link

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
 
         public TraktSettingsBase()
         {
-            BaseUrl = "https://api.trakt.tv";
+            BaseUrl = "https://trakt.tv";
             SignIn = "startOAuth";
             Rating = "0-100";
             Genres = "";


### PR DESCRIPTION
Closes #4568

#### Database Migration
NO

#### Description
Fixes up the last api.trakt reference in code.

#### Todos
-  Tests
-  Wiki Updates
- [ ] do we need a migration here?

#### Issues Fixed or Closed by this PR

* 
