### PR TITLE
New: Store and use original Series language

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,7 +46,6 @@ csharp_style_var_elsewhere = true:suggestion
 
 # Stylecop Rules
 dotnet_diagnostic.SA0001.severity = none
-dotnet_diagnostic.SA1005.severity = none
 dotnet_diagnostic.SA1025.severity = none
 dotnet_diagnostic.SA1101.severity = none
 dotnet_diagnostic.SA1116.severity = none

--- a/frontend/src/InteractiveImport/Language/SelectLanguageModalContentConnector.js
+++ b/frontend/src/InteractiveImport/Language/SelectLanguageModalContentConnector.js
@@ -11,7 +11,22 @@ function createMapStateToProps() {
   return createSelector(
     createLanguagesSelector(),
     (languages) => {
-      return languages;
+      const {
+        isFetching,
+        isPopulated,
+        error,
+        items
+      } = languages;
+
+      const filterItems = ['Any', 'Original'];
+      const filteredLanguages = items.filter((lang) => !filterItems.includes(lang.name));
+
+      return {
+        isFetching,
+        isPopulated,
+        error,
+        items: filteredLanguages
+      };
     }
   );
 }

--- a/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.js
+++ b/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.js
@@ -47,6 +47,15 @@ function SeriesIndexSortMenu(props) {
         </SortMenuItem>
 
         <SortMenuItem
+          name="originalLanguage"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          Original Language
+        </SortMenuItem>
+
+        <SortMenuItem
           name="qualityProfileId"
           sortKey={sortKey}
           sortDirection={sortDirection}

--- a/frontend/src/Series/Index/Table/SeriesIndexHeader.css
+++ b/frontend/src/Series/Index/Table/SeriesIndexHeader.css
@@ -30,6 +30,7 @@
   flex: 2 0 90px;
 }
 
+.originalLanguage,
 .qualityProfileId {
   composes: headerCell from '~Components/Table/VirtualTableHeaderCell.css';
 

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.css
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.css
@@ -66,6 +66,7 @@
   flex: 2 0 90px;
 }
 
+.originalLanguage,
 .qualityProfileId {
   composes: cell;
 

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.js
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.js
@@ -85,6 +85,7 @@ class SeriesIndexRow extends Component {
       titleSlug,
       seriesType,
       network,
+      originalLanguage,
       qualityProfile,
       nextAiring,
       previousAiring,
@@ -208,6 +209,17 @@ class SeriesIndexRow extends Component {
                   className={styles[name]}
                 >
                   {network}
+                </VirtualTableRowCell>
+              );
+            }
+
+            if (name === 'originalLanguage') {
+              return (
+                <VirtualTableRowCell
+                  key={name}
+                  className={styles[name]}
+                >
+                  {originalLanguage.name}
                 </VirtualTableRowCell>
               );
             }
@@ -511,6 +523,7 @@ SeriesIndexRow.propTypes = {
   title: PropTypes.string.isRequired,
   titleSlug: PropTypes.string.isRequired,
   seriesType: PropTypes.string.isRequired,
+  originalLanguage: PropTypes.object.isRequired,
   network: PropTypes.string,
   qualityProfile: PropTypes.object.isRequired,
   nextAiring: PropTypes.string,

--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -131,6 +131,13 @@ export const filterPredicates = {
     return predicate(item.ratings.value * 10, filterValue);
   },
 
+  originalLanguage: function(item, filterValue, type) {
+    const predicate = filterTypePredicates[type];
+    const { originalLanguage } = item;
+
+    return predicate(originalLanguage ? originalLanguage.name : '', filterValue);
+  },
+
   releaseGroups: function(item, filterValue, type) {
     const { statistics = {} } = item;
 
@@ -265,6 +272,25 @@ export const filterBuilderProps = [
       }, []);
 
       return tagList.sort(sortByName);
+    }
+  },
+  {
+    name: 'originalLanguage',
+    label: 'Original Language',
+    type: filterBuilderTypes.EXACT,
+    optionsSelector: function(items) {
+      const languageList = items.reduce((acc, series) => {
+        if (series.originalLanguage) {
+          acc.push({
+            id: series.originalLanguage.name,
+            name: series.originalLanguage.name
+          });
+        }
+
+        return acc;
+      }, []);
+
+      return languageList.sort(sortByName);
     }
   },
   {

--- a/frontend/src/Store/Actions/seriesIndexActions.js
+++ b/frontend/src/Store/Actions/seriesIndexActions.js
@@ -96,6 +96,12 @@ export const defaultState = {
       isVisible: false
     },
     {
+      name: 'originalLanguage',
+      label: 'Original Language',
+      isSortable: true,
+      isVisible: false
+    },
+    {
       name: 'added',
       label: 'Added',
       isSortable: true,
@@ -247,6 +253,12 @@ export const defaultState = {
       const { statistics = {} } = item;
 
       return statistics.seasonCount;
+    },
+
+    originalLanguage: function(item) {
+      const { originalLanguage = {} } = item;
+
+      return originalLanguage.name;
     },
 
     ratings: function(item) {

--- a/src/NzbDrone.Automation.Test/PageModel/PageBase.cs
+++ b/src/NzbDrone.Automation.Test/PageModel/PageBase.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Automation.Test.PageModel
 
         public void WaitForNoSpinner(int timeout = 30)
         {
-            //give the spinner some time to show up.
+            // give the spinner some time to show up.
             Thread.Sleep(200);
 
             var wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(timeout));

--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -394,7 +394,7 @@ namespace NzbDrone.Common.Test.DiskTests
             var destination = new DirectoryInfo(GetTempFilePath());
             Subject.TransferFolder(source.FullName, destination.FullName, TransferMode.Copy);
 
-            //Delete Random File
+            // Delete Random File
             destination.GetFiles("*.*", SearchOption.AllDirectories).First().Delete();
 
             Subject.TransferFolder(source.FullName, destination.FullName, TransferMode.Copy);

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Common.Test.Http
             Mocker.SetConstant<IHttpDispatcher>(Mocker.Resolve<TDispatcher>());
 
             // Used for manual testing of socks proxies.
-            //Mocker.GetMock<IHttpProxySettingsProvider>()
+            // Mocker.GetMock<IHttpProxySettingsProvider>()
             //      .Setup(v => v.GetProxySettings(It.IsAny<HttpRequest>()))
             //      .Returns(new HttpProxySettings(ProxyType.Socks5, "127.0.0.1", 5476, "", false));
 

--- a/src/NzbDrone.Common.Test/ServiceProviderFixture.cs
+++ b/src/NzbDrone.Common.Test/ServiceProviderFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Common.Test
     [TestFixture]
     public class ServiceProviderFixture : TestBase<ServiceProvider>
     {
-        private const string ALWAYS_INSTALLED_SERVICE = "SCardSvr"; //Smart Card
+        private const string ALWAYS_INSTALLED_SERVICE = "SCardSvr"; // Smart Card
         private const string TEMP_SERVICE_NAME = "NzbDrone_Nunit";
 
         [SetUp]

--- a/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
@@ -204,7 +204,7 @@ namespace NzbDrone.Common.EnvironmentInfo
 
         private static bool InternalIsOfficialBuild()
         {
-            //Official builds will never have such a high revision
+            // Official builds will never have such a high revision
             if (BuildInfo.Version.Major >= 10 || BuildInfo.Version.Revision > 10000)
             {
                 return false;

--- a/src/NzbDrone.Common/Expansive/Expansive.cs
+++ b/src/NzbDrone.Common/Expansive/Expansive.cs
@@ -179,10 +179,10 @@ namespace NzbDrone.Common.Expansive
         private static dynamic ToExpando(this object o)
         {
             var result = new ExpandoObject();
-            var d = result as IDictionary<string, object>; //work with the Expando as a Dictionary
+            var d = result as IDictionary<string, object>; // work with the Expando as a Dictionary
             if (o is ExpandoObject)
             {
-                return o; //shouldn't have to... but just in case
+                return o; // shouldn't have to... but just in case
             }
 
             if (o is NameValueCollection || o.GetType().IsSubclassOf(typeof(NameValueCollection)))

--- a/src/NzbDrone.Common/Expansive/TreeNode.cs
+++ b/src/NzbDrone.Common/Expansive/TreeNode.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Common.Expansive
         {
             get
             {
-                //return (Parent == null) ? this : Parent.Root;
+                // return (Parent == null) ? this : Parent.Root;
 
                 TreeNode<T> node = this;
                 while (node.Parent != null)

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Common.Extensions
 
             var info = new FileInfo(path.Trim());
 
-            //UNC
+            // UNC
             if (OsInfo.IsWindows && info.FullName.StartsWith(@"\\"))
             {
                 return info.FullName.TrimEnd('/', '\\', ' ');
@@ -167,7 +167,7 @@ namespace NzbDrone.Common.Extensions
             var parentDirInfo = dirInfo.Parent;
             if (parentDirInfo == null)
             {
-                //Drive letter
+                // Drive letter
                 return dirInfo.Name.ToUpper();
             }
 

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -174,22 +174,22 @@ namespace NzbDrone.Common.Extensions
 
         public static string ToUrlSlug(this string value)
         {
-            //First to lower case
+            // First to lower case
             value = value.ToLowerInvariant();
 
-            //Remove all accents
+            // Remove all accents
             value = value.RemoveAccent();
 
-            //Replace spaces
+            // Replace spaces
             value = Regex.Replace(value, @"\s", "-", RegexOptions.Compiled);
 
-            //Remove invalid chars
+            // Remove invalid chars
             value = Regex.Replace(value, @"[^a-z0-9\s-_]", "", RegexOptions.Compiled);
 
-            //Trim dashes from end
+            // Trim dashes from end
             value = value.Trim('-', '_');
 
-            //Replace double occurrences of - or _
+            // Replace double occurrences of - or _
             value = Regex.Replace(value, @"([-_]){2,}", "$1", RegexOptions.Compiled);
 
             return value;

--- a/src/NzbDrone.Common/OAuth/OAuthTools.cs
+++ b/src/NzbDrone.Common/OAuth/OAuthTools.cs
@@ -256,7 +256,7 @@ namespace NzbDrone.Common.OAuth
             sb.Append(!basic && !secure ? qualified : "");
             sb.Append(url.AbsolutePath);
 
-            return sb.ToString(); //.ToLower();
+            return sb.ToString(); // .ToLower();
         }
 
         /// <summary>

--- a/src/NzbDrone.Core.Test/Datastore/Migration/148_mediainfo_channel_propertiesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/148_mediainfo_channel_propertiesFixture.cs
@@ -73,17 +73,17 @@ namespace NzbDrone.Core.Test.Datastore.Migration
 
             var mediainfo = items.First().MediaInfo;
 
-            //Removed props should be null
+            // Removed props should be null
             mediainfo.AudioChannels.Should().BeNull();
             mediainfo.AudioChannelPositionsText.Should().BeNull();
 
-            //Renamed should have original value
+            // Renamed should have original value
             mediainfo.AudioChannelsContainer.Should().NotBeNull();
             mediainfo.AudioChannelPositionsTextContainer.Should().NotBeNull();
             mediainfo.AudioChannelsContainer.Should().Be(6);
             mediainfo.AudioChannelPositionsTextContainer.Should().Be("Front: L C R, Side: L R, LFE");
 
-            //Should not touch other props
+            // Should not touch other props
             mediainfo.AudioChannelPositions.Should().Be("3/2/0.1");
         }
 

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/HistorySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/HistorySpecificationFixture.cs
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
         }
 
-//        [Test]
+// [Test]
 //        public void should_return_true_if_latest_history_has_a_download_id_and_cdh_is_enabled()
 //        {
 //            GivenMostRecentForEpisode(FIRST_EPISODE_ID, "test", _notupgradableQuality, DateTime.UtcNow, HistoryEventType.Grabbed);

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
@@ -74,8 +74,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
             VerifyIdentifiable(downloadClientItem);
             downloadClientItem.RemainingSize.Should().NotBe(0);
 
-            //downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
-            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            // downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
+            // downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Queued);
         }
 
@@ -85,8 +85,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
 
             downloadClientItem.RemainingSize.Should().NotBe(0);
 
-            //downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
-            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            // downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
+            // downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Paused);
         }
 
@@ -96,8 +96,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
 
             downloadClientItem.RemainingSize.Should().NotBe(0);
 
-            //downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
-            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            // downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
+            // downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Downloading);
         }
 
@@ -105,8 +105,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
         {
             VerifyIdentifiable(downloadClientItem);
 
-            //downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
-            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            // downloadClientItem.RemainingTime.Should().NotBe(TimeSpan.Zero);
+            // downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Downloading);
         }
 
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
             downloadClientItem.RemainingSize.Should().Be(0);
             downloadClientItem.RemainingTime.Should().Be(TimeSpan.Zero);
 
-            //downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
+            // downloadClientItem.OutputPath.Should().NotBeNullOrEmpty();
             downloadClientItem.Status.Should().Be(DownloadItemStatus.Completed);
         }
 

--- a/src/NzbDrone.Core.Test/FluentTest.cs
+++ b/src/NzbDrone.Core.Test/FluentTest.cs
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Test
         {
             var result = new List<int>().MaxOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(0);
         }
 
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Test
 
             var result = list.MaxOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(10);
         }
 
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Test
 
             var result = list.MaxOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(0);
         }
 
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Test
 
             var resultString = str.Truncate(1000);
 
-            //Resolve
+            // Resolve
             var result = new UTF8Encoding().GetBytes(resultString);
             result.Length.Should().BeLessOrEqualTo(1000);
         }
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Test
 
             var resultString = str.Truncate(1000);
 
-            //Resolve
+            // Resolve
             var result = new UTF8Encoding().GetBytes(resultString);
             result.Length.Should().Be(11);
         }
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Test
         {
             var result = new List<int>().MinOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(0);
         }
 
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.Test
 
             var result = list.MinOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(3);
         }
 
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.Test
 
             var result = list.MinOrDefault();
 
-            //Resolve
+            // Resolve
             result.Should().Be(0);
         }
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
             torrentInfo.CommentUrl.Should().BeNullOrEmpty();
             torrentInfo.Indexer.Should().Be(Subject.Definition.Name);
             torrentInfo.PublishDate.Should().Be(DateTime.Parse("Tue, 24 Aug 2021 22:18:46"));
-            torrentInfo.Size.Should().Be(639211930); //609.6 MiB
+            torrentInfo.Size.Should().Be(639211930); // 609.6 MiB
             torrentInfo.MagnetUrl.Should().Be(null);
             torrentInfo.Seeders.Should().Be(4);
             torrentInfo.Peers.Should().Be(3 + 4);

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguageFixture.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
     public class AggregateLanguageFixture : CoreTest<AggregateLanguage>
     {
         private LocalEpisode _localEpisode;
+        private Series _series;
         private string _simpleReleaseTitle = "Series.Title.S01E01.xyz-RlsGroup";
 
         [SetUp]
@@ -26,11 +27,16 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
             var episodes = Builder<Episode>.CreateListOfSize(1)
                                            .BuildList();
 
+            _series = Builder<Series>.CreateNew()
+                       .With(m => m.OriginalLanguage = Language.English)
+                       .Build();
+
             _localEpisode = Builder<LocalEpisode>.CreateNew()
                                                  .With(l => l.DownloadClientEpisodeInfo = null)
                                                  .With(l => l.FolderEpisodeInfo = null)
                                                  .With(l => l.FileEpisodeInfo = null)
                                                  .With(l => l.Episodes = episodes)
+                                                 .With(l => l.Series = _series)
                                                  .Build();
         }
 
@@ -72,7 +78,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
         {
             var result = Subject.Aggregate(_localEpisode, null);
 
-            result.Languages.Should().Contain(Language.English);
+            result.Languages.Should().Contain(_series.OriginalLanguage);
         }
 
         [Test]
