### PR TITLE
Don't lowercase UrlBase in ConfigFileProvider

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -195,7 +195,7 @@ namespace NzbDrone.Core.Configuration
                     return urlBase;
                 }
 
-                return "/" + urlBase.Trim('/').ToLower();
+                return "/" + urlBase;
             }
         }
 


### PR DESCRIPTION
UrlBase should honour the case it is given.

#### Database Migration
NO

#### Description
When setting `UrlBase` with a value the characters are changed to lowercase. This causes issues where reverse proxies are case-sensitive thus fail to proxy the requests because of case differences.
