### PR TITLE
Telegram Notification: add support for group topic.

### DIFF
--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
@@ -36,14 +36,18 @@ namespace NzbDrone.Core.Notifications.Telegram
             var requestBuilder = new HttpRequestBuilder(URL).Resource("bot{token}/sendmessage").Post();
 
             var request = requestBuilder.SetSegment("token", settings.BotToken)
-                                        .AddFormParameter("chat_id", settings.ChatId)
                                         .AddFormParameter("parse_mode", "HTML")
                                         .AddFormParameter("text", text)
                                         .AddFormParameter("disable_notification", settings.SendSilently)
-                                        .AddFormParameter("message_thread_id", settings.TopicId)
-                                        .Build();
+                                        .AddFormParameter("message_thread_id", settings.TopicId);
 
-            _httpClient.Post(request);
+            var parts = settings.ChatId.Split(new char[]{'/'}, 2);
+            request = request.AddFormParameter("chat_id", parts[0]);
+            if (parts.Length > 1) {
+                request = request.AddFormParameter("message_thread_id", parts[1]);
+            }
+
+            _httpClient.Post(request.Build());
         }
 
         public ValidationFailure Test(TelegramSettings settings)

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Notifications.Telegram
         [FieldDefinition(0, Label = "Bot Token", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://core.telegram.org/bots")]
         public string BotToken { get; set; }
 
-        [FieldDefinition(1, Label = "Chat ID", HelpLink = "http://stackoverflow.com/a/37396871/882971", HelpText = "You must start a conversation with the bot or add it to your group to receive messages")]
+        [FieldDefinition(1, Label = "Chat ID", HelpLink = "http://stackoverflow.com/a/37396871/882971", HelpText = "You must start a conversation with the bot or add it to your group to receive messages. For a group topic, append /topicID to the chat ID.")]
         public string ChatId { get; set; }
 
         [FieldDefinition(2, Label = "Topic ID", HelpLink = "https://stackoverflow.com/a/75178418", HelpText = "Specify a Topic ID to send notifications to that topic. Leave blank to use the general topic (Supergroups only)")]


### PR DESCRIPTION
Similar feature on Tautulli: https://github.com/Tautulli/Tautulli/blob/e9b1db139e96f0d82ff7d047f3a91d5b45a69f45/plexpy/notifiers.py#L3989-L3992

#### Database Migration
NO

#### Description
Add the ability to send a notification to the given topic of the group chat.


#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR