### PR TITLE
New: Reduce size of Custom Formats in responses for most endpoints

### DIFF
--- a/src/Sonarr.Api.V3/Blocklist/BlocklistResource.cs
+++ b/src/Sonarr.Api.V3/Blocklist/BlocklistResource.cs
@@ -44,7 +44,7 @@ namespace Sonarr.Api.V3.Blocklist
                 SourceTitle = model.SourceTitle,
                 Languages = model.Languages,
                 Quality = model.Quality,
-                CustomFormats = formatCalculator.ParseCustomFormat(model, model.Series).ToResource(),
+                CustomFormats = formatCalculator.ParseCustomFormat(model, model.Series).ToResource(false),
                 Date = model.Date,
                 Protocol = model.Protocol,
                 Indexer = model.Indexer,

--- a/src/Sonarr.Api.V3/CustomFormats/CustomFormatController.cs
+++ b/src/Sonarr.Api.V3/CustomFormats/CustomFormatController.cs
@@ -44,7 +44,7 @@ namespace Sonarr.Api.V3.CustomFormats
 
         protected override CustomFormatResource GetResourceById(int id)
         {
-            return _formatService.GetById(id).ToResource();
+            return _formatService.GetById(id).ToResource(true);
         }
 
         [RestPostById]
@@ -69,7 +69,7 @@ namespace Sonarr.Api.V3.CustomFormats
         [Produces("application/json")]
         public List<CustomFormatResource> GetAll()
         {
-            return _formatService.All().ToResource();
+            return _formatService.All().ToResource(true);
         }
 
         [RestDeleteById]

--- a/src/Sonarr.Api.V3/CustomFormats/CustomFormatResource.cs
+++ b/src/Sonarr.Api.V3/CustomFormats/CustomFormatResource.cs
@@ -13,26 +13,32 @@ namespace Sonarr.Api.V3.CustomFormats
         [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
         public override int Id { get; set; }
         public string Name { get; set; }
-        public bool IncludeCustomFormatWhenRenaming { get; set; }
+        public bool? IncludeCustomFormatWhenRenaming { get; set; }
         public List<CustomFormatSpecificationSchema> Specifications { get; set; }
     }
 
     public static class CustomFormatResourceMapper
     {
-        public static CustomFormatResource ToResource(this CustomFormat model)
+        public static CustomFormatResource ToResource(this CustomFormat model, bool includeDetails)
         {
-            return new CustomFormatResource
+            var resource = new CustomFormatResource
             {
                 Id = model.Id,
-                Name = model.Name,
-                IncludeCustomFormatWhenRenaming = model.IncludeCustomFormatWhenRenaming,
-                Specifications = model.Specifications.Select(x => x.ToSchema()).ToList()
+                Name = model.Name
             };
+
+            if (includeDetails)
+            {
+                resource.IncludeCustomFormatWhenRenaming = model.IncludeCustomFormatWhenRenaming;
+                resource.Specifications = model.Specifications.Select(x => x.ToSchema()).ToList();
+            }
+
+            return resource;
         }
 
-        public static List<CustomFormatResource> ToResource(this IEnumerable<CustomFormat> models)
+        public static List<CustomFormatResource> ToResource(this IEnumerable<CustomFormat> models, bool includeDetails)
         {
-            return models.Select(m => m.ToResource()).ToList();
+            return models.Select(m => m.ToResource(includeDetails)).ToList();
         }
 
         public static CustomFormat ToModel(this CustomFormatResource resource, List<ICustomFormatSpecification> specifications)
@@ -41,8 +47,8 @@ namespace Sonarr.Api.V3.CustomFormats
             {
                 Id = resource.Id,
                 Name = resource.Name,
-                IncludeCustomFormatWhenRenaming = resource.IncludeCustomFormatWhenRenaming,
-                Specifications = resource.Specifications.Select(x => MapSpecification(x, specifications)).ToList()
+                IncludeCustomFormatWhenRenaming = resource.IncludeCustomFormatWhenRenaming ?? false,
+                Specifications = resource.Specifications?.Select(x => MapSpecification(x, specifications)).ToList() ?? new List<ICustomFormatSpecification>()
             };
         }
 

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -84,7 +84,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
                 QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(series.QualityProfile.Value, model.Quality),
-                CustomFormats = formatCalculationService.ParseCustomFormat(model).ToResource()
+                CustomFormats = formatCalculationService.ParseCustomFormat(model).ToResource(false)
             };
         }
     }

--- a/src/Sonarr.Api.V3/History/HistoryResource.cs
+++ b/src/Sonarr.Api.V3/History/HistoryResource.cs
@@ -49,7 +49,7 @@ namespace Sonarr.Api.V3.History
                 SourceTitle = model.SourceTitle,
                 Languages = model.Languages,
                 Quality = model.Quality,
-                CustomFormats = formatCalculator.ParseCustomFormat(model, model.Series).ToResource(),
+                CustomFormats = formatCalculator.ParseCustomFormat(model, model.Series).ToResource(false),
 
                 // QualityCutoffNotMet
                 Date = model.Date,

--- a/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
@@ -127,7 +127,7 @@ namespace Sonarr.Api.V3.Indexers
 
                 // ReleaseWeight
                 CustomFormatScore = remoteEpisode.CustomFormatScore,
-                CustomFormats = remoteEpisode.CustomFormats?.ToResource(),
+                CustomFormats = remoteEpisode.CustomFormats?.ToResource(false),
                 SceneMapping = remoteEpisode.SceneMapping.ToResource(),
 
                 MagnetUrl = torrentInfo.MagnetUrl,

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -56,7 +56,7 @@ namespace Sonarr.Api.V3.ManualImport
                 ReleaseGroup = model.ReleaseGroup,
                 Quality = model.Quality,
                 Languages = model.Languages,
-                CustomFormats = model.CustomFormats.ToResource(),
+                CustomFormats = model.CustomFormats.ToResource(false),
 
                 // QualityWeight
                 DownloadId = model.DownloadId,

--- a/src/Sonarr.Api.V3/Queue/QueueResource.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueResource.cs
@@ -57,7 +57,7 @@ namespace Sonarr.Api.V3.Queue
                 Episode = includeEpisode && model.Episode != null ? model.Episode.ToResource() : null,
                 Languages = model.Languages,
                 Quality = model.Quality,
-                CustomFormats = model.RemoteEpisode?.CustomFormats?.ToResource(),
+                CustomFormats = model.RemoteEpisode?.CustomFormats?.ToResource(false),
                 Size = model.Size,
                 Title = model.Title,
                 Sizeleft = model.Sizeleft,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As discussed on Discord this reduces the size of responses that include Custom Formats outside of `CustomFormatController` responses that need the full information.