### PR TITLE
New: Speed up mass deletes from Series Editor

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
@@ -320,7 +320,7 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                   .Setup(s => s.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), null))
                   .Returns(default(RemoteEpisode));
 
-            Subject.Handle(new SeriesDeletedEvent(remoteEpisode.Series, true, true));
+            Subject.Handle(new SeriesDeletedEvent(new List<Series> { remoteEpisode.Series }, true, true));
 
             var trackedDownloads = Subject.GetTrackedDownloads();
             trackedDownloads.Should().HaveCount(1);

--- a/src/NzbDrone.Core/Blocklisting/BlocklistRepository.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistRepository.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Blocklisting
         List<Blocklist> BlocklistedByTitle(int seriesId, string sourceTitle);
         List<Blocklist> BlocklistedByTorrentInfoHash(int seriesId, string torrentInfoHash);
         List<Blocklist> BlocklistedBySeries(int seriesId);
+        void DeleteForSeriesIds(List<int> seriesIds);
     }
 
     public class BlocklistRepository : BasicRepository<Blocklist>, IBlocklistRepository
@@ -32,6 +33,11 @@ namespace NzbDrone.Core.Blocklisting
         public List<Blocklist> BlocklistedBySeries(int seriesId)
         {
             return Query(b => b.SeriesId == seriesId);
+        }
+
+        public void DeleteForSeriesIds(List<int> seriesIds)
+        {
+            Delete(x => seriesIds.Contains(x.SeriesId));
         }
 
         protected override SqlBuilder PagedBuilder() => new SqlBuilder().Join<Blocklist, Series>((b, m) => b.SeriesId == m.Id);

--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -189,9 +189,7 @@ namespace NzbDrone.Core.Blocklisting
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            var blocklisted = _blocklistRepository.BlocklistedBySeries(message.Series.Id);
-
-            _blocklistRepository.DeleteMany(blocklisted);
+            _blocklistRepository.DeleteForSeriesIds(message.Series.Select(m => m.Id).ToList());
         }
     }
 }

--- a/src/NzbDrone.Core/Download/History/DownloadHistoryRepository.cs
+++ b/src/NzbDrone.Core/Download/History/DownloadHistoryRepository.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Download.History
     public interface IDownloadHistoryRepository : IBasicRepository<DownloadHistory>
     {
         List<DownloadHistory> FindByDownloadId(string downloadId);
-        void DeleteBySeriesId(int seriesId);
+        void DeleteBySeriesIds(List<int> seriesIds);
     }
 
     public class DownloadHistoryRepository : BasicRepository<DownloadHistory>, IDownloadHistoryRepository
@@ -23,9 +23,9 @@ namespace NzbDrone.Core.Download.History
             return Query(h => h.DownloadId == downloadId).OrderByDescending(h => h.Date).ToList();
         }
 
-        public void DeleteBySeriesId(int seriesId)
+        public void DeleteBySeriesIds(List<int> seriesIds)
         {
-            Delete(r => r.SeriesId == seriesId);
+            Delete(r => seriesIds.Contains(r.SeriesId));
         }
     }
 }

