### PR TITLE
New: Link indexer to specific download client

### DIFF
--- a/frontend/src/Components/Form/DownloadClientSelectInputConnector.js
+++ b/frontend/src/Components/Form/DownloadClientSelectInputConnector.js
@@ -1,0 +1,100 @@
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { fetchDownloadClients } from 'Store/Actions/settingsActions';
+import sortByName from 'Utilities/Array/sortByName';
+import EnhancedSelectInput from './EnhancedSelectInput';
+
+function createMapStateToProps() {
+  return createSelector(
+    (state) => state.settings.downloadClients,
+    (state, { includeAny }) => includeAny,
+    (state, { protocol }) => protocol,
+    (downloadClients, includeAny, protocolFilter) => {
+      const {
+        isFetching,
+        isPopulated,
+        error,
+        items
+      } = downloadClients;
+
+      const filteredItems = items.filter((item) => item.protocol === protocolFilter);
+
+      const values = _.map(filteredItems.sort(sortByName), (downloadClient) => {
+        return {
+          key: downloadClient.id,
+          value: downloadClient.name
+        };
+      });
+
+      if (includeAny) {
+        values.unshift({
+          key: 0,
+          value: '(Any)'
+        });
+      }
+
+      return {
+        isFetching,
+        isPopulated,
+        error,
+        values
+      };
+    }
+  );
+}
+
+const mapDispatchToProps = {
+  dispatchFetchDownloadClients: fetchDownloadClients
+};
+
+class DownloadClientSelectInputConnector extends Component {
+
+  //
+  // Lifecycle
+
+  componentDidMount() {
+    if (!this.props.isPopulated) {
+      this.props.dispatchFetchDownloadClients();
+    }
+  }
+
+  //
+  // Listeners
+
+  onChange = ({ name, value }) => {
+    this.props.onChange({ name, value: parseInt(value) });
+  }
+
+  //
+  // Render
+
+  render() {
+    return (
+      <EnhancedSelectInput
+        {...this.props}
+        onChange={this.onChange}
+      />
+    );
+  }
+}
+
+DownloadClientSelectInputConnector.propTypes = {
+  isFetching: PropTypes.bool.isRequired,
+  isPopulated: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  values: PropTypes.arrayOf(PropTypes.object).isRequired,
+  includeAny: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  dispatchFetchDownloadClients: PropTypes.func.isRequired
+};
+
+DownloadClientSelectInputConnector.defaultProps = {
+  includeAny: false,
+  protocol: 'torrent'
+};
+
+export default connect(createMapStateToProps, mapDispatchToProps)(DownloadClientSelectInputConnector);

--- a/frontend/src/Components/Form/FormInputGroup.js
+++ b/frontend/src/Components/Form/FormInputGroup.js
@@ -6,6 +6,7 @@ import AutoCompleteInput from './AutoCompleteInput';
 import CaptchaInputConnector from './CaptchaInputConnector';
 import CheckInput from './CheckInput';
 import DeviceInputConnector from './DeviceInputConnector';
+import DownloadClientSelectInputConnector from './DownloadClientSelectInputConnector';
 import KeyValueListInput from './KeyValueListInput';
 import MonitorEpisodesSelectInput from './MonitorEpisodesSelectInput';
 import NumberInput from './NumberInput';
