### PR TITLE
Fixed: Config file settings do not need to be case-sensitive

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -255,7 +255,7 @@ namespace NzbDrone.Core.Configuration
 
         public T GetValueEnum<T>(string key, T defaultValue, bool persist = true)
         {
-            return (T)Enum.Parse(typeof(T), GetValue(key, defaultValue, persist));
+            return (T)Enum.Parse(typeof(T), GetValue(key, defaultValue, persist), true);
         }
 
         public string GetValue(string key, object defaultValue, bool persist = true)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
After the correct functionality was fixed in 5326a102e23eacfc1132eb544a92af737a531df5, the values are now case sensitive. Should we support the old broken behavior with `ignoreCase: true`?
