### PR TITLE
Add InstanceName and TitleSlug to Custom Script and Webhook notifications

### DIFF
--- a/frontend/src/App/App.js
+++ b/frontend/src/App/App.js
@@ -8,7 +8,7 @@ import AppRoutes from './AppRoutes';
 
 function App({ store, history }) {
   return (
-    <DocumentTitle title="Sonarr">
+    <DocumentTitle title={window.Sonarr.instanceName}>
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <PageConnector>

--- a/frontend/src/App/AppRoutes.js
+++ b/frontend/src/App/AppRoutes.js
@@ -19,7 +19,7 @@ import CutoffUnmetConnector from 'Wanted/CutoffUnmet/CutoffUnmetConnector';
 import Settings from 'Settings/Settings';
 import MediaManagementConnector from 'Settings/MediaManagement/MediaManagementConnector';
 import Profiles from 'Settings/Profiles/Profiles';
-import Quality from 'Settings/Quality/Quality';
+import QualityConnector from 'Settings/Quality/QualityConnector';
 import IndexerSettingsConnector from 'Settings/Indexers/IndexerSettingsConnector';
 import ImportListSettingsConnector from 'Settings/ImportLists/ImportListSettingsConnector';
 import DownloadClientSettingsConnector from 'Settings/DownloadClients/DownloadClientSettingsConnector';
@@ -158,7 +158,7 @@ function AppRoutes(props) {
 
       <Route
         path="/settings/quality"
-        component={Quality}
+        component={QualityConnector}
       />
 
       <Route

--- a/frontend/src/Commands/commandNames.js
+++ b/frontend/src/Commands/commandNames.js
@@ -15,6 +15,7 @@ export const REFRESH_SERIES = 'RefreshSeries';
 export const RENAME_FILES = 'RenameFiles';
 export const RENAME_SERIES = 'RenameSeries';
 export const RESET_API_KEY = 'ResetApiKey';
+export const RESET_QUALITY_DEFINITIONS = 'ResetQualityDefinitions';
 export const RSS_SYNC = 'RssSync';
 export const SEASON_SEARCH = 'SeasonSearch';
 export const SERIES_SEARCH = 'SeriesSearch';

--- a/frontend/src/Components/Page/PageContent.js
+++ b/frontend/src/Components/Page/PageContent.js
@@ -14,7 +14,7 @@ function PageContent(props) {
 
   return (
     <ErrorBoundary errorComponent={PageContentError}>
-      <DocumentTitle title={title ? `${title} - Sonarr` : 'Sonarr'}>
+      <DocumentTitle title={title ? `${title} - ${window.Sonarr.instanceName}` : window.Sonarr.instanceName}>
         <div className={className}>
           {children}
         </div>

--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -14,6 +14,7 @@ import { fetchHealth } from 'Store/Actions/systemActions';
 import { fetchQueue, fetchQueueDetails } from 'Store/Actions/queueActions';
 import { fetchRootFolders } from 'Store/Actions/rootFolderActions';
 import { fetchTags, fetchTagDetails } from 'Store/Actions/tagActions';
+import { fetchQualityDefinitions } from 'Store/Actions/settingsActions';
 
 function getState(status) {
   switch (status) {
@@ -70,6 +71,7 @@ const mapDispatchToProps = {
   dispatchUpdateItem: updateItem,
   dispatchRemoveItem: removeItem,
   dispatchFetchHealth: fetchHealth,
+  dispatchFetchQualityDefinitions: fetchQualityDefinitions,
   dispatchFetchQueue: fetchQueue,
   dispatchFetchQueueDetails: fetchQueueDetails,
   dispatchFetchRootFolders: fetchRootFolders,
@@ -219,6 +221,10 @@ class SignalRConnector extends Component {
     } else if (action === 'deleted') {
       this.props.dispatchRemoveItem({ section, id: body.resource.id });
     }
+  }
+
+  handleQualitydefinition = () => {
+    this.props.dispatchFetchQualityDefinitions();
   }
 
   handleQueue = () => {
@@ -377,6 +383,7 @@ SignalRConnector.propTypes = {
   dispatchUpdateItem: PropTypes.func.isRequired,
   dispatchRemoveItem: PropTypes.func.isRequired,
   dispatchFetchHealth: PropTypes.func.isRequired,
+  dispatchFetchQualityDefinitions: PropTypes.func.isRequired,
   dispatchFetchQueue: PropTypes.func.isRequired,
   dispatchFetchQueueDetails: PropTypes.func.isRequired,
   dispatchFetchRootFolders: PropTypes.func.isRequired,

--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -20,6 +20,7 @@ const requiresRestartKeys = [
   'bindAddress',
   'port',
   'urlBase',
+  'instanceName',
   'enableSsl',
   'sslPort',
   'sslCertHash',

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -19,6 +19,7 @@ function HostSettings(props) {
     bindAddress,
     port,
     urlBase,
+    instanceName,
     enableSsl,
     sslPort,
     sslCertHash,
@@ -68,6 +69,22 @@ function HostSettings(props) {
           helpTextWarning="Requires restart to take effect"
           onChange={onInputChange}
           {...urlBase}
+        />
+      </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>Instance Name</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.TEXT}
+          name="instanceName"
+          helpText="Instance name in tab and for Syslog app name"
+          helpTextWarning="Requires restart to take effect"
+          onChange={onInputChange}
+          {...instanceName}
         />
       </FormGroup>
 

--- a/frontend/src/Settings/Quality/Quality.js
+++ b/frontend/src/Settings/Quality/Quality.js
@@ -1,8 +1,13 @@
-import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
 import SettingsToolbarConnector from 'Settings/SettingsToolbarConnector';
 import QualityDefinitionsConnector from './Definition/QualityDefinitionsConnector';
+import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
+import PageToolbarButton from 'Components/Page/Toolbar/PageToolbarButton';
+import { icons } from 'Helpers/Props';
+import ResetQualityDefinitionsModal from './Reset/ResetQualityDefinitionsModal';
 
 class Quality extends Component {
 
@@ -16,7 +21,8 @@ class Quality extends Component {
 
     this.state = {
       isSaving: false,
-      hasPendingChanges: false
+      hasPendingChanges: false,
+      isConfirmQualityDefinitionResetModalOpen: false
     };
   }
 
@@ -31,6 +37,14 @@ class Quality extends Component {
     this.setState(payload);
   }
 
+  onResetQualityDefinitionsPress = () => {
+    this.setState({ isConfirmQualityDefinitionResetModalOpen: true });
+  }
+
+  onCloseResetQualityDefinitionsModal = () => {
+    this.setState({ isConfirmQualityDefinitionResetModalOpen: false });
+  }
+
   onSavePress = () => {
     if (this._saveCallback) {
       this._saveCallback();
@@ -43,6 +57,7 @@ class Quality extends Component {
   render() {
     const {
       isSaving,
+      isResettingQualityDefinitions,
       hasPendingChanges
     } = this.state;
 
@@ -51,6 +66,18 @@ class Quality extends Component {
         <SettingsToolbarConnector
           isSaving={isSaving}
           hasPendingChanges={hasPendingChanges}
+          additionalButtons={
+            <Fragment>
+              <PageToolbarSeparator />
+
+              <PageToolbarButton
+                label="Reset Definitions"
+                iconName={icons.REFRESH}
+                isSpinning={isResettingQualityDefinitions}
+                onPress={this.onResetQualityDefinitionsPress}
+              />
+            </Fragment>
+          }
           onSavePress={this.onSavePress}
         />
 
@@ -60,9 +87,18 @@ class Quality extends Component {
             onChildStateChange={this.onChildStateChange}
           />
         </PageContentBody>
+
+        <ResetQualityDefinitionsModal
+          isOpen={this.state.isConfirmQualityDefinitionResetModalOpen}
+          onModalClose={this.onCloseResetQualityDefinitionsModal}
+        />
       </PageContent>
     );
   }
 }
+
+Quality.propTypes = {
+  isResettingQualityDefinitions: PropTypes.bool.isRequired
+};
 
 export default Quality;

--- a/frontend/src/Settings/Quality/QualityConnector.js
+++ b/frontend/src/Settings/Quality/QualityConnector.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
+import * as commandNames from 'Commands/commandNames';
+import Quality from './Quality';
+
+function createMapStateToProps() {
+  return createSelector(
+    createCommandExecutingSelector(commandNames.RESET_QUALITY_DEFINITIONS),
+    (isResettingQualityDefinitions) => {
+      return {
+        isResettingQualityDefinitions
+      };
+    }
+  );
+}
+
+class QualityConnector extends Component {
+
+  //
+  // Render
+
+  render() {
+    return (
+      <Quality
+        {...this.props}
+      />
+    );
+  }
+}
+
+QualityConnector.propTypes = {
+  isResettingQualityDefinitions: PropTypes.bool.isRequired
+};
+
+export default connect(createMapStateToProps)(QualityConnector);

--- a/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModal.js
+++ b/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModal.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { sizes } from 'Helpers/Props';
+import Modal from 'Components/Modal/Modal';
+import ResetQualityDefinitionsModalContentConnector from './ResetQualityDefinitionsModalContentConnector';
+
+function ResetQualityDefinitionsModal(props) {
+  const {
+    isOpen,
+    onModalClose,
+    ...otherProps
+  } = props;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      size={sizes.MEDIUM}
+      onModalClose={onModalClose}
+    >
+      <ResetQualityDefinitionsModalContentConnector
+        {...otherProps}
+        onModalClose={onModalClose}
+      />
+    </Modal>
+  );
+}
+
+ResetQualityDefinitionsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default ResetQualityDefinitionsModal;

--- a/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContent.css
+++ b/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContent.css
@@ -1,0 +1,3 @@
+.messageContainer {
+  margin-bottom: 20px;
+}

--- a/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContent.js
+++ b/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContent.js
@@ -1,0 +1,103 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { inputTypes, kinds } from 'Helpers/Props';
+import Button from 'Components/Link/Button';
+import FormGroup from 'Components/Form/FormGroup';
+import FormLabel from 'Components/Form/FormLabel';
+import FormInputGroup from 'Components/Form/FormInputGroup';
+import ModalContent from 'Components/Modal/ModalContent';
+import ModalHeader from 'Components/Modal/ModalHeader';
+import ModalBody from 'Components/Modal/ModalBody';
+import ModalFooter from 'Components/Modal/ModalFooter';
+import styles from './ResetQualityDefinitionsModalContent.css';
+
+class ResetQualityDefinitionsModalContent extends Component {
+
+  //
+  // Lifecycle
+
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      resetDefinitionTitles: false
+    };
+  }
+
+  //
+  // Listeners
+
+  onResetDefinitionTitlesChange = ({ value }) => {
+    this.setState({ resetDefinitionTitles: value });
+  }
+
+  onResetQualityDefinitionsConfirmed = () => {
+    const resetDefinitionTitles = this.state.resetDefinitionTitles;
+
+    this.setState({ resetDefinitionTitles: false });
+    this.props.onResetQualityDefinitions(resetDefinitionTitles);
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      onModalClose,
+      isResettingQualityDefinitions
+    } = this.props;
+
+    const resetDefinitionTitles = this.state.resetDefinitionTitles;
+
+    return (
+      <ModalContent
+        onModalClose={onModalClose}
+      >
+        <ModalHeader>
+          Reset Quality Definitions
+        </ModalHeader>
+
+        <ModalBody>
+          <div className={styles.messageContainer}>
+            Are you sure you want to reset quality definitions?
+          </div>
+
+          <FormGroup>
+            <FormLabel>Reset Titles</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.CHECK}
+              name="resetDefinitionTitles"
+              value={resetDefinitionTitles}
+              helpText="Reset definition titles as well as values"
+              onChange={this.onResetDefinitionTitlesChange}
+            />
+          </FormGroup>
+
+        </ModalBody>
+
+        <ModalFooter>
+          <Button onPress={onModalClose}>
+            Cancel
+          </Button>
+
+          <Button
+            kind={kinds.DANGER}
+            onPress={this.onResetQualityDefinitionsConfirmed}
+            isDisabled={isResettingQualityDefinitions}
+          >
+            Reset
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    );
+  }
+}
+
+ResetQualityDefinitionsModalContent.propTypes = {
+  onResetQualityDefinitions: PropTypes.func.isRequired,
+  isResettingQualityDefinitions: PropTypes.bool.isRequired,
+  onModalClose: PropTypes.func.isRequired
+};
+
+export default ResetQualityDefinitionsModalContent;

--- a/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContentConnector.js
+++ b/frontend/src/Settings/Quality/Reset/ResetQualityDefinitionsModalContentConnector.js
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import * as commandNames from 'Commands/commandNames';
+import { executeCommand } from 'Store/Actions/commandActions';
+import ResetQualityDefinitionsModalContent from './ResetQualityDefinitionsModalContent';
+import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
+
+function createMapStateToProps() {
+  return createSelector(
+    createCommandExecutingSelector(commandNames.RESET_QUALITY_DEFINITIONS),
+    (isResettingQualityDefinitions) => {
+      return {
+        isResettingQualityDefinitions
+      };
+    }
+  );
+}
+
+const mapDispatchToProps = {
+  executeCommand
+};
+
+class ResetQualityDefinitionsModalContentConnector extends Component {
+
+  //
+  // Listeners
+
+  onResetQualityDefinitions = (resetTitles) => {
+    this.props.executeCommand({ name: commandNames.RESET_QUALITY_DEFINITIONS, resetTitles });
+    this.props.onModalClose(true);
+  }
+
+  //
+  // Render
+
+  render() {
+    return (
+      <ResetQualityDefinitionsModalContent
+        {...this.props}
+        onResetQualityDefinitions={this.onResetQualityDefinitions}
+      />
+    );
+  }
+}
+
+ResetQualityDefinitionsModalContentConnector.propTypes = {
+  onModalClose: PropTypes.func.isRequired,
+  isResettingQualityDefinitions: PropTypes.bool.isRequired,
+  executeCommand: PropTypes.func.isRequired
+};
+
+export default connect(createMapStateToProps, mapDispatchToProps)(ResetQualityDefinitionsModalContentConnector);

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NLog" Version="4.6.6" />
+    <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
     <PackageReference Include="Sentry" Version="1.2.0" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -244,6 +244,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[HorribleSubs] Series Title! S01 [Web][MKV][h264][1080p][AAC 2.0][Softsubs (HorribleSubs)]", false)]
         [TestCase("[LostYears] Series Title - 01-17 (WEB 1080p x264 10-bit AAC) [Dual-Audio]", false)]
         [TestCase("Series.and.Titles.S01.1080p.NF.WEB.DD2.0.x264-SNEAkY", false)]
+        [TestCase("Series.Title.S02E02.This.Year.Will.Be.Different.1080p.WEB.H 265", false)]
         public void should_parse_webdl1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.WEBDL1080p, proper);
@@ -267,6 +268,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("House.of.Sonarr.AK.s05e13.UHD.4K.WEB.DL", false)]
         [TestCase("[HorribleSubs] Series Title! S01 [Web][MKV][h264][2160p][AAC 2.0][Softsubs (HorribleSubs)]", false)]
         [TestCase("Series Title S02 2013 WEB-DL 4k H265 AAC 2Audio-HDSWEB", false)]
+        [TestCase("Series.Title.S02E02.This.Year.Will.Be.Different.2160p.WEB.H.265", false)]
         public void should_parse_webdl2160p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.WEBDL2160p, proper);

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -39,6 +39,7 @@ namespace NzbDrone.Core.Configuration
         string SslCertHash { get; }
         string UrlBase { get; }
         string UiFolder { get; }
+        string InstanceName { get; }
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
@@ -205,6 +206,19 @@ namespace NzbDrone.Core.Configuration
         // public string UiFolder => GetValue("UiFolder", "UI", false);GetValue("UiFolder", "UI", false);
         public string UiFolder => "UI";
 
+        public string InstanceName
+        {
+            get
+            {
+                var instanceName = GetValue("InstanceName", BuildInfo.AppName);
+
+                if (instanceName.StartsWith(BuildInfo.AppName) || instanceName.EndsWith(BuildInfo.AppName) )
+                {
+                    return instanceName;
+                }
+                return BuildInfo.AppName;
+            }
+        }
 
         public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
 
@@ -217,7 +231,6 @@ namespace NzbDrone.Core.Configuration
         public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
 
         public string SyslogLevel => GetValue("SyslogLevel", LogLevel, persist: false).ToLowerInvariant();
-
 
         public int GetValueInt(string key, int defaultValue, bool persist = true)
         {

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -42,6 +42,9 @@ namespace NzbDrone.Core.Configuration
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
+        string SyslogServer { get; }
+        int SyslogPort { get; }
+        string SyslogLevel { get; }
     }
 
     public class ConfigFileProvider : IConfigFileProvider
@@ -209,7 +212,14 @@ namespace NzbDrone.Core.Configuration
 
         public string UpdateScriptPath => GetValue("UpdateScriptPath", "", false);
 
-        public int GetValueInt(string key, int defaultValue)
+        public string SyslogServer => GetValue("SyslogServer", "", persist: false);
+
+        public int SyslogPort => GetValueInt("SyslogPort", 514, persist: false);
+
+        public string SyslogLevel => GetValue("SyslogLevel", LogLevel, persist: false).ToLowerInvariant();
+
+
+        public int GetValueInt(string key, int defaultValue, bool persist = true)
         {
             return Convert.ToInt32(GetValue(key, defaultValue));
         }

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         public int Year { get; set; }
         public string TitleSlug { get; set; }
         public int QualityProfileId { get; set; }
+        public int LanguageProfileId { get; set; }
         public HashSet<int> Tags { get; set; }
     }
 

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
                 foreach (var item in remoteSeries)
                 {
                     if ((!Settings.ProfileIds.Any() || Settings.ProfileIds.Contains(item.QualityProfileId)) &&
-                        (!Settings.LanguageProfileIds.Any() || Settings.LanguageProfileIds.Contains(item.QualityProfileId)) &&
+                        (!Settings.LanguageProfileIds.Any() || Settings.LanguageProfileIds.Contains(item.LanguageProfileId)) &&
                         (!Settings.TagIds.Any() || Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId))))
                     {
                         series.Add(new ImportListItemInfo

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -39,6 +39,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
                 foreach (var item in remoteSeries)
                 {
                     if ((!Settings.ProfileIds.Any() || Settings.ProfileIds.Contains(item.QualityProfileId)) &&
+                        (!Settings.LanguageProfileIds.Any() || Settings.LanguageProfileIds.Contains(item.QualityProfileId)) &&
                         (!Settings.TagIds.Any() || Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId))))
                     {
                         series.Add(new ImportListItemInfo
@@ -74,16 +75,33 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             {
                 Settings.Validate().Filter("ApiKey").ThrowOnError();
 
-                var profiles = _sonarrV3Proxy.GetProfiles(Settings);
+                var profiles = _sonarrV3Proxy.GetQualityProfiles(Settings);
 
                 return new
                 {
                     options = profiles.OrderBy(d => d.Name, StringComparer.InvariantCultureIgnoreCase)
-                                            .Select(d => new
-                                            {
-                                                value = d.Id,
-                                                name = d.Name
-                                            })
+                                      .Select(d => new
+                                      {
+                                          value = d.Id,
+                                          name = d.Name
+                                      })
+                };
+            }
+
+            if (action == "getLanguageProfiles")
+            {
+                Settings.Validate().Filter("ApiKey").ThrowOnError();
+
+                var langProfiles = _sonarrV3Proxy.GetLanguageProfiles(Settings);
+
+                return new
+                {
+                    options = langProfiles.OrderBy(d => d.Name, StringComparer.InvariantCultureIgnoreCase)
+                                          .Select(d => new
+                                          {
+                                              value = d.Id,
+                                              name = d.Name
+                                          })
                 };
             }
 

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             BaseUrl = "";
             ApiKey = "";
             ProfileIds = new int[] { };
+            LanguageProfileIds = new int[] { };
             TagIds = new int[] { };
         }
 
@@ -32,10 +33,13 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         [FieldDefinition(1, Label = "API Key", HelpText = "Apikey of the Sonarr V3 instance to import from")]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(2, Type = FieldType.Select, SelectOptionsProviderAction = "getProfiles", Label = "Profiles", HelpText = "Profiles from the source instance to import from")]
+        [FieldDefinition(2, Type = FieldType.Select, SelectOptionsProviderAction = "getProfiles", Label = "Quality Profiles", HelpText = "Quality Profiles from the source instance to import from")]
         public IEnumerable<int> ProfileIds { get; set; }
 
-        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getTags", Label = "Tags", HelpText = "Tags from the source instance to import from")]
+        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getLanguageProfiles", Label = "Language Profiles", HelpText = "Language Profiles from the source instance to import from")]
+        public IEnumerable<int> LanguageProfileIds { get; set; }
+
+        [FieldDefinition(4, Type = FieldType.Select, SelectOptionsProviderAction = "getTags", Label = "Tags", HelpText = "Tags from the source instance to import from")]
         public IEnumerable<int> TagIds { get; set; }
 
         public NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
@@ -12,7 +12,8 @@ namespace NzbDrone.Core.ImportLists.Sonarr
     public interface ISonarrV3Proxy
     {
         List<SonarrSeries> GetSeries(SonarrSettings settings);
-        List<SonarrProfile> GetProfiles(SonarrSettings settings);
+        List<SonarrProfile> GetQualityProfiles(SonarrSettings settings);
+        List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings);
         List<SonarrTag> GetTags(SonarrSettings settings);
         ValidationFailure Test(SonarrSettings settings);
     }
@@ -33,9 +34,14 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             return Execute<SonarrSeries>("/api/v3/series", settings);
         }
 
-        public List<SonarrProfile> GetProfiles(SonarrSettings settings)
+        public List<SonarrProfile> GetQualityProfiles(SonarrSettings settings)
         {
             return Execute<SonarrProfile>("/api/v3/qualityprofile", settings);
+        }
+
+        public List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings)
+        {
+            return Execute<SonarrProfile>("/api/v3/languageprofile", settings);
         }
 
         public List<SonarrTag> GetTags(SonarrSettings settings)

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -36,7 +36,8 @@ namespace NzbDrone.Core.Instrumentation
 
             if (_configFileProvider.SyslogServer.IsNotNullOrWhiteSpace())
             {
-                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, minimumLogLevel);
+                var syslogLevel = LogLevel.FromString(_configFileProvider.SyslogLevel);
+                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, syslogLevel);
             }
 
             var rules = LogManager.Configuration.LoggingRules;
@@ -98,7 +99,7 @@ namespace NzbDrone.Core.Instrumentation
             syslogTarget.MessageSend.Udp.Server = syslogServer;
             syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
             syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
-            syslogTarget.MessageCreation.Rfc5424.AppName = BuildInfo.AppName;
+            syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
 
             var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
 

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NLog.Config;
+using NLog.Targets.Syslog;
+using NLog.Targets.Syslog.Settings;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Sentry;
@@ -31,6 +33,11 @@ namespace NzbDrone.Core.Instrumentation
                 minimumConsoleLogLevel = minimumLogLevel;
             else
                 minimumConsoleLogLevel = LogLevel.Info;
+
+            if (_configFileProvider.SyslogServer.IsNotNullOrWhiteSpace())
+            {
+                SetSyslogParameters(_configFileProvider.SyslogServer, _configFileProvider.SyslogPort, minimumLogLevel);
+            }
 
             var rules = LogManager.Configuration.LoggingRules;
 
@@ -79,6 +86,24 @@ namespace NzbDrone.Core.Instrumentation
             {
                 sentryTarget.SentryEnabled = RuntimeInfo.IsProduction && _configFileProvider.AnalyticsEnabled || RuntimeInfo.IsDevelopment;
             }
+        }
+
+        private void SetSyslogParameters(string syslogServer, int syslogPort, LogLevel minimumLogLevel)
+        {
+            var syslogTarget = new SyslogTarget();
+
+            syslogTarget.Name = "syslogTarget";
+            syslogTarget.MessageSend.Protocol = ProtocolType.Udp;
+            syslogTarget.MessageSend.Udp.Port = syslogPort;
+            syslogTarget.MessageSend.Udp.Server = syslogServer;
+            syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
+            syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
+            syslogTarget.MessageCreation.Rfc5424.AppName = BuildInfo.AppName;
+
+            var loggingRule = new LoggingRule("*", minimumLogLevel, syslogTarget);
+
+            LogManager.Configuration.AddTarget("syslogTarget", syslogTarget);
+            LogManager.Configuration.LoggingRules.Add(loggingRule);
         }
 
         private List<LogLevel> GetLogLevels()

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -8,6 +8,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Processes;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.HealthCheck;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.ThingiProvider;
@@ -18,12 +19,17 @@ namespace NzbDrone.Core.Notifications.CustomScript
 {
     public class CustomScript : NotificationBase<CustomScriptSettings>
     {
+        private readonly IConfigFileProvider _configFileProvider;
         private readonly IDiskProvider _diskProvider;
         private readonly IProcessProvider _processProvider;
         private readonly Logger _logger;
 
-        public CustomScript(IDiskProvider diskProvider, IProcessProvider processProvider, Logger logger)
+        public CustomScript(IConfigFileProvider configFileProvider,
+                            IDiskProvider diskProvider,
+                            IProcessProvider processProvider,
+                            Logger logger)
         {
+            _configFileProvider = configFileProvider;
             _diskProvider = diskProvider;
             _processProvider = processProvider;
             _logger = logger;
@@ -43,6 +49,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Grab");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
@@ -77,6 +84,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Download");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_IsUpgrade", message.OldFiles.Any().ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
@@ -119,6 +127,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Rename");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
@@ -143,6 +152,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "EpisodeFileDelete");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_EpisodeFile_DeleteReason", deleteMessage.Reason.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
@@ -175,6 +185,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "SeriesDelete");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
@@ -192,6 +203,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "HealthIssue");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_Health_Issue_Level", Enum.GetName(typeof(HealthCheckResult), healthCheck.Type));
             environmentVariables.Add("Sonarr_Health_Issue_Message", healthCheck.Message);
             environmentVariables.Add("Sonarr_Health_Issue_Type", healthCheck.Source.Name);
