### PR TITLE
Sentry SDK v3.23.1

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryCleanser.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryCleanser.cs
@@ -11,26 +11,41 @@ namespace NzbDrone.Common.Instrumentation.Sentry
         {
             try
             {
-                sentryEvent.Message = CleanseLogMessage.Cleanse(sentryEvent.Message);
+                if (sentryEvent.Message is not null)
+                {
+                    sentryEvent.Message.Formatted = CleanseLogMessage.Cleanse(sentryEvent.Message.Formatted);
+                    sentryEvent.Message.Message = CleanseLogMessage.Cleanse(sentryEvent.Message.Message);
+                    sentryEvent.Message.Params = sentryEvent.Message.Params?.Select(x => CleanseLogMessage.Cleanse(x switch
+                    {
+                        string str => str,
+                        _ => x.ToString()
+                    })).ToList();
+                }
 
-                if (sentryEvent.Fingerprint != null)
+                if (sentryEvent.Fingerprint.Any())
                 {
                     var fingerprint = sentryEvent.Fingerprint.Select(x => CleanseLogMessage.Cleanse(x)).ToList();
                     sentryEvent.SetFingerprint(fingerprint);
                 }
 
-                if (sentryEvent.Extra != null)
+                if (sentryEvent.Extra.Any())
                 {
-                    var extras = sentryEvent.Extra.ToDictionary(x => x.Key, y => (object)CleanseLogMessage.Cleanse((string)y.Value));
+                    var extras = sentryEvent.Extra.ToDictionary(x => x.Key, y => (object)CleanseLogMessage.Cleanse(y.Value as string));
                     sentryEvent.SetExtras(extras);
                 }
 
-                foreach (var exception in sentryEvent.SentryExceptions)
+                if (sentryEvent.SentryExceptions is not null)
                 {
-                    exception.Value = CleanseLogMessage.Cleanse(exception.Value);
-                    foreach (var frame in exception.Stacktrace.Frames)
+                    foreach (var exception in sentryEvent.SentryExceptions)
                     {
-                        frame.FileName = ShortenPath(frame.FileName);
+                        exception.Value = CleanseLogMessage.Cleanse(exception.Value);
+                        if (exception.Stacktrace is not null)
+                        {
+                            foreach (var frame in exception.Stacktrace.Frames)
+                            {
+                                frame.FileName = ShortenPath(frame.FileName);
+                            }
+                        }
                     }
                 }
             }

--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -96,12 +96,9 @@ namespace NzbDrone.Common.Instrumentation.Sentry
         {
             _sdk = SentrySdk.Init(o =>
                                   {
-                                      o.Dsn = new Dsn(dsn);
+                                      o.Dsn = dsn;
                                       o.AttachStacktrace = true;
                                       o.MaxBreadcrumbs = 200;
-                                      o.SendDefaultPii = false;
-                                      o.Debug = false;
-                                      o.DiagnosticsLevel = SentryLevel.Debug;
                                       o.Release = BuildInfo.Release;
                                       o.BeforeSend = x => SentryCleanser.CleanseEvent(x);
                                       o.BeforeBreadcrumb = x => SentryCleanser.CleanseBreadcrumb(x);

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="Sentry" Version="2.1.8" />
+    <PackageReference Include="Sentry" Version="3.23.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="System.Text.Json" Version="6.0.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
#### Database Migration
No

#### Description
The current Sentry SDK used is 2 years old. Since then, a lost of improvements and fixes were made.
This PR updates the Sentry SDK to the latest with minimal refactoring changes (only removed some options that were assigning default values) and one potential bug fix (a cast).

SDK Diff:

https://github.com/getsentry/sentry-dotnet/compare/2.1.8...3.23.1

Changelog:

https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#3231

#### Todos
* Discuss follow ups: Can we add additional Sentry features such as performance monitoring, release health, attachments', etc?
* Would a PR adding [Sentry.NLog](https://www.nuget.org/packages/Sentry.NLog) be beneficial/accepted?

#### Issues Fixed or Closed by this PR

* Didn't open an issue to discuss it since it was a quick change.