@@ -67,6 +68,9 @@ function getComponent(type) {
 
     case inputTypes.INDEXER_SELECT:
       return IndexerSelectInputConnector;
+
+    case inputTypes.DOWNLOAD_CLIENT_SELECT:
+      return DownloadClientSelectInputConnector;
 
     case inputTypes.ROOT_FOLDER_SELECT:
       return RootFolderSelectInputConnector;

--- a/frontend/src/Helpers/Props/inputTypes.js
+++ b/frontend/src/Helpers/Props/inputTypes.js
@@ -11,6 +11,7 @@ export const PATH = 'path';
 export const QUALITY_PROFILE_SELECT = 'qualityProfileSelect';
 export const LANGUAGE_PROFILE_SELECT = 'languageProfileSelect';
 export const INDEXER_SELECT = 'indexerSelect';
+export const DOWNLOAD_CLIENT_SELECT = 'downloadClientSelect';
 export const ROOT_FOLDER_SELECT = 'rootFolderSelect';
 export const SELECT = 'select';
 export const DYNAMIC_SELECT = 'dynamicSelect';
@@ -35,6 +36,7 @@ export const all = [
   QUALITY_PROFILE_SELECT,
   LANGUAGE_PROFILE_SELECT,
   INDEXER_SELECT,
+  DOWNLOAD_CLIENT_SELECT,
   ROOT_FOLDER_SELECT,
   SELECT,
   DYNAMIC_SELECT,

--- a/frontend/src/Settings/Indexers/Indexers/EditIndexerModalContent.js
+++ b/frontend/src/Settings/Indexers/Indexers/EditIndexerModalContent.js
@@ -44,7 +44,9 @@ function EditIndexerModalContent(props) {
     supportsSearch,
     tags,
     fields,
-    priority
+    priority,
+    protocol,
+    downloadClientId
   } = item;
 
   return (
@@ -147,6 +149,23 @@ function EditIndexerModalContent(props) {
                   min={1}
                   max={50}
                   {...priority}
+                  onChange={onInputChange}
+                />
+              </FormGroup>
+
+              <FormGroup
+                advancedSettings={advancedSettings}
+                isAdvanced={true}
+              >
+                <FormLabel>DownloadClient</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.DOWNLOAD_CLIENT_SELECT}
+                  name="downloadClientId"
+                  helpText={'Specify which download client is used for grabs from this indexer'}
+                  {...downloadClientId}
+                  includeAny={true}
+                  protocol={protocol.value}
                   onChange={onInputChange}
                 />
               </FormGroup>

--- a/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.Clients;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Test.Framework;
 
@@ -67,6 +68,17 @@ namespace NzbDrone.Core.Test.Download
             mock.SetupGet(v => v.Protocol).Returns(DownloadProtocol.Torrent);
 
             return mock;
+        }
+
+        private void WithTorrentIndexer(int downloadClientId)
+        {
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Find(It.IsAny<int>()))
+                .Returns(Builder<IndexerDefinition>
+                    .CreateNew()
+                    .With(v => v.Id = _nextId++)
+                    .With(v => v.DownloadClientId = downloadClientId)
+                    .Build());
         }
 
         private void GivenBlockedClient(int id)
@@ -224,6 +236,40 @@ namespace NzbDrone.Core.Test.Download
             client2.Definition.Id.Should().Be(3);
             client3.Definition.Id.Should().Be(2);
             client4.Definition.Id.Should().Be(3);
+        }
+
+        [Test]
+        public void should_always_choose_indexer_client()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentIndexer(3);
+
+            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 1);
+            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 1);
+            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 1);
+            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 1);
+            var client5 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 1);
+
+            client1.Definition.Id.Should().Be(3);
+            client2.Definition.Id.Should().Be(3);
+            client3.Definition.Id.Should().Be(3);
+            client4.Definition.Id.Should().Be(3);
+            client5.Definition.Id.Should().Be(3);
+        }
+
+        [Test]
+        public void should_fail_to_choose_client_when_indexer_reference_does_not_exist()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentIndexer(5);
+
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClient(DownloadProtocol.Torrent, 1));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
@@ -33,8 +33,8 @@ namespace NzbDrone.Core.Test.Download
                 .Returns(_downloadClients);
 
             Mocker.GetMock<IProvideDownloadClient>()
-                .Setup(v => v.GetDownloadClient(It.IsAny<DownloadProtocol>()))
-                .Returns<DownloadProtocol>(v => _downloadClients.FirstOrDefault(d => d.Protocol == v));
+                .Setup(v => v.GetDownloadClient(It.IsAny<DownloadProtocol>(), It.IsAny<int>()))
+                .Returns<DownloadProtocol, int>((v, i) => _downloadClients.FirstOrDefault(d => d.Protocol == v));
 
             var episodes = Builder<Episode>.CreateListOfSize(2)
                 .TheFirst(1).With(s => s.Id = 12)

