### PR TITLE
New: Use filename without extension if SceneName is unavailable for preferred words

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFile.cs
@@ -41,12 +41,12 @@ namespace NzbDrone.Core.MediaFiles
 
             if (RelativePath.IsNotNullOrWhiteSpace())
             {
-                return System.IO.Path.GetFileName(RelativePath);
+                return System.IO.Path.GetFileNameWithoutExtension(RelativePath);
             }
 
             if (Path.IsNotNullOrWhiteSpace())
             {
-                return System.IO.Path.GetFileName(Path);
+                return System.IO.Path.GetFileNameWithoutExtension(Path);
             }
 
             return string.Empty;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Submitting the proposed fix for 4675, where GetSceneOrFileName no longer returns the extension

#### Issues Fixed or Closed by this PR
https://github.com/Sonarr/Sonarr/issues/4675