@@ -120,13 +126,13 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
         [Test]
         public void should_return_file_language_when_file_language_is_higher_than_others()
         {
-            _localEpisode.DownloadClientEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { Language.English }, _simpleReleaseTitle);
-            _localEpisode.FolderEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { Language.English }, _simpleReleaseTitle);
+            _localEpisode.DownloadClientEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { Language.Unknown }, _simpleReleaseTitle);
+            _localEpisode.FolderEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { Language.Unknown }, _simpleReleaseTitle);
             _localEpisode.FileEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { Language.French }, _simpleReleaseTitle);
 
             GivenAugmenters(new List<Language> { Language.French },
-                new List<Language> { Language.English },
-                new List<Language> { Language.English },
+                new List<Language> { Language.Unknown },
+                new List<Language> { Language.Unknown },
                 null);
 
             Subject.Aggregate(_localEpisode, null).Languages.Should().Contain(_localEpisode.FileEpisodeInfo.Languages);
@@ -135,9 +141,9 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
         [Test]
         public void should_return_multi_language()
         {
-            GivenAugmenters(new List<Language> { Language.English },
+            GivenAugmenters(new List<Language> { Language.Unknown },
                             new List<Language> { Language.French, Language.German },
-                            new List<Language> { Language.English },
+                            new List<Language> { Language.Unknown },
                             null);
 
             Subject.Aggregate(_localEpisode, null).Languages.Should().Equal(new List<Language> { Language.French, Language.German });

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/UpgradeSpecificationFixture.cs
@@ -261,46 +261,6 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
         }
 
         [Test]
-        public void should_return_false_if_it_is_a_preferred_word_downgrade_and_equal_language_and_quality()
-        {
-            var lowFormat = new List<CustomFormat> { new CustomFormat("Bad Format", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 2 } };
-
-            CustomFormatsFixture.GivenCustomFormats(lowFormat.First());
-
-            _series.QualityProfile.Value.FormatItems = CustomFormatsFixture.GetSampleFormatItems();
-
-            Mocker.GetMock<IConfigService>()
-                  .Setup(s => s.DownloadPropersAndRepacks)
-                  .Returns(ProperDownloadTypes.DoNotPrefer);
-
-            Mocker.GetMock<ICustomFormatCalculationService>()
-                  .Setup(s => s.ParseCustomFormat(It.IsAny<EpisodeFile>()))
-                  .Returns(new List<CustomFormat>());
-
-            Mocker.GetMock<ICustomFormatCalculationService>()
-                  .Setup(s => s.ParseCustomFormat(It.IsAny<ParsedEpisodeInfo>()))
-                  .Returns(lowFormat);
-
-            _localEpisode.Quality = new QualityModel(Quality.Bluray1080p);
-
-            _localEpisode.Episodes = Builder<Episode>.CreateListOfSize(1)
-                                                     .All()
-                                                     .With(e => e.EpisodeFileId = 1)
-                                                     .With(e => e.EpisodeFile = new LazyLoaded<EpisodeFile>(
-                                                         new EpisodeFile
-                                                         {
-                                                             Quality = new QualityModel(Quality.Bluray1080p),
-                                                             Languages = new List<Language> { Language.Spanish }
-                                                         }))
-                                                     .Build()
-                                                     .ToList();
-
-            _localEpisode.FileEpisodeInfo = Builder<ParsedEpisodeInfo>.CreateNew().Build();
-
-            Subject.IsSatisfiedBy(_localEpisode, null).Accepted.Should().BeFalse();
-        }
-
-        [Test]
         public void should_return_true_if_it_is_a_preferred_word_downgrade_and_language_downgrade_and_a_quality_upgrade()
         {
             Mocker.GetMock<IConfigService>()

--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
             series.Runtime.Should().BeGreaterThan(0);
             series.TitleSlug.Should().NotBeNullOrWhiteSpace();
 
-            //series.TvRageId.Should().BeGreaterThan(0);
+            // series.TvRageId.Should().BeGreaterThan(0);
             series.TvdbId.Should().BeGreaterThan(0);
         }
 
@@ -83,7 +83,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
             {
                 ValidateEpisode(episode);
 
-                //if atleast one episdoe has title it means parse it working.
+                // if atleast one episdoe has title it means parse it working.
                 episodes.Should().Contain(c => !string.IsNullOrWhiteSpace(c.Title));
             }
         }
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         {
             episode.Should().NotBeNull();
 
-            //TODO: Is there a better way to validate that episode number or season number is greater than zero?
+            // TODO: Is there a better way to validate that episode number or season number is greater than zero?
             (episode.EpisodeNumber + episode.SeasonNumber).Should().NotBe(0);
 
             episode.Should().NotBeNull();

--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         [TestCase("Rob & Big", "Rob & Big")]
         [TestCase("M*A*S*H", "M*A*S*H")]
 
-        //[TestCase("imdb:tt0436992", "Doctor Who (2005)")]
+        // [TestCase("imdb:tt0436992", "Doctor Who (2005)")]
         [TestCase("tvdb:78804", "Doctor Who (2005)")]
         [TestCase("tvdbid:78804", "Doctor Who (2005)")]
         [TestCase("tvdbid: 78804 ", "Doctor Who (2005)")]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("backslash \\ backlash", "backslash backlash")]
         [TestCase("I'm the Boss", "Im the Boss")]
 
-        //[TestCase("", "")]
+        // [TestCase("", "")]
         public void should_get_expected_title_back(string title, string expected)
         {
             _series.Title = title;

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReplaceCharacterFixure.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReplaceCharacterFixure.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                   .Returns(new List<CustomFormat>());
         }
 
-//        { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
+// { "\\", "/", "<", ">", "?", "*", ":", "|", "\"" };
 //        { "+", "+", "", "", "!", "-", " -", "", "" };
 
         [TestCase("CSI: Crime Scene Investigation", "CSI - Crime Scene Investigation")]

--- a/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Initial_Series_Title - 14 DVD - Central Anime", "Initial Series Title", 14, 0, 0)]
         [TestCase("Initial_Series_Title_-_14(DVD)_-_(Central_Anime)[0183D922].mkv", "Initial Series Title", 14, 0, 0)]
 
-//        [TestCase("Initial D - 4th Stage Ep 01.mkv", "Initial D - 4th Stage", 1, 0, 0)]
+// [TestCase("Initial D - 4th Stage Ep 01.mkv", "Initial D - 4th Stage", 1, 0, 0)]
         [TestCase("[ChihiroDesuYo].Series.Title.-.09.1280x720.10bit.AAC.[24CCE81D]", "Series Title", 9, 0, 0)]
         [TestCase("Series Title - 001 - Fairy Tail", "Series Title", 001, 0, 0)]
         [TestCase("Series Title - 049 - The Day of Fated Meeting", "Series Title", 049, 0, 0)]
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series Title - 099 - Natsu vs. Gildarts", "Series Title", 099, 0, 0)]
         [TestCase("Series Title - 100 - Mest", "Series Title", 100, 0, 0)]
 
-//        [TestCase("Fairy Tail - 101 - Mest", "Fairy Tail", 101, 0, 0)] //This gets caught up in the 'see' numbering
+// [TestCase("Fairy Tail - 101 - Mest", "Fairy Tail", 101, 0, 0)] //This gets caught up in the 'see' numbering
         [TestCase("[Exiled-Destiny] Series Title Ep01 (D2201EC5).mkv", "Series Title", 1, 0, 0)]
         [TestCase("[Commie] Series Title - 23 [5396CA24].mkv", "Series Title", 23, 0, 0)]
         [TestCase("[FFF] Series Title - 01 [1FB538B5].mkv", "Series Title", 1, 0, 0)]
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[HorribleSubs] Series Title 21 - 101 [480p].mkv", "Series Title 21", 101, 0, 0)]
         [TestCase("[Cthuyuu].Series.Title.-.03.[720p.H264.AAC][8AD82C3A]", "Series Title", 3, 0, 0)]
 
-        //[TestCase("Series.Title.-.03.(1280x720.HEVC.AAC)", "Series Title", 3, 0, 0)]
+        // [TestCase("Series.Title.-.03.(1280x720.HEVC.AAC)", "Series Title", 3, 0, 0)]
         [TestCase("[Cthuyuu] Series Title - 03 [720p H264 AAC][8AD82C3A]", "Series Title", 3, 0, 0)]
         [TestCase("Series Title Episode 56 [VOSTFR V2][720p][AAC]-Mystic Z-Team", "Series Title", 56, 0, 0)]
         [TestCase("[Mystic Z-Team] Series Title Episode 69 [VOSTFR_Finale][1080p][AAC].mp4", "Series Title", 69, 0, 0)]
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Mob Psycho 100 S3 - 01 (1080p) [5A493522]", "Mob Psycho 100 S3", 1, 0, 0)]
         [TestCase("[SubsPlease] Mob Psycho 100 S3 - 01 (1080p) [5A493522]", "Mob Psycho 100 S3", 1, 0, 0)]
 
-        //[TestCase("", "", 0, 0, 0)]
+        // [TestCase("", "", 0, 0, 0)]
         public void should_parse_absolute_numbers(string postTitle, string title, int absoluteEpisodeNumber, int seasonNumber, int episodeNumber)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/DailyEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/DailyEpisodeParserFixture.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("A.Late.Talk.Show.140722.720p.HDTV.x264-YesTV", "A Late Talk Show", 2014, 07, 22)]
         [TestCase("A_Late_Talk_Show_140722_720p_HDTV_x264-YesTV", "A Late Talk Show", 2014, 07, 22)]
 
-        //[TestCase("Corrie.07.01.15", "Corrie", 2015, 1, 7)]
+        // [TestCase("Corrie.07.01.15", "Corrie", 2015, 1, 7)]
         [TestCase("The Show Series 2015 02 09 WEBRIP s01e13", "The Show Series", 2015, 2, 9)]
         [TestCase("Tree_Series_2018_06_22_Seth_Meyers_720p_HEVC_x265-MeGusta", "Tree Series", 2018, 6, 22)]
         [TestCase("20161024- Exotic Payback.21x41_720.mkv", "", 2016, 10, 24)]
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series and Title 20201013 Ep7432 [720p WebRip (x264)] [SUBS]", "Series and Title", 2020, 10, 13)]
         [TestCase("Series Title (1955) - 1954-01-23 05 00 00 - Cottage for Sale.ts", "Series Title (1955)", 1954, 1, 23)]
 
