### PR TITLE
New: Return static response to requests while app is starting

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/IRuntimeInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/IRuntimeInfo.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Common.EnvironmentInfo
         bool IsAdmin { get; }
         bool IsWindowsService { get; }
         bool IsWindowsTray { get; }
+        bool IsStarting { get; set; }
         bool IsExiting { get; set; }
         bool IsTray { get; }
         RuntimeMode Mode { get; }

--- a/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/RuntimeInfo.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Common.EnvironmentInfo
             _logger = logger;
 
             IsWindowsService = hostLifetime is WindowsServiceLifetime;
+            IsStarting = true;
 
             // net6.0 will return Sonarr.dll for entry assembly, we need the actual
             // executable name (Sonarr on linux).  On mono this will return the location of
@@ -82,6 +83,7 @@ namespace NzbDrone.Common.EnvironmentInfo
 
         public bool IsWindowsService { get; private set; }
 
+        public bool IsStarting { get; set; }
         public bool IsExiting { get; set; }
         public bool IsTray
         {

--- a/src/NzbDrone.Host/AppLifetime.cs
+++ b/src/NzbDrone.Host/AppLifetime.cs
@@ -56,6 +56,7 @@ namespace NzbDrone.Host
 
         private void OnAppStarted()
         {
+            _runtimeInfo.IsStarting = false;
             _runtimeInfo.IsExiting = false;
 
             if (!_startupContext.Flags.Contains(StartupContext.NO_BROWSER)

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -251,6 +251,7 @@ namespace NzbDrone.Host
 
             app.UseMiddleware<VersionMiddleware>();
             app.UseMiddleware<UrlBaseMiddleware>(configFileProvider.UrlBase);
+            app.UseMiddleware<StartingUpMiddleware>();
             app.UseMiddleware<CacheHeaderMiddleware>();
             app.UseMiddleware<IfModifiedMiddleware>();
             app.UseMiddleware<BufferingMiddleware>(new List<string> { "/api/v3/command" });

--- a/src/Sonarr.Http/Middleware/StartingUpMiddleware.cs
+++ b/src/Sonarr.Http/Middleware/StartingUpMiddleware.cs
@@ -1,0 +1,43 @@
+using System.Buffers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Lifecycle;
+using NzbDrone.Core.Messaging.Events;
+using Sonarr.Http.Extensions;
+
+namespace Sonarr.Http.Middleware
+{
+    public class StartingUpMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IRuntimeInfo _runtimeInfo;
+        private static readonly string MESSAGE = "Sonarr is starting up, please try again later";
+
+        public StartingUpMiddleware(RequestDelegate next, IRuntimeInfo runtimeInfo)
+        {
+            _next = next;
+            _runtimeInfo = runtimeInfo;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (_runtimeInfo.IsStarting)
+            {
+                var isJson = context.Request.IsApiRequest();
+                var message = isJson ? STJson.ToJson(new { ErrorMessage = MESSAGE }) : MESSAGE;
+                var bytes = Encoding.UTF8.GetBytes(message);
+
+                context.Response.StatusCode = 503;
+                context.Response.ContentType = isJson ? "application/json" : "text/plain";
+                await context.Response.Body.WriteAsync(bytes, 0, bytes.Length);
+
+                return;
+            }
+
+            await _next(context);
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Returns a 503 response as plain text or JSON when Sonarr hasn't finished starting up, but the web server is online. In the future we could look at running migrations after the web server starts to provide feedback.

#### Issues Fixed or Closed by this PR

* Closes #5402
