### PR TITLE
New: Updated naming examples

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -43,12 +43,12 @@ const fileNameTokens = [
 ];
 
 const seriesTokens = [
-  { token: '{Series Title}', example: 'Series Title!' },
-  { token: '{Series CleanTitle}', example: 'Series Title!' },
-  { token: '{Series CleanTitleYear}', example: 'Series Title! 2010' },
-  { token: '{Series TitleThe}', example: 'Series Title!, The' },
-  { token: '{Series TitleTheYear}', example: 'Series Title!, The (2010)' },
-  { token: '{Series TitleYear}', example: 'Series Title! (2010)' },
+  { token: '{Series Title}', example: 'Series Title\'s' },
+  { token: '{Series CleanTitle}', example: 'Series Titles' },
+  { token: '{Series CleanTitleYear}', example: 'Series Titles! 2010' },
+  { token: '{Series TitleThe}', example: 'Series Title\'s, The' },
+  { token: '{Series TitleTheYear}', example: 'Series Title\'s, The (2010)' },
+  { token: '{Series TitleYear}', example: 'Series Title\'s (2010)' },
   { token: '{Series TitleFirstCharacter}', example: 'S' },
   { token: '{Series Year}', example: '2010' }
 ];
@@ -81,13 +81,13 @@ const absoluteTokens = [
 ];
 
 const episodeTitleTokens = [
-  { token: '{Episode Title}', example: 'Episode Title' },
-  { token: '{Episode CleanTitle}', example: 'Episode Title' }
+  { token: '{Episode Title}', example: 'Episode\'s Title' },
+  { token: '{Episode CleanTitle}', example: 'Episodes Title' }
 ];
 
 const qualityTokens = [
-  { token: '{Quality Full}', example: 'HDTV 720p Proper' },
-  { token: '{Quality Title}', example: 'HDTV 720p' }
+  { token: '{Quality Full}', example: 'HDTV-720p Proper' },
+  { token: '{Quality Title}', example: 'HDTV-720p' }
 ];
 
 const mediaInfoTokens = [

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -44,11 +44,11 @@ const fileNameTokens = [
 
 const seriesTokens = [
   { token: '{Series Title}', example: 'Series Title!' },
-  { token: '{Series CleanTitle}', example: 'Series Title' },
-  { token: '{Series CleanTitleYear}', example: 'Series Title 2010' },
-  { token: '{Series TitleThe}', example: 'Series Title, The' },
-  { token: '{Series TitleTheYear}', example: 'Series Title, The (2010)' },
-  { token: '{Series TitleYear}', example: 'Series Title (2010)' },
+  { token: '{Series CleanTitle}', example: 'Series Title!' },
+  { token: '{Series CleanTitleYear}', example: 'Series Title! 2010' },
+  { token: '{Series TitleThe}', example: 'Series Title!, The' },
+  { token: '{Series TitleTheYear}', example: 'Series Title!, The (2010)' },
+  { token: '{Series TitleYear}', example: 'Series Title! (2010)' },
   { token: '{Series TitleFirstCharacter}', example: 'S' },
   { token: '{Series Year}', example: '2010' }
 ];


### PR DESCRIPTION
#### Database Migration
NO

#### Description
currently the modal examples implies that ! is removed from all  naming formats except {Series Title}.
Including it now in the examples to avoid confusion as a simple fix until the issue #2028 gets further attention
#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
