### PR TITLE
New: Change Today color in calendar for better visibility

### DIFF
--- a/frontend/src/Styles/Variables/colors.js
+++ b/frontend/src/Styles/Variables/colors.js
@@ -178,7 +178,7 @@ module.exports = {
   //
   // Calendar
 
-  calendarTodayBackgroundColor: '#bbb',
+  calendarTodayBackgroundColor: '#c5c5c5',
   calendarBorderColor: '#cecece',
   calendarTextDim: '#666',
   calendarTextDimAlternate: '#eee',

--- a/frontend/src/Styles/Variables/colors.js
+++ b/frontend/src/Styles/Variables/colors.js
@@ -178,7 +178,7 @@ module.exports = {
   //
   // Calendar
 
-  calendarTodayBackgroundColor: '#ddd',
+  calendarTodayBackgroundColor: '#bbb',
   calendarBorderColor: '#cecece',
   calendarTextDim: '#666',
   calendarTextDimAlternate: '#eee',


### PR DESCRIPTION
#### Database Migration
NO 

#### Description
I found it hard to see the highlighted `today` block in the calendar, so I adjusted the color for more contrast.
This is the smallest of changes, but it makes a big difference in visibility.

Let me know if there are any problems in regards to text contrast for accessibility.