### PR TITLE
No thumb tags with local images in .nfo

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -295,7 +295,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     {
                         details.Add(new XElement("thumb"));
                     }
-                    else
+                    else if (Settings.EpisodeImageThumb)
                     {
                         details.Add(new XElement("thumb", image.RemoteUrl));
                     }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
@@ -36,13 +36,16 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         [FieldDefinition(3, Label = "Episode Metadata", Type = FieldType.Checkbox, Section = MetadataSectionType.Metadata, HelpText = "<filename>.nfo")]
         public bool EpisodeMetadata { get; set; }
 
-        [FieldDefinition(4, Label = "Series Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "fanart.jpg, poster.jpg, banner.jpg")]
+        [FieldDefinition(4, Label = "Episode Metadata Image Thumbs", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "Include image thumb tags in <filename>.nfo (Requires 'Episode Metadata')", Advanced = true)]
+        public bool EpisodeImageThumb { get; set; }
+
+        [FieldDefinition(5, Label = "Series Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "fanart.jpg, poster.jpg, banner.jpg")]
         public bool SeriesImages { get; set; }
 
-        [FieldDefinition(5, Label = "Season Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "season##-poster.jpg, season##-banner.jpg, season-specials-poster.jpg, season-specials-banner.jpg")]
+        [FieldDefinition(6, Label = "Season Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "season##-poster.jpg, season##-banner.jpg, season-specials-poster.jpg, season-specials-banner.jpg")]
         public bool SeasonImages { get; set; }
 
-        [FieldDefinition(6, Label = "Episode Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "<filename>-thumb.jpg")]
+        [FieldDefinition(7, Label = "Episode Images", Type = FieldType.Checkbox, Section = MetadataSectionType.Image, HelpText = "<filename>-thumb.jpg")]
         public bool EpisodeImages { get; set; }
 
         public bool IsValid => true;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
According to the [Jellyfin docs](https://jellyfin.org/docs/general/server/metadata/nfo/#image-paths-and-urls-in-nfo-files), .nfo file thumb image tags are prioritized over local images. However Sonarr always adds the thumb image tags, meaning Jellyfin attempts to grab the images from the internet rather than using those that are available locally. This PR simply removes the tags if episode images are enabled. 

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR
