### PR TITLE
Ensure CustomFormat is taken from disk filename

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.CustomFormats
             var episodeInfo = new ParsedEpisodeInfo
             {
                 SeriesTitle = localEpisode.Series.Title,
-                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : Path.GetFileName(localEpisode.Path),
+                ReleaseTitle = Path.GetFileName(localEpisode.Path),
                 Quality = localEpisode.Quality,
                 Languages = localEpisode.Languages,
                 ReleaseGroup = localEpisode.ReleaseGroup

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.CustomFormats
             var episodeInfo = new ParsedEpisodeInfo
             {
                 SeriesTitle = localEpisode.Series.Title,
-                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : Path.GetFileName(localEpisode.Path),,
+                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : Path.GetFileName(localEpisode.Path),
                 Quality = localEpisode.Quality,
                 Languages = localEpisode.Languages,
                 ReleaseGroup = localEpisode.ReleaseGroup

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.CustomFormats
             var episodeInfo = new ParsedEpisodeInfo
             {
                 SeriesTitle = localEpisode.Series.Title,
-                ReleaseTitle = Path.GetFileName(localEpisode.Path),
+                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : Path.GetFileName(localEpisode.Path),,
                 Quality = localEpisode.Quality,
                 Languages = localEpisode.Languages,
                 ReleaseGroup = localEpisode.ReleaseGroup
@@ -157,17 +157,17 @@ namespace NzbDrone.Core.CustomFormats
         {
             var releaseTitle = string.Empty;
 
-            if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
+            if (episodeFile.RelativePath.IsNotNullOrWhiteSpace())
+            {
+                releaseTitle = Path.GetFileName(episodeFile.RelativePath);
+            }
+            else if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
             {
                 releaseTitle = episodeFile.SceneName;
             }
             else if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
             {
                 releaseTitle = Path.GetFileName(episodeFile.OriginalFilePath);
-            }
-            else if (episodeFile.RelativePath.IsNotNullOrWhiteSpace())
-            {
-                releaseTitle = Path.GetFileName(episodeFile.RelativePath);
             }
 
             var episodeInfo = new ParsedEpisodeInfo

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -161,13 +161,13 @@ namespace NzbDrone.Core.CustomFormats
             {
                 releaseTitle = Path.GetFileName(episodeFile.RelativePath);
             }
-            else if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
-            {
-                releaseTitle = episodeFile.SceneName;
-            }
             else if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
             {
                 releaseTitle = Path.GetFileName(episodeFile.OriginalFilePath);
+            }
+            else if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
+            {
+                releaseTitle = episodeFile.SceneName;
             }
 
             var episodeInfo = new ParsedEpisodeInfo


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As it stands, sonarr only relies on the scene filename, which may be incorrect (i.e. mismatch between release title and release filename). This can be worked around, by having a custom renaming scheme. However, sonarr doesn't look at the filename on disk as a priority, and thus the CF score is always based on the original release filename. This PR aims to always use what's on disk to determine the imported CF score.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
