### PR TITLE
New: UDP Syslog support and Instance Name

### DIFF
--- a/frontend/src/App/App.js
+++ b/frontend/src/App/App.js
@@ -8,7 +8,7 @@ import AppRoutes from './AppRoutes';
 
 function App({ store, history }) {
   return (
-    <DocumentTitle title="Sonarr">
+    <DocumentTitle title={window.Sonarr.instanceName}>
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <PageConnector>

--- a/frontend/src/Components/Page/PageContent.js
+++ b/frontend/src/Components/Page/PageContent.js
@@ -14,7 +14,7 @@ function PageContent(props) {
 
   return (
     <ErrorBoundary errorComponent={PageContentError}>
-      <DocumentTitle title={title ? `${title} - Sonarr` : 'Sonarr'}>
+      <DocumentTitle title={title ? `${title} - ${window.Sonarr.instanceName}` : window.Sonarr.instanceName}>
         <div className={className}>
           {children}
         </div>

--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -20,6 +20,7 @@ const requiresRestartKeys = [
   'bindAddress',
   'port',
   'urlBase',
+  'instanceName',
   'enableSsl',
   'sslPort',
   'sslCertHash',

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -19,6 +19,7 @@ function HostSettings(props) {
     bindAddress,
     port,
     urlBase,
+    instanceName,
     enableSsl,
     sslPort,
     sslCertHash,
@@ -68,6 +69,22 @@ function HostSettings(props) {
           helpTextWarning="Requires restart to take effect"
           onChange={onInputChange}
           {...urlBase}
+        />
+      </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>Instance Name</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.TEXT}
+          name="instanceName"
+          helpText="Instance name in tab and for Syslog app name"
+          helpTextWarning="Requires restart to take effect"
+          onChange={onInputChange}
+          {...instanceName}
         />
       </FormGroup>
 

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NLog" Version="4.6.6" />
+    <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
     <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -39,6 +39,7 @@ namespace NzbDrone.Core.Configuration
         string SslCertHash { get; }
         string UrlBase { get; }
         string UiFolder { get; }
+        string InstanceName { get; }
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
@@ -205,6 +206,19 @@ namespace NzbDrone.Core.Configuration
         // public string UiFolder => GetValue("UiFolder", "UI", false);GetValue("UiFolder", "UI", false);
         public string UiFolder => "UI";
 
+        public string InstanceName
+        {
+            get
+            {
+                var instanceName = GetValue("InstanceName", BuildInfo.AppName);
+
+                if (instanceName.StartsWith(BuildInfo.AppName) || instanceName.EndsWith(BuildInfo.AppName) )
+                {
+                    return instanceName;
+                }
+                return BuildInfo.AppName;
+            }
+        }
 
         public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
 
@@ -217,7 +231,6 @@ namespace NzbDrone.Core.Configuration
         public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
 
         public string SyslogLevel => GetValue("SyslogLevel", LogLevel, persist: false).ToLowerInvariant();
-
 
         public int GetValueInt(string key, int defaultValue, bool persist = true)
         {

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -42,6 +42,9 @@ namespace NzbDrone.Core.Configuration
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
+        string SyslogServer { get; }
+        int SyslogPort { get; }
+        string SyslogLevel { get; }
     }
 
     public class ConfigFileProvider : IConfigFileProvider
@@ -209,7 +212,14 @@ namespace NzbDrone.Core.Configuration
 
         public string UpdateScriptPath => GetValue("UpdateScriptPath", "", false);
 
-        public int GetValueInt(string key, int defaultValue)
+        public string SyslogServer => GetValue("SyslogServer", "", persist: false);
+
+        public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
+
+        public string SyslogLevel => GetValue("SyslogLevel", LogLevel, persist: false).ToLowerInvariant();
+
+
+        public int GetValueInt(string key, int defaultValue, bool persist = true)
         {
             return Convert.ToInt32(GetValue(key, defaultValue));
         }

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -36,7 +36,8 @@ namespace NzbDrone.Core.Instrumentation
 
             if (_configFileProvider.SyslogServer.IsNotNullOrWhiteSpace())
             {
-                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, minimumLogLevel);
+                var syslogLevel = LogLevel.FromString(_configFileProvider.SyslogLevel);
+                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, syslogLevel);
             }
 
             var rules = LogManager.Configuration.LoggingRules;
@@ -98,7 +99,7 @@ namespace NzbDrone.Core.Instrumentation
             syslogTarget.MessageSend.Udp.Server = syslogServer;
             syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
             syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
-            syslogTarget.MessageCreation.Rfc5424.AppName = BuildInfo.AppName;
+            syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
 
             var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
 

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NLog.Config;
+using NLog.Targets.Syslog;
+using NLog.Targets.Syslog.Settings;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Sentry;
@@ -31,6 +33,11 @@ namespace NzbDrone.Core.Instrumentation
                 minimumConsoleLogLevel = minimumLogLevel;
             else
                 minimumConsoleLogLevel = LogLevel.Info;
+
+            if (_configFileProvider.SyslogServer.IsNotNullOrWhiteSpace())
+            {
+                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, minimumLogLevel);
+            }
 
             var rules = LogManager.Configuration.LoggingRules;
 
@@ -79,6 +86,24 @@ namespace NzbDrone.Core.Instrumentation
             {
                 sentryTarget.SentryEnabled = RuntimeInfo.IsProduction && _configFileProvider.AnalyticsEnabled || RuntimeInfo.IsDevelopment;
             }
+        }
+
+        private void SetSyslogParameters(string syslogServer, int syslogPort, LogLevel minimumLogLevel)
+        {
+            var syslogTarget = new SyslogTarget();
+
+            syslogTarget.Name = "syslogTarget";
+            syslogTarget.MessageSend.Protocol = ProtocolType.Udp;
+            syslogTarget.MessageSend.Udp.Port = syslogPort;
+            syslogTarget.MessageSend.Udp.Server = syslogServer;
+            syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
+            syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
+            syslogTarget.MessageCreation.Rfc5424.AppName = BuildInfo.AppName;
+
+            var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
+
+            LogManager.Configuration.AddTarget("syslogTarget", syslogTarget);
+            LogManager.Configuration.LoggingRules.Add(loggingRule);
         }
 
         private List<LogLevel> GetLogLevels()

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -62,5 +62,11 @@ namespace NzbDrone.Core.Validation
         {
             return ruleBuilder.WithState(v => NzbDroneValidationState.Warning);
         }
+
+        public static IRuleBuilderOptions<T, string> StartsOrEndsWithSonarr<T>(this IRuleBuilder<T, string> ruleBuilder)
+        {
+            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            return ruleBuilder.SetValidator(new RegularExpressionValidator("^Sonarr|Sonarr$")).WithMessage("Must start or end with Sonarr");
+        }
     }
 }

