### PR TITLE
Fix call when download history can be null

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -70,8 +70,8 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
-            var grabbedHistories = _historyService.FindByDownloadId(trackedDownload.DownloadItem.DownloadId).Where(h => h.EventType == EpisodeHistoryEventType.Grabbed).ToList();
-            var historyItem = grabbedHistories.MaxBy(h => h.Date);
+            var grabbedHistories = _historyService.FindByDownloadId(trackedDownload.DownloadItem.DownloadId)?.Where(h => h.EventType == EpisodeHistoryEventType.Grabbed).ToList();
+            var historyItem = grabbedHistories?.MaxBy(h => h.Date);
 
             if (historyItem == null && trackedDownload.DownloadItem.Category.IsNullOrWhiteSpace())
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix regression introduced in f56d5048167cba855ee5b9dded87006b9ac85df7 making the ProcessFixture to fail.


```
System.ArgumentNullException : Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
   at NzbDrone.Core.Download.CompletedDownloadService.Check(TrackedDownload trackedDownload) in C:\BuildAgent\work\853acb111afc90d8\src\NzbDrone.Core\Download\CompletedDownloadService.cs:line 73
   at NzbDrone.Core.Test.Download.CompletedDownloadServiceTests.ProcessFixture.should_not_process_if_matching_history_is_not_found_and_no_category_specified() in C:\BuildAgent\work\853acb111afc90d8\src\NzbDrone.Core.Test\Download\CompletedDownloadServiceTests\ProcessFixture.cs:line 125
```
