### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,4 @@
 name: Bug Report
-title: ""
 description: 'Support Requests will be closed immediately, if you are not 100% certain this is a bug please go to our Reddit, Discord, Forums, or IRC first. Exceptions do not mean you found a bug!'
 labels: ['needs-triage']
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,4 @@
 name: Feature Request
-title: ""
 description: 'Suggest an idea for Sonarr'
 labels: ['needs-triage']
 body:


### PR DESCRIPTION
The `title` key is optional, but must not be empty if specified.

#### Database Migration
NO

#### Description
This fixes the issue templates, which were broken by https://github.com/Sonarr/Sonarr/commit/3fb5f65f0889e5bf84338a7fa92680a9ccb135e2.