--- a/src/Sonarr.Api.V3/Config/HostConfigModule.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigModule.cs
@@ -38,6 +38,7 @@ namespace Sonarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.Port).ValidPort();
 
             SharedValidator.RuleFor(c => c.UrlBase).ValidUrlBase();
+            SharedValidator.RuleFor(c => c.InstanceName).StartsOrEndsWithSonarr();
 
             SharedValidator.RuleFor(c => c.Username).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);
             SharedValidator.RuleFor(c => c.Password).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -24,6 +24,7 @@ namespace Sonarr.Api.V3.Config
         public string ApiKey { get; set; }
         public string SslCertHash { get; set; }
         public string UrlBase { get; set; }
+        public string InstanceName { get; set; }
         public bool UpdateAutomatically { get; set; }
         public UpdateMechanism UpdateMechanism { get; set; }
         public string UpdateScriptPath { get; set; }
@@ -63,6 +64,7 @@ namespace Sonarr.Api.V3.Config
                 ApiKey = model.ApiKey,
                 SslCertHash = model.SslCertHash,
                 UrlBase = model.UrlBase,
+                InstanceName = model.InstanceName,
                 UpdateAutomatically = model.UpdateAutomatically,
                 UpdateMechanism = model.UpdateMechanism,
                 UpdateScriptPath = model.UpdateScriptPath,

--- a/src/Sonarr.Api.V3/System/SystemModule.cs
+++ b/src/Sonarr.Api.V3/System/SystemModule.cs
@@ -51,6 +51,7 @@ namespace Sonarr.Api.V3.System
             return new
                    {
                        AppName = BuildInfo.AppName,
+                       InstanceName = _configFileProvider.InstanceName,
                        Version = BuildInfo.Version.ToString(),
                        BuildTime = BuildInfo.BuildDateTime,
                        IsDebug = BuildInfo.IsDebug,

--- a/src/Sonarr.Http/Frontend/InitializeJsModule.cs
+++ b/src/Sonarr.Http/Frontend/InitializeJsModule.cs
@@ -61,6 +61,7 @@ namespace Sonarr.Http.Frontend
             builder.AppendLine($"  apiKey: '{_apiKey}',");
             builder.AppendLine($"  release: '{BuildInfo.Release}',");
             builder.AppendLine($"  version: '{BuildInfo.Version.ToString()}',");
+            builder.AppendLine($"  instanceName: '{_configFileProvider.InstanceName.ToString()}',");
             builder.AppendLine($"  branch: '{_configFileProvider.Branch.ToLower()}',");
             builder.AppendLine($"  analytics: {_analyticsService.IsEnabled.ToString().ToLowerInvariant()},");
             builder.AppendLine($"  urlBase: '{_urlBase}',");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allows for UDP Syslogging and adds instance name so you can see what logs come from which instance when running multiple instances. Instance name is used in both syslog and within the tab; and requires Sonarr to be in the instance name somewhere

This is already in Radarr, Readarr, Lidarr, Prowlarr and Whisparr; commits have been loosely cherry-picked from there (sonarr-ified where required and updated to make a bit more logical sense)

Syslog is a config file only parameter set.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* #4778 
