### PR TITLE
Fixed: Kodi Metadata Subtitle Language

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -328,9 +328,12 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
                         if (episodeFile.MediaInfo.Subtitles != null && episodeFile.MediaInfo.Subtitles.Count > 0)
                         {
-                            var subtitle = new XElement("subtitle");
-                            subtitle.Add(new XElement("language", episodeFile.MediaInfo.Subtitles));
-                            streamDetails.Add(subtitle);
+                            foreach (var s in episodeFile.MediaInfo.Subtitles)
+                            {
+                                var subtitle = new XElement("subtitle");
+                                subtitle.Add(new XElement("language", s));
+                                streamDetails.Add(subtitle);
+                            }
                         }
 
                         fileInfo.Add(streamDetails);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
currently for episodes with multiple subs, only one subtitle element is created as follows:
```
     <subtitle>
        <language>engengengaracatczedangergergergrespaspabaqfinfilfreglghebhrvhuninditajpnkormaynobdutpolporporrumrusswethaturukrviechichi</language>
      </subtitle>
```

as per https://kodi.wiki/view/NFO_files/Movies multiple subtitle elements are allowed, where https://github.com/xbmc/xbmc/blob/master/xbmc/video/VideoInfoTag.cpp iterates through them.
This PR creates a seperate subtitle element for each langugae

#### Todos


#### Issues Fixed or Closed by this PR


