### PR TITLE
Fixed: Cleanse Discord Webhook URLs

### DIFF
--- a/src/NzbDrone.Common.Test/InstrumentationTests/CleanseLogMessageFixture.cs
+++ b/src/NzbDrone.Common.Test/InstrumentationTests/CleanseLogMessageFixture.cs
@@ -75,6 +75,10 @@ namespace NzbDrone.Common.Test.InstrumentationTests
         // Webhooks - Notifiarr
         [TestCase(@"https://xxx.yyy/api/v1/notification/sonarr/9pr04sg6-0123-3210-imav-eql2tyu8xyui")]
 
+        // Discord
+        [TestCase(@"https://discord.com/api/webhooks/mySecret")]
+        [TestCase(@"https://discord.com/api/webhooks/mySecret/01233210")]
+
         public void should_clean_message(string message)
         {
             var cleansedMessage = CleanseLogMessage.Cleanse(message);

--- a/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
@@ -50,7 +50,10 @@ namespace NzbDrone.Common.Instrumentation
 
                 // Webhooks
                 // Notifiarr
-                new Regex(@"api/v[0-9]/notification/sonarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+                new Regex(@"api/v[0-9]/notification/sonarr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+
+                // Discord
+                new Regex(@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase)
             };
 
         private static readonly Regex CleanseRemoteIPRegex = new Regex(@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This removes webhook ID and token from logging when using discord webhooks.

#### Todos
- [ X ] Tests


#### Issues Fixed or Closed by this PR

* #5169
