### PR TITLE
Fixed: Don't fetch quality definitions twice

### DIFF
--- a/frontend/src/Settings/Quality/Definition/QualityDefinitionsConnector.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinitionsConnector.js
@@ -38,8 +38,6 @@ class QualityDefinitionsConnector extends Component {
   // Lifecycle
 
   componentDidMount() {
-    this.props.dispatchFetchQualityDefinitions();
-
     const {
       dispatchFetchQualityDefinitions,
       dispatchSaveQualityDefinitions,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Avoid a double fetch of quality definitions on line 41 and 49

#### TODO
- [ ] Rename commit or squash on merge

#### Issues Fixed or Closed by this PR
None
