### PR TITLE
Fix: Use relative paths instead of absolute paths for webmanifest

### DIFF
--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -1,17 +1,18 @@
 {
-    "name": "",
+    "name": "Sonarr",
     "icons": [
         {
-            "src": "/Content/Images/Icons/android-chrome-192x192.png",
+            "src": "android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/Content/Images/Icons/android-chrome-512x512.png",
+            "src": "android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }
     ],
+    "start_url": "../../../../",
     "theme_color": "#3a3f51",
     "background_color": "#3a3f51",
     "display": "standalone"


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This patches the manifest.json file to use relative paths instead of absolute paths, allowing the webapp to be installable when using an alternative URL root without redirects set up.

So far I've only tested on one browser (Edge on Windows)

#### Todos
N/A


#### Issues Fixed or Closed by this PR
* Closes #5688