@@ -205,6 +217,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "ApplicationUpdate");
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_Update_Message", updateMessage.Message);
             environmentVariables.Add("Sonarr_Update_NewVersion", updateMessage.NewVersion.ToString());
             environmentVariables.Add("Sonarr_Update_PreviousVersion", updateMessage.PreviousVersion.ToString());
@@ -235,6 +248,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
                 {
                     var environmentVariables = new StringDictionary();
                     environmentVariables.Add("Sonarr_EventType", "Test");
+                    environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
 
                     var processOutput = ExecuteScript(environmentVariables);
 

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Grab");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Download");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_IsUpgrade", message.OldFiles.Any().ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "Rename");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
@@ -152,7 +152,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "EpisodeFileDelete");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_EpisodeFile_DeleteReason", deleteMessage.Reason.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "SeriesDelete");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
@@ -203,7 +203,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "HealthIssue");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Health_Issue_Level", Enum.GetName(typeof(HealthCheckResult), healthCheck.Type));
             environmentVariables.Add("Sonarr_Health_Issue_Message", healthCheck.Message);
             environmentVariables.Add("Sonarr_Health_Issue_Type", healthCheck.Source.Name);
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             var environmentVariables = new StringDictionary();
 
             environmentVariables.Add("Sonarr_EventType", "ApplicationUpdate");
