### PR TITLE
Fixed: Use route Id for PUT requests if not passed in body

### DIFF
--- a/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
@@ -8,6 +8,7 @@ using NzbDrone.SignalR;
 using Sonarr.Http;
 using Sonarr.Http.Extensions;
 using Sonarr.Http.REST;
+using Sonarr.Http.REST.Attributes;
 
 namespace Sonarr.Api.V3.Episodes
 {
@@ -47,9 +48,9 @@ namespace Sonarr.Api.V3.Episodes
             throw new BadRequestException("seriesId or episodeIds must be provided");
         }
 
-        [HttpPut("{id}")]
+        [RestPutById]
         [Consumes("application/json")]
-        public IActionResult SetEpisodeMonitored([FromBody] EpisodeResource resource, [FromRoute] int id)
+        public ActionResult<EpisodeResource> SetEpisodeMonitored([FromRoute] int id, [FromBody] EpisodeResource resource)
         {
             _episodeService.SetEpisodeMonitored(id, resource.Monitored);
 

--- a/src/Sonarr.Http/REST/RestController.cs
+++ b/src/Sonarr.Http/REST/RestController.cs
@@ -70,6 +70,12 @@ namespace Sonarr.Http.REST
 
                 foreach (var resource in resourceArgs)
                 {
+                    // Map route Id to body resource if not set in request
+                    if (Request.Method == "PUT" && resource.Id == 0 && context.RouteData.Values.TryGetValue("id", out var routeId))
+                    {
+                        resource.Id = Convert.ToInt32(routeId);
+                    }
+
                     ValidateResource(resource, skipValidate, skipShared);
                 }
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When accepting a PUT API request, if no Id is passed in the body then the request fails due to resource Id validation. This PR uses the Id from the route in those cases to supplement. The current code requires that an Id always be set in the body resource even though it's set in the route (slightly different behavior than v3). 

Example is episode PUT for monitor toggle with the following payload:

`http://localhost:8989\api\v3\episode\1234`

```
{
    monitored: true
}
```

#### Issues Fixed or Closed by this PR

* Fixes #5254
