### PR TITLE
New: Added "Season Pack" to Interactive Search custom filters

### DIFF
--- a/frontend/src/Store/Actions/releaseActions.js
+++ b/frontend/src/Store/Actions/releaseActions.js
@@ -200,6 +200,12 @@ export const defaultState = {
       name: 'rejectionCount',
       label: 'Rejection Count',
       type: filterBuilderTypes.NUMBER
+    },
+    {
+      name: 'fullSeason',
+      label: 'Season Pack',
+      type: filterBuilderTypes.EXACT,
+      valueType: filterBuilderValueTypes.BOOL
     }
   ],
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds ability to use "Season Pack" filter in Custom Filters

#### Todos
- [ ] Confirm ordering of the filter with maintainers

#### Issues Fixed or Closed by this PR

* #4780
