### PR TITLE
New: Handle missingFiles status from qBit

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -286,6 +286,27 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
+        public void missingFiles_item_should_have_required_properties()
+        {
+            var torrent = new QBittorrentTorrent
+            {
+                Hash = "HASH",
+                Name = _title,
+                Size = 1000,
+                Progress = 0.7,
+                Eta = 8640000,
+                State = "missingFiles",
+                Label = "",
+                SavePath = ""
+            };
+            GivenTorrents(new List<QBittorrentTorrent> { torrent });
+
+            var item = Subject.GetItems().Single();
+            VerifyWarning(item);
+            item.RemainingTime.Should().NotHaveValue();
+        }
+
+        [Test]
         public void single_file_torrent_outputpath_should_have_sanitised_name()
         {
             var torrent = new QBittorrentTorrent

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -269,6 +269,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Message = "The download is stalled with no connections";
                         break;
 
+                    case "missingFiles": // torrent is missing files
+                        item.Status = DownloadItemStatus.Warning;
+                        item.Message = "The download is missing files";
+                        break;
+
                     case "metaDL": // torrent magnet is being downloaded
                         if (config.DhtEnabled)
                         {


### PR DESCRIPTION
(cherry picked from radarr commit 9a2cee3104b1e8d32f2df68d3ca75967aba41868)

#### Database Migration
NO

#### Description
treat missingfiles as a warning rather than unknown state

#### Todos
- [X] Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* 
