### PR TITLE
New: Use better page size for Newznab/Torznab (up to 100) when supported by the indexer

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_use_bestpagesize_reported_by_caps()
+        public void should_use_best_pagesize_reported_by_caps()
         {
             _caps.MaxPageSize = 30;
             _caps.DefaultPageSize = 25;
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_use_not_use_over_100_pagesize_reported_by_caps()
+        public void should_not_use_pagesize_over_100_even_if_reported_in_caps()
         {
             _caps.MaxPageSize = 250;
             _caps.DefaultPageSize = 25;

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
@@ -94,12 +94,21 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_use_pagesize_reported_by_caps()
+        public void should_use_bestpagesize_reported_by_caps()
         {
             _caps.MaxPageSize = 30;
             _caps.DefaultPageSize = 25;
 
-            Subject.PageSize.Should().Be(25);
+            Subject.PageSize.Should().Be(30);
+        }
+
+        [Test]
+        public void should_use_not_use_over_100_pagesize_reported_by_caps()
+        {
+            _caps.MaxPageSize = 250;
+            _caps.DefaultPageSize = 25;
+
+            Subject.PageSize.Should().Be(100);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
@@ -136,12 +136,21 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_use_pagesize_reported_by_caps()
+        public void should_use_bestpagesize_reported_by_caps()
         {
             _caps.MaxPageSize = 30;
             _caps.DefaultPageSize = 25;
 
-            Subject.PageSize.Should().Be(25);
+            Subject.PageSize.Should().Be(30);
+        }
+
+        [Test]
+        public void should_use_not_use_over_100_pagesize_reported_by_caps()
+        {
+            _caps.MaxPageSize = 250;
+            _caps.DefaultPageSize = 25;
+
+            Subject.PageSize.Should().Be(100);
         }
 
         [TestCase("http://localhost:9117/", "/api")]

--- a/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_use_bestpagesize_reported_by_caps()
+        public void should_use_best_pagesize_reported_by_caps()
         {
             _caps.MaxPageSize = 30;
             _caps.DefaultPageSize = 25;
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_use_not_use_over_100_pagesize_reported_by_caps()
+        public void should_not_use_pagesize_over_100_even_if_reported_in_caps()
         {
             _caps.MaxPageSize = 250;
             _caps.DefaultPageSize = 25;

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         public override DownloadProtocol Protocol => DownloadProtocol.Usenet;
 
-        public override int PageSize => _capabilitiesProvider.GetCapabilities(Settings).DefaultPageSize;
+        public override int PageSize => Math.Min(100, Math.Max(_capabilitiesProvider.GetCapabilities(Settings).DefaultPageSize, _capabilitiesProvider.GetCapabilities(Settings).MaxPageSize));
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {

--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Indexers.Torznab
         public override string Name => "Torznab";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
-        public override int PageSize => _capabilitiesProvider.GetCapabilities(Settings).DefaultPageSize;
+        public override int PageSize => Math.Min(100, Math.Max(_capabilitiesProvider.GetCapabilities(Settings).DefaultPageSize, _capabilitiesProvider.GetCapabilities(Settings).MaxPageSize));
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {


### PR DESCRIPTION
Max of Default or Max and no more than 100

#### Database Migration
NO

#### Description

Change Newznab/Torznab logic to to use the largest page size of DefaultPageSize or MaxPageSize with a hardcoded max cap of 100

#### Todos
- [x] Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* Fixes: #5373
