### PR TITLE
New: Improve Manual Import logging when not parsing files

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (files.Count() > 100)
                 {
-                    _logger.Warn("Found more than 100 files for multiple series. Skipping parsing.");
+                    _logger.Warn("Found more than 100 files for multiple series or no series. Skipping parsing.");
                     return ProcessDownloadDirectory(rootFolder, files);
                 }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (files.Count() > 100)
                 {
-                    _logger.Warn("Found more than 100 files for one or more unknown series. Skipping parsing.");
+                    _logger.Warn("Found more than 100 files for multiple series. Skipping parsing.");
                     return ProcessDownloadDirectory(rootFolder, files);
                 }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -246,6 +246,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (files.Count() > 100)
                 {
+                    _logger.Warn("Found more than 100 files for one or more unknown series. Skipping parsing.");
                     return ProcessDownloadDirectory(rootFolder, files);
                 }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (files.Count() > 100)
                 {
-                    _logger.Warn("Found more than 100 files for multiple series or no series. Skipping parsing.");
+                    _logger.Warn("Unable to determine series from folder name and found more than 100 files. Skipping parsing");
                     return ProcessDownloadDirectory(rootFolder, files);
                 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Logs at warn that parse is being skipped; previously this was not clearer to the user

#### Todos
- Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* https://forums.sonarr.tv/t/sonarr-v4-interactive-manual-import-not-detecting-series/31336
