### PR TITLE
Add test to ensure Identity is maintained on Id column during migration

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/SqliteSchemaDumperTests/SqliteSchemaDumperFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/SqliteSchemaDumperTests/SqliteSchemaDumperFixture.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Test.Datastore.SqliteSchemaDumperTests
             result.Name.Should().Be(tableName);
             result.Columns.Count.Should().Be(1);
             result.Columns.First().Name.Should().Be(columnName);
+            result.Columns.First().IsIdentity.Should().BeTrue();
         }
 
         [TestCase(@"CREATE INDEX TestIndex ON TestTable (MyId)", "TestIndex", "TestTable", "MyId")]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This adds a check to the SqliteSchemaDumperFixture to ensure identity is not lost on the Id column during migration. While not a problem with Sonarr thus far, this will ensure we catch issues for any future schemas in the testing suite. 

Reference Radarr issue solved by pulling Sonarr code 

https://github.com/Radarr/Radarr/commit/ec86de78d21dd05479379ef539686b2052504046

https://github.com/Sonarr/Sonarr/commit/34faa417c1d7c48d86236ed8f29bd44518322373

#### Todos
- [x] Test

#### Issues Fixed or Closed by this PR

* 