-        //[TestCase("", "", 0, 0, 0)]
+        // [TestCase("", "", 0, 0, 0)]
         public void should_parse_daily_episode(string postTitle, string title, int year, int month, int day)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -11,21 +11,27 @@ namespace NzbDrone.Core.Test.ParserTests
     public class LanguageParserFixture : CoreTest
     {
         [TestCase("Title.the.Series.2009.S01E14.English.HDTV.XviD-LOL")]
+        [TestCase("Series Title - S01E01 - Pilot.English.sub")]
+        [TestCase("Series Title - S01E01 - Pilot.english.sub")]
+        public void should_parse_language_english(string postTitle)
+        {
+            var result = LanguageParser.ParseLanguages(postTitle);
+            result.First().Should().Be(Language.English);
+        }
+
+        [TestCase("Spanish Killroy was Here S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb")]
+        [TestCase("Title.the.Spanish.Series.S02E02.1080p.WEB.H264-CAKES")]
+        [TestCase("Title.the.Spanish.Series.S02E06.Field.of.Cloth.of.Gold.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
         [TestCase("Title.the.Series.2009.S01E14.Germany.HDTV.XviD-LOL")]
         [TestCase("Title.the.Series.2009.S01E14.HDTV.XviD-LOL")]
         [TestCase("Title.the.Italian.Series.S01E01.The.Family.720p.HDTV.x264-FTP")]
         [TestCase("Title.the.Italy.Series.S02E01.720p.HDTV.x264-TLA")]
         [TestCase("Series Title - S01E01 - Pilot.en.sub")]
         [TestCase("Series Title - S01E01 - Pilot.eng.sub")]
-        [TestCase("Series Title - S01E01 - Pilot.English.sub")]
-        [TestCase("Series Title - S01E01 - Pilot.english.sub")]
-        [TestCase("Spanish Killroy was Here S02E02 Flodden 720p AMZN WEB-DL DDP5 1 H 264-NTb")]
-        [TestCase("Title.the.Spanish.Series.S02E02.1080p.WEB.H264-CAKES")]
-        [TestCase("Title.the.Spanish.Series.S02E06.Field.of.Cloth.of.Gold.1080p.AMZN.WEBRip.DDP5.1.x264-NTb")]
-        public void should_parse_language_english(string postTitle)
+        public void should_parse_language_unknown(string postTitle)
         {
             var result = LanguageParser.ParseLanguages(postTitle);
-            result.First().Should().Be(Language.English);
+            result.First().Should().Be(Language.Unknown);
         }
 
         [TestCase("Series Title - S01E01 - Pilot.sub")]
@@ -314,7 +320,7 @@ namespace NzbDrone.Core.Test.ParserTests
         public void should_not_parse_series_or_episode_title(string postTitle)
         {
             var result = LanguageParser.ParseLanguages(postTitle);
-            result.First().Name.Should().Be(Language.English.Name);
+            result.First().Name.Should().Be(Language.Unknown.Name);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/MiniSeriesEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/MiniSeriesEpisodeParserFixture.cs
@@ -13,8 +13,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series and Show 2012 Part 1 REPACK 720p HDTV x264 2HD", "Series and Show 2012", 1)]
         [TestCase("Series Show.2016.E04.Power.720p.WEB-DL.DD5.1.H.264-MARS", "Series Show 2016", 4)]
 
-        //[TestCase("Killroy.Jumped.And.Was.Here.EP02.Episode.Title.DVDRiP.XviD-DEiTY", "Killroy.Jumped.And.Was.Here", 2)]
-        //[TestCase("", "", 0)]
+        // [TestCase("Killroy.Jumped.And.Was.Here.EP02.Episode.Title.DVDRiP.XviD-DEiTY", "Killroy.Jumped.And.Was.Here", 2)]
+        // [TestCase("", "", 0)]
         public void should_parse_mini_series_episode(string postTitle, string title, int episodeNumber)
         {
             var result = Parser.Parser.ParseTitle(postTitle);
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.E191.190121.720p-NEXT.mp4", "Series", 191, "2019-01-21")]
         [TestCase("The Series Title Challenge.E932.190120.720p-NEXT.mp4", "The Series Title Challenge", 932, "2019-01-20")]
 
-        //[TestCase("", "", 0, "")]
+        // [TestCase("", "", 0, "")]
         public void should_parse_korean_series_episode(string postTitle, string title, int episodeNumber, string airdate)
         {
             var result = Parser.Parser.ParseTitle(postTitle);
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeFalse();
 
             // We don't support both SxxExx and airdate yet
-            //result.AirDate.Should().Be(airdate);
+            // result.AirDate.Should().Be(airdate);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/MultiEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/MultiEpisodeParserFixture.cs
@@ -36,8 +36,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("The Series US S01E01-E02 720p HDTV x264", "The Series US", 1, new[] { 1, 2 })]
         [TestCase("Series Title Season 01 Episode 05-06 720p", "Series Title", 1, new[] { 5, 6 })]
 
-        //[TestCase("My Name Is Sonarr - S03E01-E02 - My Name Is Code 28301-016 [SDTV]", "My Name Is Sonarr", 3, new[] { 1, 2 })]
-        //[TestCase("Adventure Series - 5x01 - x02 - Dev the Human (2) & Sonarr the Robot (3)", "Adventure Series", 5, new [] { 1, 2 })]
+        // [TestCase("My Name Is Sonarr - S03E01-E02 - My Name Is Code 28301-016 [SDTV]", "My Name Is Sonarr", 3, new[] { 1, 2 })]
+        // [TestCase("Adventure Series - 5x01 - x02 - Dev the Human (2) & Sonarr the Robot (3)", "Adventure Series", 5, new [] { 1, 2 })]
         [TestCase("The Series And The Code - S42 Ep10718 - Ep10722", "The Series And The Code", 42, new[] { 10718, 10719, 10720, 10721, 10722 })]
         [TestCase("The Series And The Code - S42 Ep10688 - Ep10692", "The Series And The Code", 42, new[] { 10688, 10689, 10690, 10691, 10692 })]
         [TestCase("Series.S01E02E03.1080p.BluRay.x264-DeBTViD", "Series", 1, new[] { 2, 3 })]
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series Title! (2013) - S04E44-E45 - Il 200 spettacolare episodio da narcisisti!", "Series Title! (2013)", 4, new[] { 44, 45 })]
         [TestCase("Series Title! (2013) - S04E44-E45 - Il 200 spettacolare episodio da narcisisti! [NetflixHD 720p HEVC] [ITA+ENG].mkv", "Series Title! (2013)", 4, new[] { 44, 45 })]
 
-        //[TestCase("", "", , new [] {  })]
+        // [TestCase("", "", , new [] {  })]
         public void should_parse_multiple_episodes(string postTitle, string title, int season, int[] episodes)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
@@ -41,7 +42,8 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 SeriesTitle = _series.Title,
                 SeasonNumber = 1,
                 EpisodeNumbers = new[] { 1 },
-                AbsoluteEpisodeNumbers = new int[0]
+                AbsoluteEpisodeNumbers = new int[0],
+                Languages = new List<Language> { Language.English }
             };
 
             _singleEpisodeSearchCriteria = new SingleEpisodeSearchCriteria

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
@@ -7,6 +7,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
@@ -41,7 +42,8 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 SeriesTitle = _series.Title,
                 SeriesTitleInfo = new SeriesTitleInfo(),
                 SeasonNumber = 1,
-                EpisodeNumbers = new[] { 1 }
+                EpisodeNumbers = new[] { 1 },
+                Languages = new List<Language> { Language.English }
             };
 
             _singleEpisodeSearchCriteria = new SingleEpisodeSearchCriteria

--- a/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase(@"C:\Test\Series\Season 1\02 Honor Thy Father (1080p HD).m4v", 1, 2)]
         [TestCase(@"C:\Test\Series\Season 1\2 Honor Thy Developer (1080p HD).m4v", 1, 2)]
 
-        //[TestCase(@"C:\series.state.S02E04.720p.WEB-DL.DD5.1.H.264\73696S02-04.mkv", 2, 4)] //Gets treated as S01E04 (because it gets parsed as anime); 2020-01 broken test case: Expected result.EpisodeNumbers to contain 1 item(s), but found 0
+        // [TestCase(@"C:\series.state.S02E04.720p.WEB-DL.DD5.1.H.264\73696S02-04.mkv", 2, 4)] //Gets treated as S01E04 (because it gets parsed as anime); 2020-01 broken test case: Expected result.EpisodeNumbers to contain 1 item(s), but found 0
         public void should_parse_from_path(string path, int season, int episode)
         {
             var result = Parser.Parser.ParsePath(path.AsOsAgnostic());

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[Erai-raws] Series - 0955 ~ 1005 [1080p]", "Erai-raws")]
         [TestCase("[Exiled-Destiny] Series Title", "Exiled-Destiny")]
 
-        //[TestCase("", "")]
+        // [TestCase("", "")]
         public void should_parse_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S02E04.720p.WEBRip.x264-SKGTV_English", "SKGTV")]
         [TestCase("Series.Title.S02E04.720p.WEBRip.x264-SKGTV.English", "SKGTV")]
 
-        //[TestCase("", "")]
+        // [TestCase("", "")]
         public void should_not_include_language_in_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
@@ -125,8 +125,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[Anime-Koi] Series Title - S01E07 - A High-Grade Sonarr", "Anime-Koi")]
         [TestCase("[Anime-Koi] Series Title 2 - 01 [h264-720p][28D54E2C]", "Anime-Koi")]
 
-        //[TestCase("Tokyo.Ghoul.02x01.013.HDTV-720p-Anime-Koi", "Anime-Koi")]
-        //[TestCase("", "")]
+        // [TestCase("Tokyo.Ghoul.02x01.013.HDTV-720p-Anime-Koi", "Anime-Koi")]
+        // [TestCase("", "")]
         public void should_parse_anime_release_groups(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -96,22 +96,22 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("1x03 - The 112th Congress [1080p BluRay].mkv", "", 1, 3)]
         [TestCase("Series.2012.S02E14.720p.HDTV.X264-DIMENSION [PublicHD].mkv", "Series 2012", 2, 14)]
 
-        //[TestCase("Sex And The City S6E15 - Catch-38 [RavyDavy].avi", "Sex And The City", 6, 15)] // -38 is getting treated as abs number
+        // [TestCase("Sex And The City S6E15 - Catch-38 [RavyDavy].avi", "Sex And The City", 6, 15)] // -38 is getting treated as abs number
         [TestCase("Series.2009.S06E03.720p.HDTV.X264-DIMENSION [PublicHD].mkv", "Series 2009", 6, 3)]
         [TestCase("20-1.2014.S02E01.720p.HDTV.x264-CROOKS", "20-1 2014", 2, 1)]
         [TestCase("Series - S01E09 - Debate 109", "Series", 1, 9)]
         [TestCase("Series - S02E02 - My Maserati Does 185", "Series", 2, 2)]
         [TestCase("6x13 - The Series Show 100th Episode Special", "", 6, 13)]
 
-        //[TestCase("Series - S01E01 - Genesis 101 [HDTV-720p]", "Series", 1, 1)]
-        //[TestCase("The Series S02E01 HDTV x264-KILLERS [eztv]", "The Series", 2, 1)]
+        // [TestCase("Series - S01E01 - Genesis 101 [HDTV-720p]", "Series", 1, 1)]
+        // [TestCase("The Series S02E01 HDTV x264-KILLERS [eztv]", "The Series", 2, 1)]
         [TestCase("The Series And the Show - S41 E10478 - 2014-08-15", "The Series And the Show", 41, 10478)]
         [TestCase("The Series And the Show - S42 E10591 - 2015-01-27", "The Series And the Show", 42, 10591)]
         [TestCase("Series Title [1x05] Episode Title", "Series Title", 1, 5)]
         [TestCase("Series Title [S01E05] Episode Title", "Series Title", 1, 5)]
         [TestCase("Series Title Season 01 Episode 05 720p", "Series Title", 1, 5)]
 
-        //[TestCase("Off the Series - 101 - Developers (460p.x264.vorbis-2.0) [449].mkv", "Off the Series", 1, 1)]
+        // [TestCase("Off the Series - 101 - Developers (460p.x264.vorbis-2.0) [449].mkv", "Off the Series", 1, 1)]
         [TestCase("The Series And the Show - S42 E10713 - 2015-07-20.mp4", "The Series And the Show", 42, 10713)]
         [TestCase("Series.103.hdtv-lol[ettv].mp4", "Series", 1, 3)]
         [TestCase("Series - 01x02 - The Rooster Prince - [itz_theo]", "Series", 1, 2)]
@@ -154,7 +154,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series Title 1x1", "Series Title", 1, 1)]
         [TestCase("1x1", "", 1, 1)]
 
-        //[TestCase("", "", 0, 0)]
+        // [TestCase("", "", 0, 0)]
         public void should_parse_single_episode(string postTitle, string title, int seasonNumber, int episodeNumber)
         {
             var result = Parser.Parser.ParseTitle(postTitle);

--- a/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[YMDR][慕留人 -火影忍者新時代-][Anime Series Title-][2017][88-91][1080p][AVC][JAP][BIG5][MP4-AAC][繁中]", "Anime Series Title", "YMDR", new[] { 88, 89, 90, 91 })]
         [TestCase("[诸神字幕组][战栗杀机][ANIME SERIES TITLE][01-24完][简日双语字幕][720P][MP4]", "ANIME SERIES TITLE", "诸神字幕组", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24 })]
 
-        //[TestCase("【漫貓&愛戀字幕組】[五等分的新娘/五等分的花嫁/五等分の花嫁][Anime Series Title][01_03][BIG5][720P][HEVC]", "Anime Series Title", "漫貓&愛戀字幕組", new[] { 1, 2, 3 })]
+        // [TestCase("【漫貓&愛戀字幕組】[五等分的新娘/五等分的花嫁/五等分の花嫁][Anime Series Title][01_03][BIG5][720P][HEVC]", "Anime Series Title", "漫貓&愛戀字幕組", new[] { 1, 2, 3 })]
         public void should_parse_chinese_multiepisode_releases(string postTitle, string title, string subgroup, int[] absoluteEpisodeNumbers)
         {
             postTitle = XmlCleaner.ReplaceUnicode(postTitle);

--- a/src/NzbDrone.Core.Test/Profiles/QualityProfileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/QualityProfileServiceFixture.cs
@@ -38,8 +38,8 @@ namespace NzbDrone.Core.Test.Profiles
 
         [Test]
 
-        //This confirms that new profiles are added only if no other profiles exists.
-        //We don't want to keep adding them back if a user deleted them on purpose.
+        // This confirms that new profiles are added only if no other profiles exists.
+        // We don't want to keep adding them back if a user deleted them on purpose.
         public void Init_should_skip_if_any_profiles_already_exist()
         {
             Mocker.GetMock<IProfileRepository>()

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/LegacySetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/LegacySetEpisodeMontitoredFixture.cs
@@ -34,20 +34,20 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
                                         .With(e => e.Monitored = true)
                                         .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-7))
 
-                                        //Missing
+                                        // Missing
                                         .TheFirst(1)
                                         .With(e => e.EpisodeFileId = 0)
 
-                                        //Has File
+                                        // Has File
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 1)
 
-                                         //Future
+                                         // Future
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 0)
                                         .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(7))
 
-                                        //Future/TBA
+                                        // Future/TBA
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 0)
                                         .With(e => e.AirDateUtc = null)

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -34,20 +34,20 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
                                         .With(e => e.Monitored = true)
                                         .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-7))
 
-                                        //Missing
+                                        // Missing
                                         .TheFirst(1)
                                         .With(e => e.EpisodeFileId = 0)
 
-                                        //Has File
+                                        // Has File
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 1)
 
-                                         //Future
+                                         // Future
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 0)
                                         .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(7))
 
-                                        //Future/TBA
+                                        // Future/TBA
                                         .TheNext(1)
                                         .With(e => e.EpisodeFileId = 0)
                                         .With(e => e.AirDateUtc = null)

--- a/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshEpisodeServiceFixture.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Test.TvTests
         {
             UseRealHttp();
 
-            _gameOfThrones = Mocker.Resolve<SkyHookProxy>().GetSeriesInfo(121361); //Game of thrones
+            _gameOfThrones = Mocker.Resolve<SkyHookProxy>().GetSeriesInfo(121361); // Game of thrones
 
             // Remove specials.
             _gameOfThrones.Item2.RemoveAll(v => v.SeasonNumber == 0);

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -273,13 +273,13 @@ namespace NzbDrone.Core.Configuration
                         return valueHolder.First().Value.Trim();
                     }
 
-                    //Save the value
+                    // Save the value
                     if (persist)
                     {
                         SetValue(key, defaultValue);
                     }
 
-                    //return the default value
+                    // return the default value
                     return defaultValue.ToString();
                 });
         }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -13,15 +13,15 @@ namespace NzbDrone.Core.Configuration
 
         bool IsDefined(string key);
 
-        //Download Client
+        // Download Client
         string DownloadClientWorkingFolders { get; set; }
         int DownloadClientHistoryLimit { get; set; }
 
-        //Completed/Failed Download Handling (Download client)
+        // Completed/Failed Download Handling (Download client)
         bool EnableCompletedDownloadHandling { get; set; }
         bool AutoRedownloadFailed { get; set; }
 
-        //Media Management
+        // Media Management
         bool AutoUnmonitorPreviouslyDownloadedEpisodes { get; set; }
         string RecycleBin { get; set; }
         int RecycleBinCleanupDays { get; set; }
@@ -38,18 +38,18 @@ namespace NzbDrone.Core.Configuration
         RescanAfterRefreshType RescanAfterRefresh { get; set; }
         EpisodeTitleRequiredType EpisodeTitleRequired { get; set; }
 
-        //Permissions (Media Management)
+        // Permissions (Media Management)
         bool SetPermissionsLinux { get; set; }
         string ChmodFolder { get; set; }
         string ChownGroup { get; set; }
 
-        //Indexers
+        // Indexers
         int Retention { get; set; }
         int RssSyncInterval { get; set; }
         int MaximumSize { get; set; }
         int MinimumAge { get; set; }
 
-        //UI
+        // UI
         int FirstDayOfWeek { get; set; }
         string CalendarWeekColumnHeader { get; set; }
 
@@ -60,17 +60,17 @@ namespace NzbDrone.Core.Configuration
         bool EnableColorImpairedMode { get; set; }
         int UILanguage { get; set; }
 
-        //Internal
+        // Internal
         bool CleanupMetadataImages { get; set; }
         string PlexClientIdentifier { get; }
 
-        //Forms Auth
+        // Forms Auth
         string RijndaelPassphrase { get; }
         string HmacPassphrase { get; }
         string RijndaelSalt { get; }
         string HmacSalt { get; }
 
-        //Proxy
+        // Proxy
         bool ProxyEnabled { get; }
         ProxyType ProxyType { get; }
         string ProxyHostname { get; }

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -84,7 +84,8 @@ namespace NzbDrone.Core.CustomFormats
                 ExtraInfo = new Dictionary<string, object>
                 {
                     { "Size", episodeFile.Size },
-                    { "Filename", Path.GetFileName(episodeFile.RelativePath) }
+                    { "Filename", Path.GetFileName(episodeFile.RelativePath) },
+                    { "OriginalLanguage", episodeFile.Series.Value.OriginalLanguage }
                 }
             };
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -34,7 +34,11 @@ namespace NzbDrone.Core.CustomFormats
 
         protected override bool IsSatisfiedByWithoutNegate(ParsedEpisodeInfo episodeInfo)
         {
-            return episodeInfo?.Languages?.Contains((Language)Value) ?? false;
+            var comparedLanguage = episodeInfo != null && Value == Language.Original.Id && episodeInfo.ExtraInfo.ContainsKey("OriginalLanguage")
+                ? (Language)episodeInfo.ExtraInfo["OriginalLanguage"]
+                : (Language)Value;
+
+            return episodeInfo?.Languages?.Contains(comparedLanguage) ?? false;
         }
 
         public override NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
                             continue;
                         }
 
