### PR TITLE
Use Array.Empty and fix a few multiple enumerations

### DIFF
--- a/src/NzbDrone.Common/Composition/AssemblyLoader.cs
+++ b/src/NzbDrone.Common/Composition/AssemblyLoader.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Common.Composition
 
             return toLoad
                 .Select(x => AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(startupPath, $"{x}.dll")))
-                .ToArray();
+                .ToList();
         }
 
         private static Assembly ContainerResolveEventHandler(object sender, ResolveEventArgs args)

--- a/src/NzbDrone.Common/Composition/AssemblyLoader.cs
+++ b/src/NzbDrone.Common/Composition/AssemblyLoader.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Common.Composition
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(ContainerResolveEventHandler);
         }
 
-        public static IEnumerable<Assembly> Load(IEnumerable<string> assemblyNames)
+        public static IList<Assembly> Load(IList<string> assemblyNames)
         {
             var toLoad = assemblyNames.ToList();
             toLoad.Add("Sonarr.Common");
@@ -28,8 +28,9 @@ namespace NzbDrone.Common.Composition
 
             var startupPath = AppDomain.CurrentDomain.BaseDirectory;
 
-            return toLoad.Select(x =>
-                AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(startupPath, $"{x}.dll")));
+            return toLoad
+                .Select(x => AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(startupPath, $"{x}.dll")))
+                .ToArray();
         }
 
         private static Assembly ContainerResolveEventHandler(object sender, ResolveEventArgs args)

--- a/src/NzbDrone.Common/OAuth/WebParameterCollection.cs
+++ b/src/NzbDrone.Common/OAuth/WebParameterCollection.cs
@@ -15,14 +15,14 @@ namespace NzbDrone.Common.OAuth
         {
             get
             {
-                var parameters = this.Where(p => p.Name.Equals(name));
+                var parameters = this.Where(p => p.Name.Equals(name)).ToArray();
 
                 if (parameters.Empty())
                 {
                     return null;
                 }
 
-                if (parameters.Count() == 1)
+                if (parameters.Length == 1)
                 {
                     return parameters.Single();
                 }

--- a/src/NzbDrone.Core/DataAugmentation/DailySeries/DailySeriesDataProxy.cs
+++ b/src/NzbDrone.Core/DataAugmentation/DailySeries/DailySeriesDataProxy.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.DataAugmentation.DailySeries
             catch (Exception ex)
             {
                 _logger.Warn(ex, "Failed to get Daily Series");
-                return new List<int>();
+                return Array.Empty<int>();
             }
         }
     }

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Datastore
         {
             if (!ids.Any())
             {
-                return new List<TModel>();
+                return Array.Empty<TModel>();
             }
 
             var result = Query(x => ids.Contains(x.Id));

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV1.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using NLog;
@@ -61,7 +62,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             catch (DownloadClientException e)
             {
                 _logger.Error(e);
-                return new List<DownloadStationTask>();
+                return Array.Empty<DownloadStationTask>();
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV2.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -102,7 +103,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
             catch (DownloadClientException e)
             {
                 _logger.Error(e);
-                return new List<DownloadStationTask>();
+                return Array.Empty<DownloadStationTask>();
             }
         }
 

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
             if (seriesFolder.IsNullOrWhiteSpace() && seasonFolder.IsNullOrWhiteSpace())
             {
-                return new List<MetadataFile>();
+                return Array.Empty<MetadataFile>();
             }
 
             var files = new List<MetadataFile>();

--- a/src/NzbDrone.Core/ImportLists/Simkl/SimklImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/SimklImportBase.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.ImportLists.Simkl
             // Check to see if user has any activity since last sync, if not return empty to avoid work
             if (lastFetch.HasValue && lastActivity < lastFetch.Value.AddHours(-2))
             {
-                return new List<ImportListItemInfo>();
+                return Array.Empty<ImportListItemInfo>();
             }
 
             var generator = GetRequestGenerator();

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsRss)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetRecentRequests(), true);
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
@@ -83,7 +83,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Indexers
         {
             if (!SupportsSearch)
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Indexers
 
             if (!PostProcess(indexerResponse, items, releases))
             {
-                return new List<ReleaseInfo>();
+                return Array.Empty<ReleaseInfo>();
             }
 
             return releases;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -51,12 +51,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
         public List<ImportResult> Import(List<ImportDecision> decisions, bool newDownload, DownloadClientItem downloadClientItem = null, ImportMode importMode = ImportMode.Auto)
         {
-            var qualifiedImports = decisions.Where(c => c.Approved)
-               .GroupBy(c => c.LocalEpisode.Series.Id, (i, s) => s
-                   .OrderByDescending(c => c.LocalEpisode.Quality, new QualityModelComparer(s.First().LocalEpisode.Series.QualityProfile))
-                   .ThenByDescending(c => c.LocalEpisode.Size))
-               .SelectMany(c => c)
-               .ToList();
+            var qualifiedImports = decisions
+                .Where(decision => decision.Approved)
+                .GroupBy(decision => decision.LocalEpisode.Series.Id)
+                .SelectMany(group => group
+                    .OrderByDescending(decision => decision.LocalEpisode.Quality, new QualityModelComparer(group.First().LocalEpisode.Series.QualityProfile))
+                    .ThenByDescending(decision => decision.LocalEpisode.Size))
+                .ToList();
 
             var importResults = new List<ImportResult>();
 

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -186,7 +186,7 @@ namespace NzbDrone.Core.Tv
             }
         }
 
-        private void AdjustDirectToDvdAirDate(Series series, IEnumerable<Episode> allEpisodes)
+        private void AdjustDirectToDvdAirDate(Series series, IList<Episode> allEpisodes)
         {
             if (series.Status == SeriesStatusType.Ended && allEpisodes.All(v => !v.AirDateUtc.HasValue) && series.FirstAired.HasValue)
             {

--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -45,11 +45,11 @@ namespace Sonarr.Api.V3
         [Produces("application/json")]
         public List<TProviderResource> GetAll()
         {
-            var providerDefinitions = _providerFactory.All().OrderBy(p => p.ImplementationName);
+            var providerDefinitions = _providerFactory.All();
 
-            var result = new List<TProviderResource>(providerDefinitions.Count());
+            var result = new List<TProviderResource>(providerDefinitions.Count);
 
-            foreach (var definition in providerDefinitions)
+            foreach (var definition in providerDefinitions.OrderBy(p => p.ImplementationName))
             {
                 _providerFactory.SetProviderCharacteristics(definition);
 

--- a/src/Sonarr.Http/REST/RestController.cs
+++ b/src/Sonarr.Http/REST/RestController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
@@ -87,7 +88,8 @@ namespace Sonarr.Http.REST
                 }
             }
 
-            var attributes = descriptor.MethodInfo.CustomAttributes;
+            var attributes = descriptor.MethodInfo.CustomAttributes as IReadOnlyCollection<CustomAttributeData> ??
+                             descriptor.MethodInfo.CustomAttributes.ToArray();
             if (attributes.Any(x => VALIDATE_ID_ATTRIBUTES.Contains(x.AttributeType)) && !skipValidate)
             {
                 if (context.ActionArguments.TryGetValue("id", out var idObj))


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR fixes just a few multiple enumerations and reduces number of allocations by using Array.Empty

#### Todos
- [x] Tests