### PR TITLE
Fixed: Spacing between manual download and override download buttons

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.css
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.css
@@ -68,7 +68,8 @@
 .manualDownloadContent {
   position: relative;
   display: inline-block;
-  width: 100%;
+  margin: 0 2px;
+  width: 22px;
   height: 20.39px;
   vertical-align: middle;
   line-height: 20.39px;

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -271,7 +271,8 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
           onPress={onGrabPressWrapper}
         />
 
-        <Link className={styles.manualDownloadContent}
+        <Link
+          className={styles.manualDownloadContent}
           title="Override and add to download queue"
           onPress={onOverridePress}
         >

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -271,7 +271,7 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
           onPress={onGrabPressWrapper}
         />
 
-        <Link
+        <Link className={styles.manualDownloadContent}
           title="Override and add to download queue"
           onPress={onOverridePress}
         >


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixed: Spacing between manual download and override download buttons

![image](https://user-images.githubusercontent.com/1117625/233166999-28778744-380f-40af-b612-3970ee1adca4.png)



#### Issues Fixed or Closed by this PR

* 
