### PR TITLE
Fixed: Mass Editor Footer on Smaller Screens

### DIFF
--- a/frontend/src/Components/Page/PageContentFooter.css
+++ b/frontend/src/Components/Page/PageContentFooter.css
@@ -19,7 +19,7 @@
   }
 }
 
-@media only screen and (max-width: $breakpointLarge) {
+@media only screen and (max-width: $breakpointExtraLarge) {
   .contentFooter {
     flex-wrap: wrap;
   }


### PR DESCRIPTION


#### Database Migration
NO

#### Description
By reacting to breakpointExtraLarge we allow the `flex-wrap: wrap` to come in at a larger screen width ensuring the delete button is always visible. This is needed due to the amount of buttons present on the mass editor.
This does not impact negatively the other places where PageContentFooter is implemented (series import and season pass)

#### Todos
- [x] Tests
- [x] Wiki Updates


#### Issues Fixed or Closed by this PR

* #4860 
