### PR TITLE
Added an option for minimum release score.

### DIFF
--- a/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
@@ -134,7 +134,7 @@ function EditReleaseProfileModalContent(props) {
                 'The release must have this score or higher',
                 'Leave blank if a minimum is not desired'
               ]}
-			  placeholder="Optional minimum score"
+              placeholder="Optional minimum score"
               {...minimumScore}
               onChange={onInputChange}
             />

--- a/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContent.js
@@ -34,6 +34,7 @@ function EditReleaseProfileModalContent(props) {
     required,
     ignored,
     preferred,
+    minimumScore,
     includePreferredWhenRenaming,
     tags,
     indexerId
@@ -119,6 +120,22 @@ function EditReleaseProfileModalContent(props) {
               {...preferred}
               keyPlaceholder="Term"
               valuePlaceholder="Score"
+              onChange={onInputChange}
+            />
+          </FormGroup>
+		  
+          <FormGroup>
+            <FormLabel>Minimum Score</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.NUMBER}
+              name="minimumScore"
+              helpTexts={[
+                'The release must have this score or higher',
+                'Leave blank if a minimum is not desired'
+              ]}
+			  placeholder="Optional minimum score"
+              {...minimumScore}
               onChange={onInputChange}
             />
           </FormGroup>

--- a/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContentConnector.js
+++ b/frontend/src/Settings/Profiles/Release/EditReleaseProfileModalContentConnector.js
@@ -12,6 +12,7 @@ const newReleaseProfile = {
   required: [],
   ignored: [],
   preferred: [],
+  minimumScore: null,
   includePreferredWhenRenaming: false,
   tags: [],
   indexerId: 0

--- a/src/NzbDrone.Core/Datastore/Migration/170_add_minimum_score.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/170_add_minimum_score.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(170)]
+    public class add_minimum_score : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("ReleaseProfiles").AddColumn("MinimumScore").AsInt32().Nullable().WithDefaultValue(null);
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -34,6 +34,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             var required = releaseProfiles.Where(r => r.Required.Any());
             var ignored = releaseProfiles.Where(r => r.Ignored.Any());
+            var minimumScore = releaseProfiles.Where(r => r.MinimumScore.HasValue);
 
             foreach (var r in required)
             {
@@ -58,6 +59,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     var terms = string.Join(", ", foundTerms);
                     _logger.Debug("[{0}] contains these ignored terms: {1}", title, terms);
                     return Decision.Reject("Contains these ignored terms: {0}", terms);
+                }
+            }
+
+            foreach (var r in minimumScore)
+            {
+                if (subject.PreferredWordScore < r.MinimumScore)
+                {
+                    _logger.Debug("[{0}] has score {0} which is below the minimum of {1} imposed by profile {2}", title, subject.PreferredWordScore, r.MinimumScore, r.Name);
+                    return Decision.Reject("Score of {0} is below the minimum of {1}", subject.PreferredWordScore, r.MinimumScore);
                 }
             }
 

--- a/src/NzbDrone.Core/Profiles/Releases/ReleaseProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Releases/ReleaseProfile.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Profiles.Releases
         public List<string> Required { get; set; }
         public List<string> Ignored { get; set; }
         public List<KeyValuePair<string, int>> Preferred { get; set; }
+        public int? MinimumScore { get; set; }
         public bool IncludePreferredWhenRenaming { get; set; }
         public int IndexerId { get; set; }
         public HashSet<int> Tags { get; set; }
@@ -20,6 +21,7 @@ namespace NzbDrone.Core.Profiles.Releases
             Required = new List<string>();
             Ignored = new List<string>();
             Preferred = new List<KeyValuePair<string, int>>();
+            MinimumScore = null;
             IncludePreferredWhenRenaming = true;
             Tags = new HashSet<int>();
             IndexerId = 0;

--- a/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileResource.cs
+++ b/src/Sonarr.Api.V3/Profiles/Release/ReleaseProfileResource.cs
@@ -16,6 +16,7 @@ namespace Sonarr.Api.V3.Profiles.Release
         public object Required { get; set; }
         public object Ignored { get; set; }
         public List<KeyValuePair<string, int>> Preferred { get; set; }
+        public int? MinimumScore { get; set; }
         public bool IncludePreferredWhenRenaming { get; set; }
         public int IndexerId { get; set; }
         public HashSet<int> Tags { get; set; }
@@ -40,6 +41,7 @@ namespace Sonarr.Api.V3.Profiles.Release
                 Enabled = model.Enabled,
                 Required = model.Required ?? new List<string>(),
                 Ignored = model.Ignored ?? new List<string>(),
+                MinimumScore = model.MinimumScore,
                 Preferred = model.Preferred,
                 IncludePreferredWhenRenaming = model.IncludePreferredWhenRenaming,
                 IndexerId = model.IndexerId,
@@ -59,6 +61,7 @@ namespace Sonarr.Api.V3.Profiles.Release
                 Required = resource.MapRequired(),
                 Ignored = resource.MapIgnored(),
                 Preferred = resource.Preferred,
+                MinimumScore = resource.MinimumScore,
                 IncludePreferredWhenRenaming = resource.IncludePreferredWhenRenaming,
                 IndexerId = resource.IndexerId,
                 Tags = new HashSet<int>(resource.Tags)


### PR DESCRIPTION
#### Database Migration
YES

#### Description
Add an option to only grab releases above a minimum score.

Radarr has a similar feature and I find it very useful as it facilitates enforcing of a whitelist and/or blacklist.
I realize that "must contain" and "must not contains" already serve as a whitelist and blacklist but this approach allows leveraging the "preferred" list rather than having to duplicate everything. Plus the "preferred" list allows for much finer control and more complex rules.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
