### PR TITLE
Faster tag view in UI for large libraries

### DIFF
--- a/src/NzbDrone.Core/Tags/TagService.cs
+++ b/src/NzbDrone.Core/Tags/TagService.cs
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Tags
             var importLists = _importListFactory.All();
             var notifications = _notificationFactory.All();
             var restrictions = _releaseProfileService.All();
-            var series = _seriesService.GetAllSeries();
+            var series = _seriesService.GetAllSeriesTags();
             var indexers = _indexerService.All();
             var autotags = _autoTaggingService.All();
 
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Tags
                         ImportListIds = importLists.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                         NotificationIds = notifications.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                         RestrictionIds = restrictions.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
-                        SeriesIds = series.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
+                        SeriesIds = series.Where(c => c.Value.Contains(tag.Id)).Select(c => c.Key).ToList(),
                         IndexerIds = indexers.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                         AutoTagIds = autotags.Where(c => c.Tags.Contains(tag.Id)).Select(c => c.Id).ToList(),
                     });

--- a/src/NzbDrone.Core/Tv/SeriesRepository.cs
+++ b/src/NzbDrone.Core/Tv/SeriesRepository.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Tv
         Series FindByPath(string path);
         List<int> AllSeriesTvdbIds();
         Dictionary<int, string> AllSeriesPaths();
+        Dictionary<int, List<int>> AllSeriesTags();
     }
 
     public class SeriesRepository : BasicRepository<Series>, ISeriesRepository
@@ -87,6 +88,15 @@ namespace NzbDrone.Core.Tv
             {
                 var strSql = "SELECT Id AS [Key], Path AS [Value] FROM Series";
                 return conn.Query<KeyValuePair<int, string>>(strSql).ToDictionary(x => x.Key, x => x.Value);
+            }
+        }
+
+        public Dictionary<int, List<int>> AllSeriesTags()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                var strSql = "SELECT Id AS [Key], Tags AS [Value] FROM Series WHERE Tags IS NOT NULL";
+                return conn.Query<KeyValuePair<int, List<int>>>(strSql).ToDictionary(x => x.Key, x => x.Value);
             }
         }
 

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Tv
         List<Series> GetAllSeries();
         List<int> AllSeriesTvdbIds();
         Dictionary<int, string> GetAllSeriesPaths();
+        Dictionary<int, List<int>> GetAllSeriesTags();
         List<Series> AllForTag(int tagId);
         Series UpdateSeries(Series series, bool updateEpisodesToMatchSeason = true, bool publishUpdatedEvent = true);
         List<Series> UpdateSeries(List<Series> series, bool useExistingRelativeFolder);
@@ -167,6 +168,11 @@ namespace NzbDrone.Core.Tv
         public Dictionary<int, string> GetAllSeriesPaths()
         {
             return _seriesRepository.AllSeriesPaths();
+        }
+
+        public Dictionary<int, List<int>> GetAllSeriesTags()
+        {
+            return _seriesRepository.AllSeriesTags();
         }
 
         public List<Series> AllForTag(int tagId)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Avoid `AllSeries` call on Tag UI page, particularly detrimental on large libraries. 

Pulled from Radarr