--- a/src/NzbDrone.Core/Download/History/DownloadHistoryService.cs
+++ b/src/NzbDrone.Core/Download/History/DownloadHistoryService.cs
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Download.History
 
         public void Handle(SeriesDeletedEvent message)
         {
-            _repository.DeleteBySeriesId(message.Series.Id);
+            _repository.DeleteBySeriesIds(message.Series.Select(m => m.Id).ToList());
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Core.Download.Pending
 {
     public interface IPendingReleaseRepository : IBasicRepository<PendingRelease>
     {
-        void DeleteBySeriesId(int seriesId);
+        void DeleteBySeriesIds(List<int> seriesIds);
         List<PendingRelease> AllBySeriesId(int seriesId);
         List<PendingRelease> WithoutFallback();
     }
@@ -18,9 +18,9 @@ namespace NzbDrone.Core.Download.Pending
         {
         }
 
-        public void DeleteBySeriesId(int seriesId)
+        public void DeleteBySeriesIds(List<int> seriesIds)
         {
-            Delete(r => r.SeriesId == seriesId);
+            Delete(r => seriesIds.Contains(r.SeriesId));
         }
 
         public List<PendingRelease> AllBySeriesId(int seriesId)

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -445,7 +445,7 @@ namespace NzbDrone.Core.Download.Pending
 
         public void Handle(SeriesDeletedEvent message)
         {
-            _repository.DeleteBySeriesId(message.Series.Id);
+            _repository.DeleteBySeriesIds(message.Series.Select(m => m.Id).ToList());
         }
 
         public void Handle(EpisodeGrabbedEvent message)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -252,7 +252,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         {
             var cachedItems = _cache.Values.Where(t =>
                                         t.RemoteEpisode?.Series != null &&
-                                        t.RemoteEpisode.Series.Id == message.Series.Id)
+                                        message.Series.Any(s => s.Id == t.RemoteEpisode.Series.Id))
                                     .ToList();
 
             if (cachedItems.Any())

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileRepository.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileRepository.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Extras.Files
     public interface IExtraFileRepository<TExtraFile> : IBasicRepository<TExtraFile>
         where TExtraFile : ExtraFile, new()
     {
-        void DeleteForSeries(int seriesId);
+        void DeleteForSeriesIds(List<int> seriesIds);
         void DeleteForSeason(int seriesId, int seasonNumber);
         void DeleteForEpisodeFile(int episodeFileId);
         List<TExtraFile> GetFilesBySeries(int seriesId);
@@ -25,9 +25,9 @@ namespace NzbDrone.Core.Extras.Files
         {
         }
 
-        public void DeleteForSeries(int seriesId)
+        public void DeleteForSeriesIds(List<int> seriesIds)
         {
-            Delete(c => c.SeriesId == seriesId);
+            Delete(c => seriesIds.Contains(c.SeriesId));
         }
 
         public void DeleteForSeason(int seriesId, int seasonNumber)

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
@@ -97,8 +97,8 @@ namespace NzbDrone.Core.Extras.Files
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            _logger.Debug("Deleting Extra from database for series: {0}", message.Series);
-            _repository.DeleteForSeries(message.Series.Id);
+            _logger.Debug("Deleting Extra from database for series: {0}", string.Join(',', message.Series));
+            _repository.DeleteForSeriesIds(message.Series.Select(m => m.Id).ToList());
         }
 
         public void Handle(EpisodeFileDeletedEvent message)

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemovedSeriesCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemovedSeriesCheck.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public bool ShouldCheckOnEvent(SeriesDeletedEvent deletedEvent)
         {
-            return deletedEvent.Series.Status == SeriesStatusType.Deleted;
+            return deletedEvent.Series.Any(s => s.Status == SeriesStatusType.Deleted);
         }
 
         public bool ShouldCheckOnEvent(SeriesUpdatedEvent updatedEvent)

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.History
         List<EpisodeHistory> GetBySeries(int seriesId, EpisodeHistoryEventType? eventType);
         List<EpisodeHistory> GetBySeason(int seriesId, int seasonNumber, EpisodeHistoryEventType? eventType);
         List<EpisodeHistory> FindDownloadHistory(int idSeriesId, QualityModel quality);
-        void DeleteForSeries(int seriesId);
+        void DeleteForSeries(List<int> seriesIds);
         List<EpisodeHistory> Since(DateTime date, EpisodeHistoryEventType? eventType);
     }
 
@@ -100,9 +100,9 @@ namespace NzbDrone.Core.History
                  .ToList();
         }
 
-        public void DeleteForSeries(int seriesId)
+        public void DeleteForSeries(List<int> seriesIds)
         {
-            Delete(c => c.SeriesId == seriesId);
+            Delete(c => seriesIds.Contains(c.SeriesId));
         }
 
         protected override SqlBuilder PagedBuilder() => new SqlBuilder()

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -343,7 +343,7 @@ namespace NzbDrone.Core.History
 
         public void Handle(SeriesDeletedEvent message)
         {
-            _historyRepository.DeleteForSeries(message.Series.Id);
+            _historyRepository.DeleteForSeries(message.Series.Select(m => m.Id).ToList());
         }
 
         public List<EpisodeHistory> Since(DateTime date, EpisodeHistoryEventType? eventType)

--- a/src/NzbDrone.Core/ImportLists/Exclusions/ImportListExclusionService.cs
+++ b/src/NzbDrone.Core/ImportLists/Exclusions/ImportListExclusionService.cs
@@ -61,20 +61,25 @@ namespace NzbDrone.Core.ImportLists.Exclusions
                 return;
             }
 
-            var existingExclusion = _repo.FindByTvdbId(message.Series.TvdbId);
+            var exclusionsToAdd = new List<ImportListExclusion>();
 
-            if (existingExclusion != null)
+            foreach (var series in message.Series.DistinctBy(s => s.TvdbId))
             {
-                return;
+                var existingExclusion = _repo.FindByTvdbId(series.TvdbId);
+
+                if (existingExclusion != null)
+                {
+                    continue;
+                }
+
+                exclusionsToAdd.Add(new ImportListExclusion
+                {
+                    TvdbId = series.TvdbId,
+                    Title = series.Title
+                });
             }
 
