### PR TITLE
Fixed: Enable parsing of repacks with revision

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -466,16 +466,16 @@ namespace NzbDrone.Core.Test.ParserTests
             result.ResolutionDetectionSource.Should().Be(QualityDetectionSource.Name);
         }
 
-        [TestCase("Series Title S04E87 REPACK 720p HDTV x264 aAF", true)]
-        [TestCase("Series.Title.S04E87.REPACK.720p.HDTV.x264-aAF", true)]
-        [TestCase("Series.Title.S04E87.REPACK2.720p.HDTV.x264-aAF", true)]
-        [TestCase("Series.Title.S04E87.PROPER.720p.HDTV.x264-aAF", false)]
-        [TestCase("Series.Title.S01E07.RERIP.720p.BluRay.x264-DEMAND", true)]
-        [TestCase("Series.Title.S01E07.RERIP2.720p.BluRay.x264-DEMAND", true)]
-        public void should_be_able_to_parse_repack(string title, bool isRepack)
+        [TestCase("Series Title S04E87 REPACK 720p HDTV x264 aAF", true, 2)]
+        [TestCase("Series.Title.S04E87.REPACK.720p.HDTV.x264-aAF", true, 2)]
+        [TestCase("Series.Title.S04E87.REPACK2.720p.HDTV.x264-aAF", true, 3)]
+        [TestCase("Series.Title.S04E87.PROPER.720p.HDTV.x264-aAF", false, 2)]
+        [TestCase("Series.Title.S01E07.RERIP.720p.BluRay.x264-DEMAND", true, 2)]
+        [TestCase("Series.Title.S01E07.RERIP2.720p.BluRay.x264-DEMAND", true, 3)]
+        public void should_be_able_to_parse_repack(string title, bool isRepack, int version)
         {
             var result = QualityParser.ParseQuality(title);
-            result.Revision.Version.Should().Be(2);
+            result.Revision.Version.Should().Be(version);
             result.Revision.IsRepack.Should().Be(isRepack);
         }
 

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -468,8 +468,10 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("Series Title S04E87 REPACK 720p HDTV x264 aAF", true)]
         [TestCase("Series.Title.S04E87.REPACK.720p.HDTV.x264-aAF", true)]
+        [TestCase("Series.Title.S04E87.REPACK2.720p.HDTV.x264-aAF", true)]
         [TestCase("Series.Title.S04E87.PROPER.720p.HDTV.x264-aAF", false)]
         [TestCase("Series.Title.S01E07.RERIP.720p.BluRay.x264-DEMAND", true)]
+        [TestCase("Series.Title.S01E07.RERIP2.720p.BluRay.x264-DEMAND", true)]
         public void should_be_able_to_parse_repack(string title, bool isRepack)
         {
             var result = QualityParser.ParseQuality(title);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -636,24 +636,22 @@ namespace NzbDrone.Core.Parser
 
             var versionRegexResult = VersionRegex.Match(normalizedName);
 
+            if (versionRegexResult.Success)
+            {
+                result.Revision.Version = Convert.ToInt32(versionRegexResult.Groups["version"].Value);
+                result.RevisionDetectionSource = QualityDetectionSource.Name;
+            }
+
             if (ProperRegex.IsMatch(normalizedName))
             {
                 result.Revision.Version = versionRegexResult.Success ? Convert.ToInt32(versionRegexResult.Groups["version"].Value) + 1 : 2;
                 result.RevisionDetectionSource = QualityDetectionSource.Name;
-                return result;
             }
 
             if (RepackRegex.IsMatch(normalizedName))
             {
                 result.Revision.Version = versionRegexResult.Success ? Convert.ToInt32(versionRegexResult.Groups["version"].Value) + 1 : 2;
                 result.Revision.IsRepack = true;
-                result.RevisionDetectionSource = QualityDetectionSource.Name;
-                return result;
-            }
-
-            if (versionRegexResult.Success)
-            {
-                result.Revision.Version = Convert.ToInt32(versionRegexResult.Groups["version"].Value);
                 result.RevisionDetectionSource = QualityDetectionSource.Name;
             }
 

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RepackRegex = new Regex(@"\b(?<repack>repack\d?|rerip\d?)\b",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex VersionRegex = new Regex(@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]",
+        private static readonly Regex VersionRegex = new Regex(@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex RealRegex = new Regex(@"\b(?<real>REAL)\b",
@@ -634,20 +634,22 @@ namespace NzbDrone.Core.Parser
         {
             var result = new QualityModel { Quality = Quality.Unknown };
 
+            var versionRegexResult = VersionRegex.Match(normalizedName);
+
             if (ProperRegex.IsMatch(normalizedName))
             {
-                result.Revision.Version = 2;
+                result.Revision.Version = versionRegexResult.Success ? Convert.ToInt32(versionRegexResult.Groups["version"].Value) + 1 : 2;
                 result.RevisionDetectionSource = QualityDetectionSource.Name;
+                return result;
             }
 
             if (RepackRegex.IsMatch(normalizedName))
             {
-                result.Revision.Version = 2;
+                result.Revision.Version = versionRegexResult.Success ? Convert.ToInt32(versionRegexResult.Groups["version"].Value) + 1 : 2;
                 result.Revision.IsRepack = true;
                 result.RevisionDetectionSource = QualityDetectionSource.Name;
+                return result;
             }
-
-            var versionRegexResult = VersionRegex.Match(normalizedName);
 
             if (versionRegexResult.Success)
             {

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ProperRegex = new Regex(@"\b(?<proper>proper)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RepackRegex = new Regex(@"\b(?<repack>repack|rerip)\b",
+        private static readonly Regex RepackRegex = new Regex(@"\b(?<repack>repack\d?|rerip\d?)\b",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex VersionRegex = new Regex(@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]",


### PR DESCRIPTION
#### Database Migration
NO

#### Description

release names containing REPACK2 (etc) don't get parsed as a repack

#### Todos


#### Issues Fixed or Closed by this PR

* fixes #5383
