### PR TITLE
Fixed: Mapping of parsed titles when one doesn't have an alias

### DIFF
--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -93,13 +93,13 @@ namespace NzbDrone.Core.Parser
                 if (!tvdbId.HasValue)
                 {
                     _logger.Trace("Title {0} not matching any series.", title);
-                    return null;
+                    continue;
                 }
 
                 if (foundTvdbId.HasValue && tvdbId != foundTvdbId)
                 {
                     _logger.Trace("Title {0} both matches tvdbid {1} and {2}, no series selected.", parsedEpisodeInfo.SeriesTitle, foundTvdbId, tvdbId);
-                    return null;
+                    continue;
                 }
 
                 if (foundSeries == null)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Parser
                 if (foundTvdbId.HasValue && tvdbId != foundTvdbId)
                 {
                     _logger.Trace("Title {0} both matches tvdbid {1} and {2}, no series selected.", parsedEpisodeInfo.SeriesTitle, foundTvdbId, tvdbId);
-                    continue;
+                    return null;
                 }
 
                 if (foundSeries == null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
mapping all titles

#### Example
release: `Одни из нас (The Last of Us) S1E1-7 (2023)`
it is parsed as two title:
- `Одни из нас`
- `The Last of Us`

##### before fix
error: `Release Rejected: Unknown Series`
##### after fix: 
mapped