### PR TITLE
Fixed: SABnzbd assume develop version is 3.0.0

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
                 if (rawVersion.Equals("develop", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 2.0.0 or higher.")
+                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 3.0.0 or higher.")
                     {
                         IsWarning = true,
                         DetailedDescription = "Sonarr may not be able to support new features added to SABnzbd when running develop versions."

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -340,8 +340,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     return null;
                 }
 
-                major = 3;
-                minor = 5;
+                major = 2;
+                minor = 0;
                 patch = 0;
             }
 
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
                 if (rawVersion.Equals("develop", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 3.5.0 or higher.")
+                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 2.0.0 or higher.")
                     {
                         IsWarning = true,
                         DetailedDescription = "Sonarr may not be able to support new features added to SABnzbd when running develop versions."

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -340,7 +340,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     return null;
                 }
 
-                major = 2;
+                major = 3;
                 minor = 0;
                 patch = 0;
             }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -340,8 +340,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     return null;
                 }
 
-                major = 1;
-                minor = 1;
+                major = 3;
+                minor = 5;
                 patch = 0;
             }
 
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
                 if (rawVersion.Equals("develop", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 1.1.0 or higher.")
+                    return new NzbDroneValidationFailure("Version", "Sabnzbd develop version, assuming version 3.5.0 or higher.")
                     {
                         IsWarning = true,
                         DetailedDescription = "Sonarr may not be able to support new features added to SABnzbd when running develop versions."


### PR DESCRIPTION
#### Database Migration
NO

#### Description

> that code bit was back form 2017, as sab 2.x and older is defunct in various ways.. safe to assume anyone using sab develop is 3.x

_Originally posted by @thezoggy in https://github.com/Sonarr/Sonarr/issues/4911#issuecomment-1048220658_


#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* Fixes #4911

