### PR TITLE
Fixed: Subtitle tags from existing subtitle files being lost during rename

### DIFF
--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
@@ -78,6 +78,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                                            EpisodeFileId = localEpisode.Episodes.First().EpisodeFileId,
                                            RelativePath = series.Path.GetRelativePath(possibleSubtitleFile),
                                            Language = LanguageParser.ParseSubtitleLanguage(possibleSubtitleFile),
+                                           LanguageTags = LanguageParser.ParseLanguageTags(possibleSubtitleFile),
                                            Extension = extension
                                        };
 

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -185,9 +185,9 @@ namespace NzbDrone.Core.Extras.Subtitles
                 var subFile = new SubtitleFile
                 {
                     Language = language,
-                    Extension = extension
+                    Extension = extension,
+                    LanguageTags = languageTags
                 };
-                subFile.LanguageTags = languageTags.ToList();
                 subFile.RelativePath = PathExtensions.GetRelativePath(sourceFolder, file);
                 subtitleFiles.Add(subFile);
             }

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -226,7 +226,7 @@ namespace NzbDrone.Core.Parser
             return Language.Unknown;
         }
 
-        public static IEnumerable<string> ParseLanguageTags(string fileName)
+        public static List<string> ParseLanguageTags(string fileName)
         {
             try
             {
@@ -235,14 +235,14 @@ namespace NzbDrone.Core.Parser
                 var languageTags = match.Groups["tags"].Captures.Cast<Capture>()
                     .Where(tag => !tag.Value.Empty())
                     .Select(tag => tag.Value.ToLower());
-                return languageTags;
+                return languageTags.ToList();
             }
             catch (Exception ex)
             {
                 Logger.Debug(ex, "Failed parsing language tags from subtitle file: {0}", fileName);
             }
 
-            return Enumerable.Empty<string>();
+            return new List<string>();
         }
 
         private static List<Language> RegexLanguage(string title)


### PR DESCRIPTION
#### Description
When renaming episodes with associated subtitle files that weren't directly imported by Sonarr, subtitle tags like SDH, Forced, HI, would be lost. This affected setups like Bazarr or other ways of manually putting subtitle files in the series' folder. Files imported alongside video files in automatic or manual imports weren't affected.

Tags were already getting parsed, but weren't getting passed along to the records. 


#### Issues Fixed or Closed by this PR

* #5577 
