### PR TITLE
New: Add {MediaInfo VideoDynamicRangeType} token for renaming

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoDynamicRangeFixture.cs
@@ -17,8 +17,8 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase(10, "BT.2020", "HLG", "", "", "HDR")]
         [TestCase(10, "", "", "Dolby Vision", "", "HDR")]
         [TestCase(10, "", "", "SMPTE ST 2086", "HDR10", "HDR")]
-        [TestCase(8, "", "", "Dolby Vision", "", "HDR")]
-        [TestCase(8, "", "", "SMPTE ST 2086", "HDR10", "HDR")]
+        [TestCase(8, "", "", "Dolby Vision", "", "")]
+        [TestCase(8, "", "", "SMPTE ST 2086", "HDR10", "")]
         [TestCase(10, "BT.2020", "PQ", "Dolby Vision / SMPTE ST 2086", "Blu-ray / HDR10", "HDR")]
         public void should_format_video_dynamic_range(int bitDepth, string colourPrimaries, string transferCharacteristics, string hdrFormat, string hdrFormatCompatibility, string expectedVideoDynamicRange)
         {

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/HdrFormat.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/HdrFormat.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.MediaFiles.MediaInfo
+{
+    public enum HdrFormat
+    {
+        None,
+        UnknownHdr,
+        Pq10,
+        Hdr10,
+        Hdr10Plus,
+        Hlg10,
+        DolbyVision,
+        DolbyVisionHdr10
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -585,26 +585,29 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return tokens.Last();
         }
 
-        private static readonly string[] ValidHdrTransferFunctions = {"PQ", "HLG"};
-        private const string ValidHdrColourPrimaries = "BT.2020";
-        private const string VideoDynamicRangeHdr = "HDR";
-
         public static string FormatVideoDynamicRange(MediaInfoModel mediaInfo)
         {
-            if (mediaInfo.VideoHdrFormat.IsNotNullOrWhiteSpace())
-            {
-                return VideoDynamicRangeHdr;
-            }
+            return mediaInfo.GetHdrFormat() == HdrFormat.None ? "" : "HDR";
+        }
 
-            if (mediaInfo.VideoBitDepth >= 10 &&
-                mediaInfo.VideoColourPrimaries.IsNotNullOrWhiteSpace() &&
-                mediaInfo.VideoTransferCharacteristics.IsNotNullOrWhiteSpace())
+        public static string FormatVideoDynamicRangeType(MediaInfoModel mediaInfo)
+        {
+            switch(mediaInfo.GetHdrFormat())
             {
-                if (mediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries) &&
-                    ValidHdrTransferFunctions.Any(mediaInfo.VideoTransferCharacteristics.Contains))
-                {
-                    return VideoDynamicRangeHdr;
-                }
+                case HdrFormat.DolbyVision:
+                    return "DolbyVision";
+                case HdrFormat.DolbyVisionHdr10:
+                    return "DolbyVision/HDR10";
+                case HdrFormat.Hdr10:
+                    return "HDR10";
+                case HdrFormat.Hdr10Plus:
+                    return "HDR10+";
+                case HdrFormat.Hlg10:
+                    return "HLG";
+                case HdrFormat.Pq10:
+                    return "PQ";
+                case HdrFormat.UnknownHdr:
+                    return "HDR";
             }
 
             return "";

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModelExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModelExtensions.cs
@@ -1,0 +1,76 @@
+﻿using NzbDrone.Common.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Core.MediaFiles.MediaInfo
+{
+    public static class MediaInfoModelExtensions
+    {
+        private const string HlgTransferFunction = "HLG";
+        private const string PgTransferFunction = "PQ";
+        private const string ValidHdrColourPrimaries = "BT.2020";
+
+        private static readonly string[] Hdr10Formats = { "SMPTE ST 2086", "HDR10" };
+        private static readonly string[] Hdr10PlusFormats = { "SMPTE ST 2094 App 4" };
+        private static readonly string[] DolbyVisionFormats = { "Dolby Vision" };
+
+        public static HdrFormat GetHdrFormat(this MediaInfoModel mediaInfo)
+        {
+            if (mediaInfo.VideoBitDepth < 10)
+            {
+                return HdrFormat.None;
+            }
+
+            if (mediaInfo.VideoHdrFormat.IsNotNullOrWhiteSpace())
+            {
+                if(DolbyVisionFormats.Any(mediaInfo.VideoHdrFormat.ContainsIgnoreCase))
+                {
+                    if(Hdr10Formats.Any(mediaInfo.VideoHdrFormat.ContainsIgnoreCase))
+                    {
+                        return HdrFormat.DolbyVisionHdr10;
+                    }
+                    else
+                    {
+                        return HdrFormat.DolbyVision;
+                    }
+                }
+                else if(Hdr10Formats.Any(mediaInfo.VideoHdrFormat.ContainsIgnoreCase))
+                {
+                    return HdrFormat.Hdr10;
+                }
+                else if(Hdr10PlusFormats.Any(mediaInfo.VideoHdrFormat.ContainsIgnoreCase))
+                {
+                    return HdrFormat.Hdr10Plus;
+                }
+            }
+
+            //
+            // We didn't match straight from the format from MediaInfo, so try and match in ColourPrimaries and TransferCharacteristics 
+            //
+            if (mediaInfo.VideoColourPrimaries.IsNotNullOrWhiteSpace() && mediaInfo.VideoTransferCharacteristics.IsNotNullOrWhiteSpace())
+            {
+                if (mediaInfo.VideoColourPrimaries.EqualsIgnoreCase(ValidHdrColourPrimaries))
+                {
+                    if (mediaInfo.VideoTransferCharacteristics.EqualsIgnoreCase(PgTransferFunction))
+                    {
+                        return HdrFormat.Pq10;
+                    }
+                    else if (mediaInfo.VideoTransferCharacteristics.EqualsIgnoreCase(HlgTransferFunction))
+                    {
+                        return HdrFormat.Hlg10;
+                    }
+                }
+            }
+
+            if (mediaInfo.VideoHdrFormat.IsNotNullOrWhiteSpace())
+            {
+                return HdrFormat.UnknownHdr; // MediaInfo reported Hdr information, but we're unsure of what type.
+            }
+
+            return HdrFormat.None;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -603,10 +603,12 @@ namespace NzbDrone.Core.Organizer
         }
 
         private const string MediaInfoVideoDynamicRangeToken = "{MediaInfo VideoDynamicRange}";
+        private const string MediaInfoVideoDynamicRangeTypeToken = "{MediaInfo VideoDynamicRangeType}";
         private static readonly IDictionary<string, int> MinimumMediaInfoSchemaRevisions =
             new Dictionary<string, int>(FileNameBuilderTokenEqualityComparer.Instance)
         {
-            {MediaInfoVideoDynamicRangeToken, 5}
+            {MediaInfoVideoDynamicRangeToken, 5},
+            {MediaInfoVideoDynamicRangeTypeToken, 5}
         };
 
         private void AddMediaInfoTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, EpisodeFile episodeFile)
@@ -650,6 +652,8 @@ namespace NzbDrone.Core.Organizer
 
             tokenHandlers[MediaInfoVideoDynamicRangeToken] =
                 m => MediaInfoFormatter.FormatVideoDynamicRange(episodeFile.MediaInfo);
+            tokenHandlers[MediaInfoVideoDynamicRangeTypeToken] =
+                m => MediaInfoFormatter.FormatVideoDynamicRangeType(episodeFile.MediaInfo);
         }
 
         private void AddIdTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Series series)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is based off the work done by @Matty666 in #4278 and #2950

With the multiple hdr formats and some shows getting released as both DolbyVision and HDR10, Sonarr was renaming then all HDR. It is possible to use Preferred Words renaming to keep the extra metadata when it exists in the release name, but it's not always included (e.g. I believe Scene standards say it's optional if the HDR version was released first).

I added a new token instead of changing the logic of the original one. It adds a token that could be considered a dupe, but also means that existing users won't start seeing new stuff they're not expecting in their names.

The new token attempts to parse what type of HDR the media is based on the existing metadata pulls (so a rescan isn't needed and the model version doesn't change so no DB serializers need altering).

(if I'm off base on this, please comment and reject :) )

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR
* 
