### PR TITLE
Fixed: Chinese releases with season and absolute episode numbers

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
@@ -41,21 +41,21 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeFalse();
         }
 
-        [TestCase("[Lilith-Raws] 在地下城尋求邂逅是否搞錯了什麼 / Anime-Series Title S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 4,12)]
-        [TestCase("[Lilith-Raws] 魔王學院的不適任者 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2,1)]
-        [TestCase("[Lilith-Raws] 不要欺負我，長瀞同學 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2,1)]
-        [TestCase("[SweetSub&LoliHouse] 来自深渊 烈日黄金乡 / Anime-Series Title S2 - 07 [WebRip 1080p HEVC-10bit AAC][简繁日内封字幕]", "Anime-Series Title", "Lilith-Raws", 2,7)]
-        [TestCase("[LoliHouse] Love Live! 虹咲学园学园偶像同好会 第二季 / Anime-Series Title S2 - 10 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "Lilith-Raws", 2,10)]
-        [TestCase("[澄空学园&雪飘工作室&LoliHouse] 辉夜大小姐想让我告白 第三季 / Anime-Series Title S3 - 06 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "Lilith-Raws", 3,6)]
-        public void should_parse_chinese_anime_season_episode_releases(string postTitle, string title, string subgroup, int SeasonNumber, int EpisodeNumber)
+        [TestCase("[Lilith-Raws] 在地下城尋求邂逅是否搞錯了什麼 / Anime-Series Title S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 4, 12)]
+        [TestCase("[Lilith-Raws] 魔王學院的不適任者 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2, 1)]
+        [TestCase("[Lilith-Raws] 不要欺負我，長瀞同學 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2, 1)]
+        [TestCase("[SweetSub&LoliHouse] 来自深渊 烈日黄金乡 / Anime-Series Title S2 - 07 [WebRip 1080p HEVC-10bit AAC][简繁日内封字幕]", "Anime-Series Title", "SweetSub&LoliHouse", 2, 7)]
+        [TestCase("[LoliHouse] Love Live! 虹咲学园学园偶像同好会 第二季 / Anime-Series Title S2 - 10 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "LoliHouse", 2, 10)]
+        [TestCase("[澄空学园&雪飘工作室&LoliHouse] 辉夜大小姐想让我告白 第三季 / Anime-Series Title S3 - 06 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "澄空学园&雪飘工作室&LoliHouse", 3, 6)]
+        public void should_parse_chinese_anime_season_episode_releases(string postTitle, string title, string subgroup, int seasonNumber, int episodeNumber)
         {
             postTitle = XmlCleaner.ReplaceUnicode(postTitle);
 
             var result = Parser.Parser.ParseTitle(postTitle);
             result.Should().NotBeNull();
             result.ReleaseGroup.Should().Be(subgroup);
-            result.SeasonNumber.Single().Should().Be(SeasonNumber);
-            result.EpisodeNumbers.Single().Should().Be(EpisodeNumber);
+            result.SeasonNumber.Should().Be(seasonNumber);
+            result.EpisodeNumbers.Single().Should().Be(episodeNumber);
             result.SeriesTitle.Should().Be(title);
             result.FullSeason.Should().BeFalse();
         }

--- a/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UnicodeReleaseParserFixture.cs
@@ -41,6 +41,25 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeFalse();
         }
 
+        [TestCase("[Lilith-Raws] 在地下城尋求邂逅是否搞錯了什麼 / Anime-Series Title S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 4,12)]
+        [TestCase("[Lilith-Raws] 魔王學院的不適任者 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2,1)]
+        [TestCase("[Lilith-Raws] 不要欺負我，長瀞同學 / Anime-Series Title S02 - 01 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]", "Anime-Series Title", "Lilith-Raws", 2,1)]
+        [TestCase("[SweetSub&LoliHouse] 来自深渊 烈日黄金乡 / Anime-Series Title S2 - 07 [WebRip 1080p HEVC-10bit AAC][简繁日内封字幕]", "Anime-Series Title", "Lilith-Raws", 2,7)]
+        [TestCase("[LoliHouse] Love Live! 虹咲学园学园偶像同好会 第二季 / Anime-Series Title S2 - 10 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "Lilith-Raws", 2,10)]
+        [TestCase("[澄空学园&雪飘工作室&LoliHouse] 辉夜大小姐想让我告白 第三季 / Anime-Series Title S3 - 06 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime-Series Title", "Lilith-Raws", 3,6)]
+        public void should_parse_chinese_anime_season_episode_releases(string postTitle, string title, string subgroup, int SeasonNumber, int EpisodeNumber)
+        {
+            postTitle = XmlCleaner.ReplaceUnicode(postTitle);
+
+            var result = Parser.Parser.ParseTitle(postTitle);
+            result.Should().NotBeNull();
+            result.ReleaseGroup.Should().Be(subgroup);
+            result.SeasonNumber.Single().Should().Be(SeasonNumber);
+            result.EpisodeNumbers.Single().Should().Be(EpisodeNumber);
+            result.SeriesTitle.Should().Be(title);
+            result.FullSeason.Should().BeFalse();
+        }
+
         [TestCase("[喵萌奶茶屋&LoliHouse]玛娜利亚魔法学院/巴哈姆特之怒Anime Series Title - 03 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "巴哈姆特之怒Anime Series Title", "喵萌奶茶屋&LoliHouse", 3)]
         [TestCase("[悠哈璃羽字幕社&拉斯观测组&LoliHouse] 刀剑神域: Alicization / Anime Series: Title - 17 [WebRip 1080p HEVC-10bit AAC][简繁内封字幕]", "Anime Series: Title", "悠哈璃羽字幕社&拉斯观测组&LoliHouse", 17)]
         [TestCase("[ZERO字幕組]嫁給非人類·Anime-Series Title[11][BIG5][1080p]", "Anime-Series Title", "ZERO字幕組", 11)]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -28,6 +28,9 @@ namespace NzbDrone.Core.Parser
                 // Chinese LoliHouse/ZERO/Lilith-Raws releases don't use the expected brackets, normalize using brackets
                 new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
 
+                // Chinese LoliHouse/Lilith-Raws releases use Season + Absolute Episode Number, normalize using SxxExx format
+                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
+
                 // Most Chinese anime releases contain additional brackets/separators for chinese and non-chinese titles, remove junk and replace with normal anime pattern
                 new RegexReplace(@"^\[(?<subgroup>[^\]]+)\](?:\s?★[^\[ -]+\s?)?\[?(?:(?<chinesetitle>(?=[^\]]*?[\u4E00-\u9FCC])[^\]]*?)(?:\]\[|\s*[_/·]\s*)){0,2}(?<title>[^\]]+?)\]?(?:\[\d{4}\])?\[第?(?<episode>[0-9]+(?:-[0-9]+)?)(?:话|集)?(?: ?END|完| ?Fin)?\]", "[${subgroup}] ${title} - ${episode} ", RegexOptions.Compiled),
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -25,11 +25,11 @@ namespace NzbDrone.Core.Parser
                 // Some Chinese anime releases contain both English and Chinese titles, remove the Chinese title and replace with normal anime pattern
                 new RegexReplace(@"^\[(?:(?<subgroup>[^\]]+?)(?:[\u4E00-\u9FCC]+)?)\]\[(?<title>[^\]]+?)(?:\s(?<chinesetitle>[\u4E00-\u9FCC][^\]]*?))\]\[(?:(?:[\u4E00-\u9FCC]+?)?(?<episode>\d{1,4})(?:[\u4E00-\u9FCC]+?)?)\]", "[${subgroup}] ${title} - ${episode} - ", RegexOptions.Compiled),
 
-                // Chinese LoliHouse/ZERO/Lilith-Raws releases don't use the expected brackets, normalize using brackets
-                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
-
                 // Chinese LoliHouse/Lilith-Raws releases use Season + Absolute Episode Number, normalize using SxxExx format
                 new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
+
+                // Chinese LoliHouse/ZERO/Lilith-Raws releases don't use the expected brackets, normalize using brackets
+                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
 
                 // Most Chinese anime releases contain additional brackets/separators for chinese and non-chinese titles, remove junk and replace with normal anime pattern
                 new RegexReplace(@"^\[(?<subgroup>[^\]]+)\](?:\s?★[^\[ -]+\s?)?\[?(?:(?<chinesetitle>(?=[^\]]*?[\u4E00-\u9FCC])[^\]]*?)(?:\]\[|\s*[_/·]\s*)){0,2}(?<title>[^\]]+?)\]?(?:\[\d{4}\])?\[第?(?<episode>[0-9]+(?:-[0-9]+)?)(?:话|集)?(?: ?END|完| ?Fin)?\]", "[${subgroup}] ${title} - ${episode} ", RegexOptions.Compiled),

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Parser
                 new RegexReplace(@"^\[(?:(?<subgroup>[^\]]+?)(?:[\u4E00-\u9FCC]+)?)\]\[(?<title>[^\]]+?)(?:\s(?<chinesetitle>[\u4E00-\u9FCC][^\]]*?))\]\[(?:(?:[\u4E00-\u9FCC]+?)?(?<episode>\d{1,4})(?:[\u4E00-\u9FCC]+?)?)\]", "[${subgroup}] ${title} - ${episode} - ", RegexOptions.Compiled),
 
                 // Chinese LoliHouse/Lilith-Raws releases use Season + Absolute Episode Number, normalize using SxxExx format
-                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),
+                new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\].*/(?<title>[^\[\]]+?)(?:S?(?<season>(?<!\d+)\d{1,2}(?!\d+)))(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}] ${title} S${season}E${episode} [", RegexOptions.Compiled),
 
                 // Chinese LoliHouse/ZERO/Lilith-Raws releases don't use the expected brackets, normalize using brackets
                 new RegexReplace(@"^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[", "[${subgroup}][${title}][${episode}][", RegexOptions.Compiled),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Some Chinese release group (Lilith-Raws && LoliHouse) are using Season number + Episode Number in  `Sxx - xx` format, which leads the Parser using Absolute Episode Number instead of Episode Number causing import errors.

#### Test String
`[Lilith-Raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4`

#### Normalised Test String BEFORE patch
`[Lilith-Raws][ Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04][12][Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4`

This patch will normerlize it to SxxExx Format only for these two release groups

#### Normalised Test String AFTER patch
`[Lilith-Raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04E12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4`


#### Trace log for this bug
```
2023-01-08 14:40:43.0|Debug|Parser|Parsing string '[Lilith-Raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4'
2023-01-08 14:40:43.0|Trace|Parser|Replace regex: ^\[(?<subgroup>[^\]]*?(?:LoliHouse|ZERO|Lilith-Raws)[^\]]*?)\](?<title>[^\[\]]+?)(?: - (?<episode>[0-9-]+)\s*|\[第?(?<episode>[0-9]+(?:-[0-9]+)?)话?(?:END|完)?\])\[
2023-01-08 14:40:43.0|Debug|Parser|Substituted with [Lilith-Raws][ Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04][12][Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]
2023-01-08 14:40:43.0|Trace|Parser|Replace regex: ^\[(?<subgroup>[^\]]+)\](?:\s?★[^\[ -]+\s?)?\[?(?:(?<chinesetitle>[^\]]*?[\u4E00-\u9FCC][^\]]*?)(?:\]\[|\s*[_/·]\s*))?(?<title>[^\]]+?)\]?(?:\[\d{4}\])?\[第?(?<episode>[0-9]+(?:-[0-9]+)?)(?:话|集)?(?:END|完)?\]
2023-01-08 14:40:43.0|Debug|Parser|Substituted with [Lilith-Raws]  Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4]
2023-01-08 14:40:43.0|Trace|Parser|^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?)(?:(?<![-_. ]|\b[0]\d+) - )(?:[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>\[\w{8}\])?(?:$|\.mkv)
2023-01-08 14:40:43.0|Debug|Parser|Episode Parsed. Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 012 
2023-01-08 14:40:43.0|Debug|Parser|Language parsed: Chinese
2023-01-08 14:40:43.0|Debug|QualityParser|Trying to parse quality for [Lilith-Raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4
2023-01-08 14:40:43.0|Debug|Parser|Quality parsed: WEBDL-1080p v1
2023-01-08 14:40:43.0|Debug|Parser|Release Group parsed: Lilith-Raws
2023-01-08 14:40:43.0|Debug|VideoFileInfoReader|Getting media info from /data/downloads/tv-sonarr/[Lilith-Raws] Dungeon ni Deai wo Motomeru no wa Machigatteiru Darou ka S04 - 12 [Baha][WEB-DL][1080p][AVC AAC][CHT][MP4].mp4
2023-01-08 14:40:43.0|Trace|MediaInfo|Read file offset 0-16384 (16384 bytes)
2023-01-08 14:40:43.0|Trace|MediaInfo|Read file offset 753727881-754613374 (885493 bytes)
2023-01-08 14:40:43.0|Trace|MediaInfo|Read file offset 48-131120 (131072 bytes)
2023-01-08 14:40:43.0|Trace|MediaInfo|Read a total of 1032949 bytes (0.1%)
2023-01-08 14:40:43.0|Debug|ParsingService|Using absolute episode number 12 for: Is It Wrong to Try to Pick Up Girls in a Dungeon? - TVDB: 1x12
```
