### PR TITLE
New: Improve validation messages

### DIFF
--- a/src/NzbDrone.Core/Validation/FolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/FolderValidator.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Core.Validation
 {
     public class FolderValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Path";
+        protected override string GetDefaultMessageTemplate() => "Invalid Path: '{path}'";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -14,6 +14,8 @@ namespace NzbDrone.Core.Validation
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return context.PropertyValue.ToString().IsPathValid(PathValidationType.CurrentOs);
         }

--- a/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
+++ b/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
@@ -26,8 +26,7 @@ namespace NzbDrone.Core.Validation
         {
             foreach (var item in list)
             {
-                var extended = item as NzbDroneValidationFailure;
-                if (extended != null && extended.IsWarning)
+                if (item is NzbDroneValidationFailure { IsWarning: true })
                 {
                     continue;
                 }

--- a/src/NzbDrone.Core/Validation/NzbDroneValidationFailure.cs
+++ b/src/NzbDrone.Core/Validation/NzbDroneValidationFailure.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Validation
             CustomState = validationFailure.CustomState;
             var state = validationFailure.CustomState as NzbDroneValidationState;
 
-            IsWarning = state != null && state.IsWarning;
+            IsWarning = state is { IsWarning: true };
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/NzbDroneValidationResult.cs
+++ b/src/NzbDrone.Core/Validation/NzbDroneValidationResult.cs
@@ -26,8 +26,7 @@ namespace NzbDrone.Core.Validation
 
             foreach (var failureBase in failures)
             {
-                var failure = failureBase as NzbDroneValidationFailure;
-                if (failure == null)
+                if (failureBase is not NzbDroneValidationFailure failure)
                 {
                     failure = new NzbDroneValidationFailure(failureBase);
                 }

--- a/src/NzbDrone.Core/Validation/Paths/FileExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/FileExistsValidator.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "File does not exist";
+        protected override string GetDefaultMessageTemplate() => "File '{file}' does not exist";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -20,6 +20,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("file", context.PropertyValue.ToString());
 
             return _diskProvider.FileExists(context.PropertyValue.ToString());
         }

--- a/src/NzbDrone.Core/Validation/Paths/FolderWritableValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/FolderWritableValidator.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => $"Folder is not writable by user {Environment.UserName}";
+        protected override string GetDefaultMessageTemplate() => "Folder '{path}' is not writable by user '{user}'";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -21,6 +21,9 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
+            context.MessageFormatter.AppendArgument("user", Environment.UserName);
 
             return _diskProvider.FolderWritable(context.PropertyValue.ToString());
         }

--- a/src/NzbDrone.Core/Validation/Paths/PathExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/PathExistsValidator.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Core.Validation.Paths
             _diskProvider = diskProvider;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path does not exist";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' does not exist";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -20,6 +20,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return _diskProvider.FolderExists(context.PropertyValue.ToString());
         }

--- a/src/NzbDrone.Core/Validation/Paths/PathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/PathValidator.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Validation.Paths
 
     public class PathValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Path";
+        protected override string GetDefaultMessageTemplate() => "Invalid Path: '{path}'";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -23,6 +23,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return context.PropertyValue.ToString().IsPathValid(PathValidationType.CurrentOs);
         }

--- a/src/NzbDrone.Core/Validation/Paths/RecycleBinValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RecycleBinValidator.cs
@@ -13,17 +13,19 @@ namespace NzbDrone.Core.Validation.Paths
             _configService = configService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path is {relationship} configured recycle bin folder";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is {relationship} configured recycle bin folder";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
             var recycleBin = _configService.RecycleBin;
-            var folder = context.PropertyValue.ToString();
 
             if (context.PropertyValue == null || recycleBin.IsNullOrWhiteSpace())
             {
                 return true;
             }
