### PR TITLE
Fix migrations running in PostgreSQL

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/135_health_issue_notification.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/135_health_issue_notification.cs
@@ -8,8 +8,8 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Notifications").AddColumn("OnHealthIssue").AsBoolean().WithDefaultValue(0);
-            Alter.Table("Notifications").AddColumn("IncludeHealthWarnings").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("OnHealthIssue").AsBoolean().WithDefaultValue(false);
+            Alter.Table("Notifications").AddColumn("IncludeHealthWarnings").AsBoolean().WithDefaultValue(false);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/149_add_on_delete_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/149_add_on_delete_to_notifications.cs
@@ -8,8 +8,8 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Notifications").AddColumn("OnSeriesDelete").AsBoolean().WithDefaultValue(0);
-            Alter.Table("Notifications").AddColumn("OnEpisodeFileDelete").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("OnSeriesDelete").AsBoolean().WithDefaultValue(false);
+            Alter.Table("Notifications").AddColumn("OnEpisodeFileDelete").AsBoolean().WithDefaultValue(false);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/165_add_on_update_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/165_add_on_update_to_notifications.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Notifications").AddColumn("OnApplicationUpdate").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("OnApplicationUpdate").AsBoolean().WithDefaultValue(false);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/187_add_on_series_add_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/187_add_on_series_add_to_notifications.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Notifications").AddColumn("OnSeriesAdd").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("OnSeriesAdd").AsBoolean().WithDefaultValue(false);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/190_health_restored_notification.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/190_health_restored_notification.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            Alter.Table("Notifications").AddColumn("OnHealthRestored").AsBoolean().WithDefaultValue(0);
+            Alter.Table("Notifications").AddColumn("OnHealthRestored").AsBoolean().WithDefaultValue(false);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
```
ALTER TABLE "public"."Notifications" ADD "OnHealthRestored" boolean NOT NULL DEFAULT 0;
The error was 42804: column "OnHealthRestored" is of type boolean but default expression is of type integer

  ----> Npgsql.PostgresException : 42804: column "OnHealthRestored" is of type boolean but default expression is of type integer
Data:
  Severity: ERROR
  InvariantSeverity: ERROR
  SqlState: 42804
  MessageText: column "OnHealthRestored" is of type boolean but default expression is of type integer
  Hint: You will need to rewrite or cast the expression.
```

