### PR TITLE
Use BuildInfo.AppName for RARBG appId instead of hardcoded value

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/RarbgTests/RarbgFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/RarbgTests/RarbgFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Indexers.Rarbg;
@@ -19,10 +20,10 @@ namespace NzbDrone.Core.Test.IndexerTests.RarbgTests
         public void Setup()
         {
             Subject.Definition = new IndexerDefinition()
-                {
-                    Name = "Rarbg",
-                    Settings = new RarbgSettings()
-                };
+            {
+                Name = "Rarbg",
+                Settings = new RarbgSettings()
+            };
 
             Mocker.GetMock<IRarbgTokenProvider>()
                 .Setup(v => v.GetToken(It.IsAny<RarbgSettings>()))
@@ -48,7 +49,7 @@ namespace NzbDrone.Core.Test.IndexerTests.RarbgTests
             torrentInfo.Title.Should().Be("Sense8.S01E01.WEBRip.x264-FGT");
             torrentInfo.DownloadProtocol.Should().Be(DownloadProtocol.Torrent);
             torrentInfo.DownloadUrl.Should().Be("magnet:?xt=urn:btih:d8bde635f573acb390c7d7e7efc1556965fdc802&dn=Sense8.S01E01.WEBRip.x264-FGT&tr=http%3A%2F%2Ftracker.trackerfix.com%3A80%2Fannounce&tr=udp%3A%2F%2F9.rarbg.me%3A2710&tr=udp%3A%2F%2F9.rarbg.to%3A2710&tr=udp%3A%2F%2Fopen.demonii.com%3A1337%2Fannounce");
-            torrentInfo.InfoUrl.Should().Be("https://torrentapi.org/redirect_to_info.php?token=i5cx7b9agd&p=8_6_4_4_5_6__d8bde635f5&app_id=Sonarr");
+            torrentInfo.InfoUrl.Should().Be($"https://torrentapi.org/redirect_to_info.php?token=i5cx7b9agd&p=8_6_4_4_5_6__d8bde635f5&app_id={BuildInfo.AppName}");
             torrentInfo.Indexer.Should().Be(Subject.Definition.Name);
             torrentInfo.PublishDate.Should().Be(DateTime.Parse("2015-06-05 16:58:11 +0000").ToUniversalTime());
             torrentInfo.Size.Should().Be(564198371);

--- a/src/NzbDrone.Core/Indexers/Rarbg/Rarbg.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/Rarbg.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NLog;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
@@ -45,7 +46,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 try
                 {
                     var request = new HttpRequestBuilder(Settings.BaseUrl.Trim('/'))
-                           .Resource("/pubapi_v2.php?get_token=get_token")
+                           .Resource($"/pubapi_v2.php?get_token=get_token&app_id={BuildInfo.AppName}")
                            .Accept(HttpAccept.Json)
                            .Build();
 
@@ -62,7 +63,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                             siteKey = ex.CaptchaRequest.SiteKey,
                             secretToken = ex.CaptchaRequest.SecretToken,
                             responseUrl = ex.CaptchaRequest.ResponseUrl.FullUri,
-                        }                    
+                        }
                     };
                 }
 

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Parser.Model;
@@ -51,7 +52,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 torrentInfo.Title = torrent.title;
                 torrentInfo.Size = torrent.size;
                 torrentInfo.DownloadUrl = torrent.download;
-                torrentInfo.InfoUrl = torrent.info_page + "&app_id=Sonarr";
+                torrentInfo.InfoUrl = $"{torrent.info_page}&app_id={BuildInfo.AppName}";
                 torrentInfo.PublishDate = torrent.pubdate.ToUniversalTime();
                 torrentInfo.Seeders = torrent.seeders;
                 torrentInfo.Peers = torrent.leechers + torrent.seeders;

--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgTokenProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgTokenProvider.cs
@@ -2,6 +2,7 @@ using System;
 using Newtonsoft.Json.Linq;
 using NLog;
 using NzbDrone.Common.Cache;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
@@ -31,7 +32,7 @@ namespace NzbDrone.Core.Indexers.Rarbg
                 {
                     var requestBuilder = new HttpRequestBuilder(settings.BaseUrl.Trim('/'))
                         .WithRateLimit(3.0)
-                        .Resource("/pubapi_v2.php?get_token=get_token&app_id=Sonarr")
+                        .Resource($"/pubapi_v2.php?get_token=get_token&app_id={BuildInfo.AppName}")
                         .Accept(HttpAccept.Json);
 
                     if (settings.CaptchaToken.IsNotNullOrWhiteSpace())


### PR DESCRIPTION
* Added app_id to captcha check to avoid 403 forbidden error
* Migrated app_id from hard coded to BuildInfo.AppName

#### Database Migration
NO

#### Description
Previously the captcha check threw an exception in the logs since RARBG's API responds with 403 forbidden if `app_id` is skipped/overlooked in the query. I also took the opportunity to update `app_id` from hard coded to use the `BuildInfo.AppName` value instead.
