### PR TITLE
Added Discord webhook support for manual interactions.

### DIFF
--- a/frontend/src/Settings/Notifications/Notifications/Notification.js
+++ b/frontend/src/Settings/Notifications/Notifications/Notification.js
@@ -63,6 +63,7 @@ class Notification extends Component {
       onEpisodeFileDeleteForUpgrade,
       onHealthIssue,
       onApplicationUpdate,
+      onManualInteraction,
       supportsOnGrab,
       supportsOnDownload,
       supportsOnUpgrade,
@@ -71,7 +72,8 @@ class Notification extends Component {
       supportsOnEpisodeFileDelete,
       supportsOnEpisodeFileDeleteForUpgrade,
       supportsOnHealthIssue,
-      supportsOnApplicationUpdate
+      supportsOnApplicationUpdate,
+      supportsOnManualInteraction
     } = this.props;
 
     return (
@@ -133,6 +135,14 @@ class Notification extends Component {
         }
 
         {
+          supportsOnManualInteraction && onManualInteraction ?
+            <Label kind={kinds.SUCCESS}>
+              On Manual Interaction
+            </Label> :
+            null
+        }
+
+        {
           supportsOnSeriesDelete && onSeriesDelete ?
             <Label kind={kinds.SUCCESS}>
               On Series Delete
@@ -157,7 +167,7 @@ class Notification extends Component {
         }
 
         {
-          !onGrab && !onDownload && !onRename && !onHealthIssue && !onApplicationUpdate && !onSeriesDelete && !onEpisodeFileDelete ?
+          !onGrab && !onDownload && !onRename && !onHealthIssue && !onApplicationUpdate && !onManualInteraction && !onSeriesDelete && !onEpisodeFileDelete ?
             <Label
               kind={kinds.DISABLED}
               outline={true}
@@ -200,6 +210,7 @@ Notification.propTypes = {
   onEpisodeFileDeleteForUpgrade: PropTypes.bool.isRequired,
   onHealthIssue: PropTypes.bool.isRequired,
   onApplicationUpdate: PropTypes.bool.isRequired,
+  onManualInteraction: PropTypes.bool.isRequired,
   supportsOnGrab: PropTypes.bool.isRequired,
   supportsOnDownload: PropTypes.bool.isRequired,
   supportsOnSeriesDelete: PropTypes.bool.isRequired,
@@ -209,6 +220,7 @@ Notification.propTypes = {
   supportsOnRename: PropTypes.bool.isRequired,
   supportsOnHealthIssue: PropTypes.bool.isRequired,
   supportsOnApplicationUpdate: PropTypes.bool.isRequired,
+  supportsOnManualInteraction: PropTypes.bool.isRequired,
   onConfirmDeleteNotification: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.js
+++ b/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.js
@@ -23,6 +23,7 @@ function NotificationEventItems(props) {
     onEpisodeFileDeleteForUpgrade,
     onHealthIssue,
     onApplicationUpdate,
+    onManualInteraction,
     supportsOnGrab,
     supportsOnDownload,
     supportsOnUpgrade,
@@ -31,6 +32,7 @@ function NotificationEventItems(props) {
     supportsOnEpisodeFileDelete,
     supportsOnEpisodeFileDeleteForUpgrade,
     supportsOnApplicationUpdate,
+    supportsOnManualInteraction,
     supportsOnHealthIssue,
     includeHealthWarnings
   } = item;
@@ -159,6 +161,17 @@ function NotificationEventItems(props) {
               helpText="On Application Update"
               isDisabled={!supportsOnApplicationUpdate.value}
               {...onApplicationUpdate}
+              onChange={onInputChange}
+            />
+          </div>
+
+          <div>
+            <FormInputGroup
+              type={inputTypes.CHECK}
+              name="onManualInteraction"
+              helpText="On Manual Interaction"
+              isDisabled={!supportsOnManualInteraction.value}
+              {...onManualInteraction}
               onChange={onInputChange}
             />
           </div>

--- a/frontend/src/Store/Actions/Settings/notifications.js
+++ b/frontend/src/Store/Actions/Settings/notifications.js
@@ -110,6 +110,7 @@ export default {
         selectedSchema.onEpisodeFileDelete = selectedSchema.supportsOnEpisodeFileDelete;
         selectedSchema.onEpisodeFileDeleteForUpgrade = selectedSchema.supportsOnEpisodeFileDeleteForUpgrade;
         selectedSchema.onApplicationUpdate = selectedSchema.supportsOnApplicationUpdate;
+        selectedSchema.onManualInteraction = selectedSchema.supportsOnManualInteraction;
 
         return selectedSchema;
       });

--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using FluentValidation.Results;
@@ -83,6 +83,11 @@ namespace NzbDrone.Core.Test.NotificationTests
             {
                 TestLogger.Info("OnApplicationUpdate was called");
             }
+
+            public override void OnManualInteraction(ManualInteractionMessage manualInteractionMessage)
+            {
+                TestLogger.Info("OnManualInteraction was called");
+            }
         }
 
         private class TestNotificationWithNoEvents : NotificationBase<TestSetting>
@@ -122,6 +127,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnEpisodeFileDeleteForUpgrade.Should().BeTrue();
             notification.SupportsOnHealthIssue.Should().BeTrue();
             notification.SupportsOnApplicationUpdate.Should().BeTrue();
+            notification.SupportsOnManualInteraction.Should().BeTrue();
         }
 
         [Test]
@@ -138,6 +144,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnEpisodeFileDeleteForUpgrade.Should().BeFalse();
             notification.SupportsOnHealthIssue.Should().BeFalse();
             notification.SupportsOnApplicationUpdate.Should().BeFalse();
+            notification.SupportsOnManualInteraction.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/176_add_on_manual_interaction_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/176_add_on_manual_interaction_to_notifications.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(176)]
+    public class add_on_manual_interaction_to_notifications : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Notifications").AddColumn("OnManualInteraction").AsBoolean().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/177_add_on_manual_interaction_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/177_add_on_manual_interaction_to_notifications.cs
@@ -3,7 +3,7 @@ using NzbDrone.Core.Datastore.Migration.Framework;
 
 namespace NzbDrone.Core.Datastore.Migration
 {
-    [Migration(176)]
+    [Migration(177)]
     public class add_on_manual_interaction_to_notifications : NzbDroneMigrationBase
     {
         protected override void MainDbUpgrade()

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -90,7 +90,8 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(i => i.SupportsOnEpisodeFileDelete)
                   .Ignore(i => i.SupportsOnEpisodeFileDeleteForUpgrade)
                   .Ignore(i => i.SupportsOnHealthIssue)
-                  .Ignore(i => i.SupportsOnApplicationUpdate);
+                  .Ignore(i => i.SupportsOnApplicationUpdate)
+                  .Ignore(i => i.SupportsOnManualInteraction);
 
             Mapper.Entity<MetadataDefinition>("Metadata").RegisterModel()
                   .Ignore(x => x.ImplementationName)

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -12,6 +12,7 @@ using NzbDrone.Core.History;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Notifications;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
@@ -58,7 +59,7 @@ namespace NzbDrone.Core.Download
         public void Check(TrackedDownload trackedDownload)
         {
             if (trackedDownload.DownloadItem.Status != DownloadItemStatus.Completed
-                || trackedDownload.State == TrackedDownloadState.ImportPendingNotified)
+                || trackedDownload.IsManualInteractionNotified)
             {
                 return;
             }
@@ -104,7 +105,7 @@ namespace NzbDrone.Core.Download
                 if (seriesMatchType == SeriesMatchType.Id)
                 {
                     trackedDownload.Warn("Found matching series via grab history, but release was matched to series by ID. Automatic import is not possible.");
-                    trackedDownload.State = TrackedDownloadState.ImportPendingNotified;
+                    trackedDownload.IsManualInteractionNotified = true;
 
                     var manualInteractionEvent = new ManualInteractionEvent(trackedDownload);
 

--- a/src/NzbDrone.Core/Download/ManualInteractionEvent.cs
+++ b/src/NzbDrone.Core/Download/ManualInteractionEvent.cs
@@ -1,19 +1,22 @@
 using NzbDrone.Common.Messaging;
+using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Download
 {
-    public class EpisodeGrabbedEvent : IEvent
+    public class ManualInteractionEvent : IEvent
     {
         public RemoteEpisode Episode { get; private set; }
+        public TrackedDownload TrackedDownload { get; private set; }
         public int DownloadClientId { get; set; }
         public string DownloadClient { get; set; }
         public string DownloadClientName { get; set; }
         public string DownloadId { get; set; }
 
-        public EpisodeGrabbedEvent(RemoteEpisode episode)
+        public ManualInteractionEvent(TrackedDownload trackedDownload)
         {
-            Episode = episode;
+            TrackedDownload = trackedDownload;
+            Episode = trackedDownload.RemoteEpisode;
         }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                                              IExecute<CheckForFinishedDownloadCommand>,
                                              IHandle<EpisodeGrabbedEvent>,
                                              IHandle<EpisodeImportedEvent>,
+                                             IHandle<ManualInteractionEvent>,
                                              IHandle<DownloadsProcessedEvent>,
                                              IHandle<TrackedDownloadsRemovedEvent>
     {
@@ -164,6 +165,11 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         }
 
         public void Handle(EpisodeGrabbedEvent message)
+        {
+            _refreshDebounce.Execute();
+        }
+
+        public void Handle(ManualInteractionEvent message)
         {
             _refreshDebounce.Execute();
         }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.Download.TrackedDownloads
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     public enum TrackedDownloadState
     {
         Downloading,
+        ImportPendingNotified,
         ImportPending,
         Importing,
         Imported,

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         public DownloadProtocol Protocol { get; set; }
         public string Indexer { get; set; }
         public bool IsTrackable { get; set; }
+        public bool IsManualInteractionNotified { get; set; }
 
         public TrackedDownload()
         {
@@ -37,7 +38,6 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     public enum TrackedDownloadState
     {
         Downloading,
-        ImportPendingNotified,
         ImportPending,
         Importing,
         Imported,

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -330,6 +330,96 @@ namespace NzbDrone.Core.Notifications.Discord
             _proxy.SendPayload(payload, Settings);
         }
 
+        public override void OnManualInteraction(ManualInteractionMessage manualInteractionMessage)
+        {
+            var series = manualInteractionMessage.Series;
+            var episodes = manualInteractionMessage.Episode.Episodes;
+
+            var embed = new Embed
+            {
+                Author = new DiscordAuthor
+                {
+                    Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
+                    IconUrl = "https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/256.png"
+                },
+                Url = $"http://thetvdb.com/?tab=series&id={series.TvdbId}",
+                Description = "Manual interaction needed",
+                Title = GetTitle(series, episodes),
+                Color = (int)DiscordColors.Standard,
+                Fields = new List<DiscordField>(),
+                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            };
+
+            if (Settings.ManualInteractionFields.Contains((int)DiscordGrabFieldType.Poster))
+            {
+                embed.Thumbnail = new DiscordImage
+                {
+                    Url = series.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.Url
+                };
+            }
+
+            if (Settings.ManualInteractionFields.Contains((int)DiscordGrabFieldType.Fanart))
+            {
+                embed.Image = new DiscordImage
+                {
+                    Url = series.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Fanart)?.Url
+                };
+            }
+
+            foreach (var field in Settings.ManualInteractionFields)
+            {
+                var discordField = new DiscordField();
+
+                switch ((DiscordManualInteractionFieldType)field)
+                {
+                    case DiscordManualInteractionFieldType.Overview:
+                        var overview = episodes.First().Overview ?? "";
+                        discordField.Name = "Overview";
+                        discordField.Value = overview.Length <= 300 ? overview : overview.Substring(0, 300) + "...";
+                        break;
+                    case DiscordManualInteractionFieldType.Rating:
+                        discordField.Name = "Rating";
+                        discordField.Value = episodes.First().Ratings.Value.ToString();
+                        break;
+                    case DiscordManualInteractionFieldType.Genres:
+                        discordField.Name = "Genres";
+                        discordField.Value = series.Genres.Take(5).Join(", ");
+                        break;
+                    case DiscordManualInteractionFieldType.Quality:
+                        discordField.Name = "Quality";
+                        discordField.Inline = true;
+                        discordField.Value = manualInteractionMessage.Quality.Quality.Name;
+                        break;
+                    case DiscordManualInteractionFieldType.Group:
+                        discordField.Name = "Group";
+                        discordField.Value = manualInteractionMessage.Episode.ParsedEpisodeInfo.ReleaseGroup;
+                        break;
+                    case DiscordManualInteractionFieldType.Size:
+                        discordField.Name = "Size";
+                        discordField.Value = BytesToString(manualInteractionMessage.Episode.Release.Size);
+                        discordField.Inline = true;
+                        break;
+                    case DiscordManualInteractionFieldType.Release:
+                        discordField.Name = "Release";
+                        discordField.Value = string.Format("```{0}```", manualInteractionMessage.Episode.Release.Title);
+                        break;
+                    case DiscordManualInteractionFieldType.Links:
+                        discordField.Name = "Links";
+                        discordField.Value = GetLinksString(series);
+                        break;
+                }
+
+                if (discordField.Name.IsNotNullOrWhiteSpace() && discordField.Value.IsNotNullOrWhiteSpace())
+                {
+                    embed.Fields.Add(discordField);
+                }
+            }
+
+            var payload = CreatePayload(null, new List<Embed> { embed });
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
@@ -30,4 +30,18 @@ namespace NzbDrone.Core.Notifications.Discord
         Poster,
         Fanart
     }
+
+    public enum DiscordManualInteractionFieldType
+    {
+        Overview,
+        Rating,
+        Genres,
+        Quality,
+        Group,
+        Size,
+        Links,
+        Release,
+        Poster,
+        Fanart
+    }
 }

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Notifications.Discord
             //Set Default Fields
             GrabFields = new[] { 0, 1, 2, 3, 5, 6, 7, 8, 9 };
             ImportFields = new[] { 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12 };
+            ManualInteractionFields = new[] { 0, 1, 2, 3, 5, 6, 7, 8, 9 };
         }
 
         private static readonly DiscordSettingsValidator Validator = new DiscordSettingsValidator();
@@ -42,6 +43,9 @@ namespace NzbDrone.Core.Notifications.Discord
 
         [FieldDefinition(5, Label = "On Import Fields", Advanced = true, SelectOptions = typeof(DiscordImportFieldType), HelpText = "Change the fields that are passed for this 'on import' notification", Type = FieldType.TagSelect)]
         public IEnumerable<int> ImportFields { get; set; }
+
+        [FieldDefinition(6, Label = "On Manual Interaction Fields", Advanced = true, SelectOptions = typeof(DiscordManualInteractionFieldType), HelpText = "Change the fields that are passed for this 'on manual interaction' notification", Type = FieldType.TagSelect)]
+        public IEnumerable<int> ManualInteractionFields { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Notifications
         void OnSeriesDelete(SeriesDeleteMessage deleteMessage);
         void OnHealthIssue(HealthCheck.HealthCheck healthCheck);
         void OnApplicationUpdate(ApplicationUpdateMessage updateMessage);
+        void OnManualInteraction(ManualInteractionMessage manualInteractionMessage);
         void ProcessQueue();
         bool SupportsOnGrab { get; }
         bool SupportsOnDownload { get; }
@@ -26,5 +27,6 @@ namespace NzbDrone.Core.Notifications
         bool SupportsOnEpisodeFileDeleteForUpgrade { get; }
         bool SupportsOnHealthIssue { get; }
         bool SupportsOnApplicationUpdate { get; }
+        bool SupportsOnManualInteraction { get; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/ManualInteractionMessage.cs
+++ b/src/NzbDrone.Core/Notifications/ManualInteractionMessage.cs
@@ -1,0 +1,25 @@
+using System;
+using NzbDrone.Core.Download.TrackedDownloads;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Notifications
+{
+    public class ManualInteractionMessage
+    {
+        public string Message { get; set; }
+        public Series Series { get; set; }
+        public RemoteEpisode Episode { get; set; }
+        public TrackedDownload TrackedDownload { get; set; }
+        public QualityModel Quality { get; set; }
+        public string DownloadClientType { get; set; }
+        public string DownloadClientName { get; set; }
+        public string DownloadId { get; set; }
+
+        public override string ToString()
+        {
+            return Message;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Notifications
         protected const string SERIES_DELETED_TITLE = "Series Deleted";
         protected const string HEALTH_ISSUE_TITLE = "Health Check Failure";
         protected const string APPLICATION_UPDATE_TITLE = "Application Updated";
+        protected const string MANUAL_INTERACTION_TITLE = "Manual Interaction";
 
         protected const string EPISODE_GRABBED_TITLE_BRANDED = "Sonarr - " + EPISODE_GRABBED_TITLE;
         protected const string EPISODE_DOWNLOADED_TITLE_BRANDED = "Sonarr - " + EPISODE_DOWNLOADED_TITLE;
@@ -24,6 +25,7 @@ namespace NzbDrone.Core.Notifications
         protected const string SERIES_DELETED_TITLE_BRANDED = "Sonarr - " + SERIES_DELETED_TITLE;
         protected const string HEALTH_ISSUE_TITLE_BRANDED = "Sonarr - " + HEALTH_ISSUE_TITLE;
         protected const string APPLICATION_UPDATE_TITLE_BRANDED = "Sonarr - " + APPLICATION_UPDATE_TITLE;
+        protected const string MANUAL_INTERACTION_TITLE_BRANDED = "Sonarr - " + MANUAL_INTERACTION_TITLE;
 
         public abstract string Name { get; }
 
@@ -66,6 +68,10 @@ namespace NzbDrone.Core.Notifications
         {
         }
 
+        public virtual void OnManualInteraction(ManualInteractionMessage manualInteractionMessage)
+        {
+        }
+
         public virtual void ProcessQueue()
         {
         }
@@ -79,6 +85,7 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnEpisodeFileDeleteForUpgrade => SupportsOnEpisodeFileDelete;
         public bool SupportsOnHealthIssue => HasConcreteImplementation("OnHealthIssue");
         public bool SupportsOnApplicationUpdate => HasConcreteImplementation("OnApplicationUpdate");
+        public bool SupportsOnManualInteraction => HasConcreteImplementation("OnManualInteraction");
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 

--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Notifications
 {
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.Notifications
         public bool OnEpisodeFileDeleteForUpgrade { get; set; }
         public bool OnHealthIssue { get; set; }
         public bool OnApplicationUpdate { get; set; }
+        public bool OnManualInteraction { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
@@ -23,7 +24,8 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnHealthIssue { get; set; }
         public bool IncludeHealthWarnings { get; set; }
         public bool SupportsOnApplicationUpdate { get; set; }
+        public bool SupportsOnManualInteraction { get; set; }
 
-        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnSeriesDelete || OnEpisodeFileDelete || OnEpisodeFileDeleteForUpgrade || OnHealthIssue || OnApplicationUpdate;
+        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnSeriesDelete || OnEpisodeFileDelete || OnEpisodeFileDeleteForUpgrade || OnHealthIssue || OnApplicationUpdate || OnManualInteraction;
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Notifications
         List<INotification> OnEpisodeFileDeleteForUpgradeEnabled();
         List<INotification> OnHealthIssueEnabled();
         List<INotification> OnApplicationUpdateEnabled();
+        List<INotification> OnManualInteractionEnabled();
     }
 
     public class NotificationFactory : ProviderFactory<INotification, NotificationDefinition>, INotificationFactory
@@ -73,6 +74,11 @@ namespace NzbDrone.Core.Notifications
             return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnApplicationUpdate).ToList();
         }
 
+        public List<INotification> OnManualInteractionEnabled()
+        {
+            return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnManualInteraction).ToList();
+        }
+
         public override void SetProviderCharacteristics(INotification provider, NotificationDefinition definition)
         {
             base.SetProviderCharacteristics(provider, definition);
@@ -86,6 +92,7 @@ namespace NzbDrone.Core.Notifications
             definition.SupportsOnEpisodeFileDeleteForUpgrade = provider.SupportsOnEpisodeFileDeleteForUpgrade;
             definition.SupportsOnHealthIssue = provider.SupportsOnHealthIssue;
             definition.SupportsOnApplicationUpdate = provider.SupportsOnApplicationUpdate;
+            definition.SupportsOnManualInteraction = provider.SupportsOnManualInteraction;
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -131,6 +131,25 @@ namespace NzbDrone.Core.Notifications.Webhook
             _proxy.SendWebhook(payload, Settings);
         }
 
+        public override void OnManualInteraction(ManualInteractionMessage manualInteractionMessage)
+        {
+            var remoteEpisode = manualInteractionMessage.Episode;
+            var quality = manualInteractionMessage.Quality;
+
+            var payload = new WebhookManualInteractionPayload
+            {
+                EventType = WebhookEventType.Grab,
+                Series = new WebhookSeries(manualInteractionMessage.Series),
+                Episodes = remoteEpisode.Episodes.ConvertAll(x => new WebhookEpisode(x)),
+                Release = new WebhookRelease(quality, remoteEpisode),
+                DownloadClient = manualInteractionMessage.DownloadClientName,
+                DownloadClientType = manualInteractionMessage.DownloadClientType,
+                DownloadId = manualInteractionMessage.DownloadId
+            };
+
+            _proxy.SendWebhook(payload, Settings);
+        }
+
         public override string Name => "Webhook";
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookManualInteractionPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookManualInteractionPayload.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookManualInteractionPayload : WebhookPayload
+    {
+        public WebhookSeries Series { get; set; }
+        public List<WebhookEpisode> Episodes { get; set; }
+        public WebhookRelease Release { get; set; }
+        public string DownloadClient { get; set; }
+        public string DownloadClientType { get; set; }
+        public string DownloadId { get; set; }
+    }
+}

--- a/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
+++ b/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
@@ -14,6 +14,7 @@ namespace Sonarr.Api.V3.Notifications
         public bool OnEpisodeFileDeleteForUpgrade { get; set; }
         public bool OnHealthIssue { get; set; }
         public bool OnApplicationUpdate { get; set; }
+        public bool OnManualInteraction { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
@@ -23,6 +24,7 @@ namespace Sonarr.Api.V3.Notifications
         public bool SupportsOnEpisodeFileDeleteForUpgrade { get; set; }
         public bool SupportsOnHealthIssue { get; set; }
         public bool SupportsOnApplicationUpdate { get; set; }
+        public bool SupportsOnManualInteraction { get; set; }
         public bool IncludeHealthWarnings { get; set; }
         public string TestCommand { get; set; }
     }
@@ -47,6 +49,7 @@ namespace Sonarr.Api.V3.Notifications
             resource.OnEpisodeFileDeleteForUpgrade = definition.OnEpisodeFileDeleteForUpgrade;
             resource.OnHealthIssue = definition.OnHealthIssue;
             resource.OnApplicationUpdate = definition.OnApplicationUpdate;
+            resource.OnManualInteraction = definition.OnManualInteraction;
             resource.SupportsOnGrab = definition.SupportsOnGrab;
             resource.SupportsOnDownload = definition.SupportsOnDownload;
             resource.SupportsOnUpgrade = definition.SupportsOnUpgrade;
@@ -57,6 +60,7 @@ namespace Sonarr.Api.V3.Notifications
             resource.SupportsOnHealthIssue = definition.SupportsOnHealthIssue;
             resource.IncludeHealthWarnings = definition.IncludeHealthWarnings;
             resource.SupportsOnApplicationUpdate = definition.SupportsOnApplicationUpdate;
+            resource.SupportsOnManualInteraction = definition.SupportsOnManualInteraction;
 
             return resource;
         }
@@ -79,6 +83,7 @@ namespace Sonarr.Api.V3.Notifications
             definition.OnEpisodeFileDeleteForUpgrade = resource.OnEpisodeFileDeleteForUpgrade;
             definition.OnHealthIssue = resource.OnHealthIssue;
             definition.OnApplicationUpdate = resource.OnApplicationUpdate;
+            definition.OnManualInteraction = resource.OnManualInteraction;
             definition.SupportsOnGrab = resource.SupportsOnGrab;
             definition.SupportsOnDownload = resource.SupportsOnDownload;
             definition.SupportsOnUpgrade = resource.SupportsOnUpgrade;
@@ -89,6 +94,7 @@ namespace Sonarr.Api.V3.Notifications
             definition.SupportsOnHealthIssue = resource.SupportsOnHealthIssue;
             definition.IncludeHealthWarnings = resource.IncludeHealthWarnings;
             definition.SupportsOnApplicationUpdate = resource.SupportsOnApplicationUpdate;
+            definition.SupportsOnManualInteraction = resource.SupportsOnManualInteraction;
 
             return definition;
         }


### PR DESCRIPTION
#### Database Migration
YES - 177

#### Description
Adds [Discord] webhook support for manual interactions. (e.g.: an episode is downloaded and needs manual import).

**➡️ Updated frontend to include "On Manual Interaction".**

![afbeelding](https://user-images.githubusercontent.com/15276515/196231580-edbfe30d-cc6c-48ad-bacc-549834328449.png)

**➡️ Added Database migration file `#176`.**

**➡️ Added `ImportPendingNotified` TrackedDownloadState.**

**➡️ Added customizable `ManualInteractionFields` Discord settings, similar to the already present `GrabFields` & `ImportFields` (visible when using advanced mode).**

![afbeelding](https://user-images.githubusercontent.com/15276515/196232399-4f1018f6-7be8-47b7-a0df-1ad742987aba.png)

#### Todos
- [ ] Tests
- [ ] Wiki Updates [Corresponding wiki page here](https://wiki.servarr.com/sonarr/settings#connections)

#### Issues Fixed or Closed by this PR
* None that I can think of.
