### PR TITLE
New: Auto theme option to match OS theme

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -177,7 +177,7 @@ class UISettings extends Component {
                     <FormInputGroup
                       type={inputTypes.SELECT}
                       name="theme"
-                      helpText="Change Application UI Theme, Inspired by Theme.Park"
+                      helpText="Change Application UI Theme, 'Auto' Theme will use your OS Theme to set Light or Dark mode. Inspired by Theme.Park"
                       values={themeOptions}
                       onChange={onInputChange}
                       {...settings.theme}

--- a/frontend/src/Styles/Themes/index.js
+++ b/frontend/src/Styles/Themes/index.js
@@ -1,7 +1,11 @@
 import * as dark from './dark';
 import * as light from './light';
 
+const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const auto = defaultDark ? { ...dark } : { ...light };
+
 export default {
+  auto,
   light,
   dark
 };

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.Configuration
         public string LogLevel => GetValue("LogLevel", "info").ToLowerInvariant();
         public string ConsoleLogLevel => GetValue("ConsoleLogLevel", string.Empty, persist: false);
 
-        public string Theme => GetValue("Theme", "light", persist: false);
+        public string Theme => GetValue("Theme", "auto", persist: false);
         public bool LogSql => GetValueBoolean("LogSql", false, persist: false);
         public int LogRotate => GetValueInt("LogRotate", 50, persist: false);
         public bool FilterSentryEvents => GetValueBoolean("FilterSentryEvents", true, persist: false);


### PR DESCRIPTION
Update Make Auto Theme Default

Co-Authored-By: Qstick <qstick@gmail.com>

#### Database Migration
NO

#### Description
Adds support for `prefers-color-scheme` to use the OS preferred theme (light or dark) and also makes it default with the option for the user to force the theme that they want in UI Settings

#### Todos
- N/A


#### Issues Fixed or Closed by this PR

* N/A
