### PR TITLE
Fix downloading releases without an indexer

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -71,13 +71,19 @@ namespace NzbDrone.Core.Download
 
             // Get the seed configuration for this release.
             remoteEpisode.SeedConfiguration = _seedConfigProvider.GetSeedConfiguration(remoteEpisode);
-            var indexer = _indexerFactory.GetInstance(_indexerFactory.Get(remoteEpisode.Release.IndexerId));
 
             // Limit grabs to 2 per second.
             if (remoteEpisode.Release.DownloadUrl.IsNotNullOrWhiteSpace() && !remoteEpisode.Release.DownloadUrl.StartsWith("magnet:"))
             {
                 var url = new HttpUri(remoteEpisode.Release.DownloadUrl);
                 _rateLimitService.WaitAndPulse(url.Host, TimeSpan.FromSeconds(2));
+            }
+
+            IIndexer indexer = null;
+
+            if (remoteEpisode.Release.IndexerId > 0)
+            {
+                indexer = _indexerFactory.GetInstance(_indexerFactory.Get(remoteEpisode.Release.IndexerId));
             }
 
             string downloadClientId;

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Download
 
             try
             {
-                var request = indexer.GetDownloadRequest(torrentUrl);
+                var request = indexer?.GetDownloadRequest(torrentUrl) ?? new HttpRequest(torrentUrl);
                 request.RateLimitKey = remoteEpisode?.Release?.IndexerId.ToString();
                 request.Headers.Accept = "application/x-bittorrent";
                 request.AllowAutoRedirect = false;

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Download
 
             try
             {
-                var request = indexer.GetDownloadRequest(url);
+                var request = indexer?.GetDownloadRequest(url) ?? new HttpRequest(url);
                 request.RateLimitKey = remoteEpisode?.Release?.IndexerId.ToString();
                 nzbData = _httpClient.Get(request).ResponseData;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Changed the download request not to assume the indexer is always defined.

#### Issues Fixed or Closed by this PR

* Fixes #5606
