### PR TITLE
Fixed: Typo in Connection Lost modal

### DIFF
--- a/frontend/src/App/ConnectionLostModal.js
+++ b/frontend/src/App/ConnectionLostModal.js
@@ -27,7 +27,7 @@ function ConnectionLostModal(props) {
 
         <ModalBody>
           <div>
-            Sonarr has lost it's connection to the backend and will need to be reloaded to restore functionality.
+            Sonarr has lost its connection to the backend and will need to be reloaded to restore functionality.
           </div>
 
           <div className={styles.automatic}>


### PR DESCRIPTION
Was incorrectly using 'it's' instead of 'its'

#### Database Migration
NO

#### Description
Minor typo in 'ConnectionLostModal.js'
