### PR TITLE
Create overload for `ToJson()` with Formatting param

### DIFF
--- a/src/NzbDrone.Common/Serializer/Newtonsoft.Json/Json.cs
+++ b/src/NzbDrone.Common/Serializer/Newtonsoft.Json/Json.cs
@@ -121,6 +121,11 @@ namespace NzbDrone.Common.Serializer
             return JsonConvert.SerializeObject(obj, SerializerSettings);
         }
 
+        public static string ToJson(this object obj, Formatting formatting)
+        {
+            return JsonConvert.SerializeObject(obj, formatting, SerializerSettings);
+        }
+
         public static void Serialize<TModel>(TModel model, TextWriter outputStream)
         {
             var jsonTextWriter = new JsonTextWriter(outputStream);

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using Newtonsoft.Json;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -142,6 +143,7 @@ namespace NzbDrone.Core.Indexers.HDBits
             query.Passkey = Settings.ApiKey;
 
             request.SetContent(query.ToJson());
+            request.ContentSummary = query.ToJson(Formatting.None);
 
             yield return new IndexerRequest(request);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Added overload for use with `x.ToJson(Formatting.None)` to prevent spamming the logs across multiple lines.
- As an example added ContentSummary for HDBits for easier debugging.