### PR TITLE
Fixed: Updated ruTorrent stopped state helptext

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         [FieldDefinition(10, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(RTorrentPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(11, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will prevent magnets from downloading before downloading")]
+        [FieldDefinition(11, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will add torrents and magnets to ruTorrent in a stopped state. This may break magnet files.")]
         public bool AddStopped { get; set; }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updated helptext for option to add ruTorrent torrents in a stopped state.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
