### PR TITLE
Add style for default kind in ProgressBar

### DIFF
--- a/frontend/src/Components/ProgressBar.css
+++ b/frontend/src/Components/ProgressBar.css
@@ -45,6 +45,10 @@
   cursor: default;
 }
 
+.default {
+  background-color: var(--darkGray);
+}
+
 .primary {
   background-color: var(--primaryColor);
 }

--- a/frontend/src/Components/ProgressBar.css.d.ts
+++ b/frontend/src/Components/ProgressBar.css.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'backTextContainer': string;
   'container': string;
   'danger': string;
+  'default': string;
   'frontText': string;
   'frontTextContainer': string;
   'info': string;


### PR DESCRIPTION
(cherry picked from commit 4ab1cb393ac682cb06625f42ffc6131e9bd72500)

#### Database Migration
NO

#### Description
This fixes in advance any future usage of the default kind in ProgressBar, since default + 100% progressbar would result in something like this:

![firefox_2023-05-30_19-03-56](https://github.com/Sonarr/Sonarr/assets/707714/52c23b25-38cd-4f42-bdc3-67db3f2354c6)
