### PR TITLE
New: Rework List sync interval logic

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.css
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.css
@@ -7,3 +7,9 @@
 .labelIcon {
   margin-left: 8px;
 }
+
+.message {
+  composes: alert from '~Components/Alert.css';
+
+  margin-bottom: 30px;
+}

--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import SeriesMonitoringOptionsPopoverContent from 'AddSeries/SeriesMonitoringOptionsPopoverContent';
 import SeriesTypePopoverContent from 'AddSeries/SeriesTypePopoverContent';
+import Alert from 'Components/Alert';
 import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
@@ -17,6 +18,7 @@ import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
 import Popover from 'Components/Tooltip/Popover';
 import { icons, inputTypes, kinds, tooltipPositions } from 'Helpers/Props';
+import formatShortTimeSpan from 'Utilities/Date/formatShortTimeSpan';
 import styles from './EditImportListModalContent.css';
 
 function EditImportListModalContent(props) {
@@ -42,6 +44,7 @@ function EditImportListModalContent(props) {
     id,
     name,
     enableAutomaticAdd,
+    minRefreshInterval,
     shouldMonitor,
     rootFolderPath,
     qualityProfileId,
@@ -73,6 +76,14 @@ function EditImportListModalContent(props) {
         {
           !isFetching && !error ?
             <Form {...otherProps}>
+
+              <Alert
+                kind={kinds.INFO}
+                className={styles.message}
+              >
+                {`List will refresh every ${formatShortTimeSpan(minRefreshInterval.value)}`}
+              </Alert>
+
               <FormGroup>
                 <FormLabel>Name</FormLabel>
 

--- a/frontend/src/Settings/ImportLists/ImportLists/ImportList.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/ImportList.js
@@ -4,6 +4,7 @@ import Card from 'Components/Card';
 import Label from 'Components/Label';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
 import { kinds } from 'Helpers/Props';
+import formatShortTimeSpan from 'Utilities/Date/formatShortTimeSpan';
 import EditImportListModalConnector from './EditImportListModalConnector';
 import styles from './ImportList.css';
 
@@ -54,7 +55,8 @@ class ImportList extends Component {
     const {
       id,
       name,
-      enableAutomaticAdd
+      enableAutomaticAdd,
+      minRefreshInterval
     } = this.props;
 
     return (
@@ -75,6 +77,12 @@ class ImportList extends Component {
               </Label>
           }
 
+        </div>
+
+        <div className={styles.enabled}>
+          <Label kind={kinds.INFO} title='List Refresh Interval'>
+            {`Refresh: ${formatShortTimeSpan(minRefreshInterval)}`}
+          </Label>
         </div>
 
         <EditImportListModalConnector
@@ -102,6 +110,7 @@ ImportList.propTypes = {
   id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   enableAutomaticAdd: PropTypes.bool.isRequired,
+  minRefreshInterval: PropTypes.string.isRequired,
   onConfirmDeleteImportList: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Utilities/Date/formatShortTimeSpan.js
+++ b/frontend/src/Utilities/Date/formatShortTimeSpan.js
@@ -1,0 +1,25 @@
+import moment from 'moment';
+
+function formatShortTimeSpan(timeSpan) {
+  if (!timeSpan) {
+    return '';
+  }
+
+  const duration = moment.duration(timeSpan);
+
+  const hours = Math.floor(duration.asHours());
+  const minutes = Math.floor(duration.asMinutes());
+  const seconds = Math.floor(duration.asSeconds());
+
+  if (hours > 0) {
+    return `${hours} hour(s)`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes} minute(s)`;
+  }
+
+  return `${seconds} second(s)`;
+}
+
+export default formatShortTimeSpan;

--- a/src/NzbDrone.Core/Datastore/Migration/178_list_sync_time.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/178_list_sync_time.cs
@@ -1,0 +1,17 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Languages;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(178)]
+    public class list_sync_time : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Delete.Column("LastSyncListInfo").FromTable("ImportListStatus");
+
+            Alter.Table("ImportListStatus").AddColumn("LastInfoSync").AsDateTime().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -78,6 +78,7 @@ namespace NzbDrone.Core.Datastore
             Mapper.Entity<ImportListDefinition>("ImportLists").RegisterModel()
                   .Ignore(x => x.ImplementationName)
                   .Ignore(i => i.ListType)
+                  .Ignore(i => i.MinRefreshInterval)
                   .Ignore(i => i.Enable);
 
             Mapper.Entity<NotificationDefinition>("Notifications").RegisterModel()

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using FluentValidation.Results;
@@ -15,6 +16,8 @@ namespace NzbDrone.Core.ImportLists.Custom
     {
         private readonly ICustomImportProxy _customProxy;
         public override string Name => "Custom List";
+
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(24);
 
         public override ImportListType ListType => ImportListType.Advanced;
 

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
-
 using FluentValidation.Results;
-
 using NLog;
-
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Parser;
@@ -17,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.Custom
         private readonly ICustomImportProxy _customProxy;
         public override string Name => "Custom List";
 
-        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(24);
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(6);
 
         public override ImportListType ListType => ImportListType.Advanced;
 

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using NLog;
-using NzbDrone.Common.Extensions;
 using NzbDrone.Common.TPL;
 using NzbDrone.Core.Parser.Model;
 
@@ -18,11 +17,13 @@ namespace NzbDrone.Core.ImportLists
     public class FetchAndParseImportListService : IFetchAndParseImportList
     {
         private readonly IImportListFactory _importListFactory;
+        private readonly IImportListStatusService _importListStatusService;
         private readonly Logger _logger;
 
-        public FetchAndParseImportListService(IImportListFactory importListFactory, Logger logger)
+        public FetchAndParseImportListService(IImportListFactory importListFactory, IImportListStatusService importListStatusService, Logger logger)
         {
             _importListFactory = importListFactory;
+            _importListStatusService = importListStatusService;
             _logger = logger;
         }
 
@@ -46,6 +47,13 @@ namespace NzbDrone.Core.ImportLists
             foreach (var importList in importLists)
             {
                 var importListLocal = importList;
+                var importListStatus = _importListStatusService.GetLastSyncListInfo(importListLocal.Definition.Id);
+
+                if (DateTime.UtcNow < (importListStatus + importListLocal.MinRefreshInterval))
+                {
+                    _logger.Trace("Skipping refresh of Import List {0} due to minimum refresh inverval", importListLocal.Definition.Name);
+                    continue;
+                }
 
                 var task = taskFactory.StartNew(() =>
                      {
@@ -59,6 +67,8 @@ namespace NzbDrone.Core.ImportLists
 
                                  result.AddRange(importListReports);
                              }
+
+                             _importListStatusService.UpdateListSyncStatus(importList.Definition.Id);
                          }
                          catch (Exception e)
                          {
@@ -87,6 +97,14 @@ namespace NzbDrone.Core.ImportLists
             if (importList == null || !definition.EnableAutomaticAdd)
             {
                 _logger.Debug("Import list not enabled, skipping.");
+                return result;
+            }
+
+            var importListStatus = _importListStatusService.GetLastSyncListInfo(importList.Definition.Id);
+
+            if (DateTime.UtcNow < (importListStatus + importList.MinRefreshInterval))
+            {
+                _logger.Trace("Skipping refresh of Import List {0} due to minimum refresh inverval", importList.Definition.Name);
                 return result;
             }
 

--- a/src/NzbDrone.Core/ImportLists/IImportList.cs
+++ b/src/NzbDrone.Core/ImportLists/IImportList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
@@ -7,6 +8,7 @@ namespace NzbDrone.Core.ImportLists
     public interface IImportList : IProvider
     {
         ImportListType ListType { get; }
+        TimeSpan MinRefreshInterval { get; }
         IList<ImportListItemInfo> Fetch();
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Imdb/ImdbListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Imdb/ImdbListImport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.Http;
@@ -12,6 +13,7 @@ namespace NzbDrone.Core.ImportLists.Imdb
         public override string Name => "IMDb Lists";
 
         public override ImportListType ListType => ImportListType.Other;
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
 
         public ImdbListImport(IHttpClient httpClient,
                               IImportListStatusService importListStatusService,

--- a/src/NzbDrone.Core/ImportLists/ImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListBase.cs
@@ -5,6 +5,7 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
@@ -22,6 +23,8 @@ namespace NzbDrone.Core.ImportLists
         public abstract string Name { get; }
 
         public abstract ImportListType ListType { get; }
+
+        public abstract TimeSpan MinRefreshInterval { get; }
 
         public ImportListBase(IImportListStatusService importListStatusService, IConfigService configService, IParsingService parsingService, Logger logger)
         {

--- a/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
 
@@ -16,5 +17,6 @@ namespace NzbDrone.Core.ImportLists
 
         public ImportListStatus Status { get; set; }
         public ImportListType ListType { get; set; }
+        public TimeSpan MinRefreshInterval { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.ImportLists
             base.SetProviderCharacteristics(provider, definition);
 
             definition.ListType = provider.ListType;
+            definition.MinRefreshInterval = provider.MinRefreshInterval;
         }
 
         public List<IImportList> AutomaticAddEnabled(bool filterBlockedImportLists = true)

--- a/src/NzbDrone.Core/ImportLists/ImportListStatus.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListStatus.cs
@@ -1,3 +1,4 @@
+using System;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider.Status;
 
@@ -5,6 +6,6 @@ namespace NzbDrone.Core.ImportLists
 {
     public class ImportListStatus : ProviderStatusBase
     {
-        public ImportListItemInfo LastSyncListInfo { get; set; }
+        public DateTime LastInfoSync { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListStatusService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListStatusService.cs
@@ -1,16 +1,16 @@
+using System;
 using NLog;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Core.Messaging.Events;
-using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider.Status;
 
 namespace NzbDrone.Core.ImportLists
 {
     public interface IImportListStatusService : IProviderStatusServiceBase<ImportListStatus>
     {
-        ImportListItemInfo GetLastSyncListInfo(int importListId);
+        DateTime GetLastSyncListInfo(int importListId);
 
-        void UpdateListSyncStatus(int importListId, ImportListItemInfo listItemInfo);
+        void UpdateListSyncStatus(int importListId);
     }
 
     public class ImportListStatusService : ProviderStatusServiceBase<IImportList, ImportListStatus>, IImportListStatusService
@@ -20,18 +20,18 @@ namespace NzbDrone.Core.ImportLists
         {
         }
 
-        public ImportListItemInfo GetLastSyncListInfo(int importListId)
+        public DateTime GetLastSyncListInfo(int importListId)
         {
-            return GetProviderStatus(importListId).LastSyncListInfo;
+            return GetProviderStatus(importListId).LastInfoSync;
         }
 
-        public void UpdateListSyncStatus(int importListId, ImportListItemInfo listItemInfo)
+        public void UpdateListSyncStatus(int importListId)
         {
             lock (_syncRoot)
             {
                 var status = GetProviderStatus(importListId);
 
-                status.LastSyncListInfo = listItemInfo;
+                status.LastInfoSync = DateTime.UtcNow;
 
                 _providerStatusRepository.Upsert(status);
             }

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -17,6 +17,8 @@ namespace NzbDrone.Core.ImportLists.Plex
         public readonly IPlexTvService _plexTvService;
         public override ImportListType ListType => ImportListType.Plex;
 
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(6);
+
         public PlexImport(IPlexTvService plexTvService,
                                   IHttpClient httpClient,
                                   IImportListStatusService importListStatusService,

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -15,8 +15,8 @@ namespace NzbDrone.Core.ImportLists.Plex
     public class PlexImport : HttpImportListBase<PlexListSettings>
     {
         public readonly IPlexTvService _plexTvService;
-        public override ImportListType ListType => ImportListType.Plex;
 
+        public override ImportListType ListType => ImportListType.Plex;
         public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(6);
 
         public PlexImport(IPlexTvService plexTvService,

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -16,6 +16,8 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         private readonly ISonarrV3Proxy _sonarrV3Proxy;
         public override string Name => "Sonarr";
 
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(5);
+
         public override ImportListType ListType => ImportListType.Program;
 
         public SonarrImport(ISonarrV3Proxy sonarrV3Proxy,

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -16,9 +16,8 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         private readonly ISonarrV3Proxy _sonarrV3Proxy;
         public override string Name => "Sonarr";
 
-        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(5);
-
         public override ImportListType ListType => ImportListType.Program;
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(5);
 
         public SonarrImport(ISonarrV3Proxy sonarrV3Proxy,
                             IImportListStatusService importListStatusService,

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
@@ -15,6 +15,8 @@ namespace NzbDrone.Core.ImportLists.Trakt
     {
         public override ImportListType ListType => ImportListType.Trakt;
 
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(24);
+
         public const string OAuthUrl = "https://trakt.tv/oauth/authorize";
         public const string RedirectUri = "https://auth.servarr.com/v1/trakt_sonarr/auth";
         public const string RenewUri = "https://auth.servarr.com/v1/trakt_sonarr/renew";

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
@@ -14,8 +14,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
     where TSettings : TraktSettingsBase<TSettings>, new()
     {
         public override ImportListType ListType => ImportListType.Trakt;
-
-        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(24);
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
 
         public const string OAuthUrl = "https://trakt.tv/oauth/authorize";
         public const string RedirectUri = "https://auth.servarr.com/v1/trakt_sonarr/auth";

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Jobs
 
                     new ScheduledTask
                     {
-                        Interval = 24 * 60,
+                        Interval = 5,
                         TypeName = typeof(ImportListSyncCommand).FullName
                     },
 

--- a/src/Sonarr.Api.V3/ImportLists/ImportListResource.cs
+++ b/src/Sonarr.Api.V3/ImportLists/ImportListResource.cs
@@ -1,3 +1,4 @@
+using System;
 using NzbDrone.Core.ImportLists;
 using NzbDrone.Core.Tv;
 
@@ -13,6 +14,7 @@ namespace Sonarr.Api.V3.ImportLists
         public bool SeasonFolder { get; set; }
         public ImportListType ListType { get; set; }
         public int ListOrder { get; set; }
+        public TimeSpan MinRefreshInterval { get; set; }
     }
 
     public class ImportListResourceMapper : ProviderResourceMapper<ImportListResource, ImportListDefinition>
@@ -34,6 +36,7 @@ namespace Sonarr.Api.V3.ImportLists
             resource.SeasonFolder = definition.SeasonFolder;
             resource.ListType = definition.ListType;
             resource.ListOrder = (int)definition.ListType;
+            resource.MinRefreshInterval = definition.MinRefreshInterval;
 
             return resource;
         }
@@ -54,6 +57,7 @@ namespace Sonarr.Api.V3.ImportLists
             definition.SeriesType = resource.SeriesType;
             definition.SeasonFolder = resource.SeasonFolder;
             definition.ListType = resource.ListType;
+            definition.MinRefreshInterval = resource.MinRefreshInterval;
 
             return definition;
         }


### PR DESCRIPTION
#### Database Migration
YES `(178 - Add LastSync Column to List Status Table)`

#### Description
This makes a few changes to move list sync interval from global to by list implementation, allowing ListTypes which are user controlled (Sonarr Instances) to be minimal, while lists like Trakt and Plex remain more conservative. 

Currently Min Intervals by type are setup like so:
```
Sonarr - 5 mins
Plex - 6 hours (we can adjust this based on teams thoughts)
Trakt - 12 hours
IMDb - 12 hours
Custom - 6 hours
```

I choose not to make list interval user adjustable, but that's an easy add if we think that's useful in addition (this comes down to if we think users want something greater than the min intervals)

#### Todos
- [ ] Tests
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

* Fixes #5011
