### PR TITLE
New: Add bypass if above Custom Format Score to Delay Profile

### DIFF
--- a/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.js
@@ -46,6 +46,8 @@ function EditDelayProfileModalContent(props) {
     usenetDelay,
     torrentDelay,
     bypassIfHighestQuality,
+    bypassIfAboveCustomFormatScore,
+    minimumCustomFormatScore,
     tags
   } = item;
 
@@ -85,7 +87,7 @@ function EditDelayProfileModalContent(props) {
               </FormGroup>
 
               {
-                enableUsenet.value &&
+                enableUsenet.value ?
                   <FormGroup>
                     <FormLabel>Usenet Delay</FormLabel>
 
@@ -97,11 +99,12 @@ function EditDelayProfileModalContent(props) {
                       helpText="Delay in minutes to wait before grabbing a release from Usenet"
                       onChange={onInputChange}
                     />
-                  </FormGroup>
+                  </FormGroup> :
+                  null
               }
 
               {
-                enableTorrent.value &&
+                enableTorrent.value ?
                   <FormGroup>
                     <FormLabel>Torrent Delay</FormLabel>
 
@@ -113,21 +116,48 @@ function EditDelayProfileModalContent(props) {
                       helpText="Delay in minutes to wait before grabbing a torrent"
                       onChange={onInputChange}
                     />
-                  </FormGroup>
+                  </FormGroup> :
+                  null
               }
 
-              {
-                <FormGroup>
-                  <FormLabel>Bypass if Highest Quality</FormLabel>
+              <FormGroup>
+                <FormLabel>Bypass if Highest Quality</FormLabel>
 
-                  <FormInputGroup
-                    type={inputTypes.CHECK}
-                    name="bypassIfHighestQuality"
-                    {...bypassIfHighestQuality}
-                    helpText="Bypass delay when release has the highest enabled quality in the quality profile with the preferred protocol"
-                    onChange={onInputChange}
-                  />
-                </FormGroup>
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="bypassIfHighestQuality"
+                  {...bypassIfHighestQuality}
+                  helpText="Bypass delay when release has the highest enabled quality in the quality profile with the preferred protocol"
+                  onChange={onInputChange}
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <FormLabel>Bypass if Above Custom Format Score</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="bypassIfAboveCustomFormatScore"
+                  {...bypassIfAboveCustomFormatScore}
+                  helpText="Enable bypass when release has a score higher than the configured minimum custom format score"
+                  onChange={onInputChange}
+                />
+              </FormGroup>
+
+              {
+                bypassIfAboveCustomFormatScore.value ?
+                  <FormGroup>
+                    <FormLabel>Minimum Custom Format Score</FormLabel>
+
+                    <FormInputGroup
+                      type={inputTypes.NUMBER}
+                      name="minimumCustomFormatScore"
+                      {...minimumCustomFormatScore}
+                      helpText="Minimum Custom Format Score required to bypass delay for the preferred protocol"
+                      onChange={onInputChange}
+                    />
+                  </FormGroup> :
+                  null
               }
 
               {

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
@@ -117,17 +117,22 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         [Test]
         public void should_be_false_when_quality_and_language_is_last_allowed_in_profile_and_bypass_disabled()
         {
+            _remoteEpisode.Release.PublishDate = DateTime.UtcNow;
             _remoteEpisode.ParsedEpisodeInfo.Quality = new QualityModel(Quality.Bluray720p);
             _remoteEpisode.ParsedEpisodeInfo.Languages = new List<Language> { Language.French };
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _delayProfile.UsenetDelay = 720;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_true_when_quality_and_language_is_last_allowed_in_profile_and_bypass_enabled()
         {
+            _delayProfile.UsenetDelay = 720;
             _delayProfile.BypassIfHighestQuality = true;
 
+            _remoteEpisode.Release.PublishDate = DateTime.UtcNow;
             _remoteEpisode.ParsedEpisodeInfo.Quality = new QualityModel(Quality.Bluray720p);
             _remoteEpisode.ParsedEpisodeInfo.Languages = new List<Language> { Language.French };
 
@@ -203,6 +208,44 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _delayProfile.UsenetDelay = 720;
 
             Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_false_when_custom_format_score_is_above_minimum_but_bypass_disabled()
+        {
+            _remoteEpisode.Release.PublishDate = DateTime.UtcNow;
+            _remoteEpisode.CustomFormatScore = 100;
+
+            _delayProfile.UsenetDelay = 720;
+            _delayProfile.MinimumCustomFormatScore = 50;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_false_when_custom_format_score_is_above_minimum_and_bypass_enabled_but_under_minimum()
+        {
+            _remoteEpisode.Release.PublishDate = DateTime.UtcNow;
+            _remoteEpisode.CustomFormatScore = 5;
+
+            _delayProfile.UsenetDelay = 720;
+            _delayProfile.BypassIfAboveCustomFormatScore = true;
+            _delayProfile.MinimumCustomFormatScore = 50;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_be_true_when_custom_format_score_is_above_minimum_and_bypass_enabled()
+        {
+            _remoteEpisode.Release.PublishDate = DateTime.UtcNow;
+            _remoteEpisode.CustomFormatScore = 100;
+
+            _delayProfile.UsenetDelay = 720;
+            _delayProfile.BypassIfAboveCustomFormatScore = true;
+            _delayProfile.MinimumCustomFormatScore = 50;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/182_add_bypass_to_delay_profile.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/182_add_bypass_to_delay_profile.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("DelayProfiles").AddColumn("BypassIfAboveCustomFormatScore").AsBoolean().Nullable();
+            Alter.Table("DelayProfiles").AddColumn("BypassIfAboveCustomFormatScore").AsBoolean().WithDefaultValue(false);
             Alter.Table("DelayProfiles").AddColumn("MinimumCustomFormatScore").AsInt32().Nullable();
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/182_add_bypass_to_delay_profile.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/182_add_bypass_to_delay_profile.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(182)]
+    public class add_custom_format_score_bypass_to_delay_profile : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("DelayProfiles").AddColumn("BypassIfAboveCustomFormatScore").AsBoolean().Nullable();
+            Alter.Table("DelayProfiles").AddColumn("MinimumCustomFormatScore").AsInt32().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
@@ -76,6 +76,19 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
                 }
             }
 
+            // If quality meets or exceeds the best allowed quality in the profile accept it immediately
+            if (delayProfile.BypassIfAboveCustomFormatScore)
+            {
+                var score = subject.CustomFormatScore;
+                var minimum = delayProfile.MinimumCustomFormatScore;
+
+                if (score >= minimum && isPreferredProtocol)
+                {
+                    _logger.Debug("Custom format score ({0}) meets minimum ({1}) for preferred protocol, will not delay", score, minimum);
+                    return Decision.Accept();
+                }
+            }
+
             var episodeIds = subject.Episodes.Select(e => e.Id);
 
             var oldest = _pendingReleaseService.OldestPendingRelease(subject.Series.Id, episodeIds.ToArray());

--- a/src/NzbDrone.Core/Profiles/Delay/DelayProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Delay/DelayProfile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Indexers;
 
@@ -13,6 +13,8 @@ namespace NzbDrone.Core.Profiles.Delay
         public int TorrentDelay { get; set; }
         public int Order { get; set; }
         public bool BypassIfHighestQuality { get; set; }
+        public bool BypassIfAboveCustomFormatScore { get; set; }
+        public int MinimumCustomFormatScore { get; set; }
         public HashSet<int> Tags { get; set; }
 
         public DelayProfile()

--- a/src/Sonarr.Api.V3/Profiles/Delay/DelayProfileResource.cs
+++ b/src/Sonarr.Api.V3/Profiles/Delay/DelayProfileResource.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Profiles.Delay;
@@ -14,6 +14,8 @@ namespace Sonarr.Api.V3.Profiles.Delay
         public int UsenetDelay { get; set; }
         public int TorrentDelay { get; set; }
         public bool BypassIfHighestQuality { get; set; }
+        public bool BypassIfAboveCustomFormatScore { get; set; }
+        public int MinimumCustomFormatScore { get; set; }
         public int Order { get; set; }
         public HashSet<int> Tags { get; set; }
     }
@@ -37,6 +39,8 @@ namespace Sonarr.Api.V3.Profiles.Delay
                 UsenetDelay = model.UsenetDelay,
                 TorrentDelay = model.TorrentDelay,
                 BypassIfHighestQuality = model.BypassIfHighestQuality,
+                BypassIfAboveCustomFormatScore = model.BypassIfAboveCustomFormatScore,
+                MinimumCustomFormatScore = model.MinimumCustomFormatScore,
                 Order = model.Order,
                 Tags = new HashSet<int>(model.Tags)
             };
@@ -59,6 +63,8 @@ namespace Sonarr.Api.V3.Profiles.Delay
                 UsenetDelay = resource.UsenetDelay,
                 TorrentDelay = resource.TorrentDelay,
                 BypassIfHighestQuality = resource.BypassIfHighestQuality,
+                BypassIfAboveCustomFormatScore = resource.BypassIfAboveCustomFormatScore,
+                MinimumCustomFormatScore = resource.MinimumCustomFormatScore,
                 Order = resource.Order,
                 Tags = new HashSet<int>(resource.Tags)
             };


### PR DESCRIPTION

#### Database Migration
YES - 182

#### Description
Adds two more options to Delay Profiles which will bypass the delay profile if a minimum CF score is reached.

A few things:
- This operates independently from the quality bypass
- The minimum value is based on a second property in the delay profile, alternatively it could use the minimum score or cutoff from the profile instead, which would make it less related to the profile's scoring
- If we want to switch this to requiring both quality and score if configured it'd be possible with some changes (and potentially could be another value for the delay profile)

#### Todos
- [x] Tests


#### Issues Fixed or Closed by this PR

* Closes #4711
