### PR TITLE
Fixed: Validate if equals or child for startup folder

### DIFF
--- a/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Validation.Paths
         
 
         public StartupFolderValidator(IAppFolderInfo appFolderInfo)
-            : base("Path cannot be an ancestor of the start up folder")
+            : base("Path cannot be {relationship} the start up folder")
         {
             _appFolderInfo = appFolderInfo;
         }
@@ -19,7 +19,24 @@ namespace NzbDrone.Core.Validation.Paths
         {
             if (context.PropertyValue == null) return true;
 
-            return !_appFolderInfo.StartUpFolder.IsParentPath(context.PropertyValue.ToString());
+            var startupFolder = _appFolderInfo.StartUpFolder;
+            var folder = context.PropertyValue.ToString();
+
+            if (startupFolder.PathEquals(folder))
+            {
+                context.MessageFormatter.AppendArgument("relationship", "set to");
+
+                return false;
+            }
+
+            if (startupFolder.IsParentPath(folder))
+            {
+                context.MessageFormatter.AppendArgument("relationship", "child of");
+
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently startup folder validation on checks if folder settings is child, this change also checks to make sure it's not equal. This change is related to root folder and recycle bin settings. 

