### PR TITLE
Fixed: Logging when series folder is moved successfully

### DIFF
--- a/src/NzbDrone.Core/Tv/MoveSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/MoveSeriesService.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Tv
                 _diskProvider.CreateFolder(new DirectoryInfo(destinationPath).Parent.FullName);
                 _diskTransferService.TransferFolder(sourcePath, destinationPath, TransferMode.Move);
 
-                _logger.ProgressInfo("{0} moved successfully to {1}", series.Title, series.Path);
+                _logger.ProgressInfo("{0} moved successfully to {1}", series.Title, destinationPath);
 
                 _eventAggregator.PublishEvent(new SeriesMovedEvent(series, sourcePath, destinationPath));
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Just fixes a log message.

Message I got when renaming a series folder:
```
2022-08-06 09:08:01.0|Info|MoveSeriesService|Moving 12 Monkeys from '/tv/12 Monkeys' to '/tv/12 Monkeys (2015)'
2022-08-06 09:08:01.1|Info|MoveSeriesService|12 Monkeys moved successfully to /tv/12 Monkeys
```

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
