### PR TITLE
Fixed: Error on EpisodeFile summary modal if CF is null

### DIFF
--- a/frontend/src/Episode/Summary/EpisodeFileRow.js
+++ b/frontend/src/Episode/Summary/EpisodeFileRow.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Icon from 'Components/Icon';
-import Label from 'Components/Label';
 import IconButton from 'Components/Link/IconButton';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
 import Popover from 'Components/Tooltip/Popover';
+import EpisodeFormats from 'Episode/EpisodeFormats';
 import EpisodeLanguages from 'Episode/EpisodeLanguages';
 import EpisodeQuality from 'Episode/EpisodeQuality';
 import { icons, kinds, tooltipPositions } from 'Helpers/Props';
@@ -123,15 +123,9 @@ class EpisodeFileRow extends Component {
                   key={name}
                   className={styles.customFormats}
                 >
-                  {
-                    customFormats.map((format) => {
-                      return (
-                        <Label key={format.id}>
-                          {format.name}
-                        </Label>
-                      );
-                    })
-                  }
+                  <EpisodeFormats
+                    formats={customFormats}
+                  />
                 </TableRowCell>
               );
             }

--- a/src/Sonarr.Api.V3/Calendar/CalendarController.cs
+++ b/src/Sonarr.Api.V3/Calendar/CalendarController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
@@ -16,8 +17,9 @@ namespace Sonarr.Api.V3.Calendar
         public CalendarController(IBroadcastSignalRMessage signalR,
                             IEpisodeService episodeService,
                             ISeriesService seriesService,
-                            IUpgradableSpecification qualityUpgradableSpecification)
-            : base(episodeService, seriesService, qualityUpgradableSpecification, signalR)
+                            IUpgradableSpecification qualityUpgradableSpecification,
+                            ICustomFormatCalculationService formatCalculator)
+            : base(episodeService, seriesService, qualityUpgradableSpecification, formatCalculator, signalR)
         {
         }
 

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
@@ -58,12 +59,14 @@ namespace Sonarr.Api.V3.EpisodeFiles
             };
         }
 
-        public static EpisodeFileResource ToResource(this EpisodeFile model, NzbDrone.Core.Tv.Series series, IUpgradableSpecification upgradableSpecification)
+        public static EpisodeFileResource ToResource(this EpisodeFile model, NzbDrone.Core.Tv.Series series, IUpgradableSpecification upgradableSpecification, ICustomFormatCalculationService formatCalculationService)
         {
             if (model == null)
             {
                 return null;
             }
+
+            model.Series = series;
 
             return new EpisodeFileResource
             {
@@ -81,6 +84,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
                 QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(series.QualityProfile.Value, model.Quality),
+                CustomFormats = formatCalculationService.ParseCustomFormat(model).ToResource()
             };
         }
     }

--- a/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
@@ -18,8 +19,9 @@ namespace Sonarr.Api.V3.Episodes
         public EpisodeController(ISeriesService seriesService,
                              IEpisodeService episodeService,
                              IUpgradableSpecification upgradableSpecification,
+                             ICustomFormatCalculationService formatCalculator,
                              IBroadcastSignalRMessage signalRBroadcaster)
-            : base(episodeService, seriesService, upgradableSpecification, signalRBroadcaster)
+            : base(episodeService, seriesService, upgradableSpecification, formatCalculator, signalRBroadcaster)
         {
         }
 

--- a/src/Sonarr.Api.V3/Episodes/EpisodeControllerWithSignalR.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeControllerWithSignalR.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Download;
@@ -21,21 +22,25 @@ namespace Sonarr.Api.V3.Episodes
         protected readonly IEpisodeService _episodeService;
         protected readonly ISeriesService _seriesService;
         protected readonly IUpgradableSpecification _upgradableSpecification;
+        protected readonly ICustomFormatCalculationService _formatCalculator;
 
         protected EpisodeControllerWithSignalR(IEpisodeService episodeService,
                                            ISeriesService seriesService,
                                            IUpgradableSpecification upgradableSpecification,
+                                           ICustomFormatCalculationService formatCalculator,
                                            IBroadcastSignalRMessage signalRBroadcaster)
             : base(signalRBroadcaster)
         {
             _episodeService = episodeService;
             _seriesService = seriesService;
             _upgradableSpecification = upgradableSpecification;
+            _formatCalculator = formatCalculator;
         }
 
         protected EpisodeControllerWithSignalR(IEpisodeService episodeService,
                                            ISeriesService seriesService,
                                            IUpgradableSpecification upgradableSpecification,
+                                           ICustomFormatCalculationService formatCalculator,
                                            IBroadcastSignalRMessage signalRBroadcaster,
                                            string resource)
             : base(signalRBroadcaster)
@@ -43,6 +48,7 @@ namespace Sonarr.Api.V3.Episodes
             _episodeService = episodeService;
             _seriesService = seriesService;
             _upgradableSpecification = upgradableSpecification;
+            _formatCalculator = formatCalculator;
         }
 
         protected override EpisodeResource GetResourceById(int id)
@@ -67,7 +73,7 @@ namespace Sonarr.Api.V3.Episodes
 
                 if (includeEpisodeFile && episode.EpisodeFileId != 0)
                 {
-                    resource.EpisodeFile = episode.EpisodeFile.Value.ToResource(series, _upgradableSpecification);
+                    resource.EpisodeFile = episode.EpisodeFile.Value.ToResource(series, _upgradableSpecification, _formatCalculator);
                 }
 
                 if (includeImages)
@@ -101,7 +107,7 @@ namespace Sonarr.Api.V3.Episodes
 
                     if (includeEpisodeFile && episode.EpisodeFileId != 0)
                     {
-                        resource.EpisodeFile = episode.EpisodeFile.Value.ToResource(series, _upgradableSpecification);
+                        resource.EpisodeFile = episode.EpisodeFile.Value.ToResource(series, _upgradableSpecification, _formatCalculator);
                     }
 
                     if (includeImages)

--- a/src/Sonarr.Api.V3/Wanted/CutoffController.cs
+++ b/src/Sonarr.Api.V3/Wanted/CutoffController.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Tv;
@@ -19,8 +20,9 @@ namespace Sonarr.Api.V3.Wanted
                             IEpisodeService episodeService,
                             ISeriesService seriesService,
                             IUpgradableSpecification upgradableSpecification,
+                            ICustomFormatCalculationService formatCalculator,
                             IBroadcastSignalRMessage signalRBroadcaster)
-            : base(episodeService, seriesService, upgradableSpecification, signalRBroadcaster)
+            : base(episodeService, seriesService, upgradableSpecification, formatCalculator, signalRBroadcaster)
         {
             _episodeCutoffService = episodeCutoffService;
         }

--- a/src/Sonarr.Api.V3/Wanted/MissingController.cs
+++ b/src/Sonarr.Api.V3/Wanted/MissingController.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications;
@@ -17,8 +18,9 @@ namespace Sonarr.Api.V3.Wanted
         public MissingController(IEpisodeService episodeService,
                              ISeriesService seriesService,
                              IUpgradableSpecification upgradableSpecification,
+                             ICustomFormatCalculationService formatCalculator,
                              IBroadcastSignalRMessage signalRBroadcaster)
-            : base(episodeService, seriesService, upgradableSpecification, signalRBroadcaster)
+            : base(episodeService, seriesService, upgradableSpecification, formatCalculator, signalRBroadcaster)
         {
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This change ensures formats are always returned with episode files. Additionally, uses `EpisodeFormats` component in UI for EpisodeSummary which properly handles when formats property is null. 

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #5268
