### PR TITLE
New: Add qBittorrent sequential order and first and last piece priority options

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -143,20 +143,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormParameter("urls", torrentUrl);
 
-            if (settings.TvCategory.IsNotNullOrWhiteSpace())
-            {
-                request.AddFormParameter("category", settings.TvCategory);
-            }
-
-            // Note: ForceStart is handled by separate api call
-            if ((QBittorrentState)settings.InitialState == QBittorrentState.Start)
-            {
-                request.AddFormParameter("paused", false);
-            }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
-            {
-                request.AddFormParameter("paused", true);
-            }
+            AddTorrentDownloadFormParameters(request, settings);
 
             if (seedConfiguration != null)
             {
@@ -178,20 +165,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                                                 .Post()
                                                 .AddFormUpload("torrents", fileName, fileContent);
 
-            if (settings.TvCategory.IsNotNullOrWhiteSpace())
-            {
-                request.AddFormParameter("category", settings.TvCategory);
-            }
-
-            // Note: ForceStart is handled by separate api call
-            if ((QBittorrentState)settings.InitialState == QBittorrentState.Start)
-            {
-                request.AddFormParameter("paused", false);
-            }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
-            {
-                request.AddFormParameter("paused", true);
-            }
+            AddTorrentDownloadFormParameters(request, settings);
 
             if (seedConfiguration != null)
             {
@@ -257,6 +231,34 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             if (seedingTimeLimit != -2 || always)
             {
                 request.AddFormParameter("seedingTimeLimit", seedingTimeLimit);
+            }
+        }
+
+        private void AddTorrentDownloadFormParameters(HttpRequestBuilder request, QBittorrentSettings settings)
+        {
+            if (settings.TvCategory.IsNotNullOrWhiteSpace())
+            {
+                request.AddFormParameter("category", settings.TvCategory);
+            }
+
+            // Note: ForceStart is handled by separate api call
+            if ((QBittorrentState)settings.InitialState == QBittorrentState.Start)
+            {
+                request.AddFormParameter("paused", false);
+            }
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            {
+                request.AddFormParameter("paused", true);
+            }
+
+            if (settings.SequentialOrder)
+            {
+                request.AddFormParameter("sequentialDownload", true);
+            }
+
+            if (settings.FirstAndLast)
+            {
+                request.AddFormParameter("firstLastPiecePrio", true);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -63,6 +63,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(QBittorrentState), HelpText = "Initial state for torrents added to qBittorrent")]
         public int InitialState { get; set; }
 
+        [FieldDefinition(11, Label = "Sequential Order", Type = FieldType.Checkbox, HelpText = "Download in sequential order (qBittorrent 4.1.0+)")]
+        public bool SequentialOrder { get; set; }
+
+        [FieldDefinition(12, Label = "First and Last First", Type = FieldType.Checkbox, HelpText = "Download first and last pieces first (qBittorrent 4.1.0+)")]
+        public bool FirstAndLast { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));


### PR DESCRIPTION
#### Database Migration

NO

#### Description

This PR adds two settings to the download client qBittorrent: download in sequential order and prioritise first and last pieces.

Those settings were introduced in the qBittorrent API in 4.0.0 but until api v2 (4.1.0) they only work if the form is submitted as a `form-data` and not as a `x-www-form-urlencoded` (couldn't find the reason why but their doc says to use `form-data` after qBittorrent 3.3.1 and the tests I did showed this). As earlier versions of the qBittorrent API are only compatible with `x-www-form-urlencoded` and as I don't want to introduce changes to the HttpRequestBuilder to change the ContentType, this is only available for qBittorrent 4.1.0+.

![image](https://user-images.githubusercontent.com/2262141/150856832-7048d5d1-8591-41ea-8861-ef9369a22ea9.png)

#### Todos

- [x] Tests -> none added
- [x] Wiki Updates -> not needed

#### Issues Fixed or Closed by this PR
