### PR TITLE
Adding tmdb id to metadata output for Kodi/XBMC

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -173,6 +173,13 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         imdbId.SetAttributeValue("type", "imdb");
                         tvShow.Add(imdbId);
                     }
+                    
+                    if (series.TmdbId.IsNotNullOrWhiteSpace())
+                    {
+                        var tmdbId = new XElement("uniqueid", series.TmdbId);
+                        tmdbId.SetAttributeValue("type", "tmdb");
+                        tvShow.Add(tmdbId);
+                    }
 
                     foreach (var genre in series.Genres)
                     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This would add the TMDB ID (where available) to the output of `tvshow.nfo` when Kodi/XBMC metadata is enabled

#### Todos
N/A


#### Issues Fixed or Closed by this PR

* N/A
