### PR TITLE
Fixed: Calendar Grouped Series Title

### DIFF
--- a/frontend/src/Calendar/Events/CalendarEventGroup.css
+++ b/frontend/src/Calendar/Events/CalendarEventGroup.css
@@ -16,7 +16,7 @@
   @add-mixin truncate;
   flex: 1 0 1px;
   margin-right: 10px;
-  color: #3a3f51;
+  color: var(--calendarTextDimAlternate);
   font-size: $defaultFontSize;
 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes incorrect series title color in calendar event groups that have been collapsed

![image](https://user-images.githubusercontent.com/1936903/213566111-8cd8ea64-f842-4639-84d5-48003175edb4.png)

#### Todos
- N/A


#### Issues Fixed or Closed by this PR

* #5353
