### PR TITLE
Fixed: Enforce validation warnings

### DIFF
--- a/frontend/src/Store/Actions/Creators/createSaveProviderHandler.js
+++ b/frontend/src/Store/Actions/Creators/createSaveProviderHandler.js
@@ -32,9 +32,9 @@ function createSaveProviderHandler(section, url, options = {}) {
     const params = { ...queryParams };
 
     // If the user is re-saving the same provider without changes
-    // force it to be saved. Only applies to editing existing providers.
+    // force it to be saved.
 
-    if (id && _.isEqual(saveData, lastSaveData)) {
+    if (_.isEqual(saveData, lastSaveData)) {
       params.forceSave = true;
     }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -23,12 +23,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
         private static bool ShouldHaveApiKey(NewznabSettings settings)
         {
-            if (settings.BaseUrl == null)
-            {
-                return false;
-            }
-
-            return ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
+            return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
         private static readonly Regex AdditionalParametersRegex = new Regex(@"(&.+?\=.+?)+", RegexOptions.Compiled);

--- a/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
@@ -48,8 +48,6 @@ namespace NzbDrone.Core.Indexers
 
     public class SeedCriteriaSettings
     {
-        private static readonly SeedCriteriaSettingsValidator Validator = new SeedCriteriaSettingsValidator();
-
         [FieldDefinition(0, Type = FieldType.Textbox, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default. Ratio should be at least 1.0 and follow the indexers rules")]
         public double? SeedRatio { get; set; }
 

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -17,12 +17,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
         private static bool ShouldHaveApiKey(TorznabSettings settings)
         {
-            if (settings.BaseUrl == null)
-            {
-                return false;
-            }
-
-            return ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
+            return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
         private static readonly Regex AdditionalParametersRegex = new Regex(@"(&.+?\=.+?)+", RegexOptions.Compiled);

--- a/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
+++ b/src/NzbDrone.Core/Validation/NzbDroneValidationExtensions.cs
@@ -24,17 +24,7 @@ namespace NzbDrone.Core.Validation
 
         public static bool HasErrors(this List<ValidationFailure> list)
         {
-            foreach (var item in list)
-            {
-                if (item is NzbDroneValidationFailure { IsWarning: true })
-                {
-                    continue;
-                }
-
-                return true;
-            }
-
-            return false;
+            return list.Any(item => item is not NzbDroneValidationFailure { IsWarning: true });
         }
     }
 }

--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -68,9 +68,9 @@ namespace Sonarr.Api.V3
 
         [RestPostById]
         [Consumes("application/json")]
-        public ActionResult<TProviderResource> CreateProvider(TProviderResource providerResource)
+        public ActionResult<TProviderResource> CreateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
-            var providerDefinition = GetDefinition(providerResource, true, false, false);
+            var providerDefinition = GetDefinition(providerResource, true, !forceSave, false);
 
             if (providerDefinition.Enable)
             {
@@ -86,7 +86,7 @@ namespace Sonarr.Api.V3
         [Consumes("application/json")]
         public ActionResult<TProviderResource> UpdateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
-            var providerDefinition = GetDefinition(providerResource, true, false, false);
+            var providerDefinition = GetDefinition(providerResource, true, !forceSave, false);
 
             // Only test existing definitions if it is enabled and forceSave isn't set.
             if (providerDefinition.Enable && !forceSave)
@@ -252,7 +252,7 @@ namespace Sonarr.Api.V3
 
         protected void VerifyValidationResult(ValidationResult validationResult, bool includeWarnings)
         {
-            var result = new NzbDroneValidationResult(validationResult.Errors);
+            var result = validationResult as NzbDroneValidationResult ?? new NzbDroneValidationResult(validationResult.Errors);
 
             if (includeWarnings && (!result.IsValid || result.HasWarnings))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
~~Validation with `AsWarning()` doesn't work nice with arrs, and this might a regression from b95c4d37d7e1c2d699dbfd995b496a2fffde6705 allowing use of <= 0 values.~~

~~Since I fixed this in Prowlarr a while ago a few users [complained](https://github.com/Prowlarr/Prowlarr/issues/1692) that Prowlarr doesn't allow `0` and Sonarr/Radarr does.~~

~~Should we allow >= 0 or stick to `>0`?~~

Fix showing warnings in provider validation.