### PR TITLE
Fixed: Grammar in tooltip of download button

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.js
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.js
@@ -35,12 +35,12 @@ function getDownloadTooltip(isGrabbing, isGrabbed, grabError) {
   if (isGrabbing) {
     return '';
   } else if (isGrabbed) {
-    return 'Added to downloaded queue';
+    return 'Added to download queue';
   } else if (grabError) {
     return grabError;
   }
 
-  return 'Add to downloaded queue';
+  return 'Add to download queue';
 }
 
 class InteractiveSearchRow extends Component {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The tooltip should show "download queue" rather than "downloaded queue" as "downloaded" implies it has already been downloaded.

#### Todos
- [ ] Tests
- [ ] Wiki Updates