### PR TITLE
Fix usage of special characters in apikey

### DIFF
--- a/frontend/src/Calendar/iCal/CalendarLinkModalContent.js
+++ b/frontend/src/Calendar/iCal/CalendarLinkModalContent.js
@@ -40,7 +40,7 @@ function getUrls(state) {
     icalUrl += `tags=${tags.toString()}&`;
   }
 
-  icalUrl += `apikey=${window.Sonarr.apiKey}`;
+  icalUrl += `apikey=${encodeURIComponent(window.Sonarr.apiKey)}`;
 
   const iCalHttpUrl = `${window.location.protocol}//${icalUrl}`;
   const iCalWebCalUrl = `webcal://${icalUrl}`;

--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -61,7 +61,7 @@ function Logger(minimumLogLevel) {
 }
 
 Logger.prototype.cleanse = function(message) {
-  const apikey = new RegExp(`access_token=${window.Sonarr.apiKey}`, 'g');
+  const apikey = new RegExp(`access_token=${encodeURIComponent(window.Sonarr.apiKey)}`, 'g');
   return message.replace(apikey, 'access_token=(removed)');
 };
 
@@ -105,7 +105,7 @@ class SignalRConnector extends Component {
 
     this.connection = new signalR.HubConnectionBuilder()
       .configureLogging(new Logger(signalR.LogLevel.Information))
-      .withUrl(`${url}?access_token=${window.Sonarr.apiKey}`)
+      .withUrl(`${url}?access_token=${encodeURIComponent(window.Sonarr.apiKey)}`)
       .withAutomaticReconnect({
         nextRetryDelayInMilliseconds: (retryContext) => {
           if (retryContext.elapsedMilliseconds > 180000) {

--- a/src/NzbDrone.Core/HealthCheck/Checks/ApiKeyValidationCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ApiKeyValidationCheck.cs
@@ -1,0 +1,34 @@
+﻿using System.Text.RegularExpressions;
+using NLog;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Configuration.Events;
+using NzbDrone.Core.Lifecycle;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ApplicationStartedEvent))]
+    [CheckOn(typeof(ConfigSavedEvent))]
+    public class ApiKeyValidationCheck : HealthCheckBase
+    {
+        private readonly IConfigFileProvider _configFileProvider;
+        private readonly Logger _logger;
+
+        public ApiKeyValidationCheck(IConfigFileProvider configFileProvider, Logger logger)
+        {
+            _configFileProvider = configFileProvider;
+            _logger = logger;
+        }
+
+        public override HealthCheck Check()
+        {
+            if (_configFileProvider.ApiKey.Length < 20)
+            {
+                _logger.Warn("Please update your API key to be at least 20 characters long. You can do this via settings or the config file");
+
+                return new HealthCheck(GetType(), HealthCheckResult.Warning, "Please update your API key to be at least 20 characters long. You can do this via settings or the config file", "#invalid-api-key");
+            }
+
+            return new HealthCheck(GetType());
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow usage of `#` in the API key.

Radarr/Radarr#8441