### PR TITLE
Use minified jquery

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = (env) => {
         'node_modules'
       ],
       alias: {
-        jquery: 'jquery/src/jquery',
+        jquery: 'jquery/dist/jquery.min',
         'react-middle-truncate': 'react-middle-truncate/lib/react-middle-truncate'
       },
       fallback: {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The jQuery npm package comes with a minified version of the library, by using this in the webpack build, we can decrease module size by a few hundred kilobytes.

```
OLD
modules by path ./node_modules/ 5.77 MiB 597 modules

NEW
modules by path ./node_modules/ 5.56 MiB 491 modules
```

