### PR TITLE
Fixed: On Delete events for Custom Scripts not being executed

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -164,6 +164,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_EpisodeFile_ReleaseGroup", episodeFile.ReleaseGroup ?? string.Empty);
             environmentVariables.Add("Sonarr_EpisodeFile_SceneName", episodeFile.SceneName ?? string.Empty);
 
+            ExecuteScript(environmentVariables);
         }
 
         public override void OnSeriesDelete(SeriesDeleteMessage deleteMessage)


### PR DESCRIPTION
fixes bug reported in #4686

Single line fix, adding the missing call for the customscript in the OnEpisodeFileDeleted hook.
