### PR TITLE
Fixed: Improve RarBG Error Handling

### DIFF
--- a/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
+++ b/src/NzbDrone.Core/Indexers/Rarbg/RarbgParser.cs
@@ -30,9 +30,12 @@ namespace NzbDrone.Core.Indexers.Rarbg
 
             if (jsonResponse.Resource.error_code.HasValue)
             {
-                if (jsonResponse.Resource.error_code == 20 || jsonResponse.Resource.error_code == 8)
+                if (jsonResponse.Resource.error_code == 5 || jsonResponse.Resource.error_code == 8
+                    || jsonResponse.Resource.error_code == 9 || jsonResponse.Resource.error_code == 10
+                    || jsonResponse.Resource.error_code == 13 || jsonResponse.Resource.error_code == 14
+                    || jsonResponse.Resource.error_code == 20)
                 {
-                    // No results found
+                    // No results, rate limit, tvdbid not found/invalid, or imdbid not found/invalid
                     return results;
                 }
 


### PR DESCRIPTION
backport of various response code updates in jackett, prowlarr, radarr

#### Database Migration
NO

#### Description
Handle Rarbg error codes

ref from jackett
```
                case 5: // Too many requests per second. Maximum requests allowed are 1req/2sec Please try again later!
                case 8: // imdb not found, see issue #12466
                case 9: // imdb not found, see Radarr #1845
                case 10: // imdb not found, see issue #1486
                case 14: // tmdb not found, see Radarr #7625
                case 20: // no results found
```
#### Todos
- Tests
- Wiki Updates

#### Issues Fixed or Closed by this PR

* 
