### PR TITLE
Ignore API doc commits downstream

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -49,7 +49,7 @@ jobs:
           git add src
           if git status | grep -q modified
           then
-            git commit -am 'Automated API Docs update'
+            git commit -am 'Automated API Docs update' -m "ignore-downstream"
             git push -f --set-upstream origin api-docs
             curl -X POST -H "Authorization: Bearer ${{ secrets.OPENAPI_PAT }}" -H "Accept: application/vnd.github+json" https://api.github.com/repos/sonarr/sonarr/pulls -d '{"head":"api-docs","base":"develop","title":"Update API docs"}'
           else


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds `ignore-downstream` as discussed to extended description of API doc commits
