### PR TITLE
Fixed: Processing very long ETA from Transmission 

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -285,16 +285,24 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             item.RemainingTime.Should().NotHaveValue();
         }
 
-        [TestCase(2147483648)] // 2038-01-19T03:14:23Z > int.MaxValue as unix timestamp can be either an int or a long
-        public void should_support_long_values_for_eta(long eta)
+        [TestCase(2147483648)] // 2038-01-19T03:14:08Z > int.MaxValue as unix timestamp can be either an int or a long
+        public void should_support_long_values_for_eta_in_seconds(long eta)
         {
             _downloading.Eta = eta;
 
             PrepareClientToReturnDownloadingItem();
             var item = Subject.GetItems().Single();
-            item.RemainingTime.Should().Be(
-                new DateTimeOffset(eta, new TimeSpan(0)) -
-                DateTimeOffset.UtcNow);
+            item.RemainingTime.Should().Be(TimeSpan.FromSeconds(eta));
+        }
+
+        [TestCase(2147483648000)] // works with milliseconds format too
+        public void should_support_long_values_for_eta_in_milliseconds(long eta)
+        {
+            _downloading.Eta = eta;
+
+            PrepareClientToReturnDownloadingItem();
+            var item = Subject.GetItems().Single();
+            item.RemainingTime.Should().Be(TimeSpan.FromMilliseconds(eta));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -275,7 +275,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
 
         [TestCase(-1)] // Infinite/Unknown
         [TestCase(-2)] // Magnet Downloading
-        public void should_ignore_negative_eta(int eta)
+        public void should_ignore_negative_eta(long eta)
         {
             _completed.Eta = eta;
 

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -282,6 +283,18 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             PrepareClientToReturnCompletedItem();
             var item = Subject.GetItems().Single();
             item.RemainingTime.Should().NotHaveValue();
+        }
+
+        [TestCase(2147483648)] // 2038-01-19T03:14:23Z > int.MaxValue as unix timestamp can be either an int or a long
+        public void should_support_long_values_for_eta(long eta)
+        {
+            _downloading.Eta = eta;
+
+            PrepareClientToReturnDownloadingItem();
+            var item = Subject.GetItems().Single();
+            item.RemainingTime.Should().Be(
+                new DateTimeOffset(eta, new TimeSpan(0)) -
+                DateTimeOffset.UtcNow);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -271,7 +271,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
 
         [TestCase(-1)] // Infinite/Unknown
         [TestCase(-2)] // Magnet Downloading
-        public void should_ignore_negative_eta(int eta)
+        public void should_ignore_negative_eta(long eta)
         {
             _completed.Eta = eta;
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -80,7 +80,14 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 if (torrent.Eta >= 0)
                 {
-                    item.RemainingTime = TimeSpan.FromSeconds(torrent.Eta);
+                    try
+                    {
+                        item.RemainingTime = TimeSpan.FromSeconds(torrent.Eta);
+                    }
+                    catch (OverflowException)
+                    {
+                        item.RemainingTime = TimeSpan.FromMilliseconds(torrent.Eta);
+                    }
                 }
 
                 if (!torrent.ErrorString.IsNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
@@ -9,7 +9,7 @@
         public long TotalSize { get; set; }
         public long LeftUntilDone { get; set; }
         public bool IsFinished { get; set; }
-        public int Eta { get; set; }
+        public long Eta { get; set; }
         public TransmissionTorrentStatus Status { get; set; }
         public int SecondsDownloading { get; set; }
         public int SecondsSeeding { get; set; }


### PR DESCRIPTION
#### Database Migration
NO? (I don't think so but please double check)

#### Description

fixes #5444

[The transmission API spec](https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md) defines where the [Eta field is declared](https://github.com/transmission/transmission/blob/9d310b3a4d4a3fb119993e65f07ac5e80dde662a/libtransmission/transmission.h#L1439) and it derives from t_time [which can be int32 or int64](https://stackoverflow.com/questions/471248/what-is-time-t-ultimately-a-typedef-to).
My guess is that during their v4 upgrade, the upgraded underlying libs which moved to int64 to anticipate the 2038 limit on unix timestamps.

This PR changes the field on the client side from int to int64 (long) to address the overflow issue

#### Todos
- [x] Tests
- [ ] Wiki Updates N/A


#### Issues Fixed or Closed by this PR

* 
