### PR TITLE
Fixed: iCal status values

### DIFF
--- a/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
+++ b/src/NzbDrone.Api/Calendar/CalendarFeedModule.cs
@@ -3,11 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net;
+using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
-using Ical.Net.General;
-using Ical.Net.Interfaces.Serialization;
 using Ical.Net.Serialization;
-using Ical.Net.Serialization.iCalendar.Factory;
 using NzbDrone.Core.Tv;
 using Nancy.Responses;
 using NzbDrone.Core.Tags;
@@ -116,7 +114,7 @@ namespace NzbDrone.Api.Calendar
                     continue;
                 }
 
-                var occurrence = calendar.Create<Event>();
+                var occurrence = calendar.Create<CalendarEvent>();
                 occurrence.Uid = "NzbDrone_episode_" + episode.Id;
                 occurrence.Status = episode.HasFile ? EventStatus.Confirmed : EventStatus.Tentative;
                 occurrence.Description = episode.Overview;

--- a/src/NzbDrone.Api/Sonarr.Api.csproj
+++ b/src/NzbDrone.Api/Sonarr.Api.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Ical.Net" Version="2.2.32" />
+    <PackageReference Include="Ical.Net" Version="4.2.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="Nancy.Authentication.Basic" Version="2.0.0" />
     <PackageReference Include="Nancy.Authentication.Forms" Version="2.0.0" />

--- a/src/Sonarr.Api.V3/Calendar/CalendarFeedModule.cs
+++ b/src/Sonarr.Api.V3/Calendar/CalendarFeedModule.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ical.Net;
+using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
-using Ical.Net.General;
-using Ical.Net.Interfaces.Serialization;
 using Ical.Net.Serialization;
-using Ical.Net.Serialization.iCalendar.Factory;
 using Nancy;
 using Nancy.Responses;
 using NzbDrone.Common.Extensions;
@@ -86,7 +84,7 @@ namespace Sonarr.Api.V3.Calendar
                     continue;
                 }
 
-                var occurrence = calendar.Create<Event>();
+                var occurrence = calendar.Create<CalendarEvent>();
                 occurrence.Uid = "NzbDrone_episode_" + episode.Id;
                 occurrence.Status = episode.HasFile ? EventStatus.Confirmed : EventStatus.Tentative;
                 occurrence.Description = episode.Overview;

--- a/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
+++ b/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.4.0" />
-    <PackageReference Include="Ical.Net" Version="2.2.32" />
+    <PackageReference Include="Ical.Net" Version="4.2.0" />
     <PackageReference Include="Nancy" Version="2.0.0" />
     <PackageReference Include="Nancy.Authentication.Basic" Version="2.0.0" />
     <PackageReference Include="Nancy.Authentication.Forms" Version="2.0.0" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is currently a bug with the current version of Ical.Net where the tentative status string is "Tentative" instead of "TENTATIVE" [reported here.](https://github.com/rianjs/ical.net/issues/318)
This is causing issues with google calendar as [reported here.](https://old.reddit.com/r/sonarr/comments/ubl6wd/google_calendar_link_not_updating/)

This version bump and fix resolves the issue.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