-            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+            environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Update_Message", updateMessage.Message);
             environmentVariables.Add("Sonarr_Update_NewVersion", updateMessage.NewVersion.ToString());
             environmentVariables.Add("Sonarr_Update_PreviousVersion", updateMessage.PreviousVersion.ToString());
@@ -248,7 +248,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
                 {
                     var environmentVariables = new StringDictionary();
                     environmentVariables.Add("Sonarr_EventType", "Test");
-                    environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
+                    environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
 
                     var processOutput = ExecuteScript(environmentVariables);
 

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
             environmentVariables.Add("Sonarr_Series_ImdbId", series.ImdbId ?? string.Empty);
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_IsUpgrade", message.OldFiles.Any().ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -132,7 +132,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_EpisodeFile_DeleteReason", deleteMessage.Reason.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -52,6 +52,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
+            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
             environmentVariables.Add("Sonarr_Series_ImdbId", series.ImdbId ?? string.Empty);
@@ -88,6 +89,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_IsUpgrade", message.OldFiles.Any().ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
+            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -130,6 +132,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
+            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -156,6 +159,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_EpisodeFile_DeleteReason", deleteMessage.Reason.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
+            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
@@ -188,6 +192,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName.ToString());
             environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
             environmentVariables.Add("Sonarr_Series_Title", series.Title);
