### PR TITLE
Require APIKEY for iCal Feed

### DIFF
--- a/src/Sonarr.Http/Authentication/AuthenticationService.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationService.cs
@@ -144,12 +144,7 @@ namespace Sonarr.Http.Authentication
 
             if (context.Request.IsFeedRequest())
             {
-                if (ValidUser(context) || ValidApiKey(apiKey))
-                {
-                    return true;
-                }
-
-                return false;
+                return ValidApiKey(apiKey);
             }
 
             if (context.Request.IsLoginRequest())


### PR DESCRIPTION
Require the APIKEY for /feed/calendar even if authentication is disabled.

#### Database Migration
NO

#### Description
Resolve #4896 by requiring APIKEY even if Authentication is disabled. This has the /feed/calendar endpoint behave like other /api/ endpoints. 

#### Todos
- [N] Tests
- [N] Wiki Updates


#### Issues Fixed or Closed by this PR

* Fixes #4896 