+
+            var folder = context.PropertyValue.ToString();
+            context.MessageFormatter.AppendArgument("path", folder);
 
             if (recycleBin.PathEquals(folder))
             {

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderAncestorValidator.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Validation.Paths
             _rootFolderService = rootFolderService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path is an ancestor of an existing root folder";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is an ancestor of an existing root folder";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -22,6 +22,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return true;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return !_rootFolderService.All().Any(s => context.PropertyValue.ToString().IsParentPath(s.Path));
         }

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Validation.Paths
             _rootFolderService = rootFolderService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path is already configured as a root folder";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is already configured as a root folder";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -21,6 +21,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return true;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return !_rootFolderService.All().Exists(r => r.Path.PathEquals(context.PropertyValue.ToString()));
         }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesAncestorValidator.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Validation.Paths
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path is an ancestor of an existing series";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is an ancestor of an existing series";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -22,6 +22,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return true;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             return !_seriesService.GetAllSeriesPaths().Any(s => context.PropertyValue.ToString().IsParentPath(s.Value));
         }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Validation.Paths
             _seriesService = seriesService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path is already configured for another series";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is already configured for another series";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -21,6 +21,8 @@ namespace NzbDrone.Core.Validation.Paths
             {
                 return true;
             }
+
+            context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
             dynamic instance = context.ParentContext.InstanceToValidate;
             var instanceId = (int)instance.Id;

--- a/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/StartupFolderValidator.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Validation.Paths
             _appFolderInfo = appFolderInfo;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Path cannot be {relationship} the start up folder";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' cannot be {relationship} the start up folder";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Validation.Paths
 
             var startupFolder = _appFolderInfo.StartUpFolder;
             var folder = context.PropertyValue.ToString();
+            context.MessageFormatter.AppendArgument("path", folder);
 
             if (startupFolder.PathEquals(folder))
             {

--- a/src/NzbDrone.Core/Validation/Paths/SystemFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SystemFolderValidator.cs
@@ -6,11 +6,12 @@ namespace NzbDrone.Core.Validation.Paths
 {
     public class SystemFolderValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Is {relationship} system folder {systemFolder}";
+        protected override string GetDefaultMessageTemplate() => "Path '{path}' is {relationship} system folder {systemFolder}";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
             var folder = context.PropertyValue.ToString();
+            context.MessageFormatter.AppendArgument("path", folder);
 
             foreach (var systemFolder in SystemFolders.GetSystemFolders())
             {

--- a/src/NzbDrone.Core/Validation/UrlValidator.cs
+++ b/src/NzbDrone.Core/Validation/UrlValidator.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Validation
 
     public class UrlValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Invalid Url";
+        protected override string GetDefaultMessageTemplate() => "Invalid Url: '{url}'";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -22,6 +22,8 @@ namespace NzbDrone.Core.Validation
             {
                 return false;
             }
+
+            context.MessageFormatter.AppendArgument("url", context.PropertyValue.ToString());
 
             return context.PropertyValue.ToString().IsValidUrl();
         }

--- a/src/Sonarr.Api.V3/Series/SeriesFolderAsRootFolderValidator.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesFolderAsRootFolderValidator.cs
@@ -15,7 +15,7 @@ namespace Sonarr.Api.V3.Series
             _fileNameBuilder = fileNameBuilder;
         }
 
-        protected override string GetDefaultMessageTemplate() => "Root folder path contains series folder";
+        protected override string GetDefaultMessageTemplate() => "Root folder path '{rootFolderPath}' contains series folder '{seriesFolder}'";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -24,9 +24,7 @@ namespace Sonarr.Api.V3.Series
                 return true;
             }
 
-            var seriesResource = context.InstanceToValidate as SeriesResource;
-
-            if (seriesResource == null)
+            if (context.InstanceToValidate is not SeriesResource seriesResource)
             {
                 return true;
             }
@@ -41,6 +39,9 @@ namespace Sonarr.Api.V3.Series
             var rootFolder = new DirectoryInfo(rootFolderPath!).Name;
             var series = seriesResource.ToModel();
             var seriesFolder = _fileNameBuilder.GetSeriesFolder(series);
+
+            context.MessageFormatter.AppendArgument("rootFolderPath", rootFolderPath);
+            context.MessageFormatter.AppendArgument("seriesFolder", seriesFolder);
 
             if (seriesFolder == rootFolder)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is redundant from the start when using the UI, but logs with `Path: Folder is not writable by user abc` or `RootFolderPath: Invalid Path` aren't helpful at all for support or the users.

Should I continue with the rest of them?