### PR TITLE
Fixed: Parsing of numeric only titles that include a year

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -35,6 +35,31 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().Be(title.CleanSeriesTitle());
         }
 
+        [TestCase("Series S03E14 720p HDTV X264-DIMENSION", "Series")]
+        [TestCase("Series.S03E14.720p.HDTV.X264-DIMENSION", "Series")]
+        [TestCase("Series-S03E14-720p-HDTV-X264-DIMENSION", "Series")]
+        [TestCase("Series_S03E14_720p_HDTV_X264-DIMENSION", "Series")]
+        [TestCase("Series 2022 S03E14 720p HDTV X264-DIMENSION", "Series", 2022)]
+        [TestCase("Series (2022) S03E14 720p HDTV X264-DIMENSION", "Series", 2022)]
+        [TestCase("Series.2022.S03E14.720p.HDTV.X264-DIMENSION", "Series", 2022)]
+        [TestCase("Series-2022-S03E14-720p-HDTV-X264-DIMENSION", "Series", 2022)]
+        [TestCase("Series_2022_S03E14_720p_HDTV_X264-DIMENSION", "Series", 2022)]        
+        [TestCase("1234 S03E14 720p HDTV X264-DIMENSION", "1234")]
+        [TestCase("1234.S03E14.720p.HDTV.X264-DIMENSION", "1234")]
+        [TestCase("1234-S03E14-720p-HDTV-X264-DIMENSION", "1234")]
+        [TestCase("1234_S03E14_720p_HDTV_X264-DIMENSION", "1234")]
+        [TestCase("1234 2022 S03E14 720p HDTV X264-DIMENSION", "1234", 2022)]
+        [TestCase("1234 (2022) S03E14 720p HDTV X264-DIMENSION", "1234", 2022)]
+        [TestCase("1234.2022.S03E14.720p.HDTV.X264-DIMENSION", "1234", 2022)]
+        [TestCase("1234-2022-S03E14-720p-HDTV-X264-DIMENSION", "1234", 2022)]
+        [TestCase("1234_2022_S03E14_720p_HDTV_X264-DIMENSION", "1234", 2022)]
+        public void should_parse_series_title_info(string postTitle, string titleWithoutYear, int year = 0)
+        {
+            var seriesTitleInfo = Parser.Parser.ParseTitle(postTitle).SeriesTitleInfo;
+            seriesTitleInfo.TitleWithoutYear.Should().Be(titleWithoutYear);
+            seriesTitleInfo.Year.Should().Be(year);
+        }
+
         [Test]
         public void should_remove_accents_from_title()
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -455,7 +455,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VOSTFR)(?:\W|_))|(?<russian>\brus\b)|(?<dutch>nl\W?subs?)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<spanish>\b(?:español|castellano)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_)?(?<year>\d{4})",
+        private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)[-_. ]+?\(?(?<year>\d{4})\)?",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex TitleComponentsRegex = new Regex(@"^(?:(?<title>.+?) \((?<title>.+?)\)|(?<title>.+?) \| (?<title>.+?))$",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is logic to handle parsing when series year is included in release name by matching against `CleanTitle` and `Year` in `Series` table. This logic previously failed to find a match for numeric series name due to extraneous whitespace. Therefore, this PR is simply trimming numeric series names to prevent extraneous whitespace from preventing query match. See the issue description and comments for a much more in-depth explanation/rationale.

#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* #4850
