### PR TITLE
Remove incorrect exclamation mark

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -45,7 +45,7 @@ const fileNameTokens = [
 const seriesTokens = [
   { token: '{Series Title}', example: 'Series Title\'s' },
   { token: '{Series CleanTitle}', example: 'Series Titles' },
-  { token: '{Series CleanTitleYear}', example: 'Series Titles! 2010' },
+  { token: '{Series CleanTitleYear}', example: 'Series Titles 2010' },
   { token: '{Series TitleThe}', example: 'Series Title\'s, The' },
   { token: '{Series TitleTheYear}', example: 'Series Title\'s, The (2010)' },
   { token: '{Series TitleYear}', example: 'Series Title\'s (2010)' },


### PR DESCRIPTION
There is no reason for `Series Title\'s` to gain an exclamation mark.

#### Database Migration
YES

#### Description
Fix incorrect/misleading embedded documentation

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* N/A
