### PR TITLE
Fixed: Fix NullRef in Subtitle Service due to #4924

### DIFF
--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleFile.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleFile.cs
@@ -6,6 +6,11 @@ namespace NzbDrone.Core.Extras.Subtitles
 {
     public class SubtitleFile : ExtraFile
     {
+        public SubtitleFile()
+        {
+            LanguageTags = new List<string>();
+        }
+
         public Language Language { get; set; }
 
         public string AggregateString => Language + LanguageTagsAsString + Extension;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
#4924 Adds nullable DB field LanguageTags. This sets default value in SubtitleFile constructor to empty list, preventing null errors when accessed.