+            environmentVariables.Add("Sonarr_Series_Title_Slug", series.TitleSlug.ToString());
             environmentVariables.Add("Sonarr_Series_Path", series.Path);
             environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
             environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookGrabPayload
             {
                 EventType = WebhookEventType.Grab,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Series = new WebhookSeries(message.Series),
                 Episodes = remoteEpisode.Episodes.ConvertAll(x => new WebhookEpisode(x)),
                 Release = new WebhookRelease(quality, remoteEpisode),
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookImportPayload
             {
                 EventType = WebhookEventType.Download,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Series = new WebhookSeries(message.Series),
                 Episodes = episodeFile.Episodes.Value.ConvertAll(x => new WebhookEpisode(x)),
                 EpisodeFile = new WebhookEpisodeFile(episodeFile),
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookRenamePayload
             {
                 EventType = WebhookEventType.Rename,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Series = new WebhookSeries(series),
                 RenamedEpisodeFiles = renamedFiles.ConvertAll(x => new WebhookRenamedEpisodeFile(x))
             };
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookEpisodeDeletePayload
             {
                 EventType = WebhookEventType.EpisodeFileDelete,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Series = new WebhookSeries(deleteMessage.Series),
                 Episodes = deleteMessage.EpisodeFile.Episodes.Value.ConvertAll(x => new WebhookEpisode(x)),
                 EpisodeFile = deleteMessage.EpisodeFile,
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookSeriesDeletePayload
             {
                 EventType = WebhookEventType.SeriesDelete,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Series = new WebhookSeries(deleteMessage.Series),
                 DeletedFiles = deleteMessage.DeletedFiles
             };
@@ -119,7 +119,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookHealthPayload
             {
                 EventType = WebhookEventType.Health,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Level = healthCheck.Type,
                 Message = healthCheck.Message,
                 Type = healthCheck.Source.Name,
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookApplicationUpdatePayload
             {
                 EventType = WebhookEventType.ApplicationUpdate,
-                InstanceName = _configFileProvider.InstanceName,
+                InstanceName = _configFileProvider.InstanceName.ToString(),
                 Message = updateMessage.Message,
                 PreviousVersion = updateMessage.PreviousVersion.ToString(),
                 NewVersion = updateMessage.NewVersion.ToString()
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Notifications.Webhook
                 var payload = new WebhookGrabPayload
                 {
                     EventType = WebhookEventType.Test,
-                    InstanceName = _configFileProvider.InstanceName,
+                    InstanceName = _configFileProvider.InstanceName.ToString(),
                     Series = new WebhookSeries()
                     {
                         Id = 1,

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentValidation.Results;
 using NzbDrone.Core.Tv;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Validation;
 
@@ -11,10 +12,12 @@ namespace NzbDrone.Core.Notifications.Webhook
 {
     public class Webhook : NotificationBase<WebhookSettings>
     {
+        private readonly IConfigFileProvider _configFileProvider;
         private readonly IWebhookProxy _proxy;
 
-        public Webhook(IWebhookProxy proxy)
+        public Webhook(IConfigFileProvider configFileProvider, IWebhookProxy proxy)
         {
+            _configFileProvider = configFileProvider;
             _proxy = proxy;
         }
 
@@ -28,6 +31,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookGrabPayload
             {
                 EventType = WebhookEventType.Grab,
+                InstanceName = _configFileProvider.InstanceName,
                 Series = new WebhookSeries(message.Series),
                 Episodes = remoteEpisode.Episodes.ConvertAll(x => new WebhookEpisode(x)),
                 Release = new WebhookRelease(quality, remoteEpisode),
@@ -46,6 +50,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookImportPayload
             {
                 EventType = WebhookEventType.Download,
+                InstanceName = _configFileProvider.InstanceName,
                 Series = new WebhookSeries(message.Series),
                 Episodes = episodeFile.Episodes.Value.ConvertAll(x => new WebhookEpisode(x)),
                 EpisodeFile = new WebhookEpisodeFile(episodeFile),
@@ -73,6 +78,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookRenamePayload
             {
                 EventType = WebhookEventType.Rename,
+                InstanceName = _configFileProvider.InstanceName,
                 Series = new WebhookSeries(series),
                 RenamedEpisodeFiles = renamedFiles.ConvertAll(x => new WebhookRenamedEpisodeFile(x))
             };
@@ -85,6 +91,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookEpisodeDeletePayload
             {
                 EventType = WebhookEventType.EpisodeFileDelete,
+                InstanceName = _configFileProvider.InstanceName,
                 Series = new WebhookSeries(deleteMessage.Series),
                 Episodes = deleteMessage.EpisodeFile.Episodes.Value.ConvertAll(x => new WebhookEpisode(x)),
                 EpisodeFile = deleteMessage.EpisodeFile,
@@ -99,6 +106,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookSeriesDeletePayload
             {
                 EventType = WebhookEventType.SeriesDelete,
+                InstanceName = _configFileProvider.InstanceName,
                 Series = new WebhookSeries(deleteMessage.Series),
                 DeletedFiles = deleteMessage.DeletedFiles
             };
@@ -111,6 +119,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookHealthPayload
             {
                 EventType = WebhookEventType.Health,
+                InstanceName = _configFileProvider.InstanceName,
                 Level = healthCheck.Type,
                 Message = healthCheck.Message,
                 Type = healthCheck.Source.Name,
@@ -125,6 +134,7 @@ namespace NzbDrone.Core.Notifications.Webhook
             var payload = new WebhookApplicationUpdatePayload
             {
                 EventType = WebhookEventType.ApplicationUpdate,
+                InstanceName = _configFileProvider.InstanceName,
                 Message = updateMessage.Message,
                 PreviousVersion = updateMessage.PreviousVersion.ToString(),
                 NewVersion = updateMessage.NewVersion.ToString()
@@ -151,6 +161,7 @@ namespace NzbDrone.Core.Notifications.Webhook
                 var payload = new WebhookGrabPayload
                 {
                     EventType = WebhookEventType.Test,
+                    InstanceName = _configFileProvider.InstanceName,
                     Series = new WebhookSeries()
                     {
                         Id = 1,

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookPayload.cs
@@ -3,5 +3,6 @@
     public class WebhookPayload
     {
         public WebhookEventType EventType { get; set; }
+        public string InstanceName { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSeries.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSeries.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.Notifications.Webhook
     {
         public int Id { get; set; }
         public string Title { get; set; }
+        public string TitleSlug { get; set; }
         public string Path { get; set; }
         public int TvdbId { get; set; }
         public int TvMazeId { get; set; }
@@ -18,6 +19,7 @@ namespace NzbDrone.Core.Notifications.Webhook
         {
             Id = series.Id;
             Title = series.Title;
+            TitleSlug = series.TitleSlug;
             Path = series.Path;
             TvdbId = series.TvdbId;
             TvMazeId = series.TvMazeId;

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SourceRegex = new Regex(@"\b(?:
                                                                 (?<bluray>BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$))|
-                                                                (?<webdl>WEB[-_. ]DL|WEBDL|AmazonHD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|[. ]WEB[. ](?:[xh]26[45]|DDP?5[. ]1)|[. ](?-i:WEB)$|\d+0p(?:[-. ]AMZN)?[-. ]WEB[-. ]|WEB-DLMux|\b\s\/\sWEB\s\/\s\b|(?:AMZN|NF|DP)[. ]WEB[. ])|
+                                                                (?<webdl>WEB[-_. ]DL|WEBDL|AmazonHD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|[. ]WEB[. ](?:[xh][ .]?26[45]|DDP?5[. ]1)|[. ](?-i:WEB)$|\d+0p(?:[-. ]AMZN)?[-. ]WEB[-. ]|WEB-DLMux|\b\s\/\sWEB\s\/\s\b|(?:AMZN|NF|DP)[. ]WEB[. ])|
                                                                 (?<webrip>WebRip|Web-Rip|WEBMux)|
                                                                 (?<hdtv>HDTV)|
                                                                 (?<bdrip>BDRip|BDLight)|

--- a/src/NzbDrone.Core/Qualities/Commands/ResetQualityDefinitionsCommand.cs
+++ b/src/NzbDrone.Core/Qualities/Commands/ResetQualityDefinitionsCommand.cs
@@ -1,0 +1,14 @@
+﻿using NzbDrone.Core.Messaging.Commands;
+
+namespace NzbDrone.Core.Qualities.Commands
+{
+    public class ResetQualityDefinitionsCommand : Command
+    {
+        public bool ResetTitles { get; set; }
+
+        public ResetQualityDefinitionsCommand(bool resetTitles = false)
+        {
+            ResetTitles = resetTitles;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionRepository.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionRepository.cs
@@ -14,7 +14,5 @@ namespace NzbDrone.Core.Qualities
             : base(database, eventAggregator)
         {
         }
-
-      
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Validation.Paths
         
 
         public StartupFolderValidator(IAppFolderInfo appFolderInfo)
-            : base("Path cannot be an ancestor of the start up folder")
+            : base("Path cannot be {relationship} the start up folder")
         {
             _appFolderInfo = appFolderInfo;
         }
@@ -19,7 +19,24 @@ namespace NzbDrone.Core.Validation.Paths
         {
             if (context.PropertyValue == null) return true;
 
-            return !_appFolderInfo.StartUpFolder.IsParentPath(context.PropertyValue.ToString());
+            var startupFolder = _appFolderInfo.StartUpFolder;
+            var folder = context.PropertyValue.ToString();
+
+            if (startupFolder.PathEquals(folder))
+            {
+                context.MessageFormatter.AppendArgument("relationship", "set to");
+
+                return false;
+            }
+
+            if (startupFolder.IsParentPath(folder))
+            {
+                context.MessageFormatter.AppendArgument("relationship", "child of");
+
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -62,5 +62,11 @@ namespace NzbDrone.Core.Validation
         {
             return ruleBuilder.WithState(v => NzbDroneValidationState.Warning);
         }
+
+        public static IRuleBuilderOptions<T, string> StartsOrEndsWithSonarr<T>(this IRuleBuilder<T, string> ruleBuilder)
+        {
+            ruleBuilder.SetValidator(new NotEmptyValidator(null));
+            return ruleBuilder.SetValidator(new RegularExpressionValidator("^Sonarr|Sonarr$")).WithMessage("Must start or end with Sonarr");
+        }
     }
 }

--- a/src/Sonarr.Api.V3/Config/HostConfigModule.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigModule.cs
@@ -38,6 +38,7 @@ namespace Sonarr.Api.V3.Config
             SharedValidator.RuleFor(c => c.Port).ValidPort();
 
             SharedValidator.RuleFor(c => c.UrlBase).ValidUrlBase();
+            SharedValidator.RuleFor(c => c.InstanceName).StartsOrEndsWithSonarr();
 
             SharedValidator.RuleFor(c => c.Username).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);
             SharedValidator.RuleFor(c => c.Password).NotEmpty().When(c => c.AuthenticationMethod != AuthenticationType.None);

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -24,6 +24,7 @@ namespace Sonarr.Api.V3.Config
         public string ApiKey { get; set; }
         public string SslCertHash { get; set; }
         public string UrlBase { get; set; }
+        public string InstanceName { get; set; }
         public bool UpdateAutomatically { get; set; }
         public UpdateMechanism UpdateMechanism { get; set; }
         public string UpdateScriptPath { get; set; }
@@ -63,6 +64,7 @@ namespace Sonarr.Api.V3.Config
                 ApiKey = model.ApiKey,
                 SslCertHash = model.SslCertHash,
                 UrlBase = model.UrlBase,
+                InstanceName = model.InstanceName,
                 UpdateAutomatically = model.UpdateAutomatically,
                 UpdateMechanism = model.UpdateMechanism,
                 UpdateScriptPath = model.UpdateScriptPath,

--- a/src/Sonarr.Api.V3/System/SystemModule.cs
+++ b/src/Sonarr.Api.V3/System/SystemModule.cs
@@ -51,6 +51,7 @@ namespace Sonarr.Api.V3.System
             return new
                    {
                        AppName = BuildInfo.AppName,
+                       InstanceName = _configFileProvider.InstanceName,
                        Version = BuildInfo.Version.ToString(),
                        BuildTime = BuildInfo.BuildDateTime,
                        IsDebug = BuildInfo.IsDebug,

--- a/src/Sonarr.Http/Frontend/InitializeJsModule.cs
+++ b/src/Sonarr.Http/Frontend/InitializeJsModule.cs
@@ -61,6 +61,7 @@ namespace Sonarr.Http.Frontend
             builder.AppendLine($"  apiKey: '{_apiKey}',");
             builder.AppendLine($"  release: '{BuildInfo.Release}',");
             builder.AppendLine($"  version: '{BuildInfo.Version.ToString()}',");
+            builder.AppendLine($"  instanceName: '{_configFileProvider.InstanceName.ToString()}',");
             builder.AppendLine($"  branch: '{_configFileProvider.Branch.ToLower()}',");
             builder.AppendLine($"  analytics: {_analyticsService.IsEnabled.ToString().ToLowerInvariant()},");
             builder.AppendLine($"  urlBase: '{_urlBase}',");


### PR DESCRIPTION
Signed-off-by: Devin Buhl <devin@buhl.casa>

#### Database Migration
NO

#### Description

* Add `InstanceName` and `series.TitleSlug` to Custom Script and Webhook notifications.

Note: `TitleSlug` is useful in building a URL to the series in sonarr for any custom script or custom webhook to consume.

I didn't see any unit tests for these notification providers, so I skipped that, also it looks like the wiki only need the custom script section updated.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* #5059