-            var importExclusion = new ImportListExclusion
-            {
-                TvdbId = message.Series.TvdbId,
-                Title = message.Series.Title
-            };
-
-            _repo.Insert(importExclusion);
+            _repo.InsertMany(exclusionsToAdd);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -217,10 +217,13 @@ namespace NzbDrone.Core.MediaCover
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            var path = GetSeriesCoverPath(message.Series.Id);
-            if (_diskProvider.FolderExists(path))
+            foreach (var series in message.Series)
             {
-                _diskProvider.DeleteFolder(path, true);
+                var path = GetSeriesCoverPath(series.Id);
+                if (_diskProvider.FolderExists(path))
+                {
+                    _diskProvider.DeleteFolder(path, true);
+                }
             }
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -92,35 +92,37 @@ namespace NzbDrone.Core.MediaFiles
         {
             if (message.DeleteFiles)
             {
-                var series = message.Series;
                 var allSeries = _seriesService.GetAllSeries();
 
-                foreach (var s in allSeries)
+                foreach (var series in message.Series)
                 {
-                    if (s.Id == series.Id)
+                    foreach (var s in allSeries)
                     {
-                        continue;
+                        if (s.Id == series.Id)
+                        {
+                            continue;
+                        }
+
+                        if (series.Path.IsParentPath(s.Path))
+                        {
+                            _logger.Error("Series path: '{0}' is a parent of another series, not deleting files.", series.Path);
+                            return;
+                        }
+
+                        if (series.Path.PathEquals(s.Path))
+                        {
+                            _logger.Error("Series path: '{0}' is the same as another series, not deleting files.", series.Path);
+                            return;
+                        }
                     }
 
-                    if (series.Path.IsParentPath(s.Path))
+                    if (_diskProvider.FolderExists(series.Path))
                     {
-                        _logger.Error("Series path: '{0}' is a parent of another series, not deleting files.", series.Path);
-                        return;
+                        _recycleBinProvider.DeleteFolder(series.Path);
                     }
 
-                    if (series.Path.PathEquals(s.Path))
-                    {
-                        _logger.Error("Series path: '{0}' is the same as another series, not deleting files.", series.Path);
-                        return;
-                    }
+                    _eventAggregator.PublishEvent(new DeleteCompletedEvent());
                 }
-
-                if (_diskProvider.FolderExists(message.Series.Path))
-                {
-                    _recycleBinProvider.DeleteFolder(message.Series.Path);
-                }
-
-                _eventAggregator.PublishEvent(new DeleteCompletedEvent());
             }
         }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.MediaFiles
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<EpisodeFile> GetFilesWithRelativePath(int seriesId, string relativePath);
+        void DeleteForSeries(List<int> seriesIds);
     }
 
     public class MediaFileRepository : BasicRepository<EpisodeFile>, IMediaFileRepository
@@ -39,6 +40,11 @@ namespace NzbDrone.Core.MediaFiles
         {
             return Query(c => c.SeriesId == seriesId && c.RelativePath == relativePath)
                         .ToList();
+        }
+
+        public void DeleteForSeries(List<int> seriesIds)
+        {
+            Delete(x => seriesIds.Contains(x.SeriesId));
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -110,8 +110,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            var files = GetFilesBySeries(message.Series.Id);
-            _mediaFileRepository.DeleteMany(files);
+            _mediaFileRepository.DeleteForSeries(message.Series.Select(s => s.Id).ToList());
         }
 
         public static List<string> FilterExistingFiles(List<string> files, List<EpisodeFile> seriesFiles, Series series)

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -252,20 +252,23 @@ namespace NzbDrone.Core.Notifications
 
         public void Handle(SeriesDeletedEvent message)
         {
-            var deleteMessage = new SeriesDeleteMessage(message.Series, message.DeleteFiles);
-
-            foreach (var notification in _notificationFactory.OnSeriesDeleteEnabled())
+            foreach (var series in message.Series)
             {
-                try
+                var deleteMessage = new SeriesDeleteMessage(series, message.DeleteFiles);
+
+                foreach (var notification in _notificationFactory.OnSeriesDeleteEnabled())
                 {
-                    if (ShouldHandleSeries(notification.Definition, deleteMessage.Series))
+                    try
                     {
-                        notification.OnSeriesDelete(deleteMessage);
+                        if (ShouldHandleSeries(notification.Definition, deleteMessage.Series))
+                        {
+                            notification.OnSeriesDelete(deleteMessage);
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warn(ex, "Unable to send OnDelete notification to: " + notification.Definition.Name);
+                    catch (Exception ex)
+                    {
+                        _logger.Warn(ex, "Unable to send OnDelete notification to: " + notification.Definition.Name);
+                    }
                 }
             }
         }

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Tv
         List<Episode> Find(int seriesId, string date);
         List<Episode> GetEpisodes(int seriesId);
         List<Episode> GetEpisodes(int seriesId, int seasonNumber);
+        List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> GetEpisodeByFileId(int fileId);
         List<Episode> EpisodesWithFiles(int seriesId);
@@ -75,6 +76,11 @@ namespace NzbDrone.Core.Tv
         public List<Episode> GetEpisodes(int seriesId, int seasonNumber)
         {
             return Query(s => s.SeriesId == seriesId && s.SeasonNumber == seasonNumber).ToList();
+        }
+
+        public List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds)
+        {
+            return Query(s => seriesIds.Contains(s.SeriesId)).ToList();
         }
 
         public List<Episode> GetEpisodesBySceneSeason(int seriesId, int seasonNumber)

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -211,7 +211,7 @@ namespace NzbDrone.Core.Tv
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            var episodes = GetEpisodeBySeries(message.Series.Id);
+            var episodes = _episodeRepository.GetEpisodesBySeriesIds(message.Series.Select(s => s.Id).ToList());
             _episodeRepository.DeleteMany(episodes);
         }
 

