### PR TITLE
New: Updated button and calendar outline colors for dark theme

### DIFF
--- a/frontend/src/Styles/Themes/dark.js
+++ b/frontend/src/Styles/Themes/dark.js
@@ -94,9 +94,9 @@ module.exports = {
 
   defaultButtonTextColor: '#eee',
   defaultBackgroundColor: '#333',
-  defaultBorderColor: '#eaeaea',
+  defaultBorderColor: '#393f45',
   defaultHoverBackgroundColor: '#444',
-  defaultHoverBorderColor: '#d6d6d6',
+  defaultHoverBorderColor: '#5a6265',
 
   primaryBackgroundColor: '#5d9cec',
   primaryBorderColor: '#5899eb',
@@ -209,7 +209,7 @@ module.exports = {
 
   calendarTodayBackgroundColor: '#3e3e3e',
   calendarBackgroundColor: '#2a2a2a',
-  calendarBorderColor: '#cecece',
+  calendarBorderColor: '#393f45',
   calendarTextDim: '#eee',
   calendarTextDimAlternate: '#fff',
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This upgrades the border color for buttons and the calendar grid from very bright to a pleasant darker color.

##### Before

![image](https://user-images.githubusercontent.com/75278/234805796-92cf462f-6222-4dfd-892b-3fce79bff5c7.png)


##### After

![image](https://user-images.githubusercontent.com/75278/234804880-5d6b04b0-733a-466f-aabf-e0161f0150d7.png)

#### Issues Fixed or Closed by this PR

I assume that these were never supposed to be that bright considering dark mode is still work in progress(?).

There is a consideration to use the same color as the calendar headers for the calendar borders (#2a2a2a) so the connections look a bit more natural but that is also very close to the background color, contrast wise, and almost makes them disappear. Please let me know if you'd prefer that.
