### PR TITLE
Fix parsing empty string as boolean

### DIFF
--- a/src/Sonarr.Http/Extensions/RequestExtensions.cs
+++ b/src/Sonarr.Http/Extensions/RequestExtensions.cs
@@ -55,9 +55,9 @@ namespace Sonarr.Http.Extensions
         {
             var parameterValue = request.Query[parameter];
 
-            if (parameterValue.Any())
+            if (parameterValue.Any() && bool.TryParse(parameterValue.ToString(), out var value))
             {
-                return bool.Parse(parameterValue.ToString());
+                return value;
             }
 
             return defaultValue;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
```
System.FormatException: String '' was not recognized as a valid Boolean.
   at System.Boolean.Parse(ReadOnlySpan`1 value)
   at System.Boolean.Parse(String value)
```
