### PR TITLE
Fix loading eslintrc

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,17 +1,21 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = require('fs');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const typescriptEslintRecommended = require('@typescript-eslint/eslint-plugin').configs.recommended;
 
+const frontendFolder = __dirname;
+
 const dirs = fs
-  .readdirSync('frontend/src', { withFileTypes: true })
+  .readdirSync(path.join(frontendFolder, 'src'), { withFileTypes: true })
   .filter((dirent) => dirent.isDirectory())
   .map((dirent) => dirent.name)
   .join('|');
 
-const frontendFolder = __dirname;
-
 module.exports = {
+  root: true,
+
   parser: '@babel/eslint-parser',
 
   env: {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix loading eslintrc by using relative path to itself.

```
Error: Cannot read config file: ~/Projects/Sonarr/frontend/.eslintrc.js
Error: ENOENT: no such file or directory, scandir 'frontend/src'
```