### PR TITLE
New: Torrent Seed Ratio no longer advance settings

### DIFF
--- a/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Indexers
     {
         private static readonly SeedCriteriaSettingsValidator Validator = new SeedCriteriaSettingsValidator();
 
-        [FieldDefinition(0, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default", Advanced = true)]
+        [FieldDefinition(0, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default. Ratio should at least 1.0 and follow the indexers rules")]
         public double? SeedRatio { get; set; }
 
         [FieldDefinition(1, Type = FieldType.Number, Label = "Seed Time", Unit = "minutes", HelpText = "The time a torrent should be seeded before stopping, empty is download client's default", Advanced = true)]

--- a/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Indexers
     {
         private static readonly SeedCriteriaSettingsValidator Validator = new SeedCriteriaSettingsValidator();
 
-        [FieldDefinition(0, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default. Ratio should at least 1.0 and follow the indexers rules")]
+        [FieldDefinition(0, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default. Ratio should be at least 1.0 and follow the indexers rules")]
         public double? SeedRatio { get; set; }
 
         [FieldDefinition(1, Type = FieldType.Number, Label = "Seed Time", Unit = "minutes", HelpText = "The time a torrent should be seeded before stopping, empty is download client's default", Advanced = true)]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Making seed ratio a non-advanced option on indexer settings. Allows functionality of completed download removal to work without enabling advanced settings.

#### Todos


#### Issues Fixed or Closed by this PR

* 
