### PR TITLE
Feature/spanish tracker

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -1,7 +1,7 @@
-using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Test.Framework;
+using System.Linq;
 
 namespace NzbDrone.Core.Test.ParserTests
 {
@@ -151,6 +151,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Anime Title - S2010E994 [0994] [2010-02-28] - Episode Title [x264 720p][AAC 2ch][HS][Shion+GakiDave]", "Anime Title", 2010, 994)]
         [TestCase("Series Title - Temporada 2 [HDTV 720p][Cap.201][AC3 5.1 Castellano][www.pctnew.com]", "Series Title", 2, 1)]
         [TestCase("Series Title - Temporada 2 [HDTV 720p][Cap.1901][AC3 5.1 Castellano][www.pctnew.com]", "Series Title", 19, 1)]
+        [TestCase("Series Title - Temporada 2 [HDTV 720p][Cap.408]", "Series Title", 4, 8)]
         [TestCase("Series Title 1x1", "Series Title", 1, 1)]
         [TestCase("1x1", "", 1, 1)]
         [TestCase("Series Title [2022] [S25E13] [PL] [720p] [WEB-DL-CZRG] [x264] ", "Series Title [2022]", 25, 13)]

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Test.Framework;

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Test.Framework;
-using System.Linq;
 
 namespace NzbDrone.Core.Test.ParserTests
 {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -1,8 +1,3 @@
-using NLog;
-using NzbDrone.Common.Extensions;
-using NzbDrone.Common.Instrumentation;
-using NzbDrone.Core.Parser.Model;
-using NzbDrone.Core.Tv;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -1,3 +1,8 @@
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Instrumentation;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -469,7 +474,7 @@ namespace NzbDrone.Core.Parser
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly RegexReplace WebsitePostfixRegex = new RegexReplace(@"\[\s*[-a-z]+(\.[a-z0-9]+)+\s*\]$",
+        private static readonly RegexReplace WebsitePostfixRegex = new RegexReplace(@"\[\s*[-a-z]+(\.[a-z0-9]+)+\s*\]$(?<!\[Cap\.([0-9]{3})\])",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Spanish torrents are changing the way they name torrents.

Before:
  - Mrs Davis - Temporada 1 [WEB-DL 1080p][Cap.106][Dual DDP5.1 + Subs][www.AtomoHD.CARE]
  - Los Fontaneros De La Casa Blanca - Temporada 1 [WEB-DL 1080p][Cap.102][Dual DDP5.1 + Subs]

Now:
  - Mrs Davis - Temporada 1 [HDTV 1080p][Cap.108]
  - Los Fontaneros De La Casa Blanca - Temporada 1 [HDTV 1080p][Cap.104]

It seems that the new name does not contain language and and url, WebsitePostfixRegex is removing the episode number


#### Todos
- [X] Tests
- [ ] Wiki Updates