### PR TITLE
Use MinBy and MaxBy instead of OrderBy + First

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -450,12 +450,11 @@ namespace NzbDrone.Common.Disk
 
                 return mounts.Where(drive => drive.RootDirectory.PathEquals(path) ||
                                              drive.RootDirectory.IsParentPath(path))
-                          .OrderByDescending(drive => drive.RootDirectory.Length)
-                          .FirstOrDefault();
+                          .MaxBy(drive => drive.RootDirectory.Length);
             }
             catch (Exception ex)
             {
-                Logger.Debug(ex, string.Format("Failed to get mount for path {0}", path));
+                Logger.Debug(ex, $"Failed to get mount for path {path}");
                 return null;
             }
         }

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -10,7 +10,6 @@ using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download.Aggregation;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Jobs;
-using NzbDrone.Core.Languages;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
@@ -97,7 +96,7 @@ namespace NzbDrone.Core.Download.Pending
 
                     var episodeIds = decision.RemoteEpisode.Episodes.Select(e => e.Id);
 
-                    var existingReports = episodeIds.SelectMany(v => alreadyPendingByEpisode[v] ?? Enumerable.Empty<PendingRelease>())
+                    var existingReports = episodeIds.SelectMany(v => alreadyPendingByEpisode[v])
                                                     .Distinct().ToList();
 
                     var matchingReports = existingReports.Where(MatchingReleasePredicate(decision.RemoteEpisode.Release)).ToList();
@@ -243,8 +242,7 @@ namespace NzbDrone.Core.Download.Pending
 
             return seriesReleases.Select(r => r.RemoteEpisode)
                                  .Where(r => r.Episodes.Select(e => e.Id).Intersect(episodeIds).Any())
-                                 .OrderByDescending(p => p.Release.AgeHours)
-                                 .FirstOrDefault();
+                                 .MaxBy(p => p.Release.AgeHours);
         }
 
         private ILookup<int, PendingRelease> CreateEpisodeLookup(IEnumerable<PendingRelease> alreadyPending)

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -30,9 +30,7 @@ namespace NzbDrone.Core.History
 
         public EpisodeHistory MostRecentForEpisode(int episodeId)
         {
-            return Query(h => h.EpisodeId == episodeId)
-                        .OrderByDescending(h => h.Date)
-                        .FirstOrDefault();
+            return Query(h => h.EpisodeId == episodeId).MaxBy(h => h.Date);
         }
 
         public List<EpisodeHistory> FindByEpisodeId(int episodeId)
@@ -44,9 +42,7 @@ namespace NzbDrone.Core.History
 
         public EpisodeHistory MostRecentForDownloadId(string downloadId)
         {
-            return Query(h => h.DownloadId == downloadId)
-             .OrderByDescending(h => h.Date)
-             .FirstOrDefault();
+            return Query(h => h.DownloadId == downloadId).MaxBy(h => h.Date);
         }
 
         public List<EpisodeHistory> FindByDownloadId(string downloadId)

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -186,9 +186,7 @@ namespace NzbDrone.Core.RootFolders
 
         public string GetBestRootFolderPath(string path)
         {
-            var possibleRootFolder = All().Where(r => r.Path.IsParentPath(path))
-                                          .OrderByDescending(r => r.Path.Length)
-                                          .FirstOrDefault();
+            var possibleRootFolder = All().Where(r => r.Path.IsParentPath(path)).MaxBy(r => r.Path.Length);
 
             if (possibleRootFolder == null)
             {

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
@@ -50,16 +50,11 @@ namespace NzbDrone.Core.SeriesStats
                                        ReleaseGroups = seasonStatistics.SelectMany(s => s.ReleaseGroups).Distinct().ToList()
                                    };
 
-            var nextAiring = seasonStatistics.Where(s => s.NextAiring != null)
-                                             .OrderBy(s => s.NextAiring)
-                                             .FirstOrDefault();
+            var nextAiring = seasonStatistics.Where(s => s.NextAiring != null).MinBy(s => s.NextAiring);
+            var previousAiring = seasonStatistics.Where(s => s.PreviousAiring != null).MaxBy(s => s.PreviousAiring);
 
-            var previousAiring = seasonStatistics.Where(s => s.PreviousAiring != null)
-                                                 .OrderBy(s => s.PreviousAiring)
-                                                 .LastOrDefault();
-
-            seriesStatistics.NextAiringString = nextAiring != null ? nextAiring.NextAiringString : null;
-            seriesStatistics.PreviousAiringString = previousAiring != null ? previousAiring.PreviousAiringString : null;
+            seriesStatistics.NextAiringString = nextAiring?.NextAiringString;
+            seriesStatistics.PreviousAiringString = previousAiring?.PreviousAiringString;
 
             return seriesStatistics;
         }

--- a/src/NzbDrone.Core/Tv/ShouldRefreshSeries.cs
+++ b/src/NzbDrone.Core/Tv/ShouldRefreshSeries.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Tv
                 return true;
             }
 
-            var lastEpisode = _episodeService.GetEpisodeBySeries(series.Id).OrderByDescending(e => e.AirDateUtc).FirstOrDefault();
+            var lastEpisode = _episodeService.GetEpisodeBySeries(series.Id).MaxBy(e => e.AirDateUtc);
 
             if (lastEpisode != null && lastEpisode.AirDateUtc > DateTime.UtcNow.AddDays(-30))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This PR replaces `OrderBy().First()` by less resource-intensive `MinBy` and `MaxBy`.

Very simple benchmark:
```
public class Bench
{
    private IEnumerable<int> numbers = Enumerable.Range(0, 100).OrderBy(_ => Random.Shared.Next()).ToArray();

    [Benchmark]
    public void Order()
    {
        var max = numbers.OrderBy(_ => _).First();
    }
    
    [Benchmark]
    public void Min()
    {
        var max = numbers.MinBy(_ => _);
    }
}
```

```
| Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|------- |---------:|--------:|--------:|-------:|----------:|
|  Order | 807.8 ns | 1.68 ns | 1.49 ns | 0.0010 |     128 B |
|    Min | 512.0 ns | 9.53 ns | 7.96 ns |      - |      32 B |
```

#### Todos
- [ ] Tests
- [ ] Wiki Updates