### PR TITLE
Fixed: Progress bar text colour in Dark theme

### DIFF
--- a/frontend/src/Components/ProgressBar.css
+++ b/frontend/src/Components/ProgressBar.css
@@ -20,7 +20,11 @@
 
 .frontTextContainer {
   z-index: 1;
-  color: var(--white);
+  color: var(--progressBarFrontTextColor);
+}
+
+.backTextContainer {
+  color: var(--progressBarBackTextColor);
 }
 
 .backTextContainer,

--- a/frontend/src/Styles/Themes/dark.js
+++ b/frontend/src/Styles/Themes/dark.js
@@ -235,6 +235,8 @@ module.exports = {
   //
   // misc
 
+  progressBarFrontTextColor: white,
+  progressBarBackTextColor: white,
   progressBarBackgroundColor: '#727070',
   logEventsBackgroundColor: '#2a2a2a'
 };

--- a/frontend/src/Styles/Themes/light.js
+++ b/frontend/src/Styles/Themes/light.js
@@ -237,6 +237,8 @@ module.exports = {
   //
   // misc
 
-  progressBarBackgroundColor: '#fff',
-  logEventsBackgroundColor: '#fff'
+  progressBarFrontTextColor: white,
+  progressBarBackTextColor: darkGray,
+  progressBarBackgroundColor: white,
+  logEventsBackgroundColor: white
 };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Buggered up my local git so continuation of this [PR 5293](https://github.com/Sonarr/Sonarr/pull/5293)

Fixed the progress bar text colors so that they are white regardless of the background, for some reason there was a weird bug causing different parts of the episode progress text to be different colors as the bar moved along as shown in the image
![image](https://user-images.githubusercontent.com/1936903/209254454-09b21a8b-a7d4-453d-96b8-294f0c3816fb.png)

Moved the text to be a variable so can be changed depending on theme
![image](https://user-images.githubusercontent.com/1936903/209255072-2772e165-e71c-4d76-952f-8ffb949f0626.png)



#### Todos
- 


#### Issues Fixed or Closed by this PR

* 
