### PR TITLE
New: Add application URL to host configuration settings

### DIFF
--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -1,10 +1,10 @@
+import PropTypes from 'prop-types';
+import React from 'react';
 import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import { inputTypes, sizes } from 'Helpers/Props';
-import PropTypes from 'prop-types';
-import React from 'react';
 
 function HostSettings(props) {
   const {
@@ -99,7 +99,7 @@ function HostSettings(props) {
         <FormInputGroup
           type={inputTypes.TEXT}
           name="applicationUrl"
-          helpText="This applications external URL including http(s):// and optional port and/or URL base"
+          helpText="This application's external URL including http(s)://, port and URL base"
           onChange={onInputChange}
           {...applicationUrl}
         />

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -99,7 +99,7 @@ function HostSettings(props) {
         <FormInputGroup
           type={inputTypes.TEXT}
           name="applicationUrl"
-          helpText="This applications external URL including http(s):// and optionally port and/or URL base"
+          helpText="This applications external URL including http(s):// and optional port and/or URL base"
           onChange={onInputChange}
           {...applicationUrl}
         />

--- a/frontend/src/Settings/General/HostSettings.js
+++ b/frontend/src/Settings/General/HostSettings.js
@@ -1,10 +1,10 @@
-import PropTypes from 'prop-types';
-import React from 'react';
 import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import { inputTypes, sizes } from 'Helpers/Props';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function HostSettings(props) {
   const {
@@ -20,6 +20,7 @@ function HostSettings(props) {
     port,
     urlBase,
     instanceName,
+    applicationUrl,
     enableSsl,
     sslPort,
     sslCertPath,
@@ -86,6 +87,21 @@ function HostSettings(props) {
           helpTextWarning="Requires restart to take effect"
           onChange={onInputChange}
           {...instanceName}
+        />
+      </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>Application URL</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.TEXT}
+          name="applicationUrl"
+          helpText="This applications external URL including http(s):// and optionally port and/or URL base"
+          onChange={onInputChange}
+          {...applicationUrl}
         />
       </FormGroup>
 

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -45,6 +45,7 @@ namespace NzbDrone.Core.Configuration
         string UrlBase { get; }
         string UiFolder { get; }
         string InstanceName { get; }
+        string ApplicationUrl { get; }
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
@@ -229,6 +230,8 @@ namespace NzbDrone.Core.Configuration
                 return BuildInfo.AppName;
             }
         }
+
+        public string ApplicationUrl => GetValue("ApplicationUrl", "", persist: false);
 
         public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
 

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -45,7 +45,6 @@ namespace NzbDrone.Core.Configuration
         string UrlBase { get; }
         string UiFolder { get; }
         string InstanceName { get; }
-        string ApplicationUrl { get; }
         bool UpdateAutomatically { get; }
         UpdateMechanism UpdateMechanism { get; }
         string UpdateScriptPath { get; }
@@ -230,8 +229,6 @@ namespace NzbDrone.Core.Configuration
                 return BuildInfo.AppName;
             }
         }
-
-        public string ApplicationUrl => GetValue("ApplicationUrl", "", persist: false);
 
         public bool UpdateAutomatically => GetValueBoolean("UpdateAutomatically", false, false);
 

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -346,6 +346,8 @@ namespace NzbDrone.Core.Configuration
         public CertificateValidationType CertificateValidation =>
             GetValueEnum("CertificateValidation", CertificateValidationType.Enabled);
 
+        public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
+
         private string GetValue(string key)
         {
             return GetValue(key, string.Empty);

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -85,5 +85,6 @@ namespace NzbDrone.Core.Configuration
         int BackupRetention { get; }
 
         CertificateValidationType CertificateValidation { get; }
+        string ApplicationUrl { get; }
     }
 }

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -71,7 +71,6 @@ namespace Sonarr.Api.V3.Config
                 SslCertPassword = model.SslCertPassword,
                 UrlBase = model.UrlBase,
                 InstanceName = model.InstanceName,
-                ApplicationUrl = model.ApplicationUrl,
                 UpdateAutomatically = model.UpdateAutomatically,
                 UpdateMechanism = model.UpdateMechanism,
                 UpdateScriptPath = model.UpdateScriptPath,
@@ -86,7 +85,8 @@ namespace Sonarr.Api.V3.Config
                 CertificateValidation = configService.CertificateValidation,
                 BackupFolder = configService.BackupFolder,
                 BackupInterval = configService.BackupInterval,
-                BackupRetention = configService.BackupRetention
+                BackupRetention = configService.BackupRetention,
+                ApplicationUrl = configService.ApplicationUrl
             };
         }
     }

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -27,6 +27,7 @@ namespace Sonarr.Api.V3.Config
         public string SslCertPassword { get; set; }
         public string UrlBase { get; set; }
         public string InstanceName { get; set; }
+        public string ApplicationUrl { get; set; }
         public bool UpdateAutomatically { get; set; }
         public UpdateMechanism UpdateMechanism { get; set; }
         public string UpdateScriptPath { get; set; }
@@ -70,6 +71,7 @@ namespace Sonarr.Api.V3.Config
                 SslCertPassword = model.SslCertPassword,
                 UrlBase = model.UrlBase,
                 InstanceName = model.InstanceName,
+                ApplicationUrl = model.ApplicationUrl,
                 UpdateAutomatically = model.UpdateAutomatically,
                 UpdateMechanism = model.UpdateMechanism,
                 UpdateScriptPath = model.UpdateScriptPath,


### PR DESCRIPTION
Signed-off-by: Devin Buhl <devin@buhl.casa>

#### Database Migration
NO

#### Description

<img width="570" alt="image" src="https://user-images.githubusercontent.com/213795/174460464-5d454f23-b5db-4541-b52b-134159e57caa.png">

Add external Application URL to Host settings, I poked around a little and didn't see a way to easily do validation on this URL, it could easily be any of the following:

- http(s)://sonarr.domain.tld
- http(s)://domain.tld/sonarr
- http(s)://sonarr:8989
- http(s)://192.168.1.100:8989

Please let me know if there's a need for validation and any existing examples would be helpful <3

After this is merged I will create other PRs implementing the use of this in notification services for pushover, custom script and webhook.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* https://github.com/Sonarr/Sonarr/issues/5060
