### PR TITLE
Add `forceSave` to the OpenAPI docs

### DIFF
--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
-using Sonarr.Http.Extensions;
 using Sonarr.Http.REST;
 using Sonarr.Http.REST.Attributes;
 
@@ -77,10 +76,9 @@ namespace Sonarr.Api.V3
 
         [RestPutById]
         [Consumes("application/json")]
-        public ActionResult<TProviderResource> UpdateProvider(TProviderResource providerResource)
+        public ActionResult<TProviderResource> UpdateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
             var providerDefinition = GetDefinition(providerResource, true, false, false);
-            var forceSave = Request.GetBooleanQueryParameter("forceSave");
 
             // Only test existing definitions if it is enabled and forceSave isn't set.
             if (providerDefinition.Enable && !forceSave)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I didn't add this in #5612 since I'm wary about this, but since it's something supported I'll leave it up to you to decide. 