### PR TITLE
New: Disable autocomplete of port number

### DIFF
--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -51,6 +51,7 @@ function HostSettings(props) {
           name="port"
           min={1}
           max={65535}
+          autocomplete="off"
           helpTextWarning="Requires restart to take effect"
           onChange={onInputChange}
           {...port}


### PR DESCRIPTION

#### Database Migration
YES | NO

#### Description
In order to overcome a chance that the port field is automatically filled by a browser when viewing the general settings, and saved accidently, I propose to disable autocomplete on this field.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
