### PR TITLE
Fixed: Prevent ProviderRepository to deserialize to a null config contract

### DIFF
--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -169,14 +169,13 @@ namespace NzbDrone.Core.ThingiProvider
             definition.Message = provider.Message;
         }
 
-        // TODO: Remove providers even if the ConfigContract can't be deserialized (this will fail to remove providers if the settings can't be deserialized).
         private void RemoveMissingImplementations()
         {
             var storedProvider = _providerRepository.All();
 
             foreach (var invalidDefinition in storedProvider.Where(def => GetImplementation(def) == null))
             {
-                _logger.Debug("Removing {0} ", invalidDefinition.Name);
+                _logger.Warn("Removing {0}", invalidDefinition.Name);
                 _providerRepository.Delete(invalidDefinition);
             }
         }

--- a/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.ThingiProvider
                     var item = parser(reader);
                     var impType = typeof(IProviderConfig).Assembly.FindTypeByName(item.ConfigContract);
 
-                    if (body.IsNullOrWhiteSpace())
+                    if (body.IsNullOrWhiteSpace() || impType == null)
                     {
                         item.Settings = NullConfig.Instance;
                     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for `System.ArgumentNullException: Value cannot be null. (Parameter 'returnType')` when a config contract is missing.

```
System.ArgumentNullException: Value cannot be null. (Parameter 'returnType')
   at System.Text.Json.JsonSerializer.Deserialize(String json, Type returnType, JsonSerializerOptions options)
   at NzbDrone.Core.ThingiProvider.ProviderRepository`1.Query(SqlBuilder builder) in ~/RiderProjects/Radarr/src/NzbDrone.Core/ThingiProvider/ProviderRepository.cs:line 63
   at NzbDrone.Core.Datastore.BasicRepository`1.All() in ~/RiderProjects/Radarr/src/NzbDrone.Core/Datastore/BasicRepository.cs:line 88
   at NzbDrone.Core.ThingiProvider.ProviderFactory`2.All() in ~/RiderProjects/Radarr/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs:line 39
   at NzbDrone.Core.HealthCheck.Checks.ImportListRootFolderCheck.Check() in ~/RiderProjects/Radarr/src/NzbDrone.Core/HealthCheck/Checks/ImportListRootFolderCheck.cs:line 32
   at NzbDrone.Core.HealthCheck.HealthCheckService.<>c.<PerformHealthCheck>b__15_0(IProvideHealthCheck c) in ~/RiderProjects/Radarr/src/NzbDrone.Core/HealthCheck/HealthCheckService.cs:line 82
```
