### PR TITLE
New: Add indexer option for Discord on grab notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -101,6 +101,10 @@ namespace NzbDrone.Core.Notifications.Discord
                         discordField.Name = "Links";
                         discordField.Value = GetLinksString(series);
                         break;
+                    case DiscordGrabFieldType.Indexer:
+                        discordField.Name = "Indexer";
+                        discordField.Value = message.Episode.Release.Indexer;
+                        break;
                 }
 
                 if (discordField.Name.IsNotNullOrWhiteSpace() && discordField.Value.IsNotNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
@@ -11,7 +11,8 @@ namespace NzbDrone.Core.Notifications.Discord
         Links,
         Release,
         Poster,
-        Fanart
+        Fanart,
+        Indexer
     }
 
     public enum DiscordImportFieldType


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When the OnGrab Discord notification is triggered it can now display the Indexer's name from the grab.

![Minimal example of discord notification](https://user-images.githubusercontent.com/48859312/225920704-d0079339-bf94-4a32-a426-21bccb9a481d.png)

#### Todos
- [-] Tests: [no tests](https://github.com/lodu/Sonarr/tree/discord-notification-grab-indexer/src/NzbDrone.Core.Test/NotificationTests)
- [-] Wiki Updates: [no wiki entry for fields](https://wiki.servarr.com/sonarr/supported#notifications)


