### PR TITLE
New: Update core-js and use better polyfill defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
   "readmeFilename": "readme.md",
   "main": "index.js",
   "browserslist": [
-    ">0.25%",
-    "not ie 11",
-    "not op_mini all",
-    "not chrome < 60"
+    "defaults"
   ],
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.1.1",
@@ -115,7 +112,7 @@
     "babel-loader": "8.2.5",
     "babel-plugin-inline-classnames": "2.0.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
-    "core-js": "3.22.5",
+    "core-js": "3.30.1",
     "css-loader": "6.7.1",
     "css-modules-typescript-loader": "4.0.1",
     "esformatter": "0.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,10 +2600,10 @@ core-js-compat@^3.21.0, core-js-compat@^3.22.1:
   dependencies:
     browserslist "^4.21.4"
 
-core-js@3.22.5:
-  version "3.22.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.5.tgz#a5f5a58e663d5c0ebb4e680cd7be37536fb2a9cf"
-  integrity sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==
+core-js@3.30.1:
+  version "3.30.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.1.tgz#fc9c5adcc541d8e9fa3e381179433cbf795628ba"
+  integrity sha512-ZNS5nbiSwDTq4hFosEDqm65izl2CWmLz0hARJMyNQBgkUZMIF51cQiMvIQKA6hvuaeWxQDP3hEedM1JZIgTldQ==
 
 core-js@^1.0.0:
   version "1.2.7"


### PR DESCRIPTION
#### Database Migration
NO

#### Description

This updates `core-js` to the latest version and switches the browserslist used to determine which features to polyfill to the default which is `> 0.5%, last 2 versions, Firefox ESR, not dead`. 

This leads to a reduction of bundle size of ~400kb

```
OLD
modules by path ./frontend/src/ 2.59 MiB

NEW
modules by path ./frontend/src/ 2.12 MiB
```

Here is a diff for what that means in terms of supported browsers:

![image](https://user-images.githubusercontent.com/75278/234853962-d9fcba0c-0f78-47d1-bb5e-e2afe339d72c.png)
