### PR TITLE
Mediainfo improvements

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("msmpeg4, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
         [TestCase("msmpeg4v2, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
         [TestCase("msmpeg4v3, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
+        [TestCase("vp6f, 4", "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
         [TestCase("vp6, 4", "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
         [TestCase("vp7, VP70", "Sweet Seymour.avi", "VP7")]
         [TestCase("vp8, V_VP8", "Dick.mkv", "VP8")]

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -154,7 +154,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
 
             Logger.Debug()
-                  .Message("Unknown audio format: '{0}' in '{1}'.", mediaInfo.RawStreamData, sceneName)
+                  .Message("Unknown audio format: '{0}' in '{1}'. Streams: {2}", audioFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownAudioFormatFFProbe", mediaInfo.ContainerFormat, mediaInfo.AudioFormat, audioCodecID)
                   .Write();
 
@@ -236,8 +236,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "AV1";
             }
 
-            if (videoFormat == "vp6" ||
-                videoFormat == "vp7" ||
+            if (videoFormat.Contains("vp6"))
+            {
+                return "VP6";
+            }
+
+            if (videoFormat == "vp7" ||
                 videoFormat == "vp8" ||
                 videoFormat == "vp9")
             {
@@ -257,13 +261,15 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 videoFormat == "rv20" ||
                 videoFormat == "rv30" ||
                 videoFormat == "rv40" ||
-                videoFormat == "cinepak")
+                videoFormat == "cinepak" ||
+                videoFormat == "rawvideo" ||
+                videoFormat == "msvideo1")
             {
                 return "";
             }
 
             Logger.Debug()
-                  .Message("Unknown video format: '{0}' in '{1}'.", mediaInfo.RawStreamData, sceneName)
+                  .Message("Unknown video format: '{0}' in '{1}'. Streams: {2}", videoFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownVideoFormatFFProbe", mediaInfo.ContainerFormat, videoFormat, videoCodecID)
                   .Write();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There are many cases where the primary video stream on a file is an `mjpeg` or `png` codec and the secondary stream is the actual stream. This PR attempts to be a bit smarter in selecting the primary video stream by bypassing the motion image stream. 

Also, a few tweaks to the formatter for other codecs seen in Sentry

Example:
```json
[
   {
      "index":0,
      "codec_name":"mjpeg",
      "codec_long_name":"Motion JPEG",
      "profile":"Progressive",
      "codec_type":"video",
      "codec_tag_string":"[0][0][0][0]",
      "codec_tag":"0x0000",
      "width":2000,
      "height":3000,
      "coded_width":2000,
      "coded_height":3000,
      "closed_captions":0,
      "film_grain":0,
      "has_b_frames":0,
      "sample_aspect_ratio":"1:1",
      "display_aspect_ratio":"2:3",
      "pix_fmt":"yuvj420p",
      "level":-99,
      "color_range":"pc",
      "color_space":"bt470bg",
      "chroma_location":"center",
      "refs":1,
      "id":"0x0",
      "r_frame_rate":"90000/1",
      "avg_frame_rate":"0/0",
      "time_base":"1/90000",
      "start_pts":0,
      "start_time":"0:00:00.000000",
      "duration_ts":518208000,
      "duration":"1:35:57.866667",
      "bits_per_raw_sample":"8",
      "disposition":{
         "default":0,
         "dub":0,
         "original":0,
         "comment":0,
         "lyrics":0,
         "karaoke":0,
         "forced":0,
         "hearing_impaired":0,
         "visual_impaired":0,
         "clean_effects":0,
         "attached_pic":1,
         "timed_thumbnails":0,
         "captions":0,
         "descriptions":0,
         "metadata":0,
         "dependent":0,
         "still_image":0
      }
   },
   {
      "index":1,
      "codec_name":"h264",
      "codec_long_name":"H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
      "profile":"High",
      "codec_type":"video",
      "codec_tag_string":"x264",
      "codec_tag":"0x34363278",
      "width":1920,
      "height":800,
      "coded_width":1920,
      "coded_height":800,
      "closed_captions":0,
      "film_grain":0,
      "has_b_frames":2,
      "sample_aspect_ratio":"1:1",
      "display_aspect_ratio":"12:5",
      "pix_fmt":"yuv420p",
      "level":41,
      "color_range":"tv",
      "color_space":"bt709",
      "color_primaries":"bt709",
      "chroma_location":"left",
      "field_order":"progressive",
      "refs":1,
      "is_avc":"true",
      "nal_length_size":"4",
      "id":"0x1",
      "r_frame_rate":"24000/1001",
      "avg_frame_rate":"24000/1001",
      "time_base":"1/24000",
      "start_pts":2002,
      "start_time":"0:00:00.083417",
      "duration_ts":138184046,
      "duration":"1:35:57.668583",
      "bit_rate":"2059243",
      "bits_per_raw_sample":"8",
      "nb_frames":"138046",
      "extradata_size":43,
      "disposition":{
         "default":1,
         "dub":0,
         "original":0,
         "comment":0,
         "lyrics":0,
         "karaoke":0,
         "forced":0,
         "hearing_impaired":0,
         "visual_impaired":0,
         "clean_effects":0,
         "attached_pic":0,
         "timed_thumbnails":0,
         "captions":0,
         "descriptions":0,
         "metadata":0,
         "dependent":0,
         "still_image":0
      },
      "tags":{
         "creation_time":"2013-12-09T13:13:58.000000Z",
         "language":"und",
         "handler_name":"video.264#trackID=1:fps=23.976 - Imported with GPAC 0.5.0-rev",
         "vendor_id":"[0][0][0][0]"
      }
   },
   {
      "index":2,
      "codec_name":"aac",
      "codec_long_name":"AAC (Advanced Audio Coding)",
      "profile":"LC",
      "codec_type":"audio",
      "codec_tag_string":"mp4a",
      "codec_tag":"0x6134706d",
      "sample_fmt":"fltp",
      "sample_rate":"48000",
      "channels":2,
      "channel_layout":"stereo",
      "bits_per_sample":0,
      "id":"0x2",
      "r_frame_rate":"0/0",
      "avg_frame_rate":"0/0",
      "time_base":"1/48000",
      "start_pts":0,
      "start_time":"0:00:00.000000",
      "duration_ts":276377600,
      "duration":"1:35:57.866667",
      "bit_rate":"93602",
      "nb_frames":"269900",
      "extradata_size":5,
      "disposition":{
         "default":1,
         "dub":0,
         "original":0,
         "comment":0,
         "lyrics":0,
         "karaoke":0,
         "forced":0,
         "hearing_impaired":0,
         "visual_impaired":0,
         "clean_effects":0,
         "attached_pic":0,
         "timed_thumbnails":0,
         "captions":0,
         "descriptions":0,
         "metadata":0,
         "dependent":0,
         "still_image":0
      },
      "tags":{
         "creation_time":"2013-12-09T13:14:12.000000Z",
         "language":"eng",
         "handler_name":"GPAC ISO Audio Handler",
         "vendor_id":"[0][0][0][0]"
      }
   }
]
```
