### PR TITLE
Clarify Trace logs in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,6 +66,7 @@ body:
     description: |
       Trace Logs (https://wiki.servarr.com/sonarr/troubleshooting#logging-and-log-files) 
       ***Generally speaking, all bug reports must have trace logs provided.***
+      *** Info Logs are not trace logs. If the logs do not say trace and are not from a file like `*.trace.*.txt` they are not trace logs.***
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
git

skip ci is for downstream easier bot pulls; aware it does nothing here.