### PR TITLE
Allow urlbase to be specified for mediaservers

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -66,10 +66,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
         private HttpRequest BuildRequest(string path, MediaBrowserSettings settings)
         {
-            var scheme = settings.UseSsl ? "https" : "http";
-            var url = $@"{scheme}://{settings.Address}/mediabrowser";
-            
-            return new HttpRequestBuilder(url).Resource(path).Build();
+            return new HttpRequestBuilder($@"{settings.Address}/mediabrowser").Resource(path).Build();
         }
 
         private void CheckForError(HttpResponse response)

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using System;
 
 namespace NzbDrone.Core.Notifications.Emby
 {
@@ -12,6 +13,7 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.ApiKey).NotEmpty();
+            RuleFor(c => c.UrlBase).ActuallyValidUrlBase();
         }
     }
 
@@ -19,31 +21,29 @@ namespace NzbDrone.Core.Notifications.Emby
     {
         private static readonly MediaBrowserSettingsValidator Validator = new MediaBrowserSettingsValidator();
 
-        public MediaBrowserSettings()
-        {
-            Port = 8096;
-        }
-
         [FieldDefinition(0, Label = "Host")]
         public string Host { get; set; }
 
         [FieldDefinition(1, Label = "Port")]
-        public int Port { get; set; }
+        public int Port { get; set; } = 8096;
 
         [FieldDefinition(2, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Emby over HTTPS instead of HTTP")]
         public bool UseSsl { get; set; }
 
-        [FieldDefinition(3, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
+        [FieldDefinition(3, Label = "Url Base", Type = FieldType.Textbox, Advanced = true, HelpText = "Adds a prefix to the Emby server url, see http://[host]:[port]/[urlBase]")]
+        public string UrlBase { get; set; } = "";
+
+        [FieldDefinition(4, Label = "API Key", Privacy = PrivacyLevel.ApiKey)]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(4, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
+        [FieldDefinition(5, Label = "Send Notifications", HelpText = "Have MediaBrowser send notfications to configured providers", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(5, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
         [JsonIgnore]
-        public string Address => $"{Host}:{Port}";
+        public string Address => $"{(UseSsl ? "https" : "http")}://{Host}:{Port}{(String.IsNullOrEmpty(UrlBase) ? "" : $"/{UrlBase}")}";
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host) && Port > 0;
 

--- a/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClientService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClientService.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
             try
             {
                 var command = string.Format("ExecBuiltIn(Notification({0}, {1}))", header, message);
-                SendCommand(settings.Host, settings.Port, command, settings.Username, settings.Password);
+                SendCommand(settings.Address, command, settings.Username, settings.Password);
             }
             catch(Exception ex)
             {
@@ -35,16 +35,16 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
             }
         }
 
-        private string SendCommand(string host, int port, string command, string username, string password)
+        private string SendCommand(string url, string command, string username, string password)
         {
-            var url = string.Format("http://{0}:{1}/xbmcCmds/xbmcHttp?command={2}", host, port, command);
+            var full_url = $"{url}/xbmcCmds/xbmcHttp?command={command}";
 
             if (!string.IsNullOrEmpty(username))
             {
-                return _httpProvider.DownloadString(url, username, password);
+                return _httpProvider.DownloadString(full_url, username, password);
             }
 
-            return _httpProvider.DownloadString(url);
+            return _httpProvider.DownloadString(full_url);
         }
 
         public ValidationFailure Test(PlexClientSettings settings)
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
             {
                 _logger.Debug("Sending Test Notifcation to Plex Client: {0}", settings.Host);
                 var command = string.Format("ExecBuiltIn(Notification({0}, {1}))", "Test Notification", "Success! Notifications are setup correctly");
-                var result = SendCommand(settings.Host, settings.Port, command, settings.Username, settings.Password);
+                var result = SendCommand(settings.Address, command, settings.Username, settings.Password);
 
                 if (string.IsNullOrWhiteSpace(result) ||
                     result.IndexOf("error", StringComparison.InvariantCultureIgnoreCase) > -1)

--- a/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClientSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexClientSettings.cs
@@ -1,7 +1,9 @@
 ﻿using FluentValidation;
+using Newtonsoft.Json;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using System;
 
 namespace NzbDrone.Core.Notifications.Plex.HomeTheater
 {
@@ -11,6 +13,7 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+            RuleFor(c => c.UrlBase).ActuallyValidUrlBase();
         }
     }
 
@@ -18,22 +21,26 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
     {
         private static readonly PlexClientSettingsValidator Validator = new PlexClientSettingsValidator();
 
-        public PlexClientSettings()
-        {
-            Port = 3000;
-        }
-
         [FieldDefinition(0, Label = "Host")]
         public string Host { get; set; }
 
         [FieldDefinition(1, Label = "Port")]
-        public int Port { get; set; }
+        public int Port { get; set; } = 3000;
 
-        [FieldDefinition(2, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(2, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Plex over HTTPS instead of HTTP")]
+        public bool UseSsl { get; set; } = false;
+
+        [FieldDefinition(3, Label = "Url Base", Type = FieldType.Textbox, Advanced = true, HelpText = "Adds a prefix to the Plex url, see http://[host]:[port]/[urlBase]")]
+        public string UrlBase { get; set; } = "";
+
+        [FieldDefinition(4, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(3, Label = "Password", Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(5, Label = "Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
+
+        [JsonIgnore]
+        public string Address => $"{(UseSsl ? "https" : "http")}://{Host}:{Port}{(String.IsNullOrEmpty(UrlBase) ? "" : $"/{UrlBase}")}";
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host);
 

--- a/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexHomeTheaterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/HomeTheater/PlexHomeTheaterSettings.cs
@@ -8,27 +8,26 @@ namespace NzbDrone.Core.Notifications.Plex.HomeTheater
         public PlexHomeTheaterSettings()
         {
             Port = 3005;
-            Notify = true;
         }
 
         //These need to be kept in the same order as XBMC Settings, but we don't want them displayed
 
-        [FieldDefinition(2, Label = "Username", Hidden = HiddenType.Hidden)]
+        [FieldDefinition(4, Label = "Username", Hidden = HiddenType.Hidden)]
         public new string Username { get; set; }
 
-        [FieldDefinition(3, Label = "Password", Hidden = HiddenType.Hidden)]
+        [FieldDefinition(5, Label = "Password", Hidden = HiddenType.Hidden)]
         public new string Password { get; set; }
 
-        [FieldDefinition(5, Label = "GUI Notification", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
-        public new bool Notify { get; set; }
+        [FieldDefinition(7, Label = "GUI Notification", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        public new bool Notify { get; set; } = true;
 
-        [FieldDefinition(6, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        [FieldDefinition(8, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public new bool UpdateLibrary { get; set; }
 
-        [FieldDefinition(7, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        [FieldDefinition(9, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public new bool CleanLibrary { get; set; }
 
-        [FieldDefinition(8, Label = "Always Update", HelpText = "Update Library even when a video is playing?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
+        [FieldDefinition(10, Label = "Always Update", HelpText = "Update Library even when a video is playing?", Type = FieldType.Checkbox, Hidden = HiddenType.Hidden)]
         public new bool AlwaysUpdate { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
@@ -150,9 +150,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         private HttpRequestBuilder BuildRequest(string resource, HttpMethod method, PlexServerSettings settings)
         {
-            var scheme = settings.UseSsl ? "https" : "http";
-
-            var requestBuilder = new HttpRequestBuilder($"{scheme}://{settings.Host}:{settings.Port}")
+            var requestBuilder = new HttpRequestBuilder(settings.Address)
                                  .Accept(HttpAccept.Json)
                                  .AddQueryParam("X-Plex-Client-Identifier", _configService.PlexClientIdentifier)
                                  .AddQueryParam("X-Plex-Product", BuildInfo.AppName)

--- a/src/NzbDrone.Core/Notifications/Xbmc/HttpApiProvider.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/HttpApiProvider.cs
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
         private string SendCommand(XbmcSettings settings, string command)
         {
-            var url = HttpRequestBuilder.BuildBaseUrl(settings.UseSsl, settings.Host, settings.Port, $"xbmcCmds/xbmcHttp?command={command}");
+            var url = $"{settings.Address}/xbmcCmds/xbmcHttp?command={command}";
 
             if (!string.IsNullOrEmpty(settings.Username))
             {

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcJsonApiProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcJsonApiProxy.cs
@@ -75,8 +75,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
         private string ProcessRequest(XbmcSettings settings, string method, params object[] parameters)
         {
-            var url = HttpRequestBuilder.BuildBaseUrl(settings.UseSsl, settings.Host, settings.Port, "jsonrpc");
-            var requestBuilder = new JsonRpcRequestBuilder(url, method, parameters);
+            var requestBuilder = new JsonRpcRequestBuilder($"{settings.Address}/jsonrpc", method, parameters);
 
             requestBuilder.LogResponseContent = true;
 

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -1,9 +1,9 @@
-﻿using System.ComponentModel;
-using FluentValidation;
+﻿using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
+using System;
 
 namespace NzbDrone.Core.Notifications.Xbmc
 {
@@ -20,45 +20,41 @@ namespace NzbDrone.Core.Notifications.Xbmc
     {
         private static readonly XbmcSettingsValidator Validator = new XbmcSettingsValidator();
 
-        public XbmcSettings()
-        {
-            Port = 8080;
-            DisplayTime = 5;
-        }
-
         [FieldDefinition(0, Label = "Host")]
         public string Host { get; set; }
 
         [FieldDefinition(1, Label = "Port")]
-        public int Port { get; set; }
+        public int Port { get; set; } = 8080;
 
         [FieldDefinition(2, Label = "Use SSL", Type = FieldType.Checkbox, HelpText = "Connect to Kodi over HTTPS instead of HTTP")]
         public bool UseSsl { get; set; }
 
-        [FieldDefinition(3, Label = "Username", Privacy = PrivacyLevel.UserName)]
+        [FieldDefinition(3, Label = "Url Base", Type = FieldType.Textbox, Advanced = true, HelpText = "Adds a prefix to the Kodi url, see http://[host]:[port]/[urlBase]")]
+        public string UrlBase { get; set; } = "";
+
+        [FieldDefinition(4, Label = "Username", Privacy = PrivacyLevel.UserName)]
         public string Username { get; set; }
 
-        [FieldDefinition(4, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
+        [FieldDefinition(5, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [DefaultValue(5)]
-        [FieldDefinition(5, Label = "Display Time", HelpText = "How long the notification will be displayed for (In seconds)")]
-        public int DisplayTime { get; set; }
+        [FieldDefinition(6, Label = "Display Time", HelpText = "How long the notification will be displayed for (In seconds)")]
+        public int DisplayTime { get; set; } = 5;
 
-        [FieldDefinition(6, Label = "GUI Notification", Type = FieldType.Checkbox)]
+        [FieldDefinition(7, Label = "GUI Notification", Type = FieldType.Checkbox)]
         public bool Notify { get; set; }
 
-        [FieldDefinition(7, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
+        [FieldDefinition(8, Label = "Update Library", HelpText = "Update Library on Import & Rename?", Type = FieldType.Checkbox)]
         public bool UpdateLibrary { get; set; }
 
-        [FieldDefinition(8, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox)]
+        [FieldDefinition(9, Label = "Clean Library", HelpText = "Clean Library after update?", Type = FieldType.Checkbox)]
         public bool CleanLibrary { get; set; }
 
-        [FieldDefinition(9, Label = "Always Update", HelpText = "Update Library even when a video is playing?", Type = FieldType.Checkbox)]
+        [FieldDefinition(10, Label = "Always Update", HelpText = "Update Library even when a video is playing?", Type = FieldType.Checkbox)]
         public bool AlwaysUpdate { get; set; }
 
         [JsonIgnore]
-        public string Address => string.Format("{0}:{1}", Host, Port);
+        public string Address => $"{(UseSsl ? "https" : "http")}://{Host}:{Port}{(String.IsNullOrEmpty(UrlBase) ? "" : $"/{UrlBase}")}";
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -38,6 +38,10 @@ namespace NzbDrone.Core.Validation
         {
             return ruleBuilder.SetValidator(new RegularExpressionValidator(@"^(?!\/?https?://[-_a-z0-9.]+)", RegexOptions.IgnoreCase)).WithMessage($"Must be a valid URL path (ie: '{example}')");
         }
+        public static IRuleBuilderOptions<T, string> ActuallyValidUrlBase<T>(this IRuleBuilder<T, string> ruleBuilder, string example = "sonarr/base")
+        {
+            return ruleBuilder.SetValidator(new RegularExpressionValidator(@"([-_a-z0-9.]+(/[-_a-z0-9.]+)*)?", RegexOptions.IgnoreCase)).WithMessage($"Must be a valid URL path (ie: '{example}')");
+        }
 
         public static IRuleBuilderOptions<T, int> ValidPort<T>(this IRuleBuilder<T, int> ruleBuilder)
         {


### PR DESCRIPTION
#### Database Migration
NO ( Default value is empty for urlbase )

#### Description
Allows people to run emby/jellyfin/plex behind reverse proxy using subdirectory and still connect them to Sonarr.

#### Todos
- [ ] Tests
The old ones are running, I didn't see any meaningful test for urls, but can add if needed.
- [ ] Wiki Updates
Found no wiki for connection specific settings.

#### Issues Fixed or Closed by this PR
#4416 
