### PR TITLE
Imdb lists

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -1,6 +1,7 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.MetadataSource.SkyHook;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
@@ -38,6 +39,30 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
             result.Should().NotBeEmpty();
 
             result[0].Title.Should().Be(expected);
+
+            ExceptionVerification.IgnoreWarns();
+        }
+
+        [TestCase("tt0496424", "30 Rock")]
+        public void should_search_by_imdb(string title, string expected)
+        {
+            var result = Subject.SearchForNewSeriesByImdbId(title);
+
+            result.Should().NotBeEmpty();
+
+            result[0].Title.Should().Be(expected);
+
+            ExceptionVerification.IgnoreWarns();
+        }
+
+        [TestCase("4565se")]
+        public void should_not_search_by_imdb_if_invalid(string title)
+        {
+            var result = Subject.SearchForNewSeriesByImdbId(title);
+            result.Should().BeEmpty();
+
+            Mocker.GetMock<ISearchForNewSeries>()
+                  .Verify(v => v.SearchForNewSeries(It.IsAny<string>()), Times.Never());
 
             ExceptionVerification.IgnoreWarns();
         }

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.ImportLists
 
             Task.WaitAll(taskList.ToArray());
 
-            result = result.DistinctBy(r => new { r.TvdbId, r.Title }).ToList();
+            result = result.DistinctBy(r => new { r.TvdbId, r.ImdbId, r.Title }).ToList();
 
             _logger.Debug("Found {0} reports", result.Count);
 
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.ImportLists
 
             Task.WaitAll(taskList.ToArray());
 
-            result = result.DistinctBy(r => new { r.TvdbId, r.Title }).ToList();
+            result = result.DistinctBy(r => new { r.TvdbId, r.ImdbId, r.Title }).ToList();
 
             return result;
         }

--- a/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
@@ -165,9 +165,9 @@ namespace NzbDrone.Core.ImportLists
             return CleanupListItems(releases);
         }
 
