### PR TITLE
Fixed: Use indexer errors from response if Content-Type is XML before processing response

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -50,7 +50,8 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         protected override bool PreProcess(IndexerResponse indexerResponse)
         {
-            if (indexerResponse.HttpResponse.HasHttpError)
+            if (indexerResponse.HttpResponse.HasHttpError &&
+                (indexerResponse.HttpResponse.Headers.ContentType == null || !indexerResponse.HttpResponse.Headers.ContentType.Contains("xml")))
             {
                 base.PreProcess(indexerResponse);
             }

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -19,7 +19,8 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         protected override bool PreProcess(IndexerResponse indexerResponse)
         {
-            if (indexerResponse.HttpResponse.HasHttpError)
+            if (indexerResponse.HttpResponse.HasHttpError &&
+                (indexerResponse.HttpResponse.Headers.ContentType == null || !indexerResponse.HttpResponse.Headers.ContentType.Contains("xml")))
             {
                 base.PreProcess(indexerResponse);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
After complains from @bakerboy448 that `Unable to connect to indexer. Indexer API call resulted in an unexpected StatusCode [Forbidden]` is too generic, let's use the error message from the response body if the Content-Type contains `xml`. 
