### PR TITLE
Improve handling of multiple languages in post title

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -232,7 +232,7 @@ namespace NzbDrone.Core.Test.ParserTests
         public void should_parse_language_hungarian(string postTitle)
         {
             var result = LanguageParser.ParseLanguages(postTitle);
-            result.First().Id.Should().Be(Language.Hungarian.Id);
+            result.Should().Contain(lang => lang.Id == Language.Hungarian.Id);
         }
 
         [TestCase("Title.the.Series.S01-03.DVDRip.HebDub")]
@@ -307,6 +307,16 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             var result = LanguageParser.ParseLanguages(postTitle);
             result.First().Name.Should().Be(Language.English.Name);
+        }
+
+        [TestCase("[GroupName] Series Title - 08 [1080p][Multiple Subtitle] [ENG][POR-BR][SPA-LA][RUS]")]
+        public void should_parse_multiple_languages(string postTitle)
+        {
+            var result = LanguageParser.ParseLanguages(postTitle);
+            result.Should().Contain(l => l.Id == Language.English.Id);
+            result.Should().Contain(l => l.Id == Language.Portuguese.Id);
+            result.Should().Contain(l => l.Id == Language.Spanish.Id);
+            result.Should().Contain(l => l.Id == Language.Russian.Id);
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Parser
                 new RegexReplace(@".*?[_. ](S\d{2}(?:E\d{2,4})*[_. ].*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             };
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann|ger[. ]dub)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VF|VF2|VFF|VFQ|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|(?<bulgarian>\bbgaudio\b)|(?<spanish>\b(?:español|castellano)\b)|(?<ukrainian>\b(?:ukr)\b)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<english>\b(?:eng|english)\b)|(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann|ger[. ]dub)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VF|VF2|VFF|VFQ|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|(?<bulgarian>\bbgaudio\b)|(?<spanish>\b(?:español|castellano|spa-la)\b)|(?<portoguese>\b(?:portoguese|por-br)\b)|(?<ukrainian>\b(?:ukr)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b)|(?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))",
@@ -235,99 +235,111 @@ namespace NzbDrone.Core.Parser
             var languages = new List<Language>();
 
             // Case sensitive
-            var caseSensitiveMatch = CaseSensitiveLanguageRegex.Match(title);
-
-            if (caseSensitiveMatch.Groups["lithuanian"].Captures.Cast<Capture>().Any())
+            foreach (Match caseSensitiveMatch in CaseSensitiveLanguageRegex.Matches(title))
             {
-                languages.Add(Language.Lithuanian);
-            }
+                if (caseSensitiveMatch.Groups["lithuanian"].Success)
+                {
+                    languages.Add(Language.Lithuanian);
+                }
 
-            if (caseSensitiveMatch.Groups["czech"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Czech);
-            }
+                if (caseSensitiveMatch.Groups["czech"].Success)
+                {
+                    languages.Add(Language.Czech);
+                }
 
-            if (caseSensitiveMatch.Groups["polish"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Polish);
-            }
+                if (caseSensitiveMatch.Groups["polish"].Success)
+                {
+                    languages.Add(Language.Polish);
+                }
 
-            if (caseSensitiveMatch.Groups["bulgarian"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Bulgarian);
+                if (caseSensitiveMatch.Groups["bulgarian"].Success)
+                {
+                    languages.Add(Language.Bulgarian);
+                }
             }
 
             // Case insensitive
-            var match = LanguageRegex.Match(title);
-
-            if (match.Groups["italian"].Captures.Cast<Capture>().Any())
+            foreach (Match match in LanguageRegex.Matches(title))
             {
-                languages.Add(Language.Italian);
-            }
+                if (match.Groups["english"].Success)
+                {
+                    languages.Add(Language.English);
+                }
 
-            if (match.Groups["german"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.German);
-            }
+                if (match.Groups["italian"].Success)
+                {
+                    languages.Add(Language.Italian);
+                }
 
-            if (match.Groups["flemish"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Flemish);
-            }
+                if (match.Groups["german"].Success)
+                {
+                    languages.Add(Language.German);
+                }
 
-            if (match.Groups["greek"].Captures.Cast<Capture>().Any())
-            {
-                languages.Add(Language.Greek);
-            }
+                if (match.Groups["flemish"].Success)
+                {
+                    languages.Add(Language.Flemish);
+                }
 
-            if (match.Groups["french"].Success)
-            {
-                languages.Add(Language.French);
-            }
+                if (match.Groups["greek"].Success)
+                {
+                    languages.Add(Language.Greek);
+                }
 
-            if (match.Groups["russian"].Success)
-            {
-                languages.Add(Language.Russian);
-            }
+                if (match.Groups["french"].Success)
+                {
+                    languages.Add(Language.French);
+                }
 
-            if (match.Groups["dutch"].Success)
-            {
-                languages.Add(Language.Dutch);
-            }
+                if (match.Groups["russian"].Success)
+                {
+                    languages.Add(Language.Russian);
+                }
 
