### PR TITLE
Fixed: Correct typing for ImportListExclusions tvdbid column

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/192_import_exclusion_typeFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/192_import_exclusion_typeFixture.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Dapper;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class import_exclusion_typeFixture : MigrationTest<import_exclusion_type>
+    {
+        [Test]
+        public void should_alter_tvdbid_column()
+        {
+            var db = WithDapperMigrationTestDb(c =>
+            {
+                c.Insert.IntoTable("ImportListExclusions").Row(new
+                {
+                    TvdbId = "1",
+                    Title = "Some Series"
+                });
+            });
+
+            // Should be able to insert as int after migration
+            db.Execute("INSERT INTO ImportListExclusions (TvdbId, Title) VALUES (2, 'Some Other Series')");
+
+            var exclusions = db.Query<ImportListExclusions192>("SELECT * FROM ImportListExclusions");
+
+            exclusions.Should().HaveCount(2);
+            exclusions.First().TvdbId.Should().Be(1);
+        }
+    }
+
+    public class ImportListExclusions192
+    {
+        public int Id { get; set; }
+        public int TvdbId { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/192_import_exclusion_type.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/192_import_exclusion_type.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(192)]
+    public class import_exclusion_type : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("ImportListExclusions").AlterColumn("TvdbId").AsInt32();
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
YES (192 Type Alteration for TvdbId on Import List Exclusions)

#### Description
Change TvdbId column to correct type. Sqlite doesn't really care, but other DB types will 

#### Todos
- [x] Tests
