### PR TITLE
New: Update Monotorrent

### DIFF
--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="TinyTwitter" Version="1.1.2" />
     <PackageReference Include="xmlrpcnet" Version="3.0.0.266" />
-    <PackageReference Include="MonoTorrent" Version="1.0.29" />
+    <PackageReference Include="MonoTorrent" Version="2.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Marr.Data\Marr.Data.csproj" />


### PR DESCRIPTION
Monotorrent v2.0.5 addresses an issue causing certain torrents created by rutorrent to not load, see https://github.com/alanmcgovern/monotorrent/issues/517

#### Database Migration
NO

#### Description
This fixes an issue with monotorrent parsing code that resulted in Sonarr being unable to load certain torrents created by rutorrent (and possibly others) containing absolute paths. Absolute paths are now gracefully transformed into relative paths.