-            if (match.Groups["hungarian"].Success)
-            {
-                languages.Add(Language.Hungarian);
-            }
+                if (match.Groups["dutch"].Success)
+                {
+                    languages.Add(Language.Dutch);
+                }
 
-            if (match.Groups["hebrew"].Success)
-            {
-                languages.Add(Language.Hebrew);
-            }
+                if (match.Groups["hungarian"].Success)
+                {
+                    languages.Add(Language.Hungarian);
+                }
 
-            if (match.Groups["polish"].Success)
-            {
-                languages.Add(Language.Polish);
-            }
+                if (match.Groups["hebrew"].Success)
+                {
+                    languages.Add(Language.Hebrew);
+                }
 
-            if (match.Groups["chinese"].Success)
-            {
-                languages.Add(Language.Chinese);
-            }
+                if (match.Groups["polish"].Success)
+                {
+                    languages.Add(Language.Polish);
+                }
 
-            if (match.Groups["bulgarian"].Success)
-            {
-                languages.Add(Language.Bulgarian);
-            }
+                if (match.Groups["chinese"].Success)
+                {
+                    languages.Add(Language.Chinese);
+                }
 
-            if (match.Groups["ukrainian"].Success)
-            {
-                languages.Add(Language.Ukrainian);
-            }
+                if (match.Groups["bulgarian"].Success)
+                {
+                    languages.Add(Language.Bulgarian);
+                }
 
-            if (match.Groups["spanish"].Success)
-            {
-                languages.Add(Language.Spanish);
+                if (match.Groups["ukrainian"].Success)
+                {
+                    languages.Add(Language.Ukrainian);
+                }
+
+                if (match.Groups["spanish"].Success)
+                {
+                    languages.Add(Language.Spanish);
+                }
+
+                if (match.Groups["portoguese"].Success)
+                {
+                    languages.Add(Language.Portuguese);
+                }
             }
 
             return languages;

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Parser
                 new RegexReplace(@".*?[_. ](S\d{2}(?:E\d{2,4})*[_. ].*)", "$1", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             };
 
-        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<english>\b(?:eng|english)\b)|(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann|ger[. ]dub)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VF|VF2|VFF|VFQ|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|(?<bulgarian>\bbgaudio\b)|(?<spanish>\b(?:español|castellano|spa-la)\b)|(?<portoguese>\b(?:portoguese|por-br)\b)|(?<ukrainian>\b(?:ukr)\b)",
+        private static readonly Regex LanguageRegex = new Regex(@"(?:\W|_)(?<english>\b(?:eng|english)\b)|(?<italian>\b(?:ita|italian)\b)|(?<german>german\b|videomann|ger[. ]dub)|(?<flemish>flemish)|(?<greek>greek)|(?<french>(?:\W|_)(?:FR|VF|VF2|VFF|VFQ|TRUEFRENCH)(?:\W|_))|(?<russian>\brus\b)|(?<hungarian>\b(?:HUNDUB|HUN)\b)|(?<hebrew>\bHebDub\b)|(?<polish>\b(?:PL\W?DUB|DUB\W?PL|LEK\W?PL|PL\W?LEK)\b)|(?<chinese>\[(?:CH[ST]|BIG5|GB)\]|简|繁|字幕)|(?<bulgarian>\bbgaudio\b)|(?<spanish>\b(?:español|castellano|spa-la)\b)|(?<portuguese>\b(?:portuguese|por-br)\b)|(?<ukrainian>\b(?:ukr)\b)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CaseSensitiveLanguageRegex = new Regex(@"(?:(?i)(?<!SUB[\W|_|^]))(?:(?<lithuanian>\bLT\b)|(?<czech>\bCZ\b)|(?<polish>\bPL\b)|(?<bulgarian>\bBG\b))(?:(?i)(?![\W|_|^]SUB))",
@@ -336,7 +336,7 @@ namespace NzbDrone.Core.Parser
                     languages.Add(Language.Spanish);
                 }
 
-                if (match.Groups["portoguese"].Success)
+                if (match.Groups["portuguese"].Success)
                 {
                     languages.Add(Language.Portuguese);
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This improves handling of posts/titles with multiple languages in the title. For instance, I had the following example:

```
[Erai-raws] Overlord IV - 08 [1080p][Multiple Subtitle] [ENG][POR-BR][SPA-LA][RUS]
```

Sonarr concluded this was a Russian release (only) - and as shuch did not choose to download it. This PR fixes that without breaking any of the other language-parsing tests (though I had to change one of the tests because it was order dependent).


#### Todos
- [x] Tests
- [ ] Wiki Updates

I'm not sure if this warrants a wiki update?

#### Issues Fixed or Closed by this PR

I didn't find a github issue for this exact problem. I can make one if wanted - but I wanted to check whether this was something I could easily fix myself first, and it didn't seem like a big problem to resolve.
