### PR TITLE
Flood Fix: Remove duplicate call to DeleteTorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -229,7 +229,6 @@ namespace NzbDrone.Core.Download.Clients.Flood
         public override void RemoveItem(DownloadClientItem item, bool deleteData)
         {
             _proxy.DeleteTorrent(item.DownloadId, deleteData, Settings);
-            _proxy.DeleteTorrent(item.DownloadId, deleteData, Settings);
         }
 
         public override DownloadClientInfo GetStatus()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
While investigating an issue with Flood I discovered that the following lines seem to have been mistakenly duplicated in this commit [c669be3](https://github.com/Sonarr/Sonarr/commit/c669be317fffa252d59851e9a8ca9e56032a01fb#diff-94a0ab78c97ff8de1786cfd7d29d336550638b602775f1cab002591a59ba7948L205-R206), This PR simply removes the duplicate call.
https://github.com/Sonarr/Sonarr/blob/4659a8366d8a1565890d3b72442bd35c6eb8176e/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs#L229-L233