### PR TITLE
New: refresh only selected or filtered series

### DIFF
--- a/frontend/src/Series/Index/SeriesIndex.tsx
+++ b/frontend/src/Series/Index/SeriesIndex.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { SelectProvider } from 'App/SelectContext';
 import ClientSideCollectionAppState from 'App/State/ClientSideCollectionAppState';
 import SeriesAppState, { SeriesIndexAppState } from 'App/State/SeriesAppState';
-import { REFRESH_SERIES, RSS_SYNC } from 'Commands/commandNames';
+import { RSS_SYNC } from 'Commands/commandNames';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
@@ -49,6 +49,7 @@ import SeriesIndexSelectFooter from './Select/SeriesIndexSelectFooter';
 import SeriesIndexSelectModeButton from './Select/SeriesIndexSelectModeButton';
 import SeriesIndexSelectModeMenuItem from './Select/SeriesIndexSelectModeMenuItem';
 import SeriesIndexFooter from './SeriesIndexFooter';
+import SeriesIndexRefreshSeriesButton from './SeriesIndexRefreshSeriesButton';
 import SeriesIndexTable from './Table/SeriesIndexTable';
 import SeriesIndexTableOptions from './Table/SeriesIndexTableOptions';
 import styles from './SeriesIndex.css';
@@ -86,9 +87,6 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
   }: SeriesAppState & SeriesIndexAppState & ClientSideCollectionAppState =
     useSelector(createSeriesClientSideCollectionItemsSelector('seriesIndex'));
 
-  const isRefreshingSeries = useSelector(
-    createCommandExecutingSelector(REFRESH_SERIES)
-  );
   const isRssSyncExecuting = useSelector(
     createCommandExecutingSelector(RSS_SYNC)
   );
