### PR TITLE
 Fix sorting search releases by language

### DIFF
--- a/frontend/src/Store/Actions/releaseActions.js
+++ b/frontend/src/Store/Actions/releaseActions.js
@@ -44,7 +44,7 @@ export const defaultState = {
         return 10000;
       }
 
-      return item.languages[0].id;
+      return item.languages[0]?.id ?? 0;
     },
 
     rejections: function(item, direction) {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -138,6 +138,7 @@ namespace NzbDrone.Core.DecisionEngine
                             {
                                 Release = report,
                                 ParsedEpisodeInfo = parsedEpisodeInfo,
+                                Languages = parsedEpisodeInfo.Languages
                             };
 
                             decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse release"));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is to fix sorting by empty languages in https://github.com/Sonarr/Sonarr/blob/f05405fe1ce4c78a8c75e27920c863c5b83686bd/frontend/src/Store/Actions/releaseActions.js#L47 which does the same as https://github.com/Sonarr/Sonarr/blob/f05405fe1ce4c78a8c75e27920c863c5b83686bd/src/NzbDrone.Core/Parser/ParsingService.cs#L194 for a successful parsing. 

Before
![before](https://github.com/Sonarr/Sonarr/assets/707714/c09e6fdc-8ad1-4337-bd20-717b4f0f2a86)
After
![after](https://github.com/Sonarr/Sonarr/assets/707714/353bb68f-7797-4ae2-b1f4-bd8328606ad4)

