### PR TITLE
Simkl Anime List integration

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Simkl/SimklAPI.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/SimklAPI.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.ImportLists.Simkl
         public string Imdb { get; set; }
         public string Tmdb { get; set; }
         public string Tvdb { get; set; }
+        public string Mal { get; set; }
     }
 
     public class SimklSeriesPropsResource
@@ -23,11 +24,15 @@ namespace NzbDrone.Core.ImportLists.Simkl
     public class SimklSeriesResource
     {
         public SimklSeriesPropsResource Show { get; set; }
+
+        [JsonProperty("anime_type")]
+        public SimklAnimeType AnimeType { get; set; }
     }
 
     public class SimklResponse
     {
         public List<SimklSeriesResource> Shows { get; set; }
+        public List<SimklSeriesResource> Anime { get; set; }
     }
 
     public class RefreshRequestResponse
@@ -65,5 +70,11 @@ namespace NzbDrone.Core.ImportLists.Simkl
     public class SimklTvSyncActivityResource
     {
         public DateTime All { get; set; }
+    }
+
+    public enum SimklAnimeType
+    {
+        Tv,
+        Movie
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserRequestGenerator.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.ImportLists.Simkl.User
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var link = $"{Settings.BaseUrl.Trim()}/sync/all-items/shows/{((SimklUserListType)Settings.ListType).ToString().ToLowerInvariant()}";
+            var link = $"{Settings.BaseUrl.Trim()}/sync/all-items/{((SimklUserShowType)Settings.ShowType).ToString().ToLowerInvariant()}/{((SimklUserListType)Settings.ListType).ToString().ToLowerInvariant()}";
 
             var request = new ImportListRequest(link, HttpAccept.Json);
 

--- a/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserSettings.cs
@@ -19,9 +19,13 @@ namespace NzbDrone.Core.ImportLists.Simkl.User
         public SimklUserSettings()
         {
             ListType = (int)SimklUserListType.Watching;
+            ShowType = (int)SimklUserShowType.Shows;
         }
 
         [FieldDefinition(1, Label = "List Type", Type = FieldType.Select, SelectOptions = typeof(SimklUserListType), HelpText = "Type of list you're seeking to import from")]
         public int ListType { get; set; }
+
+        [FieldDefinition(1, Label = "Show Type", Type = FieldType.Select, SelectOptions = typeof(SimklUserShowType), HelpText = "Type of show you're seeking to import from")]
+        public int ShowType { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserShowType.cs
+++ b/src/NzbDrone.Core/ImportLists/Simkl/User/SimklUserShowType.cs
@@ -1,0 +1,8 @@
+namespace NzbDrone.Core.ImportLists.Simkl.User
+{
+    public enum SimklUserShowType
+    {
+        Shows = 0,
+        Anime = 1
+    }
+}

--- a/src/NzbDrone.Core/Parser/Model/ImportListItemInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ImportListItemInfo.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Parser.Model
         public int TvdbId { get; set; }
         public int TmdbId { get; set; }
         public string ImdbId { get; set; }
+        public int MalId { get; set; }
         public DateTime ReleaseDate { get; set; }
 
         public override string ToString()


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is our progress with issue 5635 so far. We added a button when going to "Settings→Import Lists→Add List→Simkl List" that allows the user to add an anime list where the button is called "Simkl Anime Watchlist". We also renamed the other button to "Simkl Shows Watchlist". 

When creating the new list for Simkl Anime Watchlist, we are able to create it in the same manner as Simkl Shows Watchlist. On the initial import, the code was able to import most of the anime shows into the Series tab with no issue. For a couple anime shows, it would import the wrong show. Some anime shows don't have a IMDB id when fetched from the Simkl API (it also does not list an IMDB link on Simkl's website). The issue is happening in ImportListServices.cs on line 99 where it is trying to search for the show on the sonarr skyhook website, and it chooses the first entry by default, which may lead to the wrong output.

Example: adding the anime show "Kono Subarashii Sekai ni Bakuen o!" returns the wrong show because when this line, 
`var mappedSeries = _seriesSearchService.SearchForNewSeries(report.Title).FirstOrDefault()`, 
is executed, it chooses the first entry from the http request from the skyhook sonarr website, which is incorrect. 

This is the [link](https://skyhook.sonarr.tv/v1/tvdb/search/en/?term=kono%20subarashii%20sekai%20ni%20bakuen%20o%21), that was used when trying to fetch "Kono Subarashii Sekai ni Bakuen o!". 


#### Issues Fixed or Closed by this PR
* https://github.com/Sonarr/Sonarr/issues/5635