-        protected virtual bool IsValidItem(ImportListItemInfo release)
+        protected virtual bool IsValidItem(ImportListItemInfo listItem)
         {
-            if (release.Title.IsNullOrWhiteSpace())
+            if (listItem.Title.IsNullOrWhiteSpace() && listItem.ImdbId.IsNullOrWhiteSpace() && listItem.TmdbId == 0)
             {
                 return false;
             }

--- a/src/NzbDrone.Core/ImportLists/Imdb/ImdbListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Imdb/ImdbListImport.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using NLog;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.ImportLists.Imdb
+{
+    public class ImdbListImport : HttpImportListBase<ImdbListSettings>
+    {
+        public override string Name => "IMDb Lists";
+
+        public override ImportListType ListType => ImportListType.Other;
+
+        public ImdbListImport(IHttpClient httpClient,
+                              IImportListStatusService importListStatusService,
+                              IConfigService configService,
+                              IParsingService parsingService,
+                              Logger logger)
+        : base(httpClient, importListStatusService, configService, parsingService, logger)
+        {
+        }
+
+        public override IEnumerable<ProviderDefinition> DefaultDefinitions
+        {
+            get
+            {
+                foreach (var def in base.DefaultDefinitions)
+                {
+                    yield return def;
+                }
+            }
+        }
+
+        public override IImportListRequestGenerator GetRequestGenerator()
+        {
+            return new ImdbListRequestGenerator()
+            {
+                Settings = Settings
+            };
+        }
+
+        public override IParseImportListResponse GetParser()
+        {
+            return new ImdbListParser();
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Imdb/ImdbListParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Imdb/ImdbListParser.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.ImportLists.Exceptions;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.Imdb
+{
+    public class ImdbListParser : IParseImportListResponse
+    {
+        public IList<ImportListItemInfo> ParseResponse(ImportListResponse importListResponse)
+        {
+            var importResponse = importListResponse;
+
+            var series = new List<ImportListItemInfo>();
+
+            if (!PreProcess(importResponse))
+            {
+                return series;
+            }
+
+            // Parse TSV response from IMDB export
+            var rows = importResponse.Content.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            series = rows.Skip(1).SelectList(m => m.Split(',')).Where(m => m.Length > 1).SelectList(i => new ImportListItemInfo { ImdbId = i[1] });
+
+            return series;
+        }
+
+        protected virtual bool PreProcess(ImportListResponse listResponse)
+        {
+            if (listResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
+            {
+                throw new ImportListException(listResponse,
+                    "Imdb call resulted in an unexpected StatusCode [{0}]",
+                    listResponse.HttpResponse.StatusCode);
+            }
+
+            if (listResponse.HttpResponse.Headers.ContentType != null &&
+                listResponse.HttpResponse.Headers.ContentType.Contains("text/json") &&
+                listResponse.HttpRequest.Headers.Accept != null &&
+                !listResponse.HttpRequest.Headers.Accept.Contains("text/json"))
+            {
+                throw new ImportListException(listResponse,
+                    "Imdb responded with html content. Site is likely blocked or unavailable.");
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Imdb/ImdbListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Imdb/ImdbListRequestGenerator.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.ImportLists.Imdb
+{
+    public class ImdbListRequestGenerator : IImportListRequestGenerator
+    {
+        public ImdbListSettings Settings { get; set; }
+
+        public virtual ImportListPageableRequestChain GetListItems()
+        {
+            var pageableRequests = new ImportListPageableRequestChain();
+            var httpRequest = new HttpRequest($"https://www.imdb.com/list/{Settings.ListId}/export", new HttpAccept("*/*"));
+            var request = new ImportListRequest(httpRequest.Url.ToString(), new HttpAccept(httpRequest.Headers.Accept));
+
+            request.HttpRequest.SuppressHttpError = true;
+
+            pageableRequests.Add(new List<ImportListRequest> { request });
+
+            return pageableRequests;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Imdb/ImdbListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Imdb/ImdbListSettings.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.Imdb
+{
+    public class ImdbSettingsValidator : AbstractValidator<ImdbListSettings>
+    {
+        public ImdbSettingsValidator()
+        {
+            RuleFor(c => c.ListId)
+                .Matches(@"^ls\d+$")
+                .WithMessage("List ID mist be an IMDb List ID of the form 'ls12345678'");
+        }
+    }
+
+    public class ImdbListSettings : IImportListSettings
+    {
+        private static readonly ImdbSettingsValidator Validator = new ImdbSettingsValidator();
+
+        public ImdbListSettings()
+        {
+        }
+
+        public string BaseUrl { get; set; }
+
+        [FieldDefinition(1, Label = "List ID", HelpText = "IMDb list ID (e.g ls12345678)")]
+        public string ListId { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexListRequestGenerator.cs
@@ -17,12 +17,12 @@ namespace NzbDrone.Core.ImportLists.Plex
         {
             var pageableRequests = new ImportListPageableRequestChain();
 
-            pageableRequests.Add(GetMoviesRequest());
+            pageableRequests.Add(GetSeriesRequest());
 
             return pageableRequests;
         }
 
-        private IEnumerable<ImportListRequest> GetMoviesRequest()
+        private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
             var request = new ImportListRequest(_plexTvService.GetWatchlist(Settings.AccessToken));
 

--- a/src/NzbDrone.Core/MetadataSource/ISearchForNewSeries.cs
+++ b/src/NzbDrone.Core/MetadataSource/ISearchForNewSeries.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MetadataSource
@@ -6,5 +6,6 @@ namespace NzbDrone.Core.MetadataSource
     public interface ISearchForNewSeries
     {
         List<Series> SearchForNewSeries(string title);
+        List<Series> SearchForNewSeriesByImdbId(string imdbId);
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -69,6 +69,20 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return new Tuple<Series, List<Episode>>(series, episodes.ToList());
         }
 
+        public List<Series> SearchForNewSeriesByImdbId(string imdbId)
+        {
+            imdbId = Parser.Parser.NormalizeImdbId(imdbId);
+
+            if (imdbId == null)
+            {
+                return new List<Series>();
+            }
+
+            var results = SearchForNewSeries($"imdb:{imdbId}");
+
+            return results;
+        }
+
         public List<Series> SearchForNewSeries(string title)
         {
             try

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -733,6 +733,24 @@ namespace NzbDrone.Core.Parser
             return title.Trim().ToLower();
         }
 
+        public static string NormalizeImdbId(string imdbId)
+        {
+            var imdbRegex = new Regex(@"^(\d{1,10}|(tt)\d{1,10})$");
+
+            if (!imdbRegex.IsMatch(imdbId))
+            {
+                return null;
+            }
+
+            if (imdbId.Length > 2)
+            {
+                imdbId = imdbId.Replace("tt", "").PadLeft(7, '0');
+                return $"tt{imdbId}";
+            }
+
+            return null;
+        }
+
         public static string ParseReleaseGroup(string title)
         {
             title = title.Trim();

--- a/src/NzbDrone.Core/Tv/SeriesRepository.cs
+++ b/src/NzbDrone.Core/Tv/SeriesRepository.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Core.Tv
         Series FindByTvdbId(int tvdbId);
         Series FindByTvRageId(int tvRageId);
         Series FindByPath(string path);
+        List<int> AllSeriesTvdbIds();
         Dictionary<int, string> AllSeriesPaths();
     }
 
@@ -71,6 +72,14 @@ namespace NzbDrone.Core.Tv
         {
             return Query(s => s.Path == path)
                         .FirstOrDefault();
+        }
+
+        public List<int> AllSeriesTvdbIds()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<int>("SELECT TvdbId FROM Series").ToList();
+            }
         }
 
         public Dictionary<int, string> AllSeriesPaths()

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Tv
         Series FindByPath(string path);
         void DeleteSeries(int seriesId, bool deleteFiles, bool addImportListExclusion);
         List<Series> GetAllSeries();
+        List<int> AllSeriesTvdbIds();
         Dictionary<int, string> GetAllSeriesPaths();
         List<Series> AllForTag(int tagId);
         Series UpdateSeries(Series series, bool updateEpisodesToMatchSeason = true, bool publishUpdatedEvent = true);
@@ -158,6 +159,11 @@ namespace NzbDrone.Core.Tv
         public List<Series> GetAllSeries()
         {
             return _seriesRepository.All().ToList();
+        }
+
+        public List<int> AllSeriesTvdbIds()
+        {
+            return _seriesRepository.AllSeriesTvdbIds().ToList();
         }
 
         public Dictionary<int, string> GetAllSeriesPaths()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR adds IMDB LS Lists as an option for import list. As well this significantly speeds up ImportListSync due to eliminating 2 DB calls per result and instead making the 2 per batch of results. 

#### Todos
- [x] Tests
- [ ] Wiki Updates

#### Issues Fixed or Closed by this PR

This needs to go in before #5235 or be reworked after that's merged

* Fixes #276
