### PR TITLE
New: Base API info endpoint

### DIFF
--- a/src/Sonarr.Http/ApiInfoController.cs
+++ b/src/Sonarr.Http/ApiInfoController.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NzbDrone.Http
+{
+    public class ApiInfoController : Controller
+    {
+        public ApiInfoController()
+        {
+        }
+
+        [HttpGet("/api")]
+        [Produces("application/json")]
+        public object GetApiInfo()
+        {
+            return new ApiInfoResource
+            {
+                Current = "v3",
+                Deprecated = new List<string>()
+            };
+        }
+    }
+}

--- a/src/Sonarr.Http/ApiInfoResource.cs
+++ b/src/Sonarr.Http/ApiInfoResource.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NzbDrone.Http
+{
+    public class ApiInfoResource
+    {
+        public string Current { get; set; }
+        public List<string> Deprecated { get; set; }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds authorized generic non-versioned endpoint for third party tools to grab latest API root and see API version status of all versions. 

**Endpoint**
```
192.168.1.1:8989/api
```

**Response**
```
{
  "latest": "/api/v3",
  "v2": "removed",
  "v3": "current"
}
```

#### Todos
- [ ] Wiki Updates
