### PR TITLE
New: Add optional Source Title column to history

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.js
+++ b/frontend/src/Activity/History/HistoryRow.js
@@ -217,6 +217,16 @@ class HistoryRow extends Component {
               );
             }
 
+            if (name === 'sourceTitle') {
+              return (
+                <TableRowCell
+                  key={name}
+                >
+                  {sourceTitle}
+                </TableRowCell>
+              );
+            }
+
             if (name === 'details') {
               return (
                 <TableRowCell

--- a/frontend/src/Store/Actions/historyActions.js
+++ b/frontend/src/Store/Actions/historyActions.js
@@ -83,6 +83,11 @@ export const defaultState = {
       isVisible: false
     },
     {
+      name: 'sourceTitle',
+      label: 'Source Title',
+      isVisible: false
+    },
+    {
       name: 'preferredWordScore',
       columnLabel: 'Preferred Word Score',
       label: React.createElement(Icon, {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I've had it a few times that a show has bulk imported, and due to mismatches between scene and TVDB they don't quite get matched up properly to an episode in Sonarr.

What I like to do here is then look at the history page and see if the releases somewhat match up with the episodes. An example here is RuPauls Drag Race Untucked. The show didn't have a season 1 (as it began as a sideshow to season 2 of the main show). Some groups released it back then as season 1 and some release it now as season 2. It can often be determined from the release title if it was the correct one as epiosde title is in there.

Looking down the history list it'd be nice to see also the release name at a glance without having to go to details. Hence this PR. Hope you find it OK.

#### Todos
- [NA] Tests
- [NA] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
