### PR TITLE
New: Filter Sonarr synchronization based on Root Folders

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         public string TitleSlug { get; set; }
         public int QualityProfileId { get; set; }
         public int LanguageProfileId { get; set; }
+        public string RootFolderPath { get; set; }
         public HashSet<int> Tags { get; set; }
     }
 
@@ -27,6 +28,12 @@ namespace NzbDrone.Core.ImportLists.Sonarr
     public class SonarrTag
     {
         public string Label { get; set; }
+        public int Id { get; set; }
+    }
+
+    public class SonarrRootFolder
+    {
+        public string Path { get; set; }
         public int Id { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -39,17 +39,31 @@ namespace NzbDrone.Core.ImportLists.Sonarr
 
                 foreach (var item in remoteSeries)
                 {
-                    if ((!Settings.ProfileIds.Any() || Settings.ProfileIds.Contains(item.QualityProfileId)) &&
-                        (!Settings.LanguageProfileIds.Any() || Settings.LanguageProfileIds.Contains(item.LanguageProfileId)) &&
-                        (!Settings.TagIds.Any() || Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId))) &&
-                        (!Settings.RootFolderPaths.Any() || Settings.RootFolderPaths.Any(rootFolderPath => item.RootFolderPath.ContainsIgnoreCase(rootFolderPath))))
+                    if (Settings.ProfileIds.Any() && !Settings.ProfileIds.Contains(item.QualityProfileId))
                     {
-                        series.Add(new ImportListItemInfo
-                        {
-                            TvdbId = item.TvdbId,
-                            Title = item.Title
-                        });
+                        continue;
                     }
+
+                    if (Settings.LanguageProfileIds.Any() && !Settings.LanguageProfileIds.Contains(item.LanguageProfileId))
+                    {
+                        continue;
+                    }
+
+                    if (Settings.TagIds.Any() && !Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId)))
+                    {
+                        continue;
+                    }
+
+                    if (Settings.RootFolderPaths.Any() && !Settings.RootFolderPaths.Any(rootFolderPath => item.RootFolderPath.ContainsIgnoreCase(rootFolderPath)))
+                    {
+                        continue;
+                    }
+
+                    series.Add(new ImportListItemInfo
+                    {
+                        TvdbId = item.TvdbId,
+                        Title = item.Title
+                    });
                 }
 
                 _importListStatusService.RecordSuccess(Definition.Id);

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -41,7 +41,8 @@ namespace NzbDrone.Core.ImportLists.Sonarr
                 {
                     if ((!Settings.ProfileIds.Any() || Settings.ProfileIds.Contains(item.QualityProfileId)) &&
                         (!Settings.LanguageProfileIds.Any() || Settings.LanguageProfileIds.Contains(item.LanguageProfileId)) &&
-                        (!Settings.TagIds.Any() || Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId))))
+                        (!Settings.TagIds.Any() || Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId))) &&
+                        (!Settings.RootFolderPaths.Any() || Settings.RootFolderPaths.Any(rootFolderPath => item.RootFolderPath.ContainsIgnoreCase(rootFolderPath))))
                     {
                         series.Add(new ImportListItemInfo
                         {
@@ -118,6 +119,23 @@ namespace NzbDrone.Core.ImportLists.Sonarr
                             value = d.Id,
                             name = d.Label
                         })
+                };
+            }
+
+            if (action == "getRootFolders")
+            {
+                Settings.Validate().Filter("ApiKey").ThrowOnError();
+
+                var remoteRootfolders = _sonarrV3Proxy.GetRootFolders(Settings);
+
+                return new
+                {
+                    options = remoteRootfolders.OrderBy(d => d.Path, StringComparer.InvariantCultureIgnoreCase)
+                                               .Select(d => new
+                                               {
+                                                   value = d.Path,
+                                                   name = d.Path
+                                               })
                 };
             }
 

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             ProfileIds = Array.Empty<int>();
             LanguageProfileIds = Array.Empty<int>();
             TagIds = Array.Empty<int>();
+            RootFolderPaths = Array.Empty<string>();
         }
 
         [FieldDefinition(0, Label = "Full URL", HelpText = "URL, including port, of the Sonarr V3 instance to import from")]
@@ -39,6 +40,9 @@ namespace NzbDrone.Core.ImportLists.Sonarr
 
         [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getLanguageProfiles", Label = "Language Profiles", HelpText = "Language Profiles from the source instance to import from")]
         public IEnumerable<int> LanguageProfileIds { get; set; }
+
+        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getRootFolders", Label = "Root Folders", HelpText = "Root Folders from the source instance to import from")]
+        public IEnumerable<string> RootFolderPaths { get; set; }
 
         [FieldDefinition(4, Type = FieldType.Select, SelectOptionsProviderAction = "getTags", Label = "Tags", HelpText = "Tags from the source instance to import from")]
         public IEnumerable<int> TagIds { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
@@ -29,10 +29,10 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             RootFolderPaths = Array.Empty<string>();
         }
 
-        [FieldDefinition(0, Label = "Full URL", HelpText = "URL, including port, of the Sonarr V3 instance to import from")]
+        [FieldDefinition(0, Label = "Full URL", HelpText = "URL, including port, of the Sonarr instance to import from")]
         public string BaseUrl { get; set; }
 
-        [FieldDefinition(1, Label = "API Key", HelpText = "Apikey of the Sonarr V3 instance to import from")]
+        [FieldDefinition(1, Label = "API Key", HelpText = "Apikey of the Sonarr instance to import from")]
         public string ApiKey { get; set; }
 
         [FieldDefinition(2, Type = FieldType.Select, SelectOptionsProviderAction = "getProfiles", Label = "Quality Profiles", HelpText = "Quality Profiles from the source instance to import from")]

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
@@ -41,11 +41,11 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getLanguageProfiles", Label = "Language Profiles", HelpText = "Language Profiles from the source instance to import from")]
         public IEnumerable<int> LanguageProfileIds { get; set; }
 
-        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getRootFolders", Label = "Root Folders", HelpText = "Root Folders from the source instance to import from")]
-        public IEnumerable<string> RootFolderPaths { get; set; }
-
         [FieldDefinition(4, Type = FieldType.Select, SelectOptionsProviderAction = "getTags", Label = "Tags", HelpText = "Tags from the source instance to import from")]
         public IEnumerable<int> TagIds { get; set; }
+
+        [FieldDefinition(5, Type = FieldType.Select, SelectOptionsProviderAction = "getRootFolders", Label = "Root Folders", HelpText = "Root Folders from the source instance to import from")]
+        public IEnumerable<string> RootFolderPaths { get; set; }
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         List<SonarrSeries> GetSeries(SonarrSettings settings);
         List<SonarrProfile> GetQualityProfiles(SonarrSettings settings);
         List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings);
+        List<SonarrRootFolder> GetRootFolders(SonarrSettings settings);
         List<SonarrTag> GetTags(SonarrSettings settings);
         ValidationFailure Test(SonarrSettings settings);
     }
@@ -42,6 +43,11 @@ namespace NzbDrone.Core.ImportLists.Sonarr
         public List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings)
         {
             return Execute<SonarrProfile>("/api/v3/languageprofile", settings);
+        }
+
+        public List<SonarrRootFolder> GetRootFolders(SonarrSettings settings)
+        {
+            return Execute<SonarrRootFolder>("api/v3/rootfolder", settings);
         }
 
         public List<SonarrTag> GetTags(SonarrSettings settings)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the option to filter imports from other Sonarr instances by Root Folder. 

Also updates the helptexts for URL and API key to not specify Sonarr V3. 


#### Issues Fixed or Closed by this PR

* #4835 
