### PR TITLE
Update RestSharp to 106.15.0 to address vulnerability

### DIFF
--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NLog" Version="4.6.6" />
     <PackageReference Include="OAuth" Version="1.0.3" />
-    <PackageReference Include="RestSharp" Version="106.6.10" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="TinyTwitter" Version="1.1.2" />
     <PackageReference Include="xmlrpcnet" Version="3.0.0.266" />
   </ItemGroup>

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NLog" Version="4.6.6" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="RestSharp" Version="106.6.10" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="Unity" Version="5.11.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pull addresses CVE-2021-27293 in RestSharp by updating the dependency to 106.15.0. All tests passed locally with no issues.

#### Todos
- [ ] Tests
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Resolves use of vulnerable version of RestSharp