### PR TITLE
Remove not implemented endpoints from API docs

### DIFF
--- a/src/Sonarr.Api.V3/Health/HealthController.cs
+++ b/src/Sonarr.Api.V3/Health/HealthController.cs
@@ -22,6 +22,12 @@ namespace Sonarr.Api.V3.Health
             _healthCheckService = healthCheckService;
         }
 
+        [NonAction]
+        public override ActionResult<HealthResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
+        }
+
         protected override HealthResource GetResourceById(int id)
         {
             throw new NotImplementedException();

--- a/src/Sonarr.Api.V3/Indexers/ReleaseControllerBase.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleaseControllerBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Profiles.Qualities;
 using Sonarr.Http.REST;
@@ -13,6 +14,12 @@ namespace Sonarr.Api.V3.Indexers
         public ReleaseControllerBase(IQualityProfileService qualityProfileService)
         {
             _qualityProfile = qualityProfileService.GetDefaultProfile(string.Empty);
+        }
+
+        [NonAction]
+        public override ActionResult<ReleaseResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
         }
 
         protected override ReleaseResource GetResourceById(int id)

--- a/src/Sonarr.Api.V3/Profiles/Languages/LanguageProfileSchemaController.cs
+++ b/src/Sonarr.Api.V3/Profiles/Languages/LanguageProfileSchemaController.cs
@@ -32,9 +32,15 @@ namespace Sonarr.Api.V3.Profiles.Languages
             };
         }
 
+        [NonAction]
+        public override ActionResult<LanguageProfileResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
+        }
+
         protected override LanguageProfileResource GetResourceById(int id)
         {
-            throw new global::System.NotImplementedException();
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -68,6 +68,7 @@ namespace Sonarr.Api.V3
 
         [RestPostById]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public ActionResult<TProviderResource> CreateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
             var providerDefinition = GetDefinition(providerResource, true, !forceSave, false);
@@ -84,6 +85,7 @@ namespace Sonarr.Api.V3
 
         [RestPutById]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public ActionResult<TProviderResource> UpdateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
             var providerDefinition = GetDefinition(providerResource, true, !forceSave, false);
@@ -101,6 +103,7 @@ namespace Sonarr.Api.V3
 
         [HttpPut("bulk")]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public ActionResult<TProviderResource> UpdateProvider([FromBody] TBulkProviderResource providerResource)
         {
             var definitionsToUpdate = _providerFactory.Get(providerResource.Ids).ToList();
@@ -198,6 +201,7 @@ namespace Sonarr.Api.V3
         }
 
         [HttpPost("testall")]
+        [Produces("application/json")]
         public IActionResult TestAll()
         {
             var providerDefinitions = _providerFactory.All()
@@ -225,6 +229,7 @@ namespace Sonarr.Api.V3
         [SkipValidation]
         [HttpPost("action/{name}")]
         [Consumes("application/json")]
+        [Produces("application/json")]
         public IActionResult RequestAction(string name, [FromBody] TProviderResource resource)
         {
             var providerDefinition = GetDefinition(resource, false, false, false);

--- a/src/Sonarr.Api.V3/Queue/QueueController.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueController.cs
@@ -58,6 +58,12 @@ namespace Sonarr.Api.V3.Queue
             _qualityComparer = new QualityModelComparer(qualityProfileService.GetDefaultProfile(string.Empty));
         }
 
+        [NonAction]
+        public override ActionResult<QueueResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
+        }
+
         protected override QueueResource GetResourceById(int id)
         {
             throw new NotImplementedException();

--- a/src/Sonarr.Api.V3/Queue/QueueDetailsController.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueDetailsController.cs
@@ -26,6 +26,12 @@ namespace Sonarr.Api.V3.Queue
             _pendingReleaseService = pendingReleaseService;
         }
 
+        [NonAction]
+        public override ActionResult<QueueResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
+        }
+
         protected override QueueResource GetResourceById(int id)
         {
             throw new NotImplementedException();

--- a/src/Sonarr.Api.V3/Queue/QueueStatusController.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueStatusController.cs
@@ -30,6 +30,12 @@ namespace Sonarr.Api.V3.Queue
             _broadcastDebounce = new Debouncer(BroadcastChange, TimeSpan.FromSeconds(5));
         }
 
