### PR TITLE
Fixed: text color of complete seasons dark mode

### DIFF
--- a/frontend/src/SeasonPass/SeasonPassSeason.css
+++ b/frontend/src/SeasonPass/SeasonPassSeason.css
@@ -21,4 +21,5 @@
 
 .allEpisodes {
   background-color: #e0ffe0;
+  color: var(--darkGray);
 }


### PR DESCRIPTION


#### Database Migration
NO

#### Description
the readability of complete seasons on season pass is not great. changed from light gray to dark gray:
![image](https://user-images.githubusercontent.com/1117625/218331936-877443c0-35c9-4b0f-b36e-ff6e625abc30.png)
 to 
![image](https://user-images.githubusercontent.com/1117625/218331957-e0f9e1b9-bd84-4734-a29b-0d829f7002bd.png)



#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
