### PR TITLE
Improve handling of releases without video files

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -147,6 +147,18 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
+            if (importResults.Count == 1)
+            {
+                var firstResult = importResults.First();
+
+                if (firstResult.Result == ImportResultType.Rejected && firstResult.ImportDecision.LocalEpisode == null)
+                {
+                    trackedDownload.Warn(new TrackedDownloadStatusMessage(firstResult.Errors.First(), new List<string>()));
+
+                    return;
+                }
+            }
+
             var statusMessages = new List<TrackedDownloadStatusMessage>
                                  {
                                     new TrackedDownloadStatusMessage("One or more episodes expected in this release were not imported or missing", new List<string>())

--- a/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.MediaFiles
+{
+    internal static class FileExtensions
+    {
+        private static List<string> _archiveExtensions = new List<string>
+        {
+            ".rar",
+            ".r00",
+            ".zip",
+            ".tar",
+            ".gz",
+            ".tar.gz"
+        };
+
+        private static List<string> _executableExtensions = new List<string>
+        {
+            ".exe",
+            ".bat",
+            ".cmd",
+            ".sh"
+        };
+
+        public static HashSet<string> ArchiveExtensions => new HashSet<string>(_archiveExtensions, StringComparer.OrdinalIgnoreCase);
+        public static HashSet<string> ExecutableExtensions => new HashSet<string>(_executableExtensions, StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Show warning in queue if download contains executable or archive file and no video file was detected, instead of a generic message that no video files were found.

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Closes #5101
