### PR TITLE
New: Option to show release group column on series list

### DIFF
--- a/frontend/src/Series/Index/Table/SeriesIndexHeader.css
+++ b/frontend/src/Series/Index/Table/SeriesIndexHeader.css
@@ -37,6 +37,7 @@
   flex: 1 0 125px;
 }
 
+.releaseGroups,
 .nextAiring,
 .previousAiring,
 .added,

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.css
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.css
@@ -73,6 +73,7 @@
   flex: 1 0 125px;
 }
 
+.releaseGroups,
 .nextAiring,
 .previousAiring,
 .added,

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.js
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.js
@@ -416,7 +416,9 @@ class SeriesIndexRow extends Component {
 
             if (name === 'releaseGroups') {
               const joinedReleaseGroups = releaseGroups.join(', ');
-              const truncatedReleaseGroups = releaseGroups.slice(0, 4).join(', ');
+              const truncatedReleaseGroups = releaseGroups.length > 3 ?
+                `${releaseGroups.slice(0, 3).join(', ')}...` :
+                joinedReleaseGroups;
 
               return (
                 <VirtualTableRowCell

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.js
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.js
@@ -415,7 +415,8 @@ class SeriesIndexRow extends Component {
             }
 
             if (name === 'releaseGroups') {
-              const joinedReleaseGroups = releaseGroups.sort((a, b) => a.localeCompare(b)).join(', ');
+              const joinedReleaseGroups = releaseGroups.join(', ');
+              const truncatedReleaseGroups = releaseGroups.slice(0, 4).join(', ');
 
               return (
                 <VirtualTableRowCell
@@ -423,7 +424,7 @@ class SeriesIndexRow extends Component {
                   className={styles[name]}
                 >
                   <span title={joinedReleaseGroups}>
-                    {joinedReleaseGroups}
+                    {truncatedReleaseGroups}
                   </span>
                 </VirtualTableRowCell>
               );

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.js
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.js
@@ -114,6 +114,7 @@ class SeriesIndexRow extends Component {
       episodeCount,
       episodeFileCount,
       totalEpisodeCount,
+      releaseGroups,
       sizeOnDisk
     } = statistics;
 
@@ -413,6 +414,21 @@ class SeriesIndexRow extends Component {
               );
             }
 
+            if (name === 'releaseGroups') {
+              const joinedReleaseGroups = releaseGroups.sort((a, b) => a.localeCompare(b)).join(', ');
+
+              return (
+                <VirtualTableRowCell
+                  key={name}
+                  className={styles[name]}
+                >
+                  <span title={joinedReleaseGroups}>
+                    {joinedReleaseGroups}
+                  </span>
+                </VirtualTableRowCell>
+              );
+            }
+
             if (name === 'tags') {
               return (
                 <VirtualTableRowCell
@@ -534,7 +550,8 @@ SeriesIndexRow.defaultProps = {
     seasonCount: 0,
     episodeCount: 0,
     episodeFileCount: 0,
-    totalEpisodeCount: 0
+    totalEpisodeCount: 0,
+    releaseGroups: []
   },
   genres: [],
   tags: []

--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -276,27 +276,7 @@ export const filterBuilderProps = [
   {
     name: 'releaseGroups',
     label: 'Release Groups',
-    type: filterBuilderTypes.ARRAY,
-    optionsSelector: function(items) {
-      const releaseGroupsList = items.reduce((acc, series) => {
-        const { statistics = {} } = series;
-
-        const {
-          releaseGroups = []
-        } = statistics;
-
-        releaseGroups.forEach((releaseGroup) => {
-          acc.push({
-            id: releaseGroup,
-            name: releaseGroup
-          });
-        });
-
-        return acc;
-      }, []);
-
-      return releaseGroupsList.sort(sortByName);
-    }
+    type: filterBuilderTypes.ARRAY
   },
   {
     name: 'ratings',

--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -131,6 +131,18 @@ export const filterPredicates = {
     return predicate(item.ratings.value * 10, filterValue);
   },
 
+  releaseGroups: function(item, filterValue, type) {
+    const { statistics = {} } = item;
+
+    const {
+      releaseGroups = []
+    } = statistics;
+
+    const predicate = filterTypePredicates[type];
+
+    return predicate(releaseGroups, filterValue);
+  },
+
   seasonCount: function(item, filterValue, type) {
     const predicate = filterTypePredicates[type];
     const seasonCount = item.statistics ? item.statistics.seasonCount : 0;
@@ -259,6 +271,31 @@ export const filterBuilderProps = [
       }, []);
 
       return tagList.sort(sortByName);
+    }
+  },
+  {
+    name: 'releaseGroups',
+    label: 'Release Groups',
+    type: filterBuilderTypes.ARRAY,
+    optionsSelector: function(items) {
+      const releaseGroupsList = items.reduce((acc, series) => {
+        const { statistics = {} } = series;
+
+        const {
+          releaseGroups = []
+        } = statistics;
+
+        releaseGroups.forEach((releaseGroup) => {
+          acc.push({
+            id: releaseGroup,
+            name: releaseGroup
+          });
+        });
+
+        return acc;
+      }, []);
+
+      return releaseGroupsList.sort(sortByName);
     }
   },
   {

--- a/frontend/src/Store/Actions/seriesIndexActions.js
+++ b/frontend/src/Store/Actions/seriesIndexActions.js
@@ -168,6 +168,12 @@ export const defaultState = {
       isVisible: false
     },
     {
+      name: 'releaseGroups',
+      label: 'Release Groups',
+      isSortable: false,
+      isVisible: false
+    },
+    {
       name: 'tags',
       label: 'Tags',
       isSortable: true,

--- a/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Datastore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using NzbDrone.Common.Extensions;
-using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.SeriesStats
 {
@@ -63,14 +63,19 @@ namespace NzbDrone.Core.SeriesStats
         {
             get
             {
-                List<string> releaseGroups = null;
+                var releasegroups = new List<string>();
 
                 if (ReleaseGroupsString.IsNotNullOrWhiteSpace())
                 {
-                    releaseGroups = ReleaseGroupsString.Split('|').Distinct().ToList();
+                    releasegroups = ReleaseGroupsString
+                        .Split('|')
+                        .Distinct()
+                        .Where(rg => rg.IsNotNullOrWhiteSpace())
+                        .OrderBy(rg => rg)
+                        .ToList();
                 }
 
-                return releaseGroups;
+                return releasegroups;
             }
         }
     }

--- a/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.SeriesStats
@@ -14,6 +17,7 @@ namespace NzbDrone.Core.SeriesStats
         public int AvailableEpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
         public long SizeOnDisk { get; set; }
+        public string ReleaseGroupsString { get; set; }
 
         public DateTime? NextAiring
         {
@@ -52,6 +56,21 @@ namespace NzbDrone.Core.SeriesStats
                 }
 
                 return previousAiring;
+            }
+        }
+
+        public List<string> ReleaseGroups
+        {
+            get
+            {
+                List<string> releaseGroups = null;
+
+                if (ReleaseGroupsString.IsNotNullOrWhiteSpace())
+                {
+                    releaseGroups = ReleaseGroupsString.Split('|').Distinct().ToList();
+                }
+
+                return releaseGroups;
             }
         }
     }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.SeriesStats
         public int EpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
         public long SizeOnDisk { get; set; }
+        public List<string> ReleaseGroups { get; set; }
         public List<SeasonStatistics> SeasonStatistics { get; set; }
 
         public DateTime? NextAiring

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsRepository.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsRepository.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.SeriesStats
 
         private string GetSelectClause(bool series)
         {
-            return @"SELECT Episodes.*, SUM(EpisodeFiles.Size) as SizeOnDisk FROM
+            return @"SELECT Episodes.*, SUM(EpisodeFiles.Size) as SizeOnDisk, GROUP_CONCAT(EpisodeFiles.ReleaseGroup, '|') AS ReleaseGroupsString FROM
                      (SELECT
                      Episodes.SeriesId,
                      Episodes.SeasonNumber,

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
@@ -43,7 +43,8 @@ namespace NzbDrone.Core.SeriesStats
                                        EpisodeFileCount = seasonStatistics.Sum(s => s.EpisodeFileCount),
                                        EpisodeCount = seasonStatistics.Sum(s => s.EpisodeCount),
                                        TotalEpisodeCount = seasonStatistics.Sum(s => s.TotalEpisodeCount),
-                                       SizeOnDisk = seasonStatistics.Sum(s => s.SizeOnDisk)
+                                       SizeOnDisk = seasonStatistics.Sum(s => s.SizeOnDisk),
+                                       ReleaseGroups = seasonStatistics.Where(s => s.ReleaseGroups != null).SelectMany(s => s.ReleaseGroups).Distinct().ToList()
                                    };
 
             var nextAiring = seasonStatistics.Where(s => s.NextAiring != null)
@@ -56,6 +57,7 @@ namespace NzbDrone.Core.SeriesStats
 
             seriesStatistics.NextAiringString = nextAiring != null ? nextAiring.NextAiringString : null;
             seriesStatistics.PreviousAiringString = previousAiring != null ? previousAiring.PreviousAiringString : null;
+
 
             return seriesStatistics;
         }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.SeriesStats
                                        EpisodeCount = seasonStatistics.Sum(s => s.EpisodeCount),
                                        TotalEpisodeCount = seasonStatistics.Sum(s => s.TotalEpisodeCount),
                                        SizeOnDisk = seasonStatistics.Sum(s => s.SizeOnDisk),
-                                       ReleaseGroups = seasonStatistics.Where(s => s.ReleaseGroups != null).SelectMany(s => s.ReleaseGroups).Distinct().ToList()
+                                       ReleaseGroups = seasonStatistics.SelectMany(s => s.ReleaseGroups).Distinct().ToList()
                                    };
 
             var nextAiring = seasonStatistics.Where(s => s.NextAiring != null)
@@ -57,7 +57,6 @@ namespace NzbDrone.Core.SeriesStats
 
             seriesStatistics.NextAiringString = nextAiring != null ? nextAiring.NextAiringString : null;
             seriesStatistics.PreviousAiringString = previousAiring != null ? previousAiring.PreviousAiringString : null;
-
 
             return seriesStatistics;
         }

--- a/src/Sonarr.Api.V3/Series/SeasonStatisticsResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeasonStatisticsResource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NzbDrone.Core.SeriesStats;
 
 namespace Sonarr.Api.V3.Series
@@ -11,6 +12,7 @@ namespace Sonarr.Api.V3.Series
         public int EpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
         public long SizeOnDisk { get; set; }
+        public List<string> ReleaseGroups { get; set; }
 
         public decimal PercentOfEpisodes
         {
@@ -36,7 +38,8 @@ namespace Sonarr.Api.V3.Series
                 EpisodeFileCount = model.EpisodeFileCount,
                 EpisodeCount = model.EpisodeCount,
                 TotalEpisodeCount = model.TotalEpisodeCount,
-                SizeOnDisk = model.SizeOnDisk
+                SizeOnDisk = model.SizeOnDisk,
+                ReleaseGroups = model.ReleaseGroups
             };
         }
     }

--- a/src/Sonarr.Api.V3/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesResource.cs
@@ -121,6 +121,7 @@ namespace Sonarr.Api.V3.Series
                        Certification = model.Certification,
                        Genres = model.Genres,
                        Tags = model.Tags,
+                       //ReleaseGroups
                        Added = model.Added,
                        AddOptions = model.AddOptions,
                        Ratings = model.Ratings

--- a/src/Sonarr.Api.V3/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesResource.cs
@@ -121,7 +121,6 @@ namespace Sonarr.Api.V3.Series
                        Certification = model.Certification,
                        Genres = model.Genres,
                        Tags = model.Tags,
-                       //ReleaseGroups
                        Added = model.Added,
                        AddOptions = model.AddOptions,
                        Ratings = model.Ratings

--- a/src/Sonarr.Api.V3/Series/SeriesStatisticsResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesStatisticsResource.cs
@@ -11,6 +11,7 @@ namespace Sonarr.Api.V3.Series
         public int EpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
         public long SizeOnDisk { get; set; }
+        public List<string> ReleaseGroups { get; set; }
 
         public decimal PercentOfEpisodes
         {
@@ -37,7 +38,8 @@ namespace Sonarr.Api.V3.Series
                 EpisodeFileCount = model.EpisodeFileCount,
                 EpisodeCount = model.EpisodeCount,
                 TotalEpisodeCount = model.TotalEpisodeCount,
-                SizeOnDisk = model.SizeOnDisk
+                SizeOnDisk = model.SizeOnDisk,
+                ReleaseGroups = model.ReleaseGroups
             };
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Add Release Groups for Seasons and Series to Statistics entities.
- Include Release Groups column in Index Page (Table).
- Include Release Groups filter in Index Page (Table).

![image](https://user-images.githubusercontent.com/5982912/151985442-7bc228ce-98f6-4ecf-869b-2cf273736105.png)

![image](https://user-images.githubusercontent.com/5982912/151985630-278d9f8d-1a2b-41ae-9ea0-b0a442881138.png)

#### Todos
- [ ] Tests
- [ ] Wiki Updates

