### PR TITLE
New: Add version and timestamp to backup archive

### DIFF
--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -69,7 +69,8 @@ namespace NzbDrone.Core.Backup
             _diskProvider.EnsureFolder(_backupTempFolder);
             _diskProvider.EnsureFolder(GetBackupFolder(backupType));
 
-            var backupFilename = string.Format("sonarr_backup_v{0}_{1:yyyy.MM.dd_HH.mm.ss}.zip", BuildInfo.Version, DateTime.Now);
+            var dateNow = DateTime.Now;
+            var backupFilename = $"sonarr_backup_v{BuildInfo.Version}_{dateNow:yyyy.MM.dd_HH.mm.ss}.zip";
             var backupPath = Path.Combine(GetBackupFolder(backupType), backupFilename);
 
             Cleanup();
@@ -81,7 +82,7 @@ namespace NzbDrone.Core.Backup
 
             BackupConfigFile();
             BackupDatabase();
-            CreateVersionInfo();
+            CreateVersionInfo(dateNow);
 
             _logger.ProgressDebug("Creating backup zip");
 
@@ -203,11 +204,15 @@ namespace NzbDrone.Core.Backup
             _diskTransferService.TransferFile(configFile, tempConfigFile, TransferMode.Copy);
         }
 
-        private void CreateVersionInfo()
+        private void CreateVersionInfo(DateTime dateNow)
         {
-            var builder = new StringBuilder();
+            var tempFile = Path.Combine(_backupTempFolder, "INFO");
 
-            builder.AppendLine(BuildInfo.Version.ToString());
+            var builder = new StringBuilder();
+            builder.AppendLine($"v{BuildInfo.Version}");
+            builder.AppendLine($"{dateNow:yyyy-MM-dd HH:mm:ss}");
+
+            _diskProvider.WriteAllText(tempFile, builder.ToString());
         }
 
         private void CleanupOldBackups(BackupType backupType)


### PR DESCRIPTION
(cherry picked from commit 43fa4cb5b9dca1aed25acb169c63ddd9a8e2712b)

#### Database Migration
NO

#### Description
Currently `CreateVersionInfo` doesn't seem to do anything, so I'm thinking of adding version and timestamp to the zip file.
