### PR TITLE
Fixed: Avoid Sqlite Error when all profiles have lowest quality cutoff

### DIFF
--- a/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Profiles.Qualities;
@@ -41,6 +42,13 @@ namespace NzbDrone.Core.Tv
                 {
                     qualitiesBelowCutoff.Add(new QualitiesBelowCutoff(profile.Id, belowCutoff.SelectMany(i => i.GetQualities().Select(q => q.Id))));
                 }
+            }
+
+            if (qualitiesBelowCutoff.Empty())
+            {
+                pagingSpec.Records = new List<Episode>();
+
+                return pagingSpec;
             }
 
             return _episodeRepository.EpisodesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff, languagesBelowCutoff, false);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If the cutoff quality on every profile is the lowest quality, `qualitiesBelowCutoff` will be empty in EpisodeCutoffService. This results in SQLite error when query is run on the DB due to the Where clause calculating to `AND ()`. This fix returns empty list before going into Repo.

```
System.Data.SQLite.SQLiteException: 'SQL logic error
near ")": syntax error'
```

Ref: https://github.com/Readarr/Readarr/issues/1911