### PR TITLE
New: Make Release Group Outline Not Show as Required

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.css
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.css
@@ -27,3 +27,11 @@
 .customFormatTooltip {
   max-width: 250px;
 }
+
+.optional {
+  display: inline-block;
+  margin: -8px 0;
+  width: 100%;
+  height: 25px;
+  border: 2px dashed var(--gray);
+}

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.js
@@ -319,7 +319,9 @@ class InteractiveImportRow extends Component {
         >
           {
             showReleaseGroupPlaceholder ?
-              <InteractiveImportRowCellPlaceholder /> :
+              <InteractiveImportRowCellPlaceholder
+                className={styles.optional}
+              /> :
               releaseGroup
           }
         </TableRowCellButton>

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRowCellPlaceholder.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRowCellPlaceholder.js
@@ -1,10 +1,19 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './InteractiveImportRowCellPlaceholder.css';
 
-function InteractiveImportRowCellPlaceholder() {
+function InteractiveImportRowCellPlaceholder({ className }) {
   return (
-    <span className={styles.placeholder} />
+    <span className={className} />
   );
 }
+
+InteractiveImportRowCellPlaceholder.propTypes = {
+  className: PropTypes.string.isRequired
+};
+
+InteractiveImportRowCellPlaceholder.defaultProps = {
+  className: styles.placeholder
+};
 
 export default InteractiveImportRowCellPlaceholder;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When doing a manual import the Release Group setting shows as if it is a required setting, this changes that to not look like that

![image](https://user-images.githubusercontent.com/1936903/216829447-939d4d3b-0a98-4d2b-b75d-10598a497a3a.png)

#### Todos


#### Issues Fixed or Closed by this PR

* 
