### PR TITLE
Fixed: Clarify Indexer Priority Helptext

### DIFF
--- a/frontend/src/Settings/Indexers/Indexers/EditIndexerModalContent.js
+++ b/frontend/src/Settings/Indexers/Indexers/EditIndexerModalContent.js
@@ -143,7 +143,7 @@ function EditIndexerModalContent(props) {
                 <FormInputGroup
                   type={inputTypes.NUMBER}
                   name="priority"
-                  helpText="Indexer Priority from 1 (Highest) to 50 (Lowest). Default: 25."
+                  helpText="Indexer Priority from 1 (Highest) to 50 (Lowest). Default: 25. Used when grabbing releases as a tiebreaker for otherwise equal releases, Sonarr will still use all enabled indexers for RSS Sync and Searching."
                   min={1}
                   max={50}
                   {...priority}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently many users commonly are mislead by the existing helptext that implies indexer priority will change how indexers are searched or any other possibilities other than simply being a tiebreaker.

This clarifies the currently confusing helptext

#### Todos
-  Tests
- Wiki Updates - Already done `(Advanced Option) Indexer Priority - Priority of this indexer to prefer one indexer over another in release tiebreaker scenarios. 1 is highest priority and 50 is lowest priority.`


#### Issues Fixed or Closed by this PR

* 
