### PR TITLE
Add support for token-based authorization in ntfy.sh notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -114,12 +114,16 @@ namespace NzbDrone.Core.Notifications.Ntfy
                     requestBuilder.Headers.Add("X-Click", settings.ClickUrl);
                 }
 
-                var request = requestBuilder.Build();
-
-                if (!settings.UserName.IsNullOrWhiteSpace() && !settings.Password.IsNullOrWhiteSpace())
+                if (!settings.AccessToken.IsNullOrWhiteSpace())
                 {
-                    request.Credentials = new BasicNetworkCredential(settings.UserName, settings.Password);
+                    requestBuilder.Headers.Add("Authorization", "Bearer " + settings.AccessToken);
                 }
+                else if (!settings.UserName.IsNullOrWhiteSpace() && !settings.Password.IsNullOrWhiteSpace())
+                {
+                    requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.UserName, settings.Password);
+                }
+
+                var request = requestBuilder.Build();
 
                 _httpClient.Execute(request);
             }

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
@@ -16,8 +16,8 @@ namespace NzbDrone.Core.Notifications.Ntfy
             RuleFor(c => c.Priority).InclusiveBetween(1, 5);
             RuleFor(c => c.ServerUrl).IsValidUrl().When(c => !c.ServerUrl.IsNullOrWhiteSpace());
             RuleFor(c => c.ClickUrl).IsValidUrl().When(c => !c.ClickUrl.IsNullOrWhiteSpace());
-            RuleFor(c => c.UserName).NotEmpty().When(c => !c.Password.IsNullOrWhiteSpace());
-            RuleFor(c => c.Password).NotEmpty().When(c => !c.UserName.IsNullOrWhiteSpace());
+            RuleFor(c => c.UserName).NotEmpty().When(c => !c.Password.IsNullOrWhiteSpace() && c.AccessToken.IsNullOrWhiteSpace());
+            RuleFor(c => c.Password).NotEmpty().When(c => !c.UserName.IsNullOrWhiteSpace() && c.AccessToken.IsNullOrWhiteSpace());
             RuleForEach(c => c.Topics).NotEmpty().Matches("[a-zA-Z0-9_-]+").Must(c => !InvalidTopics.Contains(c)).WithMessage("Invalid topic");
         }
 
@@ -43,16 +43,19 @@ namespace NzbDrone.Core.Notifications.Ntfy
         [FieldDefinition(2, Label = "Password", Type = FieldType.Password, HelpText = "Optional Password", Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        [FieldDefinition(3, Label = "Priority", Type = FieldType.Select, SelectOptions = typeof(NtfyPriority))]
+        [FieldDefinition(3, Label = "Access Token", HelpText = "Optional token-based authorization; takes priority over username/password", HelpLink = "https://docs.ntfy.sh/config/#access-tokens")]
+        public string AccessToken { get; set; }
+
+        [FieldDefinition(4, Label = "Priority", Type = FieldType.Select, SelectOptions = typeof(NtfyPriority))]
         public int Priority { get; set; }
 
-        [FieldDefinition(4, Label = "Topics", HelpText = "List of Topics to send notifications to", Type = FieldType.Tag)]
+        [FieldDefinition(5, Label = "Topics", HelpText = "List of Topics to send notifications to", Type = FieldType.Tag)]
         public IEnumerable<string> Topics { get; set; }
 
-        [FieldDefinition(5, Label = "Ntfy Tags and Emojis", Type = FieldType.Tag, HelpText = "Optional list of tags or emojis to use", HelpLink = "https://ntfy.sh/docs/emojis/")]
+        [FieldDefinition(6, Label = "Ntfy Tags and Emojis", Type = FieldType.Tag, HelpText = "Optional list of tags or emojis to use", HelpLink = "https://ntfy.sh/docs/emojis/")]
         public IEnumerable<string> Tags { get; set; }
 
-        [FieldDefinition(6, Label = "Click Url", Type = FieldType.Url, HelpText = "Optional link when user clicks notification")]
+        [FieldDefinition(7, Label = "Click Url", Type = FieldType.Url, HelpText = "Optional link when user clicks notification")]
         public string ClickUrl { get; set; }
 
         public NzbDroneValidationResult Validate()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
ntfy.sh added support for token-based authorization [^1] in version 2.0.0.
This adds another field where the user can input the token.
Using a token takes precedence over username and password-based authentication.

NOTE: I have 0 experience with C# so I just tried to copy the code around it.
I've tested the changes with Visual Studio 2022 and everything works as advertised, though.

[^1]: https://docs.ntfy.sh/releases/#ntfy-server-v200

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
