### PR TITLE
Limit Discord embed title length to 256 characters

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -558,7 +558,9 @@ namespace NzbDrone.Core.Notifications.Discord
 
             var episodeTitles = string.Join(" + ", episodes.Select(e => e.Title));
 
-            return $"{series.Title} - {episodes.First().SeasonNumber}{episodeNumbers} - {episodeTitles}";
+            var title = $"{series.Title} - {episodes.First().SeasonNumber}{episodeNumbers} - {episodeTitles}";
+
+            return title.Length > 256 ? $"{title.AsSpan(0, 253)}..." : title;
         }
     }
 }


### PR DESCRIPTION
See https://discord.com/developers/docs/resources/channel#embed-object-embed-limits

#### Database Migration
NO

#### Description
For long embed titles, Discord will reject the embed with a 400. This limits the embed title length to 256 characters max.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
