### PR TITLE
Fixes Systemd Restart=on-failure endless restarts

### DIFF
--- a/distribution/debian/sonarr.service
+++ b/distribution/debian/sonarr.service
@@ -3,6 +3,8 @@
 # Or use systemd built-in override functionality using 'systemctl edit sonarr'
 [Unit]
 Description=Sonarr Daemon
+StartLimitIntervalSec=60
+StartLimitBurst=3
 After=network.target
 
 [Service]


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Enforce a limit to how many times the service can restart in case of failure. 
 
When Sonarr is restarted from the WebUI as Sonar's UI uses an internal killall->start mechanic instead of using Systemd to restart Sonarr. If the Sonarr's Systemd Service is started manually afterward the service will fail since there's already an instance of Sonarr running on the desired **ip:port**, the sonarr.service will fail and trigger the service "Restart=on-failure" command. And since there's no limit set in the sonarr.service Systemd Service to limit how many times the server should restart, Systemd will try to restart the service indefinitely. 

I had two instances where the Sonarr's systemd service hit Systemd internal limit (5 restarts in 10 seconds), however, for all my other tries Systemd just keep going on trying to restart the service.

It's easy to reproduce the issue, start the sonarr Systemd Service, restart Sonarr from the webUI, restart sonarr's systemd service manually "systemctl start sonarr" and watch Systemd tirelessly trying to restart the service using "systemctl status sonarr" or "journalctl -xe -u sonarr". Otherwise I can forward journalctl logs privately. 

The same issue occurs with the Sonarr.service Systemd service that comes with the APT source install .deb file.  

StartLimitIntervalSec=interval
StartLimitBurst=burst
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval


#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 