### PR TITLE
Fixed: Improved messaging when episode file was detected as deleted from disk

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.js
+++ b/frontend/src/Activity/History/Details/HistoryDetails.js
@@ -207,7 +207,7 @@ function HistoryDetails(props) {
         reasonMessage = 'File was deleted by via UI';
         break;
       case 'MissingFromDisk':
-        reasonMessage = 'Sonarr was unable to find the file on disk so it was removed';
+        reasonMessage = 'Sonarr was unable to find the file on disk so the file was unlinked from the episode in the database';
         break;
       case 'Upgrade':
         reasonMessage = 'File was deleted to import an upgrade';


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Due to the confusing message, users frequently incorrectly believe Sonarr deleted the file when it simply could no longer be seen.

#### Todos
-  Tests
-  Wiki Updates


#### Issues Fixed or Closed by this PR

https://forums.sonarr.tv/t/unable-to-find-file-on-disk-so-it-was-deleted/29282