--- a/src/NzbDrone.Core/Tv/Events/SeriesDeletedEvent.cs
+++ b/src/NzbDrone.Core/Tv/Events/SeriesDeletedEvent.cs
@@ -1,14 +1,15 @@
-﻿using NzbDrone.Common.Messaging;
+using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
 
 namespace NzbDrone.Core.Tv.Events
 {
     public class SeriesDeletedEvent : IEvent
     {
-        public Series Series { get; private set; }
+        public List<Series> Series { get; private set; }
         public bool DeleteFiles { get; private set; }
         public bool AddImportListExclusion { get; private set; }
 
-        public SeriesDeletedEvent(Series series, bool deleteFiles, bool addImportListExclusion)
+        public SeriesDeletedEvent(List<Series> series, bool deleteFiles, bool addImportListExclusion)
         {
             Series = series;
             DeleteFiles = deleteFiles;

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Tv
         Series FindByTitle(string title, int year);
         Series FindByTitleInexact(string title);
         Series FindByPath(string path);
-        void DeleteSeries(int seriesId, bool deleteFiles, bool addImportListExclusion);
+        void DeleteSeries(List<int> seriesIds, bool deleteFiles, bool addImportListExclusion);
         List<Series> GetAllSeries();
         List<int> AllSeriesTvdbIds();
         Dictionary<int, string> GetAllSeriesPaths();
@@ -149,10 +149,10 @@ namespace NzbDrone.Core.Tv
             return _seriesRepository.FindByTitle(title.CleanSeriesTitle(), year);
         }
 
-        public void DeleteSeries(int seriesId, bool deleteFiles, bool addImportListExclusion)
+        public void DeleteSeries(List<int> seriesIds, bool deleteFiles, bool addImportListExclusion)
         {
-            var series = _seriesRepository.Get(seriesId);
-            _seriesRepository.Delete(seriesId);
+            var series = _seriesRepository.Get(seriesIds).ToList();
+            _seriesRepository.DeleteMany(seriesIds);
             _eventAggregator.PublishEvent(new SeriesDeletedEvent(series, deleteFiles, addImportListExclusion));
         }
 

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -172,7 +172,7 @@ namespace Sonarr.Api.V3.Series
             var deleteFiles = Request.GetBooleanQueryParameter("deleteFiles");
             var addImportListExclusion = Request.GetBooleanQueryParameter("addImportListExclusion");
 
-            _seriesService.DeleteSeries(id, deleteFiles, addImportListExclusion);
+            _seriesService.DeleteSeries(new List<int> { id }, deleteFiles, addImportListExclusion);
         }
 
         private SeriesResource GetSeriesResource(NzbDrone.Core.Tv.Series series, bool includeSeasonImages)
@@ -292,7 +292,10 @@ namespace Sonarr.Api.V3.Series
         [NonAction]
         public void Handle(SeriesDeletedEvent message)
         {
-            BroadcastResourceChange(ModelAction.Deleted, message.Series.ToResource());
+            foreach (var series in message.Series)
+            {
+                BroadcastResourceChange(ModelAction.Deleted, series.ToResource());
+            }
         }
 
         [NonAction]

--- a/src/Sonarr.Api.V3/Series/SeriesEditorController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesEditorController.cs
@@ -94,10 +94,7 @@ namespace Sonarr.Api.V3.Series
         [HttpDelete]
         public object DeleteSeries([FromBody] SeriesEditorResource resource)
         {
-            foreach (var seriesId in resource.SeriesIds)
-            {
-                _seriesService.DeleteSeries(seriesId, resource.DeleteFiles, resource.AddImportListExclusion);
-            }
+            _seriesService.DeleteSeries(resource.SeriesIds, resource.DeleteFiles, resource.AddImportListExclusion);
 
             return new { };
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This change significantly speeds up mass delete of series by ensuring most DB calls are only called once per mass delete instead of once per series per mass delete (including a GetAllSeries call).

#### Todos
- [ ] Tests