--- a/src/NzbDrone.Core/Datastore/Migration/164_download_client_per_indexer.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/164_download_client_per_indexer.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(164)]
+    public class download_client_per_indexer : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Indexers").AddColumn("DownloadClientId").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/DownloadClientProvider.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientProvider.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Common.Cache;
+using NzbDrone.Core.Download.Clients;
 using NLog;
 
 namespace NzbDrone.Core.Download
 {
     public interface IProvideDownloadClient
     {
-        IDownloadClient GetDownloadClient(DownloadProtocol downloadProtocol);
+        IDownloadClient GetDownloadClient(DownloadProtocol downloadProtocol, int indexerId = 0);
         IEnumerable<IDownloadClient> GetDownloadClients();
         IDownloadClient Get(int id);
     }
@@ -18,21 +19,39 @@ namespace NzbDrone.Core.Download
         private readonly Logger _logger;
         private readonly IDownloadClientFactory _downloadClientFactory;
         private readonly IDownloadClientStatusService _downloadClientStatusService;
+        private readonly IIndexerFactory _indexerFactory;
         private readonly ICached<int> _lastUsedDownloadClient;
 
-        public DownloadClientProvider(IDownloadClientStatusService downloadClientStatusService, IDownloadClientFactory downloadClientFactory, ICacheManager cacheManager, Logger logger)
+        public DownloadClientProvider(IDownloadClientStatusService downloadClientStatusService,
+                                      IDownloadClientFactory downloadClientFactory,
+                                      IIndexerFactory indexerFactory,
+                                      ICacheManager cacheManager, 
+                                      Logger logger)
         {
             _logger = logger;
             _downloadClientFactory = downloadClientFactory;
             _downloadClientStatusService = downloadClientStatusService;
+            _indexerFactory = indexerFactory;
             _lastUsedDownloadClient = cacheManager.GetCache<int>(GetType(), "lastDownloadClientId");
         }
 
-        public IDownloadClient GetDownloadClient(DownloadProtocol downloadProtocol)
+        public IDownloadClient GetDownloadClient(DownloadProtocol downloadProtocol, int indexerId = 0)
         {
             var availableProviders = _downloadClientFactory.GetAvailableProviders().Where(v => v.Protocol == downloadProtocol).ToList();
 
             if (!availableProviders.Any()) return null;
+
+            if (indexerId > 0)
+            {
+                var indexer = _indexerFactory.Find(indexerId);
+
+                if (indexer != null && indexer.DownloadClientId > 0)
+                {
+                    var client = availableProviders.SingleOrDefault(d => d.Definition.Id == indexer.DownloadClientId);
+
+                    return client ?? throw new DownloadClientUnavailableException($"Indexer specified download client is not available");
+                }
+            }
 
             var blockedProviders = new HashSet<int>(_downloadClientStatusService.GetBlockedProviders().Select(v => v.ProviderId));
 

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Download
             Ensure.That(remoteEpisode.Episodes, () => remoteEpisode.Episodes).HasItems();
 
             var downloadTitle = remoteEpisode.Release.Title;
-            var downloadClient = _downloadClientProvider.GetDownloadClient(remoteEpisode.Release.DownloadProtocol);
+            var downloadClient = _downloadClientProvider.GetDownloadClient(remoteEpisode.Release.DownloadProtocol, remoteEpisode.Release.IndexerId);
 
             if (downloadClient == null)
             {

--- a/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Core.Indexers
         public bool EnableRss { get; set; }
         public bool EnableAutomaticSearch { get; set; }
         public bool EnableInteractiveSearch { get; set; }
+        public int DownloadClientId { get; set; }
         public DownloadProtocol Protocol { get; set; }
         public bool SupportsRss { get; set; }
         public bool SupportsSearch { get; set; }

--- a/src/NzbDrone.Core/ThingiProvider/IProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/IProviderFactory.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.ThingiProvider
         List<TProviderDefinition> All();
         List<TProvider> GetAvailableProviders();
         bool Exists(int id);
+        TProviderDefinition Find(int id);
         TProviderDefinition Get(int id);
         TProviderDefinition Create(TProviderDefinition definition);
         void Update(TProviderDefinition definition);

--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -101,6 +101,11 @@ namespace NzbDrone.Core.ThingiProvider
             return _providerRepository.Get(id);
         }
 
+        public TProviderDefinition Find(int id)
+        {
+            return _providerRepository.Find(id);
+        }
+
         public virtual TProviderDefinition Create(TProviderDefinition definition)
         {
             var result = _providerRepository.Insert(definition);

--- a/src/Sonarr.Api.V3/Indexers/IndexerResource.cs
+++ b/src/Sonarr.Api.V3/Indexers/IndexerResource.cs
@@ -11,6 +11,7 @@ namespace Sonarr.Api.V3.Indexers
         public bool SupportsSearch { get; set; }
         public DownloadProtocol Protocol { get; set; }
         public int Priority { get; set; }
+        public int DownloadClientId { get; set; }
     }
 
     public class IndexerResourceMapper : ProviderResourceMapper<IndexerResource, IndexerDefinition>
@@ -28,6 +29,7 @@ namespace Sonarr.Api.V3.Indexers
             resource.SupportsSearch = definition.SupportsSearch;
             resource.Protocol = definition.Protocol;
             resource.Priority = definition.Priority;
+            resource.DownloadClientId = definition.DownloadClientId;
 
             return resource;
         }
@@ -42,6 +44,7 @@ namespace Sonarr.Api.V3.Indexers
             definition.EnableAutomaticSearch = resource.EnableAutomaticSearch;
             definition.EnableInteractiveSearch = resource.EnableInteractiveSearch;
             definition.Priority = resource.Priority;
+            definition.DownloadClientId = resource.DownloadClientId;
 
             return definition;
         }


### PR DESCRIPTION
#### Database Migration
YES - 164 (DownloadClientId on Indexers)

#### Description
Allow user to specify a particular client for an indexer
Basically copied from this radarr change: 
https://github.com/Radarr/Radarr/pull/6858

#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

Closes [#1215](https://github.com/Sonarr/Sonarr/issues/1215)
