### PR TITLE
Fixed: Allow restore to process backups up to ~500MB

### DIFF
--- a/src/Sonarr.Api.V3/System/Backup/BackupController.cs
+++ b/src/Sonarr.Api.V3/System/Backup/BackupController.cs
@@ -90,6 +90,7 @@ namespace Sonarr.Api.V3.System.Backup
         }
 
         [HttpPost("restore/upload")]
+        [RequestFormLimits(MultipartBodyLengthLimit = 500000000)]
         public object UploadAndRestore()
         {
             var files = Request.Form.Files;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow backup uploads up to 500MB for upload endpoint only. We can disable size completely, but this may result in allowing uploads up to 2GB (max int size) which I'm not quite sure we want to do. 

#### Issues Fixed or Closed by this PR

* Fixes #5725 
