### PR TITLE
Bump ImageSharp to 2.1.3

### DIFF
--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="3.3.2" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.5" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
TVDB Image conversions when uploading PNGs seem to be just changing the file extension, thus many images are PNG saved as JPG. There is an old bug in ImageSharp when handling these. 

Pulls in this https://github.com/SixLabors/ImageSharp/issues/1704

#### Todos
- [ ] Tests
