### PR TITLE
Remove unused ReactDOM import

### DIFF
--- a/frontend/src/Components/FileBrowser/FileBrowserModalContent.js
+++ b/frontend/src/Components/FileBrowser/FileBrowserModalContent.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 import Alert from 'Components/Alert';
 import PathInput from 'Components/Form/PathInput';
 import Button from 'Components/Link/Button';


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fixes error with mono: "error  'ReactDOM' is defined but never used  no-unused-vars"