-                        //hack to deal with Fate/Zero
+                        // hack to deal with Fate/Zero
                         if (series.Key == 79151 && seasonNumber > 1)
                         {
                             continue;

--- a/src/NzbDrone.Core/Datastore/Migration/017_reset_scene_names.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/017_reset_scene_names.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            //we were storing new file name as scene name.
+            // we were storing new file name as scene name.
             Execute.Sql(@"UPDATE EpisodeFiles SET SceneName = NULL where SceneName != NULL");
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/029_add_formats_to_naming_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/029_add_formats_to_naming_config.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Datastore.Migration
                         var includeQuality = namingConfigReader.GetBoolean(includeQualityIndex);
                         var replaceSpaces = namingConfigReader.GetBoolean(replaceSpacesIndex);
 
-                        //Output settings
+                        // Output settings
                         var seriesTitlePattern = "";
                         var episodeTitlePattern = "";
                         var dailyEpisodePattern = "{Air-Date}";

--- a/src/NzbDrone.Core/Datastore/Migration/030_add_season_folder_format_to_naming_config.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/030_add_season_folder_format_to_naming_config.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Datastore.Migration
                 {
                     while (namingConfigReader.Read())
                     {
-                        //only getting one column, so its index is 0
+                        // only getting one column, so its index is 0
                         seasonFormat = namingConfigReader.GetString(0);
 
                         seasonFormat = seasonFormat.Replace("%sn", "{Series Title}")

--- a/src/NzbDrone.Core/Datastore/Migration/033_add_api_key_to_pushover.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/033_add_api_key_to_pushover.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Datastore.Migration
                         var settings = Json.Deserialize<PushoverSettingsForV33>(reader.GetString(settingsIndex));
                         settings.ApiKey = API_KEY;
 
-                        //Set priority to high if its currently emergency
+                        // Set priority to high if its currently emergency
                         if (settings.Priority == 2)
                         {
                             settings.Priority = 1;

--- a/src/NzbDrone.Core/Datastore/Migration/044_fix_xbmc_episode_metadata.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/044_fix_xbmc_episode_metadata.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            //Convert Episode Metadata to proper type
+            // Convert Episode Metadata to proper type
             Execute.Sql("UPDATE MetadataFiles " +
                         "SET Type = 2 " +
                         "WHERE Consumer = 'XbmcMetadata' " +
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Datastore.Migration
                         "AND Type = 4 " +
                         "AND RelativePath LIKE '%.nfo'");
 
-            //Convert Episode Images to proper type
+            // Convert Episode Images to proper type
             Execute.Sql("UPDATE MetadataFiles " +
                         "SET Type = 5 " +
                         "WHERE Consumer = 'XbmcMetadata' " +

--- a/src/NzbDrone.Core/Datastore/Migration/052_add_columns_for_anime.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/052_add_columns_for_anime.cs
@@ -8,11 +8,11 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            //Support XEM names
+            // Support XEM names
             Alter.Table("SceneMappings").AddColumn("Type").AsString().Nullable();
             Execute.Sql("DELETE FROM SceneMappings");
 
-            //Add AnimeEpisodeFormat (set to Standard Episode format for now)
+            // Add AnimeEpisodeFormat (set to Standard Episode format for now)
             Alter.Table("NamingConfig").AddColumn("AnimeEpisodeFormat").AsString().Nullable();
             Execute.Sql("UPDATE NamingConfig SET AnimeEpisodeFormat = StandardEpisodeFormat");
         }

--- a/src/NzbDrone.Core/Datastore/Migration/054_rename_profiles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/054_rename_profiles.cs
@@ -15,11 +15,11 @@ namespace NzbDrone.Core.Datastore.Migration
             Alter.Table("Profiles").AddColumn("GrabDelayMode").AsInt32().Nullable();
             Execute.Sql("UPDATE Profiles SET Language = 1, GrabDelay = 0, GrabDelayMode = 0");
 
-            //Rename QualityProfileId in Series
+            // Rename QualityProfileId in Series
             Alter.Table("Series").AddColumn("ProfileId").AsInt32().Nullable();
             Execute.Sql("UPDATE Series SET ProfileId = QualityProfileId");
 
-            //Add HeldReleases
+            // Add HeldReleases
             Create.TableForModel("PendingReleases")
                   .WithColumn("SeriesId").AsInt32()
                   .WithColumn("Title").AsString()

--- a/src/NzbDrone.Core/Datastore/Migration/057_convert_episode_file_path_to_relative.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/057_convert_episode_file_path_to_relative.cs
@@ -12,8 +12,8 @@ namespace NzbDrone.Core.Datastore.Migration
         {
             Create.Column("RelativePath").OnTable("EpisodeFiles").AsString().Nullable();
 
-            //TODO: Add unique contraint for series ID and Relative Path
-            //TODO: Warn if multiple series share the same path
+            // TODO: Add unique contraint for series ID and Relative Path
+            // TODO: Warn if multiple series share the same path
 
             Execute.WithConnection(UpdateRelativePaths);
         }

--- a/src/NzbDrone.Core/Datastore/Migration/101_add_ultrahd_quality_in_profiles.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/101_add_ultrahd_quality_in_profiles.cs
@@ -21,12 +21,12 @@ namespace NzbDrone.Core.Datastore.Migration
             updater.Commit();
 
             // WEBRip migrations.
-            //updater.SplitQualityAppend(1, 11);   // HDTV480p    after  SDTV
-            //updater.SplitQualityPrepend(8, 12);  // WEBRip480p  before WEBDL480p
-            //updater.SplitQualityAppend(2, 13);   // Bluray480p  after  DVD
-            //updater.SplitQualityPrepend(5, 14);  // WEBRip720p  before WEBDL720p
-            //updater.SplitQualityPrepend(3, 15);  // WEBRip1080p before WEBDL1080p
-            //updater.SplitQualityPrepend(18, 17); // WEBRip2160p before WEBDL2160p
+            // updater.SplitQualityAppend(1, 11);   // HDTV480p    after  SDTV
+            // updater.SplitQualityPrepend(8, 12);  // WEBRip480p  before WEBDL480p
+            // updater.SplitQualityAppend(2, 13);   // Bluray480p  after  DVD
+            // updater.SplitQualityPrepend(5, 14);  // WEBRip720p  before WEBDL720p
+            // updater.SplitQualityPrepend(3, 15);  // WEBRip1080p before WEBDL1080p
+            // updater.SplitQualityPrepend(18, 17); // WEBRip2160p before WEBDL2160p
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/163_mediainfo_to_ffmpeg.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/163_mediainfo_to_ffmpeg.cs
@@ -682,7 +682,7 @@ namespace NzbDrone.Core.Datastore.Migration
             var audioChannelsContainer = mediaInfo.AudioChannelsContainer;
             var audioChannelsStream = mediaInfo.AudioChannelsStream;
 
-            //Skip if the positions texts give us nothing
+            // Skip if the positions texts give us nothing
             if ((audioChannelPositionsTextContainer.IsNullOrWhiteSpace() || audioChannelPositionsTextContainer == "Object Based") &&
                 (audioChannelPositionsTextStream.IsNullOrWhiteSpace() || audioChannelPositionsTextStream == "Object Based"))
             {

--- a/src/NzbDrone.Core/Datastore/Migration/171_add_custom_formats.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/171_add_custom_formats.cs
@@ -16,30 +16,30 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            //Add Custom Format Columns
+            // Add Custom Format Columns
             Create.TableForModel("CustomFormats")
                 .WithColumn("Name").AsString().Unique()
                 .WithColumn("Specifications").AsString().WithDefaultValue("[]")
                 .WithColumn("IncludeCustomFormatWhenRenaming").AsBoolean().WithDefaultValue(false);
 
-            //Add Custom Format Columns to Quality Profiles
+            // Add Custom Format Columns to Quality Profiles
             Alter.Table("QualityProfiles").AddColumn("FormatItems").AsString().WithDefaultValue("[]");
             Alter.Table("QualityProfiles").AddColumn("MinFormatScore").AsInt32().WithDefaultValue(0);
             Alter.Table("QualityProfiles").AddColumn("CutoffFormatScore").AsInt32().WithDefaultValue(0);
 
-            //Migrate Preferred Words to Custom Formats
+            // Migrate Preferred Words to Custom Formats
             Execute.WithConnection(MigratePreferredTerms);
             Execute.WithConnection(MigrateNamingConfigs);
 
-            //Remove Preferred Word Columns from ReleaseProfiles
+            // Remove Preferred Word Columns from ReleaseProfiles
             Delete.Column("Preferred").FromTable("ReleaseProfiles");
             Delete.Column("IncludePreferredWhenRenaming").FromTable("ReleaseProfiles");
 
-            //Remove Profiles that will no longer validate
+            // Remove Profiles that will no longer validate
             Execute.Sql("DELETE FROM ReleaseProfiles WHERE Required == '[]' AND Ignored == '[]'");
 
-            //TODO: Kill any references to Preferred in History and Files
-            //Data.PreferredWordScore
+            // TODO: Kill any references to Preferred in History and Files
+            // Data.PreferredWordScore
         }
 
         private void MigratePreferredTerms(IDbConnection conn, IDbTransaction tran)
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Datastore.Migration
                 }
             }
 
-            //Generate List of Custom Formats from Preferred Words
+            // Generate List of Custom Formats from Preferred Words
             using (var cmd = conn.CreateCommand())
             {
                 cmd.Transaction = tran;

--- a/src/NzbDrone.Core/Datastore/Migration/175_language_profiles_to_custom_formats.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/175_language_profiles_to_custom_formats.cs
@@ -17,12 +17,12 @@ namespace NzbDrone.Core.Datastore.Migration
             Alter.Table("Blocklist")
                  .AddColumn("Languages").AsString().NotNullable().WithDefaultValue("[]");
 
-            //Migrate Language to Languages in all tables
+            // Migrate Language to Languages in all tables
             Execute.Sql("UPDATE EpisodeFiles SET Languages = '[' || Language || ']'");
             Execute.Sql("UPDATE History SET Languages = '[' || Language || ']'");
             Execute.Sql("UPDATE Blocklist SET Languages = '[' || Language || ']'");
 
-            //Migrate Language Profiles to CFs
+            // Migrate Language Profiles to CFs
 
             Delete.Column("Language").FromTable("EpisodeFiles");
             Delete.Column("Language").FromTable("History");

--- a/src/NzbDrone.Core/Datastore/Migration/176_original_language.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/176_original_language.cs
@@ -1,0 +1,16 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Languages;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(176)]
+    public class original_language : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series")
+                .AddColumn("OriginalLanguage").AsInt32().WithDefaultValue((int)Language.English);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
@@ -206,7 +206,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             {
                 table.Indexes = ReadIndexes(table.SchemaName, table.Name);
 
-                //table.ForeignKeys = ReadForeignKeys(table.SchemaName, table.Name);
+                // table.ForeignKeys = ReadForeignKeys(table.SchemaName, table.Name);
             }
 
             return tables;

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
             {
                 var firstFile = torrent.Files?.FirstOrDefault();
 
-                //skip metadata download
+                // skip metadata download
                 if (firstFile?.Path?.Contains("[METADATA]") == true)
                 {
                     continue;

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
     {
         public TorrentBlackholeSettingsValidator()
         {
-            //Todo: Validate that the path actually exists
+            // Todo: Validate that the path actually exists
             RuleFor(c => c.TorrentFolder).IsValidPath();
             RuleFor(c => c.MagnetFileExtension).NotEmpty();
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeProxy.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             var filter = new Dictionary<string, object>();
 
             // TODO: get_torrents_status returns the files as well, which starts to cause deluge timeouts when you get enough season packs.
-            //var response = ProcessRequest<Dictionary<String, DelugeTorrent>>(settings, "core.get_torrents_status", filter, new String[0]);
+            // var response = ProcessRequest<Dictionary<String, DelugeTorrent>>(settings, "core.get_torrents_status", filter, new String[0]);
             var response = ProcessRequest<DelugeUpdateUIResult>(settings, "web.update_ui", RequiredProperties, filter);
 
             return GetTorrents(response);
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             var filter = new Dictionary<string, object>();
             filter.Add("label", label);
 
-            //var response = ProcessRequest<Dictionary<String, DelugeTorrent>>(settings, "core.get_torrents_status", filter, new String[0]);
+            // var response = ProcessRequest<Dictionary<String, DelugeTorrent>>(settings, "core.get_torrents_status", filter, new String[0]);
             var response = ProcessRequest<DelugeUpdateUIResult>(settings, "web.update_ui", RequiredProperties, filter);
 
             return GetTorrents(response);

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
             title = FileNameBuilder.CleanFileName(title);
 
-            //Save to the Pneumatic directory (The user will need to ensure its accessible by XBMC)
+            // Save to the Pneumatic directory (The user will need to ensure its accessible by XBMC)
             var nzbFile = Path.Combine(Settings.NzbFolder, title + ".nzb");
 
             _logger.Debug("Downloading NZB from: {0} to: {1}", url, nzbFile);

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
@@ -209,7 +209,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
             if (!Json.TryDeserialize<SabnzbdJsonError>(response.Content, out result))
             {
-                //Handle plain text responses from SAB
+                // Handle plain text responses from SAB
                 result = new SabnzbdJsonError();
 
                 if (response.Content.StartsWith("error", StringComparison.InvariantCultureIgnoreCase))

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentProxy.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 "d.ratio=", // long
                 "d.is_open=", // long
                 "d.is_active=", // long
-                "d.complete=", //long
+                "d.complete=", // long
                 "d.timestamp.finished="); // long (unix timestamp)
 
             var torrents = document.XPathSelectElement("./methodResponse/params/param/value/array/data")

--- a/src/NzbDrone.Core/Download/Pending/PendingRelease.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingRelease.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Download.Pending
         public PendingReleaseReason Reason { get; set; }
         public PendingReleaseAdditionalInfo AdditionalInfo { get; set; }
 
-        //Not persisted
+        // Not persisted
         public RemoteEpisode RemoteEpisode { get; set; }
     }
 

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -197,7 +197,7 @@ namespace NzbDrone.Core.Download.Pending
                 }
             }
 
-            //Return best quality release for each episode
+            // Return best quality release for each episode
             var deduped = queued.GroupBy(q => q.Episode.Id).Select(g =>
             {
                 var series = g.First().Series;
@@ -381,8 +381,8 @@ namespace NzbDrone.Core.Download.Pending
                 var compare = new QualityModelComparer(profile).Compare(remoteEpisode.ParsedEpisodeInfo.Quality,
                                                                         existingReport.RemoteEpisode.ParsedEpisodeInfo.Quality);
 
-                //Only remove lower/equal quality pending releases
-                //It is safer to retry these releases on the next round than remove it and try to re-add it (if its still in the feed)
+                // Only remove lower/equal quality pending releases
+                // It is safer to retry these releases on the next round than remove it and try to re-add it (if its still in the feed)
                 if (compare >= 0)
                 {
                     _logger.Debug("Removing previously pending release, as it was grabbed.");

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Download
 
         internal List<DownloadDecision> GetQualifiedReports(IEnumerable<DownloadDecision> decisions)
         {
-            //Process both approved and temporarily rejected
+            // Process both approved and temporarily rejected
             return decisions.Where(c => (c.Approved || c.TemporarilyRejected) && c.RemoteEpisode.Episodes.Any()).ToList();
         }
 

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadStatusMessage.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadStatusMessage.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             Messages = new List<string> { message };
         }
 
-        //Constructor for use when deserializing JSON
+        // Constructor for use when deserializing JSON
         private TrackedDownloadStatusMessage()
         {
         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                                RelativePath = series.Path.GetRelativePath(path)
                            };
 
-            //Series and season images are both named folder.jpg, only season ones sit in season folders
+            // Series and season images are both named folder.jpg, only season ones sit in season folders
             if (Path.GetFileNameWithoutExtension(filename).Equals(parentdir.Name, StringComparison.InvariantCultureIgnoreCase))
             {
                 var seasonMatch = SeasonImagesRegex.Match(parentdir.Name);
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
 
         public override MetadataFileResult SeriesMetadata(Series series)
         {
-            //Series metadata is not supported
+            // Series metadata is not supported
             return null;
         }
 
@@ -216,7 +216,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 return new List<ImageFileResult>();
             }
 
-            //Roksbox only supports one season image, so first of all try for poster otherwise just use whatever is first in the collection
+            // Roksbox only supports one season image, so first of all try for poster otherwise just use whatever is first in the collection
             var image = season.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? season.Images.FirstOrDefault();
             if (image == null)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                                RelativePath = series.Path.GetRelativePath(path)
                            };
 
-            //Series and season images are both named folder.jpg, only season ones sit in season folders
+            // Series and season images are both named folder.jpg, only season ones sit in season folders
             if (Path.GetFileName(filename).Equals("folder.jpg", StringComparison.InvariantCultureIgnoreCase))
             {
                 var parentdir = Directory.GetParent(path);
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
 
         public override MetadataFileResult SeriesMetadata(Series series)
         {
-            //Series metadata is not supported
+            // Series metadata is not supported
             return null;
         }
 
@@ -152,9 +152,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                     details.Add(new XElement("actor", string.Join(" / ", series.Actors.ConvertAll(c => c.Name + " - " + c.Character))));
                     details.Add(new XElement("overview", episode.Overview));
 
-                    //Todo: get guest stars, writer and director
-                    //details.Add(new XElement("credits", tvdbEpisode.Writer.FirstOrDefault()));
-                    //details.Add(new XElement("director", tvdbEpisode.Directors.FirstOrDefault()));
+                    // Todo: get guest stars, writer and director
+                    // details.Add(new XElement("credits", tvdbEpisode.Writer.FirstOrDefault()));
+                    // details.Add(new XElement("director", tvdbEpisode.Directors.FirstOrDefault()));
 
                     doc.Add(details);
                     doc.Save(xw);
@@ -176,7 +176,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                 return new List<ImageFileResult>();
             }
 
-            //Because we only support one image, attempt to get the Poster type, then if that fails grab the first
+            // Because we only support one image, attempt to get the Poster type, then if that fails grab the first
             var image = series.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? series.Images.FirstOrDefault();
             if (image == null)
             {
@@ -202,7 +202,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
 
             var seasonFolders = GetSeasonFolders(series);
 
-            //Work out the path to this season - if we don't have a matching path then skip this season.
+            // Work out the path to this season - if we don't have a matching path then skip this season.
             string seasonFolder;
             if (!seasonFolders.TryGetValue(season.SeasonNumber, out seasonFolder))
             {
@@ -210,7 +210,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                 return new List<ImageFileResult>();
             }
 
-            //WDTV only supports one season image, so first of all try for poster otherwise just use whatever is first in the collection
+            // WDTV only supports one season image, so first of all try for poster otherwise just use whatever is first in the collection
             var image = season.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? season.Images.FirstOrDefault();
             if (image == null)
             {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -337,9 +337,9 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         details.Add(fileInfo);
                     }
 
-                    //Todo: get guest stars, writer and director
-                    //details.Add(new XElement("credits", tvdbEpisode.Writer.FirstOrDefault()));
-                    //details.Add(new XElement("director", tvdbEpisode.Directors.FirstOrDefault()));
+                    // Todo: get guest stars, writer and director
+                    // details.Add(new XElement("credits", tvdbEpisode.Writer.FirstOrDefault()));
+                    // details.Add(new XElement("director", tvdbEpisode.Directors.FirstOrDefault()));
 
                     doc.Add(details);
                     doc.Save(xw);

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -486,7 +486,7 @@ namespace NzbDrone.Core.Extras.Metadata
                 return null;
             }
 
-            //Remove duplicate metadata files from DB and disk
+            // Remove duplicate metadata files from DB and disk
             foreach (var file in matchingMetadataFiles.Skip(1))
             {
                 var path = Path.Combine(series.Path, file.RelativePath);

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.History
             var episodeIds = trackedDownload.EpisodeInfo.Episodes.Select(c => c.Id).ToList();
             var allHistory = _historyRepository.FindDownloadHistory(trackedDownload.EpisodeInfo.Series.Id, trackedDownload.ImportedEpisode.Quality);
 
-            //Find download related items for these episodes
+            // Find download related items for these episodes
             var episodesHistory = allHistory.Where(h => episodeIds.Contains(h.EpisodeId)).ToList();
 
             var processedDownloadId = episodesHistory

--- a/src/NzbDrone.Core/Http/HttpProxySettingsProvider.cs
+++ b/src/NzbDrone.Core/Http/HttpProxySettingsProvider.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Http
 
         public bool ShouldProxyBeBypassed(HttpProxySettings proxySettings, HttpUri url)
         {
-            //We are utilising the WebProxy implementation here to save us having to reimplement it. This way we use Microsofts implementation
+            // We are utilising the WebProxy implementation here to save us having to reimplement it. This way we use Microsofts implementation
             var proxy = new WebProxy(proxySettings.Host + ":" + proxySettings.Port, proxySettings.BypassLocalAddress, proxySettings.BypassListAsArray);
 
             return proxy.IsBypassed((Uri)url);

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 
-            //remove any repeating +s
+            // remove any repeating +s
             cleanTitle = Regex.Replace(cleanTitle, @"\+{2,}", "+");
             cleanTitle = cleanTitle.RemoveAccent();
             return cleanTitle.Trim('+', ' ');

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                 torrentInfo.DownloadUrl = RegexProtocol.Replace(torrent.DownloadURL, protocol);
                 torrentInfo.InfoUrl = string.Format("{0}//broadcasthe.net/torrents.php?id={1}&torrentid={2}", protocol, torrent.GroupID, torrent.TorrentID);
 
-                //torrentInfo.CommentUrl =
+                // torrentInfo.CommentUrl =
                 if (torrent.TvdbID.HasValue)
                 {
                     torrentInfo.TvdbId = torrent.TvdbID.Value;
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
                 torrentInfo.PublishDate = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).ToUniversalTime().AddSeconds(torrent.Time);
 
-                //torrentInfo.MagnetUrl =
+                // torrentInfo.MagnetUrl =
                 torrentInfo.InfoHash = torrent.InfoHash;
                 torrentInfo.Seeders = torrent.Seeders;
                 torrentInfo.Peers = torrent.Leechers + torrent.Seeders;

--- a/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Indexers.FileList
             {
                 var id = result.Id;
 
-                //if (result.FreeLeech)
+                // if (result.FreeLeech)
 
                 torrentInfos.Add(new TorrentInfo()
                 {

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -50,19 +50,19 @@ namespace NzbDrone.Core.Instrumentation
 
             var rules = LogManager.Configuration.LoggingRules;
 
-            //Console
+            // Console
             SetMinimumLogLevel(rules, "consoleLogger", minimumConsoleLogLevel);
 
-            //Log Files
+            // Log Files
             SetMinimumLogLevel(rules, "appFileInfo", minimumLogLevel <= LogLevel.Info ? LogLevel.Info : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileDebug", minimumLogLevel <= LogLevel.Debug ? LogLevel.Debug : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileTrace", minimumLogLevel <= LogLevel.Trace ? LogLevel.Trace : LogLevel.Off);
             SetLogRotation();
 
-            //Log Sql
+            // Log Sql
             SqlBuilderExtensions.LogSql = _configFileProvider.LogSql;
 
-            //Sentry
+            // Sentry
             ReconfigureSentry();
 
             LogManager.ReconfigExistingLoggers();

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -102,6 +102,7 @@ namespace NzbDrone.Core.Languages
         public static Language Malayalam => new Language(29, "Malayalam");
         public static Language Ukrainian => new Language(30, "Ukrainian");
         public static Language Slovak => new Language(31, "Slovak");
+        public static Language Original => new Language(-2, "Original");
 
         public static List<Language> All
         {
@@ -140,7 +141,8 @@ namespace NzbDrone.Core.Languages
                     Bulgarian,
                     Malayalam,
                     Ukrainian,
-                    Slovak
+                    Slovak,
+                    Original
                 };
             }
         }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguage.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguage.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
         public LocalEpisode Aggregate(LocalEpisode localEpisode, DownloadClientItem downloadClientItem)
         {
-            var languages = new List<Language> { Language.English };
+            var languages = new List<Language> { localEpisode.Series?.OriginalLanguage ?? Language.Unknown };
             var languagesConfidence = Confidence.Default;
 
             foreach (var augmentLanguage in _augmentLanguages)
@@ -37,7 +37,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
                 if (augmentedLanguage?.Languages != null &&
                     augmentedLanguage.Languages.Count > 0 &&
-                    !(augmentedLanguage.Languages.Count == 1 && augmentedLanguage.Languages.Contains(Language.English)) &&
                     !(augmentedLanguage.Languages.Count == 1 && augmentedLanguage.Languages.Contains(Language.Unknown)))
                 {
                     languages = augmentedLanguage.Languages;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromDownloadClientItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromDownloadClientItem.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators.Augment
 
             foreach (var episode in localEpisode.Episodes)
             {
-                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title, false);
+                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title);
 
                 languages = languages.Except(episodeTitleLanguage).ToList();
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFileName.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFileName.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators.Augment
 
             foreach (var episode in localEpisode.Episodes)
             {
-                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title, false);
+                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title);
 
                 languages = languages.Except(episodeTitleLanguage).ToList();
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFolder.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Language/AugmentLanguageFromFolder.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators.Augment
 
             foreach (var episode in localEpisode.Episodes)
             {
-                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title, false);
+                var episodeTitleLanguage = LanguageParser.ParseLanguages(episode.Title);
 
                 languages = languages.Except(episodeTitleLanguage).ToList();
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -73,25 +73,25 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
         private int GetMinimumAllowedRuntime(Series series)
         {
-            //Anime short - 15 seconds
+            // Anime short - 15 seconds
             if (series.Runtime <= 3)
             {
                 return 15;
             }
 
-            //Webisodes - 90 seconds
+            // Webisodes - 90 seconds
             if (series.Runtime <= 10)
             {
                 return 90;
             }
 
-            //30 minute episodes - 5 minutes
+            // 30 minute episodes - 5 minutes
             if (series.Runtime <= 30)
             {
                 return 300;
             }
 
-            //60 minute episodes - 10 minutes
+            // 60 minute episodes - 10 minutes
             return 600;
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
                 try
                 {
-                    //check if already imported
+                    // check if already imported
                     if (importResults.SelectMany(r => r.ImportDecision.LocalEpisode.Episodes)
                                          .Select(e => e.Id)
                                          .Intersect(localEpisode.Episodes.Select(e => e.Id))
@@ -150,7 +150,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                 }
             }
 
-            //Adding all the rejected decisions
+            // Adding all the rejected decisions
             importResults.AddRange(decisions.Where(c => !c.Approved)
                                             .Select(d => new ImportResult(d, d.Rejections.Select(r => r.Reason).ToArray())));
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -179,8 +179,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             }
             catch (Exception e)
             {
-                //e.Data.Add("report", remoteEpisode.Report.ToJson());
-                //e.Data.Add("parsed", remoteEpisode.ParsedEpisodeInfo.ToJson());
+                // e.Data.Add("report", remoteEpisode.Report.ToJson());
+                // e.Data.Add("parsed", remoteEpisode.ParsedEpisodeInfo.ToJson());
                 _logger.Error(e, "Couldn't evaluate decision on {0}", localEpisode.Path);
                 return new Rejection($"{spec.GetType().Name}: {e.Message}");
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -487,7 +487,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 localEpisode.Quality = file.Quality;
                 localEpisode.Languages = file.Languages;
 
-                //TODO: Cleanup non-tracked downloads
+                // TODO: Cleanup non-tracked downloads
 
                 var importDecision = new ImportDecision(localEpisode);
 

--- a/src/NzbDrone.Core/MediaFiles/MediaFileAttributeService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileAttributeService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.MediaFiles
         {
             if (OsInfo.IsWindows)
             {
-                //Wrapped in Try/Catch to prevent this from causing issues with remote NAS boxes
+                // Wrapped in Try/Catch to prevent this from causing issues with remote NAS boxes
                 try
                 {
                     _diskProvider.InheritFolderPermissions(path);

--- a/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
@@ -12,10 +12,10 @@ namespace NzbDrone.Core.MediaFiles
         {
             _fileExtensions = new Dictionary<string, Quality>(StringComparer.OrdinalIgnoreCase)
             {
-                //Unknown
+                // Unknown
                 { ".webm", Quality.Unknown },
 
-                //SDTV
+                // SDTV
                 { ".m4v", Quality.SDTV },
                 { ".3gp", Quality.SDTV },
                 { ".nsv", Quality.SDTV },
@@ -55,17 +55,17 @@ namespace NzbDrone.Core.MediaFiles
                 { ".flv", Quality.SDTV },
                 { ".wpl", Quality.SDTV },
 
-                //DVD
+                // DVD
                 { ".img", Quality.DVD },
                 { ".iso", Quality.DVD },
                 { ".vob", Quality.DVD },
 
-                //HD
+                // HD
                 { ".mkv", Quality.HDTV720p },
                 { ".ts", Quality.HDTV720p },
                 { ".wtv", Quality.HDTV720p },
 
-                //Bluray
+                // Bluray
                 { ".m2ts", Quality.Bluray720p }
             };
         }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public void Delete(EpisodeFile episodeFile, DeleteMediaFileReason reason)
         {
-            //Little hack so we have the episodes and series attached for the event consumers
+            // Little hack so we have the episodes and series attached for the event consumers
             episodeFile.Episodes.LazyLoad();
             episodeFile.Path = Path.Combine(episodeFile.Series.Value.Path, episodeFile.RelativePath);
 

--- a/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.MediaFiles
                         continue;
                     }
 
-//                    var localEpsiode = _parsingService.GetLocalEpisode(episodeFile.Path, series);
+// var localEpsiode = _parsingService.GetLocalEpisode(episodeFile.Path, series);
 //
 //                    if (localEpsiode == null || episodes.Count != localEpsiode.Episodes.Count)
 //                    {

--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Messaging.Events
                 subscribers = target as EventSubscribers<TEvent>;
             }
 
-            //call synchronous handlers first.
+            // call synchronous handlers first.
             var handlers = subscribers._syncHandlers;
             foreach (var handler in handlers)
             {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string Title { get; set; }
         public string Overview { get; set; }
 
-        //public string Language { get; set; }
+        // public string Language { get; set; }
         public string Slug { get; set; }
         public string FirstAired { get; set; }
         public int? TvRageId { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
 {
@@ -29,6 +29,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
 
         public string Network { get; set; }
         public string ImdbId { get; set; }
+        public string OriginalLanguage { get; set; }
 
         public List<ActorResource> Actors { get; set; }
         public List<string> Genres { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -9,8 +9,10 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.DataAugmentation.DailySeries;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MetadataSource.SkyHook
@@ -157,6 +159,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             series.Title = show.Title;
             series.CleanTitle = Parser.Parser.CleanSeriesTitle(show.Title);
             series.SortTitle = SeriesTitleNormalizer.Normalize(show.Title, show.TvdbId);
+
+            series.OriginalLanguage = IsoLanguages.Find(show.OriginalLanguage.ToLower())?.Language ?? Language.English;
 
             if (show.FirstAired != null)
             {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             episode.Ratings = MapRatings(oracleEpisode.Rating);
 
-            //Don't include series fanart images as episode screenshot
+            // Don't include series fanart images as episode screenshot
             if (oracleEpisode.Image != null)
             {
                 episode.Images.Add(new MediaCover.MediaCover(MediaCoverTypes.Screenshot, oracleEpisode.Image));

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -382,7 +382,7 @@ namespace NzbDrone.Core.Notifications.Discord
 
         private string BytesToString(long byteCount)
         {
-            string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" }; //Longs run out around EB
+            string[] suf = { "B", "KB", "MB", "GB", "TB", "PB", "EB" }; // Longs run out around EB
             if (byteCount == 0)
             {
                 return "0 " + suf[0];

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.Discord
     {
         public DiscordSettings()
         {
-            //Set Default Fields
+            // Set Default Fields
             GrabFields = new[] { 0, 1, 2, 3, 5, 6, 7, 8, 9 };
             ImportFields = new[] { 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12 };
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             _logger.Debug("Looking for error in response: {0}", response);
 
-            //TODO: actually check for the error
+            // TODO: actually check for the error
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Pushover
             Devices = new string[] { };
         }
 
-        //TODO: Get Pushover to change our app name (or create a new app) when we have a new logo
+        // TODO: Get Pushover to change our app name (or create a new app) when we have a new logo
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://pushover.net/apps/clone/sonarr")]
         public string ApiKey { get; set; }
 

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Notifications.Telegram
 
         public void SendNotification(string title, string message, TelegramSettings settings)
         {
-            //Format text to add the title before and bold using markdown
+            // Format text to add the title before and bold using markdown
             var text = $"<b>{HttpUtility.HtmlEncode(title)}</b>\n{HttpUtility.HtmlEncode(message)}";
 
             var requestBuilder = new HttpRequestBuilder(URL).Resource("bot{token}/sendmessage").Post();

--- a/src/NzbDrone.Core/Notifications/Trakt/TraktService.cs
+++ b/src/NzbDrone.Core/Notifications/Trakt/TraktService.cs
@@ -219,7 +219,7 @@ namespace NzbDrone.Core.Notifications.Trakt
         {
             var traktResolution = string.Empty;
 
-            //var interlacedTypes = new string[] { "Interlaced", "MBAFF", "PAFF" };
+            // var interlacedTypes = new string[] { "Interlaced", "MBAFF", "PAFF" };
             var scanIdentifier = scanType.IsNotNullOrWhiteSpace() && TraktInterlacedTypes.interlacedTypes.Contains(scanType) ? "i" : "p";
 
             switch (resolution)

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Twitter
             RuleFor(c => c.AccessToken).NotEmpty();
             RuleFor(c => c.AccessTokenSecret).NotEmpty();
 
-            //TODO: Validate that it is a valid username (numbers, letters and underscores - I think)
+            // TODO: Validate that it is a valid username (numbers, letters and underscores - I think)
             RuleFor(c => c.Mention).NotEmpty().When(c => c.DirectMessage);
 
             RuleFor(c => c.DirectMessage).Equal(true)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Organizer
         private static readonly Regex ScenifyRemoveChars = new Regex(@"(?<=\s)(,|<|>|\/|\\|;|:|'|""|\||`|~|!|\?|@|$|%|^|\*|-|_|=){1}(?=\s)|('|:|\?|,)(?=(?:(?:s|m)\s)|\s|$)|(\(|\)|\[|\]|\{|\})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ScenifyReplaceChars = new Regex(@"[\/]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        //TODO: Support Written numbers (One, Two, etc) and Roman Numerals (I, II, III etc)
+        // TODO: Support Written numbers (One, Two, etc) and Roman Numerals (I, II, III etc)
         private static readonly Regex MultiPartCleanupRegex = new Regex(@"(?:\:?\s?(?:\(\d+\)|(Part|Pt\.?)\s?\d+))$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly char[] EpisodeTitleTrimCharacters = new[] { ' ', '.', '?' };
@@ -497,7 +497,7 @@ namespace NzbDrone.Core.Organizer
                         seasonEpisodePattern = FormatRangeNumberTokens(seasonEpisodePattern, formatPattern, episodes);
                         break;
 
-                    //MultiEpisodeStyle.Extend
+                    // MultiEpisodeStyle.Extend
                     default:
                         formatPattern = "-" + episodeFormat.EpisodePattern;
                         seasonEpisodePattern = FormatNumberTokens(seasonEpisodePattern, formatPattern, episodes);
@@ -571,7 +571,7 @@ namespace NzbDrone.Core.Organizer
                         absoluteEpisodePattern = FormatAbsoluteNumberTokens(absoluteEpisodePattern, formatPattern, eps);
                         break;
 
-                        //MultiEpisodeStyle.Extend
+                        // MultiEpisodeStyle.Extend
                     default:
                         formatPattern = "-" + absoluteEpisodeFormat.AbsoluteEpisodePattern;
                         absoluteEpisodePattern = FormatAbsoluteNumberTokens(absoluteEpisodePattern, formatPattern, episodes);
@@ -1037,7 +1037,7 @@ namespace NzbDrone.Core.Organizer
 
         private string CleanupEpisodeTitle(string title)
         {
-            //this will remove (1),(2) from the end of multi part episodes.
+            // this will remove (1),(2) from the end of multi part episodes.
             return MultiPartCleanupRegex.Replace(title, string.Empty).Trim();
         }
 

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -48,12 +48,12 @@ namespace NzbDrone.Core.Parser
         {
             if (isoCode.Length == 2)
             {
-                //Lookup ISO639-1 code
+                // Lookup ISO639-1 code
                 return All.FirstOrDefault(l => l.TwoLetterCode == isoCode);
             }
             else if (isoCode.Length == 3)
             {
-                //Lookup ISO639-2T code
+                // Lookup ISO639-2T code
                 if (FileNameBuilder.Iso639BTMap.TryGetValue(isoCode, out var mapped))
                 {
                     isoCode = mapped;

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SubtitleLanguageRegex = new Regex(".+?[-_. ](?<iso_code>[a-z]{2,3})([-_. ](?<tags>full|forced|foreign|default|cc|psdh|sdh))*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static List<Language> ParseLanguages(string title, bool defaultToEnglish = true)
+        public static List<Language> ParseLanguages(string title)
         {
             foreach (var regex in CleanSeriesTitleRegex)
             {
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Parser
 
             if (!languages.Any())
             {
-                languages.Add(defaultToEnglish ? Language.English : Language.Unknown);
+                languages.Add(Language.Unknown);
             }
 
             return languages.DistinctBy(l => (int)l).ToList();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -40,8 +40,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex[] ReportTitleRegex = new[]
             {
-                //Anime - Absolute Episode Number + Title + Season+Episode
-                //Todo: This currently breaks series that start with numbers
+                // Anime - Absolute Episode Number + Title + Season+Episode
+                // Todo: This currently breaks series that start with numbers
 //                new Regex(@"^(?:(?<absoluteepisode>\d{2,3})(?:_|-|\s|\.)+)+(?<title>.+?)(?:\W|_)+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)",
 //                          RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -49,115 +49,115 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^^(?<title>.+?\((?<titleyear>\d{4})\))[-_. ]+(?<airyear>19[4-9]\d|20\d\d)(?<sep>[-_]?)(?<airmonth>0\d|1[0-2])\k<sep>(?<airday>[0-2]\d|3[01])[-_. ]\d{2}[-_. ]\d{2}[-_. ]\d{2}",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Daily episodes without title (2018-10-12, 20181012) (Strict pattern to avoid false matches)
+                // Daily episodes without title (2018-10-12, 20181012) (Strict pattern to avoid false matches)
                 new Regex(@"^(?<airyear>19[6-9]\d|20\d\d)(?<sep>[-_]?)(?<airmonth>0\d|1[0-2])\k<sep>(?<airday>[0-2]\d|3[01])(?!\d)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-Part episodes without a title (S01E05.S01E06)
+                // Multi-Part episodes without a title (S01E05.S01E06)
                 new Regex(@"^(?:\W*S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:e{1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-Part episodes without a title (1x05.1x06)
+                // Multi-Part episodes without a title (1x05.1x06)
                 new Regex(@"^(?:\W*(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:x{1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes without a title, Multi (S01E04E05, 1x04x05, etc)
+                // Episodes without a title, Multi (S01E04E05, 1x04x05, etc)
                 new Regex(@"^(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_]|[ex]){1,2}(?<episode>\d{2,3}(?!\d+))){2,})",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes without a title, Single (S01E05, 1x05)
+                // Episodes without a title, Single (S01E05, 1x05)
                 new Regex(@"^(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_ ]?[ex])(?<episode>\d{2,3}(?!\d+))))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Episode Absolute Episode Number ([SubGroup] Series Title Episode 01)
+                // Anime - [SubGroup] Title Episode Absolute Episode Number ([SubGroup] Series Title Episode 01)
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Absolute Episode Number + Season+Episode
+                // Anime - [SubGroup] Title Absolute Episode Number + Season+Episode
                 new Regex(@"^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?))+(?:_|-|\s|\.)+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+).*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Season+Episode + Absolute Episode Number
+                // Anime - [SubGroup] Title Season+Episode + Absolute Episode Number
                 new Regex(@"^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()\[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:(?:_|-|\s|\.)+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+|\-[a-z])))+.*?(?<hash>\[\w{8}\])?(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Season+Episode
+                // Anime - [SubGroup] Title Season+Episode
                 new Regex(@"^(?:\[(?<subgroup>.+?)\](?:_|-|\s|\.)?)(?<title>.+?)(?:[-_\W](?<![()\[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]){1,2}(?<episode>\d{2}(?!\d+)))+)(?:\s|\.).*?(?<hash>\[\w{8}\])?(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title with trailing number Absolute Episode Number - Batch separated with tilde
+                // Anime - [SubGroup] Title with trailing number Absolute Episode Number - Batch separated with tilde
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?[^-]+?)(?:(?<![-_. ]|\b[0]\d+) - )[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+))\s?~\s?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+))(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title with season number in brackets Absolute Episode Number
+                // Anime - [SubGroup] Title with season number in brackets Absolute Episode Number
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?)[_. ]+?\(Season[_. ](?<season>\d+)\)[-_. ]+?(?:[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title with trailing number Absolute Episode Number
+                // Anime - [SubGroup] Title with trailing number Absolute Episode Number
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?)(?:(?<![-_. ]|\b[0]\d+) - )(?:[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title with trailing number Absolute Episode Number
+                // Anime - [SubGroup] Title with trailing number Absolute Episode Number
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?)(?:(?<![-_. ]|\b[0]\d+)[_ ]+)(?:[-_. ]?(?<absoluteepisode>\d{3}(\.\d{1,2})?(?!\d+|-[a-z]+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title - Absolute Episode Number
+                // Anime - [SubGroup] Title - Absolute Episode Number
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:(?<!\b[0]\d+))(?:[. ]-[. ](?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-])))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Absolute Episode Number - Absolute Episode Number (batches without full separator between title and absolute episode numbers)
+                // Anime - [SubGroup] Title Absolute Episode Number - Absolute Episode Number (batches without full separator between title and absolute episode numbers)
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:(?<!\b[0]\d+))(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))[. ]-[. ](?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - [SubGroup] Title Absolute Episode Number
+                // Anime - [SubGroup] Title Absolute Episode Number
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+\(?(?:[-_. ]?#?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|-[a-z]+)))+\)?(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-episode Repeated (S01E05 - S01E06)
+                // Multi-episode Repeated (S01E05 - S01E06)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:e|[-_. ]e){1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-episode Repeated (1x05 - 1x06)
+                // Multi-episode Repeated (1x05 - 1x06)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:x{1,2}(?<episode>\d{1,3}(?!\d+)))+){2,}",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Single episodes with a title (S01E05, 1x05, etc) and trailing info in slashes
+                // Single episodes with a title (S01E05, 1x05, etc) and trailing info in slashes
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+|(?:[ex]|\W[ex]|_|-){1,2}\d+))).+?(?:\[.+?\])(?!\\)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Season EpisodeNumber + Absolute Episode Number [SubGroup]
+                // Anime - Title Season EpisodeNumber + Absolute Episode Number [SubGroup]
                 new Regex(@"^(?<title>.+?)(?:[-_\W](?<![()\[!]))+(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:[ex]|\W[ex]|-){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))+)[-_. (]+?(?:[-_. ]?(?<absoluteepisode>(?<!\d+)\d{3}(\.\d{1,2})?(?!\d+|[pi])))+.+?\[(?<subgroup>.+?)\](?:$|\.mkv)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-Episode with a title (S01E05E06, S01E05-06, S01E05 E06, etc) and trailing info in slashes
+                // Multi-Episode with a title (S01E05E06, S01E05-06, S01E05 E06, etc) and trailing info in slashes
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+)))+).+?(?:\[.+?\])(?!\\)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number [SubGroup] [Hash]? (Series Title Episode 99-100 [RlsGroup] [ABCD1234])
+                // Anime - Title Absolute Episode Number [SubGroup] [Hash]? (Series Title Episode 99-100 [RlsGroup] [ABCD1234])
                 new Regex(@"^(?<title>.+?)[-_. ]Episode(?:[-_. ]+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number [SubGroup] [Hash]
+                // Anime - Title Absolute Episode Number [SubGroup] [Hash]
                 new Regex(@"^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{3}(\.\d{1,2})(?!\d+)))+(?:.+?)\[(?<subgroup>.+?)\].*?(?<hash>\[\w{8}\])?(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number (Year) [SubGroup]
+                // Anime - Title Absolute Episode Number (Year) [SubGroup]
                 new Regex(@"^(?<title>.+?)[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2}(?!\d+))[-_. ](\(\d{4}\))[-_. ]\[(?<subgroup>.+?)\]",
                             RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title with trailing number, Absolute Episode Number and hash
+                // Anime - Title with trailing number, Absolute Episode Number and hash
                 new Regex(@"^(?<title>[^-]+?)(?:(?<![-_. ]|\b[0]\d+) - )(?:[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])(?:$|\.mkv)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number [Hash]
+                // Anime - Title Absolute Episode Number [Hash]
                 new Regex(@"^(?<title>.+?)(?:(?:_|-|\s|\.)+(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?[-_. ]+.*?(?<hash>\[\w{8}\])(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate AND season/episode number, capture season/episode only
+                // Episodes with airdate AND season/episode number, capture season/episode only
                 new Regex(@"^(?<title>.+?)?\W*(?<airdate>\d{4}\W+[0-1][0-9]\W+[0-3][0-9])(?!\W+[0-3][0-9])[-_. ](?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate AND season/episode number
+                // Episodes with airdate AND season/episode number
                 new Regex(@"^(?<title>.+?)?\W*(?<airyear>\d{4})\W+(?<airmonth>[0-1][0-9])\W+(?<airday>[0-3][0-9])(?!\W+[0-3][0-9]).+?(?:s?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+)))(?:[ex](?<episode>(?<!\d+)(?:\d{1,3})(?!\d+)))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -165,15 +165,15 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^(?<title>.+?)(?:[-_\W](?<![()\[!]))+S(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))E(?<episode>\d{1,2}(?!\d+))(?:-(?<episode>\d{1,2}(?!\d+)))+(?:[-_. ]|$)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
+                // Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:[ex]|\W[ex]){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+)))*)\W?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with a title, 4 digit season number, Single episodes (S2016E05, etc) & Multi-episode (S2016E05E06, S2016E05-06, S2016E05 E06, etc)
+                // Episodes with a title, 4 digit season number, Single episodes (S2016E05, etc) & Multi-episode (S2016E05E06, S2016E05-06, S2016E05 E06, etc)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:e|\We|_){1,2}(?<episode>\d{2,4}(?!\d+))(?:(?:\-|e|\We|_){1,2}(?<episode>\d{2,3}(?!\d+)))*)\W?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with a title, 4 digit season number, Single episodes (2016x05, etc) & Multi-episode (2016x05x06, 2016x05-06, 2016x05 x06, etc)
+                // Episodes with a title, 4 digit season number, Single episodes (2016x05, etc) & Multi-episode (2016x05x06, 2016x05-06, 2016x05 x06, etc)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+(?<season>(?<!\d+)(?:\d{4})(?!\d+))(?:x|\Wx){1,2}(?<episode>\d{2,4}(?!\d+))(?:(?:\-|x|\Wx|_){1,2}(?<episode>\d{2,3}(?!\d+)))*)\W?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -189,35 +189,35 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>.+?)[-_. ]+?(?<absoluteepisode>\d{4}(\.\d{1,2})?(?!\d+))",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title 4-digit Absolute Episode Number [SubGroup]
+                // Anime - Title 4-digit Absolute Episode Number [SubGroup]
                 new Regex(@"^(?<title>.+?)[-_. ]+(?<absoluteepisode>(?<!\d+)\d{4}(?!\d+))[-_. ]\[(?<subgroup>.+?)\]",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Mini-Series with year in title, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
+                // Mini-Series with year in title, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
                 new Regex(@"^(?<title>.+?\d{4})(?:\W+(?:(?:Part\W?|e)(?<episode>\d{1,2}(?!\d+)))+)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Mini-Series, treated as season 1, multi episodes are labelled as E1-E2
+                // Mini-Series, treated as season 1, multi episodes are labelled as E1-E2
                 new Regex(@"^(?<title>.+?)(?:[-._ ][e])(?<episode>\d{2,3}(?!\d+))(?:(?:\-?[e])(?<episode>\d{2,3}(?!\d+)))+",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate and part (2018.04.28.Part.2)
+                // Episodes with airdate and part (2018.04.28.Part.2)
                 new Regex(@"^(?<title>.+?)?\W*(?<airyear>\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])(?![-_. ]+[0-3][0-9])[-_. ]+Part[-_. ]?(?<part>[1-9])",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Mini-Series, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
+                // Mini-Series, treated as season 1, episodes are labelled as Part01, Part 01, Part.1
                 new Regex(@"^(?<title>.+?)(?:\W+(?:(?:(?<!\()Part\W?|(?<!\d+\W+)e)(?<episode>\d{1,2}(?!\d+|\))))+)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Mini-Series, treated as season 1, episodes are labelled as Part One/Two/Three/...Nine, Part.One, Part_One
+                // Mini-Series, treated as season 1, episodes are labelled as Part One/Two/Three/...Nine, Part.One, Part_One
                 new Regex(@"^(?<title>.+?)(?:\W+(?:Part[-._ ](?<episode>One|Two|Three|Four|Five|Six|Seven|Eight|Nine)(?>[-._ ])))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Mini-Series, treated as season 1, episodes are labelled as XofY
+                // Mini-Series, treated as season 1, episodes are labelled as XofY
                 new Regex(@"^(?<title>.+?)(?:\W+(?:(?<episode>(?<!\d+)\d{1,2}(?!\d+))of\d+)+)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Supports Season 01 Episode 03
+                // Supports Season 01 Episode 03
                 new Regex(@"(?:.*(?:\""|^))(?<title>.*?)(?:[-_\W](?<![()\[]))+(?:\W?Season\W?)(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)+(?:Episode\W)(?:[-_. ]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -225,27 +225,27 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"(?:.*(?:^))(?<title>.*?)[-._ ]+\[S(?<season>(?<!\d+)\d{2}(?!\d+))(?:[E-]{1,2}(?<episode>(?<!\d+)\d{2}(?!\d+)))+\]",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-episode release with no space between series title and season (S01E11E12)
+                // Multi-episode release with no space between series title and season (S01E11E12)
                 new Regex(@"(?:.*(?:^))(?<title>.*?)S(?<season>(?<!\d+)\d{2}(?!\d+))(?:E(?<episode>(?<!\d+)\d{2}(?!\d+)))+",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Multi-episode with single episode numbers (S6.E1-E2, S6.E1E2, S6E1E2, etc)
+                // Multi-episode with single episode numbers (S6.E1-E2, S6.E1E2, S6E1E2, etc)
                 new Regex(@"^(?<title>.+?)[-_. ]S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:[-_. ]?[ex]?(?<episode>(?<!\d+)\d{1,2}(?!\d+)))+",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Single episode season or episode S1E1 or S1-E1 or S1.Ep1 or S01.Ep.01
+                // Single episode season or episode S1E1 or S1-E1 or S1.Ep1 or S01.Ep.01
                 new Regex(@"(?:.*(?:\""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:\W|_)?Ep?[ ._]?(?<episode>(?<!\d+)\d{1,2}(?!\d+))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //3 digit season S010E05
+                // 3 digit season S010E05
                 new Regex(@"(?:.*(?:\""|^))(?<title>.*?)(?:\W?|_)S(?<season>(?<!\d+)\d{3}(?!\d+))(?:\W|_)?E(?<episode>(?<!\d+)\d{1,2}(?!\d+))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //5 digit episode number with a title
+                // 5 digit episode number with a title
                 new Regex(@"^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //5 digit multi-episode with a title
+                // 5 digit multi-episode with a title
                 new Regex(@"^(?:(?<title>.+?)(?:_|-|\s|\.)+)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:(?:[-_. ]{1,3}ep){1,2}(?<episode>(?<!\d+)\d{5}(?!\d+)))+",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -271,57 +271,57 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)(?<title>.+?)[-_. ]+?\[(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+))\]",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Season only releases
+                // Season only releases
                 new Regex(@"^(?<title>.+?)[-_. ]+?(?:S|Season|Saison|Series)[-_. ]?(?<season>\d{1,2}(?![-_. ]?\d+))(?:[-_. ]|$)+(?<extras>EXTRAS|SUBPACK)?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //4 digit season only releases
+                // 4 digit season only releases
                 new Regex(@"^(?<title>.+?)[-_. ]+?(?:S|Season|Saison|Series)[-_. ]?(?<season>\d{4}(?![-_. ]?\d+))(\W+|_|$)(?<extras>EXTRAS|SUBPACK)?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with a title and season/episode in square brackets
+                // Episodes with a title and season/episode in square brackets
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+\[S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>(?<!\d+)\d{2}(?!\d+|i|p)))+\])\W?(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Supports 103/113 naming
+                // Supports 103/113 naming
                 new Regex(@"^(?<title>.+?)?(?:(?:[_.-](?<![()\[!]))+(?<season>(?<!\d+)[1-9])(?<episode>[1-9][0-9]|[0][1-9])(?![a-z]|\d+))+(?:[_.]|$)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //4 digit episode number
-                //Episodes without a title, Single (S01E05, 1x05) AND Multi (S01E04E05, 1x04x05, etc)
+                // 4 digit episode number
+                // Episodes without a title, Single (S01E05, 1x05) AND Multi (S01E04E05, 1x04x05, etc)
                 new Regex(@"^(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)(\W+|_|$)(?!\\)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //4 digit episode number
-                //Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
+                // 4 digit episode number
+                // Episodes with a title, Single episodes (S01E05, 1x05, etc) & Multi-episode (S01E05E06, S01E05-06, S01E05 E06, etc)
                 new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>\d{4}(?!\d+|i|p)))+)\W?(?!\\)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate (2018.04.28)
+                // Episodes with airdate (2018.04.28)
                 new Regex(@"^(?<title>.+?)?\W*(?<airyear>\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])(?![-_. ]+[0-3][0-9])",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate (04.28.2018)
+                // Episodes with airdate (04.28.2018)
                 new Regex(@"^(?<title>.+?)?\W*(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])[-_. ]+(?<airyear>\d{4})(?!\d+)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with airdate (20180428)
+                // Episodes with airdate (20180428)
                 new Regex(@"^(?<title>.+?)?\W*(?<!\d+)(?<airyear>\d{4})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9])(?!\d+)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Supports 1103/1113 naming
+                // Supports 1103/1113 naming
                 new Regex(@"^(?<title>.+?)?(?:(?:[-_.](?<![()\[!]))*(?<season>(?<!\d+|\(|\[|e|x)\d{2})(?<episode>(?<!e|x)(?:[1-9][0-9]|[0][1-9])(?!p|i|\d+|\)|\]|\W\d+|\W(?:e|ep|x)\d+)))+([-_.]+|$)(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes with single digit episode number (S01E1, S01E5E6, etc)
+                // Episodes with single digit episode number (S01E1, S01E5E6, etc)
                 new Regex(@"^(?<title>.*?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)\d{1,2}(?!\d+))(?:(?:\-|[ex]){1,2}(?<episode>\d{1}))+)+(\W+|_|$)(?!\\)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //iTunes Season 1\05 Title (Quality).ext
+                // iTunes Season 1\05 Title (Quality).ext
                 new Regex(@"^(?:Season(?:_|-|\s|\.)(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?:_|-|\s|\.)(?<episode>(?<!\d+)\d{1,2}(?!\d+))",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //iTunes 1-05 Title (Quality).ext
+                // iTunes 1-05 Title (Quality).ext
                 new Regex(@"^(?:(?<season>(?<!\d+)(?:\d{1,2})(?!\d+))(?:-(?<episode>\d{2,3}(?!\d+))))",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
@@ -329,39 +329,39 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^(?<title>.+?)(?:[-_. ]+?Temporada.+?\[Cap[-_.])(?<season>(?<!\d+)\d{1,2})(?<episode>(?<!e|x)(?:[1-9][0-9]|[0][1-9]))(?:\])",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime Range - Title Absolute Episode Number (ep01-12)
+                // Anime Range - Title Absolute Episode Number (ep01-12)
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:_|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,3}(\.\d{1,2})?)-(?<absoluteepisode>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-)).*?(?<hash>\[\w{8}\])?(?:$|\.)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number (e66)
+                // Anime - Title Absolute Episode Number (e66)
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:_|-|\s|\.)+(?:e|ep)(?<absoluteepisode>\d{2,4}(\.\d{1,2})?))+[-_. ].*?(?<hash>\[\w{8}\])?(?:$|\.)",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Episode Absolute Episode Number (Series Title Episode 01)
+                // Anime - Title Episode Absolute Episode Number (Series Title Episode 01)
                 new Regex(@"^(?<title>.+?)[-_. ](?:Episode)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime Range - Title Absolute Episode Number (1 or 2 digit absolute episode numbers in a range, 1-10)
+                // Anime Range - Title Absolute Episode Number (1 or 2 digit absolute episode numbers in a range, 1-10)
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)[_. ]+(?<absoluteepisode>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+))-(?<absoluteepisode>(?<!\d+)\d{1,2}(\.\d{1,2})?(?!\d+|-))(?:_|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title Absolute Episode Number
+                // Anime - Title Absolute Episode Number
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:[-_. ]+(?<absoluteepisode>(?<!\d+)\d{2,4}(\.\d{1,2})?(?!\d+|[ip])))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Anime - Title {Absolute Episode Number}
+                // Anime - Title {Absolute Episode Number}
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ]?)?(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+(?<absoluteepisode>(?<!\d+)\d{2,3}(\.\d{1,2})?(?!\d+|[ip])))+(?:_|-|\s|\.)*?(?<hash>\[.{8}\])?(?:$|\.)?",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Extant, terrible multi-episode naming (extant.10708.hdtv-lol.mp4)
+                // Extant, terrible multi-episode naming (extant.10708.hdtv-lol.mp4)
                 new Regex(@"^(?<title>.+?)[-_. ](?<season>[0]?\d?)(?:(?<episode>\d{2}){2}(?!\d+))[-_. ]",
                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Season only releases for poorly named anime
+                // Season only releases for poorly named anime
                 new Regex(@"^(?:\[(?<subgroup>.+?)\][-_. ])?(?<title>.+?)[-_. ]+?[\[(](?:S|Season|Saison|Series)[-_. ]?(?<season>\d{1,2}(?![-_. ]?\d+))(?:[-_. )\]]|$)+(?<extras>EXTRAS|SUBPACK)?(?!\\)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-                //Episodes without a title, Single episode numbers (S1E1, 1x1)
+                // Episodes without a title, Single episode numbers (S1E1, 1x1)
                 new Regex(@"^(?:S?(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?!\d+))(?:(?:[-_ ]?[ex])(?<episode>\d{1}(?!\d+))))",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled)
             };
@@ -388,19 +388,19 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^[A-Z]{11}\d{3}$", RegexOptions.Compiled),
                 new Regex(@"^[a-z]{12}\d{3}$", RegexOptions.Compiled),
 
-                //Backup filename (Unknown origins)
+                // Backup filename (Unknown origins)
                 new Regex(@"^Backup_\d{5,}S\d{2}-\d{2}$", RegexOptions.Compiled),
 
-                //123 - Started appearing December 2014
+                // 123 - Started appearing December 2014
                 new Regex(@"^123$", RegexOptions.Compiled),
 
-                //abc - Started appearing January 2015
+                // abc - Started appearing January 2015
                 new Regex(@"^abc$", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
-                //abc - Started appearing 2020
+                // abc - Started appearing 2020
                 new Regex(@"^abc[-_. ]xyz", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
-                //b00bs - Started appearing January 2015
+                // b00bs - Started appearing January 2015
                 new Regex(@"^b00bs$", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
                 // 170424_26 - Started appearing August 2018
@@ -424,7 +424,7 @@ namespace NzbDrone.Core.Parser
                 new Regex(@"^(Season[ ._-]*\d+|Specials)$", RegexOptions.Compiled)
             };
 
-        //Regex to detect whether the title was reversed.
+        // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E\d{2}S)[-._ ]", RegexOptions.Compiled);
 
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)(a(?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
@@ -470,11 +470,11 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex AnimeReleaseGroupRegex = new Regex(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        //Handle Exception Release Groups that don't follow -RlsGrp; Manual List
+        // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
         // name only...be very careful with this last; high chance of false positives
         private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"(?<releasegroup>(?:D\-Z0N3|Fight-BB)\b)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        //groups whose releases end with RlsGroup) or RlsGroup]
+        // groups whose releases end with RlsGroup) or RlsGroup]
         private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)[-_. ]+?\(?(?<year>\d{4})\)?",
@@ -691,7 +691,7 @@ namespace NzbDrone.Core.Parser
         {
             long number = 0;
 
-            //If Title only contains numbers return it as is.
+            // If Title only contains numbers return it as is.
             if (long.TryParse(title, out number))
             {
                 return title;
@@ -715,7 +715,7 @@ namespace NzbDrone.Core.Parser
             }
 
             // Disabled, Until we run into specific testcases for the removal of these words.
-            //title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
+            // title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
 
             title = PunctuationRegex.Replace(title, " ");
             title = DuplicateSpacesRegex.Replace(title, " ");
@@ -863,7 +863,7 @@ namespace NzbDrone.Core.Parser
                     var episodeCaptures = matchGroup.Groups["episode"].Captures.Cast<Capture>().ToList();
                     var absoluteEpisodeCaptures = matchGroup.Groups["absoluteepisode"].Captures.Cast<Capture>().ToList();
 
-                    //Allows use to return a list of 0 episodes (We can handle that as a full season release)
+                    // Allows use to return a list of 0 episodes (We can handle that as a full season release)
                     if (episodeCaptures.Any())
                     {
                         var first = ParseNumber(episodeCaptures.First().Value);
@@ -918,7 +918,7 @@ namespace NzbDrone.Core.Parser
 
                     if (!episodeCaptures.Any() && !absoluteEpisodeCaptures.Any())
                     {
-                        //Check to see if this is an "Extras" or "SUBPACK" release, if it is, set
+                        // Check to see if this is an "Extras" or "SUBPACK" release, if it is, set
                         // IsSeasonExtra so they can be filtered out
                         if (!matchCollection[0].Groups["extras"].Value.IsNullOrWhiteSpace())
                         {
@@ -954,7 +954,7 @@ namespace NzbDrone.Core.Parser
                     }
                 }
 
-                //If more than 1 season was parsed set IsMultiSeason to true so it can be rejected later
+                // If more than 1 season was parsed set IsMultiSeason to true so it can be rejected later
                 if (seasons.Distinct().Count() > 1)
                 {
                     result.IsMultiSeason = true;

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ResolutionRegex = new Regex(@"\b(?:(?<R360p>360p)|(?<R480p>480p|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H265)|(?:UHD|HEVC|BD|H265)[-_. ]4k))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        //Handle cases where no resolution is in the release name; assume if UHD then 4k
+        // Handle cases where no resolution is in the release name; assume if UHD then 4k
         private static readonly Regex ImpliedResolutionRegex = new Regex(@"\b(?<R2160p>UHD)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/src/NzbDrone.Core/Parser/SceneChecker.cs
+++ b/src/NzbDrone.Core/Parser/SceneChecker.cs
@@ -2,8 +2,8 @@
 {
     public static class SceneChecker
     {
-        //This method should prefer false negatives over false positives.
-        //It's better not to use a title that might be scene than to use one that isn't scene
+        // This method should prefer false negatives over false positives.
+        // It's better not to use a title that might be scene than to use one that isn't scene
         public static bool IsSceneTitle(string title)
         {
             if (!title.Contains("."))

--- a/src/NzbDrone.Core/Qualities/Quality.cs
+++ b/src/NzbDrone.Core/Qualities/Quality.cs
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.Qualities
         public static Quality HDTV1080p => new Quality(9,  "HDTV-1080p", QualitySource.Television, 1080);
         public static Quality RAWHD => new Quality(10, "Raw-HD", QualitySource.TelevisionRaw, 1080);
 
-        //public static Quality HDTV480p    { get { return new Quality(11, "HDTV-480p", QualitySource.Television, 480); } }
+        // public static Quality HDTV480p    { get { return new Quality(11, "HDTV-480p", QualitySource.Television, 480); } }
         public static Quality WEBRip480p
         {
             get { return new Quality(12, "WEBRip-480p", QualitySource.WebRip, 480); }

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.RootFolders
                     }
                 }
 
-                //We don't want an exception to prevent the root folders from loading in the UI, so they can still be deleted
+                // We don't want an exception to prevent the root folders from loading in the UI, so they can still be deleted
                 catch (Exception ex)
                 {
                     _logger.Error(ex, "Unable to get free space and unmapped folders for root folder {0}", folder.Path);

--- a/src/NzbDrone.Core/ThingiProvider/IProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/IProviderRepository.cs
@@ -5,6 +5,6 @@ namespace NzbDrone.Core.ThingiProvider
     public interface IProviderRepository<TProvider> : IBasicRepository<TProvider>
         where TProvider : ModelBase, new()
     {
-//        void DeleteImplementations(string implementation);
+// void DeleteImplementations(string implementation);
     }
 }

--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -170,7 +170,7 @@ namespace NzbDrone.Core.ThingiProvider
             definition.Message = provider.Message;
         }
 
-        //TODO: Remove providers even if the ConfigContract can't be deserialized (this will fail to remove providers if the settings can't be deserialized).
+        // TODO: Remove providers even if the ConfigContract can't be deserialized (this will fail to remove providers if the settings can't be deserialized).
         private void RemoveMissingImplementations()
         {
             var storedProvider = _providerRepository.All();

--- a/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Tv
             var languagesBelowCutoff = new List<LanguagesBelowCutoff>();
             var profiles = _qualityProfileService.All();
 
-            //Get all items less than the cutoff
+            // Get all items less than the cutoff
             foreach (var profile in profiles)
             {
                 var cutoff = profile.UpgradeAllowed ? profile.Cutoff : profile.FirststAllowedQuality().Id;

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Tv
 
         private List<Episode> MapAbsoluteEpisodeNumbers(List<Episode> remoteEpisodes)
         {
-            //Return all episodes with no abs number, but distinct for those with abs number
+            // Return all episodes with no abs number, but distinct for those with abs number
             return remoteEpisodes.Where(e => e.AbsoluteEpisodeNumber.HasValue)
                                  .OrderByDescending(e => e.SeasonNumber)
                                  .DistinctBy(e => e.AbsoluteEpisodeNumber.Value)

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -91,6 +91,7 @@ namespace NzbDrone.Core.Tv
             series.ImdbId = seriesInfo.ImdbId;
             series.AirTime = seriesInfo.AirTime;
             series.Overview = seriesInfo.Overview;
+            series.OriginalLanguage = seriesInfo.OriginalLanguage;
             series.Status = seriesInfo.Status;
             series.CleanTitle = seriesInfo.CleanTitle;
             series.SortTitle = seriesInfo.SortTitle;

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Tv
             {
                 var existingSeason = series.Seasons.FirstOrDefault(s => s.SeasonNumber == season.SeasonNumber);
 
-                //Todo: Should this should use the previous season's monitored state?
+                // Todo: Should this should use the previous season's monitored state?
                 if (existingSeason == null)
                 {
                     if (season.SeasonNumber == 0)

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Profiles.Qualities;
 
 namespace NzbDrone.Core.Tv
@@ -15,6 +16,7 @@ namespace NzbDrone.Core.Tv
             Actors = new List<Actor>();
             Seasons = new List<Season>();
             Tags = new HashSet<int>();
+            OriginalLanguage = Language.English;
         }
 
         public int TvdbId { get; set; }
@@ -47,6 +49,7 @@ namespace NzbDrone.Core.Tv
         public DateTime Added { get; set; }
         public DateTime? FirstAired { get; set; }
         public LazyLoaded<QualityProfile> QualityProfile { get; set; }
+        public Language OriginalLanguage { get; set; }
 
         public List<Season> Seasons { get; set; }
         public HashSet<int> Tags { get; set; }

--- a/src/NzbDrone.Host/AccessControl/FirewallAdapter.cs
+++ b/src/NzbDrone.Host/AccessControl/FirewallAdapter.cs
@@ -77,7 +77,7 @@ namespace NzbDrone.Host.AccessControl
                 var netFwMgrType = Type.GetTypeFromProgID("HNetCfg.FwMgr", false);
                 var mgr = (INetFwMgr)Activator.CreateInstance(netFwMgrType);
 
-                //Open the port for the standard profile, should help when the user has multiple network adapters
+                // Open the port for the standard profile, should help when the user has multiple network adapters
                 mgr.LocalPolicy.GetProfileByType(FIREWALL_PROFILE).GloballyOpenPorts.Add(port);
             }
             catch (Exception ex)

--- a/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/ReleaseFixture.cs
@@ -36,8 +36,8 @@ namespace NzbDrone.Integration.Test.ApiTests
             // InternalServerError is caused by the Release being invalid for download (no Series).
             // But if it didn't accept it, it would return NotFound.
             // TODO: Maybe we should create a full mock Newznab server endpoint.
-            //var result = Releases.Post(new ReleaseResource { Guid = releases.First().Guid });
-            //result.Guid.Should().Be(releases.First().Guid);
+            // var result = Releases.Post(new ReleaseResource { Guid = releases.First().Guid });
+            // result.Guid.Should().Be(releases.First().Guid);
 
             var result = Releases.Post(new ReleaseResource { Guid = releases.First().Guid }, HttpStatusCode.InternalServerError);
         }
@@ -50,9 +50,9 @@ namespace NzbDrone.Integration.Test.ApiTests
             releaseResource.DownloadUrl.Should().NotBeNullOrWhiteSpace();
             releaseResource.SeriesTitle.Should().NotBeNullOrWhiteSpace();
 
-            //TODO: uncomment these after moving to restsharp for rss
-            //releaseResource.NzbInfoUrl.Should().NotBeNullOrWhiteSpace();
-            //releaseResource.Size.Should().BeGreaterThan(0);
+            // TODO: uncomment these after moving to restsharp for rss
+            // releaseResource.NzbInfoUrl.Should().NotBeNullOrWhiteSpace();
+            // releaseResource.Size.Should().BeGreaterThan(0);
 
             return true;
         }

--- a/src/NzbDrone.Test.Common/LoggingTest.cs
+++ b/src/NzbDrone.Test.Common/LoggingTest.cs
@@ -95,8 +95,8 @@ namespace NzbDrone.Test.Common
         [TearDown]
         public void LoggingDownBase()
         {
-            //can't use because of a bug in mono with 2.6.2,
-            //https://bugs.launchpad.net/nunitv2/+bug/1076932
+            // can't use because of a bug in mono with 2.6.2,
+            // https://bugs.launchpad.net/nunitv2/+bug/1076932
             if (BuildInfo.IsDebug && TestContext.CurrentContext.Result.Outcome == ResultState.Success)
             {
                 ExceptionVerification.AssertNoUnexpectedLogs();

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -61,8 +61,8 @@ namespace Sonarr.Api.V3.Config
                 AuthenticationRequired = model.AuthenticationRequired,
                 AnalyticsEnabled = model.AnalyticsEnabled,
 
-                //Username
-                //Password
+                // Username
+                // Password
                 LogLevel = model.LogLevel,
                 ConsoleLogLevel = model.ConsoleLogLevel,
                 Branch = model.Branch,

--- a/src/Sonarr.Api.V3/Config/NamingExampleResource.cs
+++ b/src/Sonarr.Api.V3/Config/NamingExampleResource.cs
@@ -32,12 +32,12 @@ namespace Sonarr.Api.V3.Config
                 SeasonFolderFormat = model.SeasonFolderFormat,
                 SpecialsFolderFormat = model.SpecialsFolderFormat
 
-                //IncludeSeriesTitle
-                //IncludeEpisodeTitle
-                //IncludeQuality
-                //ReplaceSpaces
-                //Separator
-                //NumberStyle
+                // IncludeSeriesTitle
+                // IncludeEpisodeTitle
+                // IncludeQuality
+                // ReplaceSpaces
+                // Separator
+                // NumberStyle
             };
         }
 

--- a/src/Sonarr.Api.V3/Config/UiConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/UiConfigResource.cs
@@ -5,11 +5,11 @@ namespace Sonarr.Api.V3.Config
 {
     public class UiConfigResource : RestResource
     {
-        //Calendar
+        // Calendar
         public int FirstDayOfWeek { get; set; }
         public string CalendarWeekColumnHeader { get; set; }
 
-        //Dates
+        // Dates
         public string ShortDateFormat { get; set; }
         public string LongDateFormat { get; set; }
         public string TimeFormat { get; set; }

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -45,7 +45,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 SeasonNumber = model.SeasonNumber,
                 RelativePath = model.RelativePath,
 
-                //Path
+                // Path
                 Size = model.Size,
                 DateAdded = model.DateAdded,
                 SceneName = model.SceneName,
@@ -54,7 +54,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName)
 
-                //QualityCutoffNotMet
+                // QualityCutoffNotMet
             };
         }
 

--- a/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
@@ -37,7 +37,7 @@ namespace Sonarr.Api.V3.Episodes
 
         public List<MediaCover> Images { get; set; }
 
-        //Hiding this so people don't think its usable (only used to set the initial state)
+        // Hiding this so people don't think its usable (only used to set the initial state)
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool Grabbed { get; set; }
     }
@@ -65,7 +65,7 @@ namespace Sonarr.Api.V3.Episodes
                 AirDateUtc = model.AirDateUtc,
                 Overview = model.Overview,
 
-                //EpisodeFile
+                // EpisodeFile
 
                 HasFile = model.HasFile,
                 Monitored = model.Monitored,
@@ -76,7 +76,7 @@ namespace Sonarr.Api.V3.Episodes
                 UnverifiedSceneNumbering = model.UnverifiedSceneNumbering,
                 SeriesTitle = model.SeriesTitle,
 
-                //Series = model.Series.MapToResource(),
+                // Series = model.Series.MapToResource(),
             };
         }
 

--- a/src/Sonarr.Api.V3/FileSystem/FileSystemController.cs
+++ b/src/Sonarr.Api.V3/FileSystem/FileSystemController.cs
@@ -41,7 +41,7 @@ namespace Sonarr.Api.V3.FileSystem
                 return new { type = "file" };
             }
 
-            //Return folder even if it doesn't exist on disk to avoid leaking anything from the UI about the underlying system
+            // Return folder even if it doesn't exist on disk to avoid leaking anything from the UI about the underlying system
             return new { type = "folder" };
         }
 

--- a/src/Sonarr.Api.V3/History/HistoryResource.cs
+++ b/src/Sonarr.Api.V3/History/HistoryResource.cs
@@ -51,7 +51,7 @@ namespace Sonarr.Api.V3.History
                 Quality = model.Quality,
                 CustomFormats = formatCalculator.ParseCustomFormat(model).ToResource(),
 
-                //QualityCutoffNotMet
+                // QualityCutoffNotMet
                 Date = model.Date,
                 DownloadId = model.DownloadId,
 
@@ -59,8 +59,8 @@ namespace Sonarr.Api.V3.History
 
                 Data = model.Data
 
-                //Episode
-                //Series
+                // Episode
+                // Series
             };
         }
     }

--- a/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
@@ -92,7 +92,7 @@ namespace Sonarr.Api.V3.Indexers
                 Guid = releaseInfo.Guid,
                 Quality = parsedEpisodeInfo.Quality,
 
-                //QualityWeight
+                // QualityWeight
                 Age = releaseInfo.Age,
                 AgeHours = releaseInfo.AgeHours,
                 AgeMinutes = releaseInfo.AgeMinutes,
@@ -125,7 +125,7 @@ namespace Sonarr.Api.V3.Indexers
                 EpisodeRequested = remoteEpisode.EpisodeRequested,
                 DownloadAllowed = remoteEpisode.DownloadAllowed,
 
-                //ReleaseWeight
+                // ReleaseWeight
                 CustomFormatScore = remoteEpisode.CustomFormatScore,
                 CustomFormats = remoteEpisode.CustomFormats?.ToResource(),
                 SceneMapping = remoteEpisode.SceneMapping.ToResource(),

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -55,7 +55,7 @@ namespace Sonarr.Api.V3.ManualImport
                 Quality = model.Quality,
                 Languages = model.Languages,
 
-                //QualityWeight
+                // QualityWeight
                 DownloadId = model.DownloadId,
                 Rejections = model.Rejections
             };

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -44,7 +44,7 @@ namespace Sonarr.Api.V3.Qualities
         [HttpPut("update")]
         public object UpdateMany([FromBody] List<QualityDefinitionResource> resource)
         {
-            //Read from request
+            // Read from request
             var qualityDefinitions = resource
                                                  .ToModel()
                                                  .ToList();

--- a/src/Sonarr.Api.V3/RootFolders/RootFolderResource.cs
+++ b/src/Sonarr.Api.V3/RootFolders/RootFolderResource.cs
@@ -48,9 +48,9 @@ namespace Sonarr.Api.V3.RootFolders
 
                 Path = resource.Path
 
-                //Accessible
-                //FreeSpace
-                //UnmappedFolders
+                // Accessible
+                // FreeSpace
+                // UnmappedFolders
             };
         }
 

--- a/src/Sonarr.Api.V3/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesResource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Tv;
 using Sonarr.Http.REST;
@@ -30,7 +31,7 @@ namespace Sonarr.Api.V3.Series
         public string Network { get; set; }
         public string AirTime { get; set; }
         public List<MediaCover> Images { get; set; }
-
+        public Language OriginalLanguage { get; set; }
         public string RemotePoster { get; set; }
         public List<SeasonResource> Seasons { get; set; }
         public int Year { get; set; }
@@ -100,6 +101,7 @@ namespace Sonarr.Api.V3.Series
 
                        Seasons = model.Seasons.ToResource(includeSeasonImages),
                        Year = model.Year,
+                       OriginalLanguage = model.OriginalLanguage,
 
                        Path = model.Path,
                        QualityProfileId = model.QualityProfileId,
@@ -161,6 +163,7 @@ namespace Sonarr.Api.V3.Series
 
                        Seasons = resource.Seasons?.ToModel() ?? new List<Season>(),
                        Year = resource.Year,
+                       OriginalLanguage = resource.OriginalLanguage,
 
                        Path = resource.Path,
                        QualityProfileId = resource.QualityProfileId,

--- a/src/Sonarr.Api.V3/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesResource.cs
@@ -10,11 +10,11 @@ namespace Sonarr.Api.V3.Series
 {
     public class SeriesResource : RestResource
     {
-        //Todo: Sorters should be done completely on the client
-        //Todo: Is there an easy way to keep IgnoreArticlesWhenSorting in sync between, Series, History, Missing?
-        //Todo: We should get the entire QualityProfile instead of ID and Name separately
+        // Todo: Sorters should be done completely on the client
+        // Todo: Is there an easy way to keep IgnoreArticlesWhenSorting in sync between, Series, History, Missing?
+        // Todo: We should get the entire QualityProfile instead of ID and Name separately
 
-        //View Only
+        // View Only
         public string Title { get; set; }
         public List<AlternateTitleResource> AlternateTitles { get; set; }
         public string SortTitle { get; set; }
@@ -36,11 +36,11 @@ namespace Sonarr.Api.V3.Series
         public List<SeasonResource> Seasons { get; set; }
         public int Year { get; set; }
 
-        //View & Edit
+        // View & Edit
         public string Path { get; set; }
         public int QualityProfileId { get; set; }
 
-        //Editing Only
+        // Editing Only
         public bool SeasonFolder { get; set; }
         public bool Monitored { get; set; }
 
@@ -83,18 +83,18 @@ namespace Sonarr.Api.V3.Series
 
                        Title = model.Title,
 
-                       //AlternateTitles
+                       // AlternateTitles
                        SortTitle = model.SortTitle,
 
-                       //TotalEpisodeCount
-                       //EpisodeCount
-                       //EpisodeFileCount
-                       //SizeOnDisk
+                       // TotalEpisodeCount
+                       // EpisodeCount
+                       // EpisodeFileCount
+                       // SizeOnDisk
                        Status = model.Status,
                        Overview = model.Overview,
 
-                       //NextAiring
-                       //PreviousAiring
+                       // NextAiring
+                       // PreviousAiring
                        Network = model.Network,
                        AirTime = model.AirTime,
                        Images = model.Images,
@@ -145,18 +145,18 @@ namespace Sonarr.Api.V3.Series
 
                        Title = resource.Title,
 
-                       //AlternateTitles
+                       // AlternateTitles
                        SortTitle = resource.SortTitle,
 
-                       //TotalEpisodeCount
-                       //EpisodeCount
-                       //EpisodeFileCount
-                       //SizeOnDisk
+                       // TotalEpisodeCount
+                       // EpisodeCount
+                       // EpisodeFileCount
+                       // SizeOnDisk
                        Status = resource.Status,
                        Overview = resource.Overview,
 
-                       //NextAiring
-                       //PreviousAiring
+                       // NextAiring
+                       // PreviousAiring
                        Network = resource.Network,
                        AirTime = resource.AirTime,
                        Images = resource.Images,

--- a/src/Sonarr.Api.V3/Update/UpdateResource.cs
+++ b/src/Sonarr.Api.V3/Update/UpdateResource.cs
@@ -40,9 +40,9 @@ namespace Sonarr.Api.V3.Update
                 FileName = model.FileName,
                 Url = model.Url,
 
-                //Installed
-                //Installable
-                //Latest
+                // Installed
+                // Installable
+                // Latest
                 Changes = model.Changes,
                 Hash = model.Hash,
             };

--- a/src/Sonarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Sonarr.Http/Extensions/RequestExtensions.cs
@@ -15,7 +15,7 @@ namespace Sonarr.Http.Extensions
         // See src/Readarr.Api.V1/Queue/QueueModule.cs
         private static readonly HashSet<string> VALID_SORT_KEYS = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "series.sortname", //Workaround authors table properties not being added on isValidSortKey call
+            "series.sortname", // Workaround authors table properties not being added on isValidSortKey call
             "timeleft",
             "estimatedCompletionTime",
             "protocol",


### PR DESCRIPTION
#### Database Migration
YES (176 - add original language to Series)

#### Description
Store Original Language in DB for Series. 
Use Original Language for parsing fallback.
Add Original Language to Index Table as Column option
Add Original Language to Index as Sort and Filter option
Allow Original Language usage in Custom Formats

#### Todos
- [ ] Tests