@@ -104,14 +102,6 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
   useEffect(() => {
     dispatch(fetchSeries());
     dispatch(fetchQueueDetails({ all: true }));
-  }, [dispatch]);
-
-  const onRefreshSeriesPress = useCallback(() => {
-    dispatch(
-      executeCommand({
-        name: REFRESH_SERIES,
-      })
-    );
   }, [dispatch]);
 
   const onRssSyncPress = useCallback(() => {
@@ -227,13 +217,9 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
       <PageContent>
         <PageToolbar>
           <PageToolbarSection>
-            <PageToolbarButton
-              label="Update all"
-              iconName={icons.REFRESH}
-              spinningName={icons.REFRESH}
-              isSpinning={isRefreshingSeries}
-              isDisabled={hasNoSeries}
-              onPress={onRefreshSeriesPress}
+            <SeriesIndexRefreshSeriesButton
+              isSelectMode={isSelectMode}
+              selectedFilterKey={selectedFilterKey}
             />
 
             <PageToolbarButton

--- a/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
+++ b/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
@@ -42,11 +42,19 @@ function SeriesIndexRefreshSeriesButton(
       ? selectedSeriesIds
       : items.map((m) => m.id);
 
-  const refreshIndexLabel =
-    selectedFilterKey === 'all' ? 'Update All' : 'Update Filtered';
+  let refreshLabel = 'Update All';
 
-  const refreshSelectLabel =
-    selectedSeriesIds.length > 0 ? 'Update Selected' : 'Update All';
+  if (selectedSeriesIds.length > 0) {
+    refreshLabel = 'Update Selected';
+  } else if (selectedFilterKey !== 'all') {
+    refreshLabel = 'Update Filtered';
+  }
+
+  //  const refreshIndexLabel =
+  //  selectedFilterKey === 'all' ? 'Update All' : 'Update Filtered';
+  //
+  // const refreshSelectLabel =
+  //  selectedSeriesIds.length > 0 ? 'Update Selected' : 'Update All';
 
   const onPress = useCallback(() => {
     dispatch(
@@ -59,7 +67,7 @@ function SeriesIndexRefreshSeriesButton(
 
   return (
     <PageToolbarButton
-      label={isSelectMode ? refreshSelectLabel : refreshIndexLabel}
+      label={refreshLabel}
       isSpinning={isRefreshing}
       isDisabled={!totalItems}
       iconName={icons.REFRESH}

--- a/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
+++ b/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
@@ -50,12 +50,6 @@ function SeriesIndexRefreshSeriesButton(
     refreshLabel = 'Update Filtered';
   }
 
-  //  const refreshIndexLabel =
-  //  selectedFilterKey === 'all' ? 'Update All' : 'Update Filtered';
-  //
-  // const refreshSelectLabel =
-  //  selectedSeriesIds.length > 0 ? 'Update Selected' : 'Update All';
-
   const onPress = useCallback(() => {
     dispatch(
       executeCommand({

--- a/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
+++ b/frontend/src/Series/Index/SeriesIndexRefreshSeriesButton.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useSelect } from 'App/SelectContext';
+import ClientSideCollectionAppState from 'App/State/ClientSideCollectionAppState';
+import SeriesAppState, { SeriesIndexAppState } from 'App/State/SeriesAppState';
+import { REFRESH_SERIES } from 'Commands/commandNames';
+import PageToolbarButton from 'Components/Page/Toolbar/PageToolbarButton';
+import { icons } from 'Helpers/Props';
+import { executeCommand } from 'Store/Actions/commandActions';
+import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
+import createSeriesClientSideCollectionItemsSelector from 'Store/Selectors/createSeriesClientSideCollectionItemsSelector';
+import getSelectedIds from 'Utilities/Table/getSelectedIds';
+
+interface SeriesIndexRefreshSeriesButtonProps {
+  isSelectMode: boolean;
+  selectedFilterKey: string;
+}
+
+function SeriesIndexRefreshSeriesButton(
+  props: SeriesIndexRefreshSeriesButtonProps
+) {
+  const isRefreshing = useSelector(
+    createCommandExecutingSelector(REFRESH_SERIES)
+  );
+  const {
+    items,
+    totalItems,
+  }: SeriesAppState & SeriesIndexAppState & ClientSideCollectionAppState =
+    useSelector(createSeriesClientSideCollectionItemsSelector('seriesIndex'));
+
+  const dispatch = useDispatch();
+  const { isSelectMode, selectedFilterKey } = props;
+  const [selectState] = useSelect();
+  const { selectedState } = selectState;
+
+  const selectedSeriesIds = useMemo(() => {
+    return getSelectedIds(selectedState);
+  }, [selectedState]);
+
+  const seriesToRefresh =
+    isSelectMode && selectedSeriesIds.length > 0
+      ? selectedSeriesIds
+      : items.map((m) => m.id);
+
+  const refreshIndexLabel =
+    selectedFilterKey === 'all' ? 'Update All' : 'Update Filtered';
+
+  const refreshSelectLabel =
+    selectedSeriesIds.length > 0 ? 'Update Selected' : 'Update All';
+
+  const onPress = useCallback(() => {
+    dispatch(
+      executeCommand({
+        name: REFRESH_SERIES,
+        seriesIds: seriesToRefresh,
+      })
+    );
+  }, [dispatch, seriesToRefresh]);
+
+  return (
+    <PageToolbarButton
+      label={isSelectMode ? refreshSelectLabel : refreshIndexLabel}
+      isSpinning={isRefreshing}
+      isDisabled={!totalItems}
+      iconName={icons.REFRESH}
+      onPress={onPress}
+    />
+  );
+}
+
+export default SeriesIndexRefreshSeriesButton;

--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2 && s.Seasons.Single(season => season.SeasonNumber == 2).Monitored == true), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2 && s.Seasons.Single(season => season.SeasonNumber == 2).Monitored == false), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(series);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2 && s.Seasons.Single(season => season.SeasonNumber == 0).Monitored == false), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.TvRageId == newSeriesInfo.TvRageId), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.TvMazeId == newSeriesInfo.TvMazeId), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Test.TvTests
         [Test]
         public void should_log_error_if_tvdb_id_not_found()
         {
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Status == SeriesStatusType.Deleted), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Test.TvTests
         [Test]
         public void should_mark_as_deleted_if_tvdb_id_not_found()
         {
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Status == SeriesStatusType.Deleted), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
@@ -162,7 +162,7 @@ namespace NzbDrone.Core.Test.TvTests
         {
             _series.Status = SeriesStatusType.Deleted;
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.IsAny<Series>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                 .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.TvdbId == newSeriesInfo.TvdbId), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -204,7 +204,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                   .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -224,7 +224,7 @@ namespace NzbDrone.Core.Test.TvTests
 
             GivenNewSeriesInfo(newSeriesInfo);
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<ISeriesService>()
                   .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2), It.IsAny<bool>(), It.IsAny<bool>()));
@@ -237,7 +237,7 @@ namespace NzbDrone.Core.Test.TvTests
                   .Setup(s => s.GetSeriesInfo(_series.Id))
                   .Throws(new IOException());
 
-            Assert.Throws<IOException>(() => Subject.Execute(new RefreshSeriesCommand(_series.Id)));
+            Assert.Throws<IOException>(() => Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id })));
 
             Mocker.GetMock<IDiskScanService>()
                   .Verify(v => v.Scan(_series), Times.Once());
@@ -252,7 +252,7 @@ namespace NzbDrone.Core.Test.TvTests
                   .Setup(s => s.GetSeriesInfo(_series.Id))
                   .Throws(new SeriesNotFoundException(_series.Id));
 
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<IDiskScanService>()
                   .Verify(v => v.Scan(_series), Times.Never());

--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -75,23 +75,6 @@ namespace NzbDrone.Core.Test.TvTests
         }
 
         [Test]
