### PR TITLE
Properly handle 119 Errorcode on Diskstation client

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Responses/DiskStationError.cs
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Responses
 
         public int Code { get; set; }
 
-        public bool SessionError => Code == 105 || Code == 106 || Code == 107;
+        public bool SessionError => Code == 105 || Code == 106 || Code == 107 || Code == 119;
 
         public string GetMessage(DiskStationApi api)
         {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Try to authenticate on the next request when sid not found is received.
