### PR TITLE
Don't set background image to `undefined` when fanart is missing

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -248,6 +248,8 @@ class SeriesDetails extends Component {
       expandIcon = icons.EXPAND;
     }
 
+    const fanartUrl = getFanartUrl(images);
+
     return (
       <PageContent title={title}>
         <PageToolbar>
@@ -327,9 +329,11 @@ class SeriesDetails extends Component {
           <div className={styles.header}>
             <div
               className={styles.backdrop}
-              style={{
-                backgroundImage: `url(${getFanartUrl(images)})`
-              }}
+              style={
+                fanartUrl ?
+                  { backgroundImage: `url(${fanartUrl})` } :
+                  null
+              }
             >
               <div className={styles.backdropOverlay} />
             </div>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Series with no fanart (eg. tvdb:423396) make an unnecessary request to `/series/undefined`.

![image](https://github.com/Sonarr/Sonarr/assets/707714/4299dba4-5864-4079-9544-46ba895f856f)
