### PR TITLE
New: Improve messaging for rejected quality upgrades

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
@@ -48,8 +48,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (qualityCompare < 0)
                 {
-                    _logger.Debug("This file isn't a quality upgrade for all episodes. Skipping {0}", localEpisode.Path);
-                    return Decision.Reject("Not an upgrade for existing episode file(s)");
+                    _logger.Debug("This file isn't a quality upgrade for all episodes. Quality Detected is [{0}]. Skipping {1}", episodeFile.Quality.Quality, localEpisode.Path);
+                    return Decision.Reject("Not an upgrade for existing episode file(s). Quality Detected is [{0}]", episodeFile.Quality.Quality);
                 }
 
                 // Same quality, is not a language upgrade, propers/repacks are preferred and it is not a revision update

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
@@ -48,8 +48,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (qualityCompare < 0)
                 {
-                    _logger.Debug("This file isn't a quality upgrade for all episodes. Quality Detected is {0}. Skipping {1}", localEpisode.Quality.Quality, localEpisode.Path);
-                    return Decision.Reject("Not an upgrade for existing episode file(s). Quality Detected is {0}", localEpisode.Quality.Quality);
+                    _logger.Debug("This file isn't a quality upgrade for all episodes. New Quality is {0}. Skipping {1}", localEpisode.Quality.Quality, localEpisode.Path);
+                    return Decision.Reject("Not an upgrade for existing episode file(s). New Quality is {0}", localEpisode.Quality.Quality);
                 }
 
                 // Same quality, is not a language upgrade, propers/repacks are preferred and it is not a revision update

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
@@ -48,8 +48,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (qualityCompare < 0)
                 {
-                    _logger.Debug("This file isn't a quality upgrade for all episodes. Quality Detected is [{0}]. Skipping {1}", episodeFile.Quality.Quality, localEpisode.Path);
-                    return Decision.Reject("Not an upgrade for existing episode file(s). Quality Detected is [{0}]", episodeFile.Quality.Quality);
+                    _logger.Debug("This file isn't a quality upgrade for all episodes. Quality Detected is {0}. Skipping {1}", localEpisode.Quality.Quality, localEpisode.Path);
+                    return Decision.Reject("Not an upgrade for existing episode file(s). Quality Detected is {0}", localEpisode.Quality.Quality);
                 }
 
                 // Same quality, is not a language upgrade, propers/repacks are preferred and it is not a revision update


### PR DESCRIPTION
#### Database Migration
NO

#### Description
useful for instances where the queue file quality (from the client) doesn't match the on-disk rejected file e.g. quality mismatch

#### Todos
- Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* 
