### PR TITLE
Fixed: Nyaa episode title search

### DIFF
--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -91,9 +91,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
 
             foreach (var queryTitle in searchCriteria.EpisodeQueryTitles)
             {
-                pageableRequests.Add(GetPagedRequests(MaxPages,
-                    string.Format("&term={0}",
-                    PrepareQuery(queryTitle))));
+                pageableRequests.Add(GetPagedRequests(MaxPages, PrepareQuery(queryTitle)));
             }
 
             return pageableRequests;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`NyaaRequestGenerator::GetSearchRequest` attempts to prepend `&term=` to the title being searched, even though `GetPagedRequests` already does this in constructing the search URL. I noticed this during inspection.

#### Todos
- [X] Tests (N/A)
- [X] Wiki Updates (N/A)


#### Issues Fixed or Closed by this PR
