### PR TITLE
Fixed: File Size in Custom Formats

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -88,6 +88,11 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                     }
 
+                    if (report.Size > 0)
+                    {
+                        parsedEpisodeInfo.ExtraInfo.Add("Size", report.Size);
+                    }
+
                     if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
                     {
                         var remoteEpisode = _parsingService.Map(parsedEpisodeInfo, report.TvdbId, report.TvRageId, searchCriteria);

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                     }
 
-                    if (report.Size > 0)
+                    if (parsedEpisodeInfo != null && report.Size > 0)
                     {
                         parsedEpisodeInfo.ExtraInfo.Add("Size", report.Size);
                     }


### PR DESCRIPTION

#### Database Migration
NO

#### Description
Custom formats for size weren't working because size would default to 0 since the reported size wasn't being passed in 'parsedEpisodeInfo'.

#### Todos
- Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* 
