### PR TITLE
New: Time column is first column on events page

### DIFF
--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -87,6 +87,13 @@ export const defaultState = {
         isModifiable: false
       },
       {
+        name: 'time',
+        label: 'Time',
+        isSortable: true,
+        isVisible: true,
+        isModifiable: false
+      },
+      {
         name: 'logger',
         label: 'Component',
         isSortable: false,
@@ -96,13 +103,6 @@ export const defaultState = {
       {
         name: 'message',
         label: 'Message',
-        isVisible: true,
-        isModifiable: false
-      },
-      {
-        name: 'time',
-        label: 'Time',
-        isSortable: true,
         isVisible: true,
         isModifiable: false
       },

--- a/frontend/src/System/Events/LogsTableRow.js
+++ b/frontend/src/System/Events/LogsTableRow.js
@@ -58,9 +58,9 @@ class LogsTableRow extends Component {
   render() {
     const {
       level,
+      time,
       logger,
       message,
-      time,
       exception,
       columns
     } = this.props;
@@ -96,6 +96,15 @@ class LogsTableRow extends Component {
               );
             }
 
+            if (name === 'time') {
+              return (
+                <RelativeDateCellConnector
+                  key={name}
+                  date={time}
+                />
+              );
+            }
+
             if (name === 'logger') {
               return (
                 <TableRowCell key={name}>
@@ -109,15 +118,6 @@ class LogsTableRow extends Component {
                 <TableRowCell key={name}>
                   {message}
                 </TableRowCell>
-              );
-            }
-
-            if (name === 'time') {
-              return (
-                <RelativeDateCellConnector
-                  key={name}
-                  date={time}
-                />
               );
             }
 
@@ -148,9 +148,9 @@ class LogsTableRow extends Component {
 
 LogsTableRow.propTypes = {
   level: PropTypes.string.isRequired,
+  time: PropTypes.string.isRequired,
   logger: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
   exception: PropTypes.string,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired
 };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Moves the time column to be after the event type as this is more typical for logging. This was cherry-picked from Radarr (and has gone downstream to all others) https://github.com/Radarr/Radarr/commit/c14ef7bee7477ad5d29498f1cba94267eb11daf0


![image](https://user-images.githubusercontent.com/19610103/141087174-ed195a54-0984-46fc-b1a7-7c92844afcf1.png)