-        public void should_monitor_new_seasons_automatically_if_series_is_monitored_single_seriesId()
-        {
-            _series.Monitored = true;
-            var newSeriesInfo = _series.JsonClone();
-            newSeriesInfo.Seasons.Add(Builder<Season>.CreateNew()
-                                         .With(s => s.SeasonNumber = 2)
-                                         .Build());
-
-            GivenNewSeriesInfo(newSeriesInfo);
-
-            Subject.Execute(new RefreshSeriesCommand(_series.Id));
-
-            Mocker.GetMock<ISeriesService>()
-                .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2 && s.Seasons.Single(season => season.SeasonNumber == 2).Monitored == true), It.IsAny<bool>(), It.IsAny<bool>()));
-        }
-
-        [Test]
         public void should_not_monitor_new_seasons_automatically_if_series_is_not_monitored()
         {
             _series.Monitored = false;

--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -75,6 +75,23 @@ namespace NzbDrone.Core.Test.TvTests
         }
 
         [Test]
+        public void should_monitor_new_seasons_automatically_if_series_is_monitored_single_seriesId()
+        {
+            _series.Monitored = true;
+            var newSeriesInfo = _series.JsonClone();
+            newSeriesInfo.Seasons.Add(Builder<Season>.CreateNew()
+                                         .With(s => s.SeasonNumber = 2)
+                                         .Build());
+
+            GivenNewSeriesInfo(newSeriesInfo);
+
+            Subject.Execute(new RefreshSeriesCommand(_series.Id));
+
+            Mocker.GetMock<ISeriesService>()
+                .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Count == 2 && s.Seasons.Single(season => season.SeasonNumber == 2).Monitored == true), It.IsAny<bool>(), It.IsAny<bool>()));
+        }
+
+        [Test]
         public void should_not_monitor_new_seasons_automatically_if_series_is_not_monitored()
         {
             _series.Monitored = false;

--- a/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
+++ b/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
@@ -1,25 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
 using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.Tv.Commands
 {
     public class RefreshSeriesCommand : Command
     {
-        public int? SeriesId { get; set; }
+        public List<int> SeriesIds { get; set; }
         public bool IsNewSeries { get; set; }
 
         public RefreshSeriesCommand()
         {
+            SeriesIds = new List<int>();
         }
 
-        public RefreshSeriesCommand(int? seriesId, bool isNewSeries = false)
+        public RefreshSeriesCommand(List<int> seriesIds, bool isNewSeries = false)
         {
-            SeriesId = seriesId;
+            SeriesIds = seriesIds;
             IsNewSeries = isNewSeries;
         }
 
         public override bool SendUpdatesToClient => true;
 
-        public override bool UpdateScheduledTask => !SeriesId.HasValue;
+        public override bool UpdateScheduledTask => !SeriesIds.Any();
 
         public override bool IsLongRunning => true;
     }

--- a/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
+++ b/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
@@ -1,23 +1,32 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.Tv.Commands
 {
     public class RefreshSeriesCommand : Command
     {
-        public int? SeriesId { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int SeriesId
+        {
+            get => 0;
+            set
+            {
+                if (SeriesIds.Empty())
+                {
+                    SeriesIds.Add(value);
+                }
+            }
+        }
+
         public List<int> SeriesIds { get; set; }
         public bool IsNewSeries { get; set; }
 
         public RefreshSeriesCommand()
         {
             SeriesIds = new List<int>();
-        }
-
-        public RefreshSeriesCommand(int seriesId, bool isNewSeries = false)
-        {
-            SeriesIds = new List<int> { seriesId };
         }
 
         public RefreshSeriesCommand(List<int> seriesIds, bool isNewSeries = false)

--- a/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
+++ b/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
@@ -6,12 +6,18 @@ namespace NzbDrone.Core.Tv.Commands
 {
     public class RefreshSeriesCommand : Command
     {
+        public int? SeriesId { get; set; }
         public List<int> SeriesIds { get; set; }
         public bool IsNewSeries { get; set; }
 
         public RefreshSeriesCommand()
         {
             SeriesIds = new List<int>();
+        }
+
+        public RefreshSeriesCommand(int seriesId, bool isNewSeries = false)
+        {
+            SeriesIds = new List<int> { seriesId };
         }
 
         public RefreshSeriesCommand(List<int> seriesIds, bool isNewSeries = false)

--- a/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
+++ b/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Messaging.Commands;
@@ -37,7 +36,7 @@ namespace NzbDrone.Core.Tv.Commands
 
         public override bool SendUpdatesToClient => true;
 
-        public override bool UpdateScheduledTask => !SeriesIds.Any();
+        public override bool UpdateScheduledTask => SeriesIds.Empty();
 
         public override bool IsLongRunning => true;
     }

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -232,26 +232,29 @@ namespace NzbDrone.Core.Tv
             var isNew = message.IsNewSeries;
             _eventAggregator.PublishEvent(new SeriesRefreshStartingEvent(trigger == CommandTrigger.Manual));
 
-            if (message.SeriesId.HasValue)
+            if (message.SeriesIds.Any())
             {
-                var series = _seriesService.GetSeries(message.SeriesId.Value);
+                foreach (var seriesId in message.SeriesIds)
+                {
+                    var series = _seriesService.GetSeries(seriesId);
 
-                try
-                {
-                    series = RefreshSeriesInfo(message.SeriesId.Value);
-                    UpdateTags(series);
-                    RescanSeries(series, isNew, trigger);
-                }
-                catch (SeriesNotFoundException)
-                {
-                    _logger.Error("Series '{0}' (tvdbid {1}) was not found, it may have been removed from TheTVDB.", series.Title, series.TvdbId);
-                }
-                catch (Exception e)
-                {
-                    _logger.Error(e, "Couldn't refresh info for {0}", series);
-                    UpdateTags(series);
-                    RescanSeries(series, isNew, trigger);
-                    throw;
+                    try
+                    {
+                        series = RefreshSeriesInfo(seriesId);
+                        UpdateTags(series);
+                        RescanSeries(series, isNew, trigger);
+                    }
+                    catch (SeriesNotFoundException)
+                    {
+                        _logger.Error("Series '{0}' (tvdbid {1}) was not found, it may have been removed from TheTVDB.", series.Title, series.TvdbId);
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.Error(e, "Couldn't refresh info for {0}", series);
+                        UpdateTags(series);
+                        RescanSeries(series, isNew, trigger);
+                        throw;
+                    }
                 }
             }
             else

--- a/src/NzbDrone.Core/Tv/SeriesAddedHandler.cs
+++ b/src/NzbDrone.Core/Tv/SeriesAddedHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
@@ -18,12 +19,12 @@ namespace NzbDrone.Core.Tv
 
         public void Handle(SeriesAddedEvent message)
         {
-            _commandQueueManager.Push(new RefreshSeriesCommand(message.Series.Id, true));
+            _commandQueueManager.Push(new RefreshSeriesCommand(new List<int> { message.Series.Id }, true));
         }
 
         public void Handle(SeriesImportedEvent message)
         {
-            _commandQueueManager.PushMany(message.SeriesIds.Select(s => new RefreshSeriesCommand(s, true)).ToList());
+            _commandQueueManager.PushMany(message.SeriesIds.Select(s => new RefreshSeriesCommand(new List<int> { s }, true)).ToList());
         }
     }
 }

--- a/src/NzbDrone.Core/Tv/SeriesEditedService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesEditedService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Tv.Commands;
@@ -18,7 +19,7 @@ namespace NzbDrone.Core.Tv
         {
             if (message.Series.SeriesType != message.OldSeries.SeriesType)
             {
-                _commandQueueManager.Push(new RefreshSeriesCommand(message.Series.Id, false));
+                _commandQueueManager.Push(new RefreshSeriesCommand(new List<int> { message.Series.Id }, false));
             }
         }
     }

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -305,7 +305,7 @@ namespace NzbDrone.Integration.Test
                 Directory.CreateDirectory(Path.GetDirectoryName(path));
                 File.WriteAllText(path, "Fake Episode");
 
-                Commands.PostAndWait(new RefreshSeriesCommand(series.Id));
+                Commands.PostAndWait(new RefreshSeriesCommand(new List<int> { series.Id }));
 
                 Commands.WaitAll();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Brings in the functionality already present in Radarr to allow the update series button to only update the selected items or the filtered items.

#### Todos
- [X] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* closes #5611 
