### PR TITLE
Fixed: Store Custom Format score during import

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.js
+++ b/frontend/src/Activity/History/HistoryRow.js
@@ -63,6 +63,7 @@ class HistoryRow extends Component {
       languageCutoffNotMet,
       quality,
       customFormats,
+      customFormatScore,
       qualityCutoffNotMet,
       eventType,
       sourceTitle,
@@ -213,7 +214,7 @@ class HistoryRow extends Component {
                   key={name}
                   className={styles.customFormatScore}
                 >
-                  {formatPreferredWordScore(data.customFormatScore)}
+                  {formatPreferredWordScore(customFormatScore)}
                 </TableRowCell>
               );
             }
@@ -282,6 +283,7 @@ HistoryRow.propTypes = {
   languageCutoffNotMet: PropTypes.bool.isRequired,
   quality: PropTypes.object.isRequired,
   customFormats: PropTypes.arrayOf(PropTypes.object),
+  customFormatScore: PropTypes.number.isRequired,
   qualityCutoffNotMet: PropTypes.bool.isRequired,
   eventType: PropTypes.string.isRequired,
   sourceTitle: PropTypes.string.isRequired,

--- a/frontend/src/Episode/History/EpisodeHistoryRow.js
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.js
@@ -70,6 +70,7 @@ class EpisodeHistoryRow extends Component {
       quality,
       qualityCutoffNotMet,
       customFormats,
+      customFormatScore,
       date,
       data
     } = this.props;
@@ -129,7 +130,7 @@ class EpisodeHistoryRow extends Component {
         <TableRowCell className={styles.customFormatScore}>
           <Tooltip
             anchor={
-              formatPreferredWordScore(data.customFormatScore, customFormats.length)
+              formatPreferredWordScore(customFormatScore, customFormats.length)
             }
             tooltip={<EpisodeFormats formats={customFormats} />}
             position={tooltipPositions.BOTTOM}
@@ -170,6 +171,7 @@ EpisodeHistoryRow.propTypes = {
   quality: PropTypes.object.isRequired,
   qualityCutoffNotMet: PropTypes.bool.isRequired,
   customFormats: PropTypes.arrayOf(PropTypes.object),
+  customFormatScore: PropTypes.number.isRequired,
   date: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
   onMarkAsFailedPress: PropTypes.func.isRequired

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -219,6 +219,7 @@ namespace NzbDrone.Core.History
                 history.Data.Add("DownloadClient", message.DownloadClientInfo?.Type);
                 history.Data.Add("DownloadClientName", message.DownloadClientInfo?.Name);
                 history.Data.Add("ReleaseGroup", message.EpisodeInfo.ReleaseGroup);
+                history.Data.Add("CustomFormatScore", message.EpisodeInfo.CustomFormatScore.ToString());
 
                 _historyRepository.Insert(history);
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -140,6 +140,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                 }
                 else
                 {
+                    localEpisode.CustomFormats = _formatCalculator.ParseCustomFormat(localEpisode);
+                    localEpisode.CustomFormatScore = localEpisode.Series.QualityProfile?.Value.CalculateCustomFormatScore(localEpisode.CustomFormats) ?? 0;
+
                     decision = GetDecision(localEpisode, downloadClientItem);
                 }
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -487,6 +487,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 // Augment episode file so imported files have all additional information an automatic import would
                 localEpisode = _aggregationService.Augment(localEpisode, trackedDownload?.DownloadItem);
+                localEpisode.CustomFormats = _formatCalculator.ParseCustomFormat(localEpisode);
+                localEpisode.CustomFormatScore = localEpisode.Series.QualityProfile?.Value.CalculateCustomFormatScore(localEpisode.CustomFormats) ?? 0;
 
                 // Apply the user-chosen values.
                 localEpisode.Series = series;

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -134,6 +134,8 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_EpisodeFile_MediaInfo_Subtitles", episodeFile.MediaInfo.Subtitles.ConcatToString(" / "));
             environmentVariables.Add("Sonarr_EpisodeFile_MediaInfo_VideoCodec", MediaInfoFormatter.FormatVideoCodec(episodeFile.MediaInfo, null));
             environmentVariables.Add("Sonarr_EpisodeFile_MediaInfo_VideoDynamicRangeType", MediaInfoFormatter.FormatVideoDynamicRangeType(episodeFile.MediaInfo));
+            environmentVariables.Add("Sonarr_EpisodeFile_CustomFormat", string.Join("|", message.EpisodeInfo.CustomFormats));
+            environmentVariables.Add("Sonarr_EpisodeFile_CustomFormatScore", message.EpisodeInfo.CustomFormatScore.ToString());
 
             if (message.OldFiles.Any())
             {

--- a/src/NzbDrone.Core/Notifications/DownloadMessage.cs
+++ b/src/NzbDrone.Core/Notifications/DownloadMessage.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications
@@ -9,6 +10,7 @@ namespace NzbDrone.Core.Notifications
     {
         public string Message { get; set; }
         public Series Series { get; set; }
+        public LocalEpisode EpisodeInfo { get; set; }
         public EpisodeFile EpisodeFile { get; set; }
         public List<EpisodeFile> OldFiles { get; set; }
         public string SourcePath { get; set; }

--- a/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
@@ -104,6 +104,8 @@ namespace NzbDrone.Core.Notifications.Notifiarr
             variables.Add("Sonarr_EpisodeFile_MediaInfo_Subtitles", episodeFile.MediaInfo.Subtitles.ConcatToString(" / "));
             variables.Add("Sonarr_EpisodeFile_MediaInfo_VideoCodec", MediaInfoFormatter.FormatVideoCodec(episodeFile.MediaInfo, null));
             variables.Add("Sonarr_EpisodeFile_MediaInfo_VideoDynamicRangeType", MediaInfoFormatter.FormatVideoDynamicRangeType(episodeFile.MediaInfo));
+            variables.Add("Sonarr_EpisodeFile_CustomFormat", string.Join("|", message.EpisodeInfo.CustomFormats));
+            variables.Add("Sonarr_EpisodeFile_CustomFormatScore", message.EpisodeInfo.CustomFormatScore.ToString());
 
             if (message.OldFiles.Any())
             {

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -152,6 +152,7 @@ namespace NzbDrone.Core.Notifications
             {
                 Message = GetMessage(message.EpisodeInfo.Series, message.EpisodeInfo.Episodes, message.EpisodeInfo.Quality),
                 Series = message.EpisodeInfo.Series,
+                EpisodeInfo = message.EpisodeInfo,
                 EpisodeFile = message.ImportedEpisode,
                 OldFiles = message.OldFiles,
                 SourcePath = message.EpisodeInfo.Path,

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -42,7 +42,8 @@ namespace NzbDrone.Core.Notifications.Webhook
                 Release = new WebhookRelease(quality, remoteEpisode),
                 DownloadClient = message.DownloadClientName,
                 DownloadClientType = message.DownloadClientType,
-                DownloadId = message.DownloadId
+                DownloadId = message.DownloadId,
+                CustomFormatInfo = new WebhookCustomFormatInfo(remoteEpisode.CustomFormats, remoteEpisode.CustomFormatScore)
             };
 
             _proxy.SendWebhook(payload, Settings);
@@ -63,7 +64,8 @@ namespace NzbDrone.Core.Notifications.Webhook
                 IsUpgrade = message.OldFiles.Any(),
                 DownloadClient = message.DownloadClientInfo?.Name,
                 DownloadClientType = message.DownloadClientInfo?.Type,
-                DownloadId = message.DownloadId
+                DownloadId = message.DownloadId,
+                CustomFormatInfo = new WebhookCustomFormatInfo(message.EpisodeInfo.CustomFormats, message.EpisodeInfo.CustomFormatScore)
             };
 
             if (message.OldFiles.Any())

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookCustomFormat.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookCustomFormat.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+using NzbDrone.Core.CustomFormats;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookCustomFormat
+    {
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public WebhookCustomFormat(CustomFormat customFormat)
+        {
+            Id = customFormat.Id;
+            Name = customFormat.Name;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookCustomFormatInfo.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookCustomFormatInfo.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.CustomFormats;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookCustomFormatInfo
+    {
+        public List<WebhookCustomFormat> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
+
+        public WebhookCustomFormatInfo(List<CustomFormat> customFormats, int customFormatScore)
+        {
+            CustomFormats = customFormats.Select(c => new WebhookCustomFormat(c)).ToList();
+            CustomFormatScore = customFormatScore;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookGrabPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookGrabPayload.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.Notifications.Webhook
 {
@@ -10,5 +10,6 @@ namespace NzbDrone.Core.Notifications.Webhook
         public string DownloadClient { get; set; }
         public string DownloadClientType { get; set; }
         public string DownloadId { get; set; }
+        public WebhookCustomFormatInfo CustomFormatInfo { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookImportPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookImportPayload.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace NzbDrone.Core.Notifications.Webhook
 {
@@ -12,5 +12,6 @@ namespace NzbDrone.Core.Notifications.Webhook
         public string DownloadClientType { get; set; }
         public string DownloadId { get; set; }
         public List<WebhookEpisodeFile> DeletedFiles { get; set; }
+        public WebhookCustomFormatInfo CustomFormatInfo { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Qualities;
@@ -31,6 +32,8 @@ namespace NzbDrone.Core.Parser.Model
         public string ReleaseGroup { get; set; }
         public string SceneName { get; set; }
         public bool OtherVideoFiles { get; set; }
+        public List<CustomFormat> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
 
         public int SeasonNumber
         {

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Parser.Model
         {
             Episodes = new List<Episode>();
             Languages = new List<Language>();
+            CustomFormats = new List<CustomFormat>();
         }
 
         public string Path { get; set; }

--- a/src/Sonarr.Api.V3/History/HistoryResource.cs
+++ b/src/Sonarr.Api.V3/History/HistoryResource.cs
@@ -19,6 +19,7 @@ namespace Sonarr.Api.V3.History
         public List<Language> Languages { get; set; }
         public QualityModel Quality { get; set; }
         public List<CustomFormatResource> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
         public bool QualityCutoffNotMet { get; set; }
         public DateTime Date { get; set; }
         public string DownloadId { get; set; }
@@ -40,6 +41,9 @@ namespace Sonarr.Api.V3.History
                 return null;
             }
 
+            var customFormats = formatCalculator.ParseCustomFormat(model, model.Series);
+            var customFormatScore = model.Series.QualityProfile.Value.CalculateCustomFormatScore(customFormats);
+
             return new HistoryResource
             {
                 Id = model.Id,
@@ -49,7 +53,8 @@ namespace Sonarr.Api.V3.History
                 SourceTitle = model.SourceTitle,
                 Languages = model.Languages,
                 Quality = model.Quality,
-                CustomFormats = formatCalculator.ParseCustomFormat(model, model.Series).ToResource(false),
+                CustomFormats = customFormats.ToResource(false),
+                CustomFormatScore = customFormatScore,
 
                 // QualityCutoffNotMet
                 Date = model.Date,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This now stores CF score when importing episodes to align with grabs, but other events would still be lacking this score so it feels a bit janky, but not sure we want to store it for others or at all. Given CF is recalculated for everything else should the score be as well? Should we have some sort of caching for CF to allow quicker look ups when given the same information over and over?

#### TODOs

- [ ] Add to notifications/connections

#### Issues Fixed or Closed by this PR

* Closes #5291
