### PR TITLE
Fixed: (Qbittorrent) Handle checkingResumeData

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -201,6 +201,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         [TestCase("uploading")]
         [TestCase("stalledUP")]
         [TestCase("forcedUP")]
+        [TestCase("checkingResumeData")]
         public void completed_item_should_have_required_properties(string state)
         {
             var torrent = new QBittorrentTorrent

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -201,7 +201,6 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         [TestCase("uploading")]
         [TestCase("stalledUP")]
         [TestCase("forcedUP")]
-        [TestCase("checkingResumeData")]
         public void completed_item_should_have_required_properties(string state)
         {
             var torrent = new QBittorrentTorrent
@@ -226,6 +225,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         [TestCase("checkingDL")]
         [TestCase("checkingUP")]
         [TestCase("metaDL")]
+        [TestCase("checkingResumeData")]
         public void queued_item_should_have_required_properties(string state)
         {
             var torrent = new QBittorrentTorrent

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -251,6 +251,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     case "queuedDL": // queuing is enabled and torrent is queued for download
                     case "checkingDL": // same as checkingUP, but torrent has NOT finished downloading
                     case "checkingUP": // torrent has finished downloading and is being checked. Set when `recheck torrent on completion` is enabled. In the event the check fails we shouldn't treat it as completed.
+                    case "checkingResumeData": // torrent is checking resume data on load
                         item.Status = DownloadItemStatus.Queued;
                         break;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes Unknown download state: checkingResumeData

#### Todos
- Tests
- Wiki Updates


#### Issues Fixed or Closed by this PR

* 
