### PR TITLE
Fixed: DrunkenSlug Default URL

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             get
             {
                 yield return GetDefinition("DOGnzb", GetSettings("https://api.dognzb.cr"));
-                yield return GetDefinition("DrunkenSlug", GetSettings("https://api.drunkenslug.com"));
+                yield return GetDefinition("DrunkenSlug", GetSettings("https://drunkenslug.com"));
                 yield return GetDefinition("Nzb.su", GetSettings("https://api.nzb.su"));
                 yield return GetDefinition("NZBCat", GetSettings("https://nzb.cat"));
                 yield return GetDefinition("NZBFinder.ws", GetSettings("https://nzbfinder.ws", categories: new[] { 5010, 5030, 5040, 5045, 5090 }));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
https://github.com/Prowlarr/Prowlarr/commit/55788ac04dea7adfd3b678b6df9e4631abd037be
`https://api.drunkenslug.com/ gives a 301`

#### Todos
- Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* 
