### PR TITLE
Enforce rule IDE0005 on build

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,6 +30,13 @@
     <!-- A test project gets the test sdk packages automatically added -->
     <TestProject>false</TestProject>
     <TestProject Condition="$(MSBuildProjectName.EndsWith('.Test'))">true</TestProject>
+
+    <!-- XML documentation comments are needed to enforce rule IDE0005 on build -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+        CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+    -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -7,7 +7,6 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http.Proxy;

--- a/src/NzbDrone.Common/OAuth/OAuthRequest.cs
+++ b/src/NzbDrone.Common/OAuth/OAuthRequest.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Common.OAuth
         public virtual string Version { get; set; }
         public virtual string SessionHandle { get; set; }
 
-        /// <seealso cref="http://oauth.net/core/1.0#request_urls"/>
+        /// <seealso href="http://oauth.net/core/1.0#request_urls"/>
         public virtual string RequestUrl { get; set; }
 
 #if !WINRT

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesGrabSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesGrabSpecificationFixture.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
@@ -35,13 +35,13 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         /// </summary>
         /// <param name="settings">Indexer Settings to use for Parser</param>
         /// <returns>Parsed Settings or <c>null</c></returns>
-        public TorrentRssIndexerParserSettings Detect(TorrentRssIndexerSettings indexerSettings)
+        public TorrentRssIndexerParserSettings Detect(TorrentRssIndexerSettings settings)
         {
-            _logger.Debug("Evaluating TorrentRss feed '{0}'", indexerSettings.BaseUrl);
+            _logger.Debug("Evaluating TorrentRss feed '{0}'", settings.BaseUrl);
 
             try
             {
-                var requestGenerator = new TorrentRssIndexerRequestGenerator { Settings = indexerSettings };
+                var requestGenerator = new TorrentRssIndexerRequestGenerator { Settings = settings };
                 var request = requestGenerator.GetRecentRequests().GetAllTiers().First().First();
 
                 HttpResponse httpResponse = null;
@@ -56,14 +56,14 @@ namespace NzbDrone.Core.Indexers.TorrentRss
                 }
 
                 var indexerResponse = new IndexerResponse(request, httpResponse);
-                return GetParserSettings(indexerResponse, indexerSettings);
+                return GetParserSettings(indexerResponse, settings);
             }
             catch (Exception ex)
             {
-                ex.WithData("FeedUrl", indexerSettings.BaseUrl);
+                ex.WithData("FeedUrl", settings.BaseUrl);
                 throw;
             }
-    }
+        }
 
         private TorrentRssIndexerParserSettings GetParserSettings(IndexerResponse response, TorrentRssIndexerSettings indexerSettings)
         {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateReleaseInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateReleaseInfo.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -9,7 +9,6 @@ using NzbDrone.Core.Download;
 using NzbDrone.Core.Extras;
 using NzbDrone.Core.MediaFiles.Commands;
 using NzbDrone.Core.MediaFiles.Events;
-using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -4,7 +4,6 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
-using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
-using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.HealthCheck;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;

--- a/src/NzbDrone.Core/Notifications/Signal/SignalError.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalError.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace NzbDrone.Core.Notifications.Signal
+﻿namespace NzbDrone.Core.Notifications.Signal
 {
     public class SignalError
     {

--- a/src/NzbDrone.Core/Notifications/Signal/SignalProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalProxy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Text;
-using System.Web;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;

--- a/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeController.cs
@@ -6,7 +6,6 @@ using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Tv;
 using NzbDrone.SignalR;
 using Sonarr.Http;
-using Sonarr.Http.Extensions;
 using Sonarr.Http.REST;
 using Sonarr.Http.REST.Attributes;
 

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -19,7 +19,6 @@ using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 using NzbDrone.SignalR;
 using Sonarr.Http;
-using Sonarr.Http.Extensions;
 using Sonarr.Http.REST;
 using Sonarr.Http.REST.Attributes;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Since c6b543e0729bc20f15e37d074fbf31d8c76c187a apparently a few unused import already got in, thus let's add a Github Action to prevent this.

I noticed the build.sh is little different from downstream and if I'm assuming correctly that in TC it's used with `build.sh --all` and not step by step like `build.sh --lint`, then I think I can add `LintBackend` to run on `$LINT_BACKEND == "YES"`.