### PR TITLE
Improved http timeout handling

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -132,6 +132,16 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
+        public void should_throw_timeout_request()
+        {
+            var request = new HttpRequest($"https://{_httpBinHost}/delay/10");
+
+            request.RequestTimeout = new TimeSpan(0, 0, 5);
+
+            Assert.ThrowsAsync<WebException>(async () => await Subject.ExecuteAsync(request));
+        }
+
+        [Test]
         public async Task should_execute_https_get()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently when request is made and our timeout is exceeded (100s or request.RequestTimeout) HttpClient throws `ThreadCanceledException` with inner `SocketException` from the Socket Handler. This PR catches that in `ManageHttpDispatcher` and throws appropriate `WebException` with Timeout WebExceptionStatus. Also adds test to ensure correct handling of timeouts from HttpClient.

There is some argument to throw System.TimeoutException instead, however it's not currently handled anywhere either whereas WebException is. This can be discussed.

#### Todos
- [x] Tests
