### PR TITLE
Fixed: Movies with Umlauts are now correctly matched and have correct CleanTitles.

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -68,6 +68,14 @@ namespace NzbDrone.Core.Test.ParserTests
             title.CleanSeriesTitle().Should().Be("seriaes");
         }
 
+        [Test]
+        public void should_replace_umlauts_in_title()
+        {
+            const string title = "Tote Mädchen lügen nicht";
+
+            title.CleanSeriesTitle().Should().Be("totemaedchenluegennicht");
+        }
+
         [TestCase("Sonar TV - Series Title : 02 Road From Code [S04].mp4")]
         public void should_clean_up_invalid_path_characters(string postTitle)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -674,8 +674,10 @@ namespace NzbDrone.Core.Parser
 
             // Replace `%` with `percent` to deal with the 3% case
             title = PercentRegex.Replace(title, "percent");
+            title = NormalizeRegex.Replace(title).ToLower();
+            title = ReplaceGermanUmlauts(title);
 
-            return NormalizeRegex.Replace(title).ToLower().RemoveAccent();
+            return title.RemoveAccent();
         }
 
         public static string NormalizeEpisodeTitle(string title)
@@ -707,6 +709,19 @@ namespace NzbDrone.Core.Parser
             title = DuplicateSpacesRegex.Replace(title, " ");
 
             return title.Trim().ToLower();
+        }
+
+        public static string ReplaceGermanUmlauts(string title)
+        {
+            title = title.Replace("ä", "ae");
+            title = title.Replace("ö", "oe");
+            title = title.Replace("ü", "ue");
+            title = title.Replace("Ä", "Ae");
+            title = title.Replace("Ö", "Oe");
+            title = title.Replace("Ü", "Ue");
+            title = title.Replace("ß", "ss");
+            
+            return title;
         }
 
         public static string ParseReleaseGroup(string title)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This fixes series with umlauts not getting mapped correctly. 
For example:
`Die.Pfefferkoerner.S17E13.Lebensretter.German.HDTVRip.x264-ATAX` would not get mapped to the Series `Die Pfefferkörner`.
Currently you have to make a request on the Scene Mapping Form to make it work. This should fix especially a lot of german releases getting parsed correctly and should therefore also decrease the [Scene naming requests](https://forums.sonarr.tv/t/scene-naming-tvdb-naming-conflicts/137)
This fix is being ported from [Radarr](https://github.com/Radarr/Radarr/commit/10091b94541cf3b1f6a891cb12c57765de9a1724).

#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
