### PR TITLE
New: Added new series title rename tokens without year

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -46,9 +46,12 @@ const seriesTokens = [
   { token: '{Series Title}', example: 'Series Title\'s' },
   { token: '{Series CleanTitle}', example: 'Series Titles' },
   { token: '{Series CleanTitleYear}', example: 'Series Titles! 2010' },
+  { token: '{Series CleanTitleWithoutYear}', example: 'Series Titles!' },
   { token: '{Series TitleThe}', example: 'Series Title\'s, The' },
   { token: '{Series TitleTheYear}', example: 'Series Title\'s, The (2010)' },
+  { token: '{Series TitleTheWithoutYear}', example: 'Series Title\'s, The' },
   { token: '{Series TitleYear}', example: 'Series Title\'s (2010)' },
+  { token: '{Series TitleWithoutYear}', example: 'Series Title\'s' },
   { token: '{Series TitleFirstCharacter}', example: 'S' },
   { token: '{Series Year}', example: '2010' }
 ];

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleWithoutYearFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleWithoutYearFixture.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class CleanTitleWithoutYearFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", 2018, "The Mist")]
+        [TestCase("The Rat Pack (A&E)", 1999, "The Rat Pack AandE")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 2016, "The Climax I Almost Got Away With It")]
+        public void should_get_expected_title_back(string title, int year, string expected)
+        {
+            _series.Title = title;
+            _series.Year = year;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [Test]
+        public void should_not_include_0_for_year()
+        {
+            _series.Title = "The Alienist";
+            _series.Year = 0;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be("The Alienist");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheWithoutYearFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleTheWithoutYearFixture.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class TitleTheWithoutYearFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", 2018, "Mist, The")]
+        [TestCase("The Rat Pack (A&E)", 1999, "Rat Pack, The (A&E)")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 2016, "Climax - I (Almost) Got Away With It, The")]
+        [TestCase("A", 2017, "A")]
+        public void should_get_expected_title_back(string title, int year, string expected)
+        {
+            _series.Title = title;
+            _series.Year = year;
+            _namingConfig.StandardEpisodeFormat = "{Series TitleTheWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [Test]
+        public void should_not_include_0_for_year()
+        {
+            _series.Title = "The Alienist";
+            _series.Year = 0;
+            _namingConfig.StandardEpisodeFormat = "{Series TitleTheWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be("Alienist, The");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleWithoutYearFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TitleWithoutYearFixture.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class TitleWithoutYearFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", 2018, "The Mist")]
+        [TestCase("The Rat Pack (A&E)", 1999, "The Rat Pack (A&E)")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 2016, "The Climax - I (Almost) Got Away With It")]
+        public void should_get_expected_title_back(string title, int year, string expected)
+        {
+            _series.Title = title;
+            _series.Year = year;
+            _namingConfig.StandardEpisodeFormat = "{Series TitleWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [Test]
+        public void should_not_include_0_for_year()
+        {
+            _series.Title = "The Alienist";
+            _series.Year = 0;
+            _namingConfig.StandardEpisodeFormat = "{Series TitleWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be("The Alienist");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -372,12 +372,6 @@ namespace NzbDrone.Core.Organizer
 
         public static string TitleWithoutYear(string title)
         {
-            // Regex match incase the year in the title doesn't match the year, for whatever reason.
-            // if (YearRegex.IsMatch(title))
-            // {
-            //    return title;
-            // }
-
             title = YearRegex.Replace(title, "");
 
             return title;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Organizer
 
         public static readonly Regex AirDateRegex = new Regex(@"\{Air(\s|\W|_)Date\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static readonly Regex SeriesTitleRegex = new Regex(@"(?<token>\{(?:Series)(?<separator>[- ._])(Clean)?Title(The)?(Year)?\})",
+        public static readonly Regex SeriesTitleRegex = new Regex(@"(?<token>\{(?:Series)(?<separator>[- ._])(Clean)?Title(The)?(Without)?(Year)?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
@@ -370,6 +370,19 @@ namespace NzbDrone.Core.Organizer
             return $"{title} ({year})";
         }
 
+        public static string TitleWithoutYear(string title)
+        {
+            // Regex match incase the year in the title doesn't match the year, for whatever reason.
+            // if (YearRegex.IsMatch(title))
+            // {
+            //    return title;
+            // }
+
+            title = YearRegex.Replace(title, "");
+
+            return title;
+        }
+
         public static string CleanFileName(string name, bool replace = true)
         {
             string result = name;
@@ -453,9 +466,12 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Series Title}"] = m => series.Title;
             tokenHandlers["{Series CleanTitle}"] = m => CleanTitle(series.Title);
             tokenHandlers["{Series CleanTitleYear}"] = m => CleanTitle(TitleYear(series.Title, series.Year));
+            tokenHandlers["{Series CleanTitleWithoutYear}"] = m => CleanTitle(TitleWithoutYear(series.Title));
             tokenHandlers["{Series TitleThe}"] = m => TitleThe(series.Title);
             tokenHandlers["{Series TitleYear}"] = m => TitleYear(series.Title, series.Year);
+            tokenHandlers["{Series TitleWithoutYear}"] = m => TitleWithoutYear(series.Title);
             tokenHandlers["{Series TitleTheYear}"] = m => TitleYear(TitleThe(series.Title), series.Year);
+            tokenHandlers["{Series TitleTheWithoutYear}"] = m => TitleWithoutYear(TitleThe(series.Title));
             tokenHandlers["{Series TitleFirstCharacter}"] = m => TitleThe(series.Title).Substring(0, 1).FirstCharToUpper();
             tokenHandlers["{Series Year}"] = m => series.Year.ToString();
         }

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
adds the naming tokens: 

* `{Series TitleWithoutYear}`
* `{Series TitleTheWithoutYear}`
* `{Series CleanTitleWithoutYear}`

#### Todos


#### Issues Fixed or Closed by this PR

* fixes #5369 
