### PR TITLE
Implement OnDelete notification for emby/jellyfin

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/163_add_on_delete_to_emby_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/163_add_on_delete_to_emby_notifications.cs
@@ -1,0 +1,16 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(163)]
+    public class add_on_delete_to_emby_notifications : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.Sql("UPDATE Notifications SET OnSeriesDelete = 1 WHERE Implementation = 'MediaBrowser'");
+            Execute.Sql("UPDATE Notifications SET OnEpisodeFileDelete = 1 WHERE Implementation = 'MediaBrowser'");
+            Execute.Sql("UPDATE Notifications SET OnEpisodeFileDeleteForUpgrade = 1 WHERE Implementation = 'MediaBrowser'");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -48,6 +48,32 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
+        public override void OnEpisodeFileDelete(EpisodeDeleteMessage deleteMessage)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, EPISODE_DELETED_TITLE_BRANDED, deleteMessage.Message);
+            }
+
+            if (Settings.UpdateLibrary)
+            {
+                _mediaBrowserService.Update(Settings, deleteMessage.Series, "Deleted");
+            }
+        }
+
+        public override void OnSeriesDelete(SeriesDeleteMessage deleteMessage)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, SERIES_DELETED_TITLE_BRANDED, deleteMessage.Message);
+            }
+
+            if (Settings.UpdateLibrary)
+            {
+                _mediaBrowserService.Update(Settings, deleteMessage.Series, "Deleted");
+            }
+        }
+
         public override void OnHealthIssue(HealthCheck.HealthCheck message)
         {
             if (Settings.Notify)

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Emby
         [FieldDefinition(4, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import, Rename, or Delete?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
         [JsonIgnore]


### PR DESCRIPTION
#### Database Migration
YES ( auto enable delete updates )

#### Description
Like for plex, notify emby and jellyfin for delete operations.

#### Todos
- [ ] Tests
Tested it locally, found no existing tests for emby connection.
```
Emby.Server.Implementations.Session.SessionWebSocketListener: Watching 1 WebSockets.
Jellyfin.Server.Middleware.LegacyEmbyRouteRewriteMiddleware: Removing "/mediabrowser" from route.
Jellyfin.Api.Auth.CustomAuthenticationHandler: AuthenticationScheme: "CustomAuthentication" was successfully authenticated.
Emby.Server.Implementations.IO.LibraryMonitor: New file refresher created for "Y:\XXX"
Emby.Server.Implementations.IO.LibraryMonitor: "XXX" ("Y:\XXX") will be refreshed.
MediaBrowser.Controller.Entities.BaseItem: Removed item: Y:\XXX\Season 1\XXX - S01E10.mkv
```
- [ ] Wiki Updates
Found nothing relevant for it, so no update needed.


#### Issues Fixed or Closed by this PR
#4743
