### PR TITLE
Fixed: Show calculated (rather than stored) custom format score on season and series history, to match episode history

### DIFF
--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -191,8 +191,8 @@ SeriesHistoryRow.propTypes = {
   fullSeries: PropTypes.bool.isRequired,
   series: PropTypes.object.isRequired,
   episode: PropTypes.object.isRequired,
-  onMarkAsFailedPress: PropTypes.func.isRequired,
-  customFormatScore: PropTypes.number.isRequired
+  customFormatScore: PropTypes.number.isRequired,
+  onMarkAsFailedPress: PropTypes.func.isRequired
 };
 
 export default SeriesHistoryRow;

--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -191,7 +191,8 @@ SeriesHistoryRow.propTypes = {
   fullSeries: PropTypes.bool.isRequired,
   series: PropTypes.object.isRequired,
   episode: PropTypes.object.isRequired,
-  onMarkAsFailedPress: PropTypes.func.isRequired
+  onMarkAsFailedPress: PropTypes.func.isRequired,
+  customFormatScore: PropTypes.number.isRequired
 };
 
 export default SeriesHistoryRow;

--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -75,7 +75,8 @@ class SeriesHistoryRow extends Component {
       data,
       fullSeries,
       series,
-      episode
+      episode,
+      customFormatScore
     } = this.props;
 
     const {
@@ -145,7 +146,7 @@ class SeriesHistoryRow extends Component {
         <TableRowCell className={styles.customFormatScore}>
           <Tooltip
             anchor={
-              formatPreferredWordScore(data.customFormatScore, customFormats.length)
+              formatPreferredWordScore(customFormatScore, customFormats.length)
             }
             tooltip={<EpisodeFormats formats={customFormats} />}
             position={tooltipPositions.BOTTOM}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
@markus101 updated episode history to show freshly calculated custom format score (rather than the one stored at time of import) in #5292. However, series and season history still show the stored value. This PR updates series and season to display the freshly calculated score.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
