### PR TITLE
Fix bug_report.yml description field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: 'Support Requests will be closed immediately, if you are not 100% certain this is a bug please go to our Reddit, Discord, Forums, or IRC first. Exceptions do not mean you found a bug! Sonarr v2 is EOL & unsupported.'
+description: 'Support Requests will be closed immediately, if you are not 100% certain this is a bug please go to our Reddit, Discord, Forums, or IRC first. Sonarr v2 is EOL & unsupported.'
 labels: ['needs-triage']
 body:
 - type: checkboxes


### PR DESCRIPTION


#### Database Migration
NO

#### Description
field was over 200 chars and apparently not valid! Causes bug report template to not show on the new issues page.

#### Todos


#### Issues Fixed or Closed by this PR