+        [NonAction]
+        public override ActionResult<QueueStatusResource> GetResourceByIdWithErrorHandler(int id)
+        {
+            return base.GetResourceByIdWithErrorHandler(id);
+        }
+
         protected override QueueStatusResource GetResourceById(int id)
         {
             throw new NotImplementedException();

--- a/src/Sonarr.Api.V3/openapi.json
+++ b/src/Sonarr.Api.V3/openapi.json
@@ -1401,17 +1401,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientResource"
                 }
@@ -1457,17 +1447,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientResource"
                 }
@@ -1544,17 +1524,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DownloadClientResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DownloadClientResource"
                 }
@@ -2244,36 +2214,6 @@
         }
       }
     },
-    "/api/v3/health/{id}": {
-      "get": {
-        "tags": [
-          "Health"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HealthResource"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v3/history": {
       "get": {
         "tags": [
@@ -2613,17 +2553,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListResource"
                 }
@@ -2669,17 +2599,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListResource"
                 }
@@ -2756,17 +2676,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportListResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ImportListResource"
                 }
@@ -3084,17 +2994,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerResource"
                 }
@@ -3140,17 +3040,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerResource"
                 }
@@ -3227,17 +3117,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IndexerResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexerResource"
                 }
@@ -3686,36 +3566,6 @@
         "deprecated": true
       }
     },
-    "/api/v3/languageprofile/schema/{id}": {
-      "get": {
-        "tags": [
-          "LanguageProfileSchema"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LanguageProfileResource"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v3/localization": {
       "get": {
         "tags": [
@@ -4107,17 +3957,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataResource"
                 }
@@ -4163,17 +4003,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataResource"
                 }
@@ -4250,17 +4080,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MetadataResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MetadataResource"
                 }
@@ -4748,17 +4568,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationResource"
                 }
@@ -4804,17 +4614,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationResource"
                 }
@@ -4891,17 +4691,7 @@
           "200": {
             "description": "Success",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotificationResource"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/NotificationResource"
                 }
@@ -5455,34 +5245,6 @@
             "description": "Success"
           }
         }
-      },
-      "get": {
-        "tags": [
-          "Queue"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueResource"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/v3/queue/bulk": {
@@ -5682,70 +5444,10 @@
         }
       }
     },
-    "/api/v3/queue/details/{id}": {
-      "get": {
-        "tags": [
-          "QueueDetails"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueResource"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v3/queue/status": {
       "get": {
         "tags": [
           "QueueStatus"
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/QueueStatusResource"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/queue/status/{id}": {
-      "get": {
-        "tags": [
-          "QueueStatus"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
         ],
         "responses": {
           "200": {
@@ -5821,36 +5523,6 @@
                   "items": {
                     "$ref": "#/components/schemas/ReleaseResource"
                   }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/release/{id}": {
-      "get": {
-        "tags": [
-          "Release"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseResource"
                 }
               }
             }
@@ -6089,36 +5761,6 @@
                   "items": {
                     "$ref": "#/components/schemas/ReleaseResource"
                   }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v3/release/push/{id}": {
-      "get": {
-        "tags": [
-          "ReleasePush"
-        ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReleaseResource"
                 }
               }
             }

--- a/src/Sonarr.Http/REST/RestController.cs
+++ b/src/Sonarr.Http/REST/RestController.cs
@@ -48,7 +48,7 @@ namespace Sonarr.Http.REST
 
         [RestGetById]
         [Produces("application/json")]
-        public ActionResult<TResource> GetResourceByIdWithErrorHandler(int id)
+        public virtual ActionResult<TResource> GetResourceByIdWithErrorHandler(int id)
         {
             try
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I noticed some endpoints aren't implemented but still present in the API docs. 

I can remove the openapi.json from the commit, but I pushed it only to see the differences along with the changes.