### PR TITLE
Check only clients not in failure status in DownloadClientSortingCheck

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientSortingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientSortingCheck.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
-            var clients = _downloadClientProvider.GetDownloadClients();
+            var clients = _downloadClientProvider.GetDownloadClients(true);
 
             foreach (var client in clients)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If marked as failed already there's no need to check for the sorting mode anymore since it's expected to fail.