### PR TITLE
Fixed: Better error messaging if you try to import an invalid Custom Format

### DIFF
--- a/src/Sonarr.Api.V3/CustomFormats/CustomFormatResource.cs
+++ b/src/Sonarr.Api.V3/CustomFormats/CustomFormatResource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -47,7 +48,16 @@ namespace Sonarr.Api.V3.CustomFormats
 
         private static ICustomFormatSpecification MapSpecification(CustomFormatSpecificationSchema resource, List<ICustomFormatSpecification> specifications)
         {
-            var type = specifications.SingleOrDefault(x => x.GetType().Name == resource.Implementation).GetType();
+            var matchingSpec =
+                specifications.SingleOrDefault(x => x.GetType().Name == resource.Implementation);
+
+            if (matchingSpec is null)
+            {
+                throw new ArgumentException(
+                    $"{resource.Implementation} is not a valid specification implementation");
+            }
+
+            var type = matchingSpec.GetType();
 
             // Finding the exact current specification isn't possible given the dynamic nature of them and the possibility that multiple
             // of the same type exist within the same format. Passing in null is safe as long as there never exists a specification that


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Previously, if the spec was not found, you'd get a
`NullReferenceException` back in the API response because the code always
assumed the `SingleOrDefault()` method would return non-null. This change
introduces a safety check for `null` and throws `ArgumentException` with
a more helpful error message that makes the issue more apparent to
clients of the API.

The use case for this is custom format import via API (and might also
apply to import on the frontend too, although I did not test this). If
you take a CF meant for Radarr and import it into Sonarr, you get this
issue.

#### Todos

- [X] Tests
- [X] Wiki Updates

