### PR TITLE
New: Async and HTTP/2 in HttpClient

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NLog;
@@ -121,21 +122,21 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_execute_simple_get()
+        public async Task should_execute_simple_get()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-            var response = Subject.Execute(request);
+            var response = await Subject.ExecuteAsync(request);
 
             response.Content.Should().NotBeNullOrWhiteSpace();
         }
 
         [Test]
-        public void should_execute_https_get()
+        public async Task should_execute_https_get()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-            var response = Subject.Execute(request);
+            var response = await Subject.ExecuteAsync(request);
 
             response.Content.Should().NotBeNullOrWhiteSpace();
         }
@@ -147,47 +148,47 @@ namespace NzbDrone.Common.Test.Http
             Mocker.GetMock<IConfigService>().SetupGet(x => x.CertificateValidation).Returns(validationType);
             var request = new HttpRequest($"https://expired.badssl.com");
 
-            Assert.Throws<HttpRequestException>(() => Subject.Execute(request));
+            Assert.ThrowsAsync<HttpRequestException>(async () => await Subject.ExecuteAsync(request));
             ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
-        public void bad_ssl_should_pass_if_remote_validation_disabled()
+        public async Task bad_ssl_should_pass_if_remote_validation_disabled()
         {
             Mocker.GetMock<IConfigService>().SetupGet(x => x.CertificateValidation).Returns(CertificateValidationType.Disabled);
 
             var request = new HttpRequest($"https://expired.badssl.com");
 
-            Subject.Execute(request);
+            await Subject.ExecuteAsync(request);
             ExceptionVerification.ExpectedErrors(0);
         }
 
         [Test]
-        public void should_execute_typed_get()
+        public async Task should_execute_typed_get()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get?test=1");
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Url.EndsWith("/get?test=1");
             response.Resource.Args.Should().Contain("test", "1");
         }
 
         [Test]
-        public void should_execute_simple_post()
+        public async Task should_execute_simple_post()
         {
             var message = "{ my: 1 }";
 
             var request = new HttpRequest($"https://{_httpBinHost}/post");
             request.SetContent(message);
 
-            var response = Subject.Post<HttpBinResource>(request);
+            var response = await Subject.PostAsync<HttpBinResource>(request);
 
             response.Resource.Data.Should().Be(message);
         }
 
         [Test]
-        public void should_execute_post_with_content_type()
+        public async Task should_execute_post_with_content_type()
         {
             var message = "{ my: 1 }";
 
@@ -195,16 +196,16 @@ namespace NzbDrone.Common.Test.Http
             request.SetContent(message);
             request.Headers.ContentType = "application/json";
 
-            var response = Subject.Post<HttpBinResource>(request);
+            var response = await Subject.PostAsync<HttpBinResource>(request);
 
             response.Resource.Data.Should().Be(message);
         }
 
         [Test]
-        public void should_execute_get_using_gzip()
+        public async Task should_execute_get_using_gzip()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/gzip");
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers["Accept-Encoding"].ToString().Should().Contain("gzip");
 
@@ -213,10 +214,10 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_execute_get_using_brotli()
+        public async Task should_execute_get_using_brotli()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/brotli");
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers["Accept-Encoding"].ToString().Should().Contain("br");
 
@@ -234,7 +235,7 @@ namespace NzbDrone.Common.Test.Http
         {
             var request = new HttpRequest($"https://{_httpBinHost}/status/{statusCode}");
 
-            var exception = Assert.Throws<HttpException>(() => Subject.Get<HttpBinResource>(request));
+            var exception = Assert.ThrowsAsync<HttpException>(async () => await Subject.GetAsync<HttpBinResource>(request));
 
             ((int)exception.Response.StatusCode).Should().Be(statusCode);
 
@@ -247,7 +248,7 @@ namespace NzbDrone.Common.Test.Http
             var request = new HttpRequest($"https://{_httpBinHost}/status/{HttpStatusCode.NotFound}");
             request.SuppressHttpErrorStatusCodes = new[] { HttpStatusCode.NotFound };
 
-            Assert.Throws<HttpException>(() => Subject.Get<HttpBinResource>(request));
+            Assert.ThrowsAsync<HttpException>(async () => await Subject.GetAsync<HttpBinResource>(request));
 
             ExceptionVerification.IgnoreWarns();
         }
@@ -257,7 +258,7 @@ namespace NzbDrone.Common.Test.Http
         {
             var request = new HttpRequest($"https://{_httpBinHost}/status/{HttpStatusCode.NotFound}");
 
-            var exception = Assert.Throws<HttpException>(() => Subject.Get<HttpBinResource>(request));
+            var exception = Assert.ThrowsAsync<HttpException>(async () => await Subject.GetAsync<HttpBinResource>(request));
 
             ExceptionVerification.ExpectedWarns(1);
         }
@@ -268,28 +269,28 @@ namespace NzbDrone.Common.Test.Http
             var request = new HttpRequest($"https://{_httpBinHost}/status/{HttpStatusCode.NotFound}");
             request.LogHttpError = false;
 
-            Assert.Throws<HttpException>(() => Subject.Get<HttpBinResource>(request));
+            Assert.ThrowsAsync<HttpException>(async () => await Subject.GetAsync<HttpBinResource>(request));
 
             ExceptionVerification.ExpectedWarns(0);
         }
 
         [Test]
-        public void should_not_follow_redirects_when_not_in_production()
+        public async Task should_not_follow_redirects_when_not_in_production()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/redirect/1");
 
-            Subject.Get(request);
+            await Subject.GetAsync(request);
 
             ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]
-        public void should_follow_redirects()
+        public async Task should_follow_redirects()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/redirect/1");
             request.AllowAutoRedirect = true;
 
-            var response = Subject.Get(request);
+            var response = await Subject.GetAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -297,12 +298,12 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_not_follow_redirects()
+        public async Task should_not_follow_redirects()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/redirect/1");
             request.AllowAutoRedirect = false;
 
-            var response = Subject.Get(request);
+            var response = await Subject.GetAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
@@ -310,14 +311,14 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_follow_redirects_to_https()
+        public async Task should_follow_redirects_to_https()
         {
             var request = new HttpRequestBuilder($"https://{_httpBinHost}/redirect-to")
                 .AddQueryParam("url", $"https://sonarr.tv/")
                 .Build();
             request.AllowAutoRedirect = true;
 
-            var response = Subject.Get(request);
+            var response = await Subject.GetAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.Content.Should().Contain("Sonarr");
@@ -331,17 +332,17 @@ namespace NzbDrone.Common.Test.Http
             var request = new HttpRequest($"https://{_httpBinHost}/redirect/6");
             request.AllowAutoRedirect = true;
 
-            Assert.Throws<WebException>(() => Subject.Get(request));
+            Assert.ThrowsAsync<WebException>(async () => await Subject.GetAsync(request));
 
             ExceptionVerification.ExpectedErrors(0);
         }
 
         [Test]
-        public void should_send_user_agent()
+        public async Task should_send_user_agent()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers.Should().ContainKey("User-Agent");
 
@@ -351,24 +352,24 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [TestCase("Accept", "text/xml, text/rss+xml, application/rss+xml")]
-        public void should_send_headers(string header, string value)
+        public async Task should_send_headers(string header, string value)
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");
             request.Headers.Add(header, value);
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers[header].ToString().Should().Be(value);
         }
 
         [Test]
-        public void should_download_file()
+        public async Task should_download_file()
         {
             var file = GetTempFilePath();
 
             var url = "https://sonarr.tv/img/slider/seriesdetails.png";
 
-            Subject.DownloadFile(url, file);
+            await Subject.DownloadFileAsync(url, file);
 
             File.Exists(file).Should().BeTrue();
             File.Exists(file + ".part").Should().BeFalse();
@@ -379,7 +380,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_download_file_with_redirect()
+        public async Task should_download_file_with_redirect()
         {
             var file = GetTempFilePath();
 
@@ -387,7 +388,7 @@ namespace NzbDrone.Common.Test.Http
                 .AddQueryParam("url", $"https://sonarr.tv/img/slider/seriesdetails.png")
                 .Build();
 
-            Subject.DownloadFile(request.Url.FullUri, file);
+            await Subject.DownloadFileAsync(request.Url.FullUri, file);
 
             ExceptionVerification.ExpectedErrors(0);
 
@@ -401,7 +402,7 @@ namespace NzbDrone.Common.Test.Http
         {
             var file = GetTempFilePath();
 
-            Assert.Throws<HttpException>(() => Subject.DownloadFile("https://download.sonarr.tv/wrongpath", file));
+            Assert.ThrowsAsync<HttpException>(async () => await Subject.DownloadFileAsync("https://download.sonarr.tv/wrongpath", file));
 
             File.Exists(file).Should().BeFalse();
             File.Exists(file + ".part").Should().BeFalse();
@@ -410,7 +411,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_not_write_redirect_content_to_stream()
+        public async Task should_not_write_redirect_content_to_stream()
         {
             var file = GetTempFilePath();
 
@@ -420,7 +421,7 @@ namespace NzbDrone.Common.Test.Http
                 request.AllowAutoRedirect = false;
                 request.ResponseStream = fileStream;
 
-                var response = Subject.Get(request);
+                var response = await Subject.GetAsync(request);
 
                 response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             }
@@ -435,12 +436,12 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_send_cookie()
+        public async Task should_send_cookie()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/get");
             request.Cookies["my"] = "cookie";
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers.Should().ContainKey("Cookie");
 
@@ -469,13 +470,13 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_preserve_cookie_during_session()
+        public async Task should_preserve_cookie_during_session()
         {
             GivenOldCookie();
 
             var request = new HttpRequest($"https://{_httpBinHost2}/get");
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers.Should().ContainKey("Cookie");
 
@@ -485,30 +486,30 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_not_send_cookie_to_other_host()
+        public async Task should_not_send_cookie_to_other_host()
         {
             GivenOldCookie();
 
             var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-            var response = Subject.Get<HttpBinResource>(request);
+            var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers.Should().NotContainKey("Cookie");
         }
 
         [Test]
-        public void should_not_store_request_cookie()
+        public async Task should_not_store_request_cookie()
         {
             var requestGet = new HttpRequest($"https://{_httpBinHost}/get");
             requestGet.Cookies.Add("my", "cookie");
             requestGet.AllowAutoRedirect = false;
             requestGet.StoreRequestCookie = false;
             requestGet.StoreResponseCookie = false;
-            var responseGet = Subject.Get<HttpBinResource>(requestGet);
+            var responseGet = await Subject.GetAsync<HttpBinResource>(requestGet);
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.AllowAutoRedirect = false;
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().BeEmpty();
 
@@ -516,18 +517,18 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_store_request_cookie()
+        public async Task should_store_request_cookie()
         {
             var requestGet = new HttpRequest($"https://{_httpBinHost}/get");
             requestGet.Cookies.Add("my", "cookie");
             requestGet.AllowAutoRedirect = false;
             requestGet.StoreRequestCookie.Should().BeTrue();
             requestGet.StoreResponseCookie = false;
-            var responseGet = Subject.Get<HttpBinResource>(requestGet);
+            var responseGet = await Subject.GetAsync<HttpBinResource>(requestGet);
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.AllowAutoRedirect = false;
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -535,7 +536,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_delete_request_cookie()
+        public async Task should_delete_request_cookie()
         {
             var requestDelete = new HttpRequest($"https://{_httpBinHost}/cookies/delete?my");
             requestDelete.Cookies.Add("my", "cookie");
@@ -544,13 +545,13 @@ namespace NzbDrone.Common.Test.Http
             requestDelete.StoreResponseCookie = false;
 
             // Delete and redirect since that's the only way to check the internal temporary cookie container
-            var responseCookies = Subject.Get<HttpCookieResource>(requestDelete);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestDelete);
 
             responseCookies.Resource.Cookies.Should().BeEmpty();
         }
 
         [Test]
-        public void should_clear_request_cookie()
+        public async Task should_clear_request_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestSet.Cookies.Add("my", "cookie");
@@ -558,7 +559,7 @@ namespace NzbDrone.Common.Test.Http
             requestSet.StoreRequestCookie = true;
             requestSet.StoreResponseCookie = false;
 
-            var responseSet = Subject.Get<HttpCookieResource>(requestSet);
+            var responseSet = await Subject.GetAsync<HttpCookieResource>(requestSet);
 
             var requestClear = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestClear.Cookies.Add("my", null);
@@ -566,24 +567,24 @@ namespace NzbDrone.Common.Test.Http
             requestClear.StoreRequestCookie = true;
             requestClear.StoreResponseCookie = false;
 
-            var responseClear = Subject.Get<HttpCookieResource>(requestClear);
+            var responseClear = await Subject.GetAsync<HttpCookieResource>(requestClear);
 
             responseClear.Resource.Cookies.Should().BeEmpty();
         }
 
         [Test]
-        public void should_not_store_response_cookie()
+        public async Task should_not_store_response_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies/set?my=cookie");
             requestSet.AllowAutoRedirect = false;
             requestSet.StoreRequestCookie = false;
             requestSet.StoreResponseCookie.Should().BeFalse();
 
-            var responseSet = Subject.Get(requestSet);
+            var responseSet = await Subject.GetAsync(requestSet);
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
 
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().BeEmpty();
 
@@ -591,18 +592,18 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_store_response_cookie()
+        public async Task should_store_response_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies/set?my=cookie");
             requestSet.AllowAutoRedirect = false;
             requestSet.StoreRequestCookie = false;
             requestSet.StoreResponseCookie = true;
 
-            var responseSet = Subject.Get(requestSet);
+            var responseSet = await Subject.GetAsync(requestSet);
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
 
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -610,13 +611,13 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_temp_store_response_cookie()
+        public async Task should_temp_store_response_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies/set?my=cookie");
             requestSet.AllowAutoRedirect = true;
             requestSet.StoreRequestCookie = false;
             requestSet.StoreResponseCookie.Should().BeFalse();
-            var responseSet = Subject.Get<HttpCookieResource>(requestSet);
+            var responseSet = await Subject.GetAsync<HttpCookieResource>(requestSet);
 
             // Set and redirect since that's the only way to check the internal temporary cookie container
             responseSet.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
@@ -625,7 +626,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_overwrite_response_cookie()
+        public async Task should_overwrite_response_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies/set?my=cookie");
             requestSet.Cookies.Add("my", "oldcookie");
@@ -633,11 +634,11 @@ namespace NzbDrone.Common.Test.Http
             requestSet.StoreRequestCookie = false;
             requestSet.StoreResponseCookie = true;
 
-            var responseSet = Subject.Get(requestSet);
+            var responseSet = await Subject.GetAsync(requestSet);
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
 
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -645,7 +646,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_overwrite_temp_response_cookie()
+        public async Task should_overwrite_temp_response_cookie()
         {
             var requestSet = new HttpRequest($"https://{_httpBinHost}/cookies/set?my=cookie");
             requestSet.Cookies.Add("my", "oldcookie");
@@ -653,13 +654,13 @@ namespace NzbDrone.Common.Test.Http
             requestSet.StoreRequestCookie = true;
             requestSet.StoreResponseCookie = false;
 
-            var responseSet = Subject.Get<HttpCookieResource>(requestSet);
+            var responseSet = await Subject.GetAsync<HttpCookieResource>(requestSet);
 
             responseSet.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
 
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "oldcookie");
 
@@ -667,14 +668,14 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_not_delete_response_cookie()
+        public async Task should_not_delete_response_cookie()
         {
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.Cookies.Add("my", "cookie");
             requestCookies.AllowAutoRedirect = false;
             requestCookies.StoreRequestCookie = true;
             requestCookies.StoreResponseCookie = false;
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -683,13 +684,13 @@ namespace NzbDrone.Common.Test.Http
             requestDelete.StoreRequestCookie = false;
             requestDelete.StoreResponseCookie = false;
 
-            var responseDelete = Subject.Get(requestDelete);
+            var responseDelete = await Subject.GetAsync(requestDelete);
 
             requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.StoreRequestCookie = false;
             requestCookies.StoreResponseCookie = false;
 
-            responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -697,14 +698,14 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_delete_response_cookie()
+        public async Task should_delete_response_cookie()
         {
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.Cookies.Add("my", "cookie");
             requestCookies.AllowAutoRedirect = false;
             requestCookies.StoreRequestCookie = true;
             requestCookies.StoreResponseCookie = false;
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -713,13 +714,13 @@ namespace NzbDrone.Common.Test.Http
             requestDelete.StoreRequestCookie = false;
             requestDelete.StoreResponseCookie = true;
 
-            var responseDelete = Subject.Get(requestDelete);
+            var responseDelete = await Subject.GetAsync(requestDelete);
 
             requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.StoreRequestCookie = false;
             requestCookies.StoreResponseCookie = false;
 
-            responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().BeEmpty();
 
@@ -727,14 +728,14 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_delete_temp_response_cookie()
+        public async Task should_delete_temp_response_cookie()
         {
             var requestCookies = new HttpRequest($"https://{_httpBinHost}/cookies");
             requestCookies.Cookies.Add("my", "cookie");
             requestCookies.AllowAutoRedirect = false;
             requestCookies.StoreRequestCookie = true;
             requestCookies.StoreResponseCookie = false;
-            var responseCookies = Subject.Get<HttpCookieResource>(requestCookies);
+            var responseCookies = await Subject.GetAsync<HttpCookieResource>(requestCookies);
 
             responseCookies.Resource.Cookies.Should().HaveCount(1).And.Contain("my", "cookie");
 
@@ -742,7 +743,7 @@ namespace NzbDrone.Common.Test.Http
             requestDelete.AllowAutoRedirect = true;
             requestDelete.StoreRequestCookie = false;
             requestDelete.StoreResponseCookie = false;
-            var responseDelete = Subject.Get<HttpCookieResource>(requestDelete);
+            var responseDelete = await Subject.GetAsync<HttpCookieResource>(requestDelete);
 
             responseDelete.Resource.Cookies.Should().BeEmpty();
 
@@ -760,13 +761,13 @@ namespace NzbDrone.Common.Test.Http
         {
             var request = new HttpRequest($"https://{_httpBinHost}/status/429");
 
-            Assert.Throws<TooManyRequestsException>(() => Subject.Get(request));
+            Assert.ThrowsAsync<TooManyRequestsException>(async () => await Subject.GetAsync(request));
 
             ExceptionVerification.IgnoreWarns();
         }
 
         [Test]
-        public void should_call_interceptor()
+        public async Task should_call_interceptor()
         {
             Mocker.SetConstant<IEnumerable<IHttpRequestInterceptor>>(new[] { Mocker.GetMock<IHttpRequestInterceptor>().Object });
 
@@ -780,7 +781,7 @@ namespace NzbDrone.Common.Test.Http
 
             var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-            Subject.Get(request);
+            await Subject.GetAsync(request);
 
             Mocker.GetMock<IHttpRequestInterceptor>()
                 .Verify(v => v.PreRequest(It.IsAny<HttpRequest>()), Times.Once());
@@ -791,7 +792,7 @@ namespace NzbDrone.Common.Test.Http
 
         [TestCase("en-US")]
         [TestCase("es-ES")]
-        public void should_parse_malformed_cloudflare_cookie(string culture)
+        public async Task should_parse_malformed_cloudflare_cookie(string culture)
         {
             var origCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(culture);
@@ -807,11 +808,11 @@ namespace NzbDrone.Common.Test.Http
                 requestSet.AllowAutoRedirect = false;
                 requestSet.StoreResponseCookie = true;
 
-                var responseSet = Subject.Get(requestSet);
+                var responseSet = await Subject.GetAsync(requestSet);
 
                 var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-                var response = Subject.Get<HttpBinResource>(request);
+                var response = await Subject.GetAsync<HttpBinResource>(request);
 
                 response.Resource.Headers.Should().ContainKey("Cookie");
 
@@ -829,7 +830,7 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [TestCase("lang_code=en; expires=Wed, 23-Dec-2026 18:09:14 GMT; Max-Age=31536000; path=/; domain=.abc.com")]
-        public void should_reject_malformed_domain_cookie(string malformedCookie)
+        public async Task should_reject_malformed_domain_cookie(string malformedCookie)
         {
             try
             {
@@ -839,11 +840,11 @@ namespace NzbDrone.Common.Test.Http
                 requestSet.AllowAutoRedirect = false;
                 requestSet.StoreResponseCookie = true;
 
-                var responseSet = Subject.Get(requestSet);
+                var responseSet = await Subject.GetAsync(requestSet);
 
                 var request = new HttpRequest($"https://{_httpBinHost}/get");
 
-                var response = Subject.Get<HttpBinResource>(request);
+                var response = await Subject.GetAsync<HttpBinResource>(request);
 
                 response.Resource.Headers.Should().NotContainKey("Cookie");
 
@@ -855,12 +856,12 @@ namespace NzbDrone.Common.Test.Http
         }
 
         [Test]
-        public void should_correctly_use_basic_auth()
+        public async Task should_correctly_use_basic_auth()
         {
             var request = new HttpRequest($"https://{_httpBinHost}/basic-auth/username/password");
             request.Credentials = new BasicNetworkCredential("username", "password");
 
-            var response = Subject.Execute(request);
+            var response = await Subject.ExecuteAsync(request);
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
         }

--- a/src/NzbDrone.Common/Http/Dispatchers/IHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/IHttpDispatcher.cs
@@ -1,9 +1,10 @@
 using System.Net;
+using System.Threading.Tasks;
 
 namespace NzbDrone.Common.Http.Dispatchers
 {
     public interface IHttpDispatcher
     {
-        HttpResponse GetResponse(HttpRequest request, CookieContainer cookies);
+        Task<HttpResponse> GetResponseAsync(HttpRequest request, CookieContainer cookies);
     }
 }

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -45,7 +45,11 @@ namespace NzbDrone.Common.Http.Dispatchers
 
         public HttpResponse GetResponse(HttpRequest request, CookieContainer cookies)
         {
-            var requestMessage = new HttpRequestMessage(request.Method, (Uri)request.Url);
+            var requestMessage = new HttpRequestMessage(request.Method, (Uri)request.Url)
+            {
+                Version = HttpVersion.Version20,
+                VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
+            };
             requestMessage.Headers.UserAgent.ParseAdd(_userAgentBuilder.GetUserAgent(request.UseSimplifiedUserAgent));
             requestMessage.Headers.ConnectionClose = !request.ConnectionKeepAlive;
 
@@ -122,7 +126,7 @@ namespace NzbDrone.Common.Http.Dispatchers
 
                 headers.Add(responseMessage.Content.Headers.ToNameValueCollection());
 
-                return new HttpResponse(request, new HttpHeader(headers), data, responseMessage.StatusCode);
+                return new HttpResponse(request, new HttpHeader(headers), data, responseMessage.StatusCode, responseMessage.Version);
             }
         }
 
@@ -159,6 +163,8 @@ namespace NzbDrone.Common.Http.Dispatchers
 
             var client = new System.Net.Http.HttpClient(handler)
             {
+                DefaultRequestVersion = HttpVersion.Version20,
+                DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
                 Timeout = Timeout.InfiniteTimeSpan
             };
 

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Common.Http.Dispatchers
             _credentialCache = cacheManager.GetCache<CredentialCache>(typeof(ManagedHttpDispatcher), "credentialcache");
         }
 
-        public HttpResponse GetResponse(HttpRequest request, CookieContainer cookies)
+        public async Task<HttpResponse> GetResponseAsync(HttpRequest request, CookieContainer cookies)
         {
             var requestMessage = new HttpRequestMessage(request.Method, (Uri)request.Url)
             {
@@ -102,7 +102,7 @@ namespace NzbDrone.Common.Http.Dispatchers
 
             var httpClient = GetClient(request.Url);
 
-            using var responseMessage = httpClient.Send(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+            using var responseMessage = await httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token);
             {
                 byte[] data = null;
 
@@ -110,7 +110,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                 {
                     if (request.ResponseStream != null && responseMessage.StatusCode == HttpStatusCode.OK)
                     {
-                        responseMessage.Content.CopyTo(request.ResponseStream, null, cts.Token);
+                        await responseMessage.Content.CopyToAsync(request.ResponseStream, null, cts.Token);
                     }
                     else
                     {

--- a/src/NzbDrone.Common/Http/HttpRequest.cs
+++ b/src/NzbDrone.Common/Http/HttpRequest.cs
@@ -16,6 +16,7 @@ namespace NzbDrone.Common.Http
             Method = HttpMethod.Get;
             Url = new HttpUri(url);
             Headers = new HttpHeader();
+            ConnectionKeepAlive = true;
             AllowAutoRedirect = true;
             StoreRequestCookie = true;
             LogHttpError = true;

--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -9,28 +9,31 @@ namespace NzbDrone.Common.Http
 {
     public class HttpResponse
     {
-        private static readonly Regex RegexSetCookie = new Regex("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
+        private static readonly Regex RegexSetCookie = new ("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
 
-        public HttpResponse(HttpRequest request, HttpHeader headers, byte[] binaryData, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public HttpResponse(HttpRequest request, HttpHeader headers, byte[] binaryData, HttpStatusCode statusCode = HttpStatusCode.OK, Version version = null)
         {
             Request = request;
             Headers = headers;
             ResponseData = binaryData;
             StatusCode = statusCode;
+            Version = version;
         }
 
-        public HttpResponse(HttpRequest request, HttpHeader headers, string content, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public HttpResponse(HttpRequest request, HttpHeader headers, string content, HttpStatusCode statusCode = HttpStatusCode.OK, Version version = null)
         {
             Request = request;
             Headers = headers;
             ResponseData = Headers.GetEncodingFromContentType().GetBytes(content);
             _content = content;
             StatusCode = statusCode;
+            Version = version;
         }
 
         public HttpRequest Request { get; private set; }
         public HttpHeader Headers { get; private set; }
         public HttpStatusCode StatusCode { get; private set; }
+        public Version Version { get; private set; }
         public byte[] ResponseData { get; private set; }
 
         private string _content;
@@ -84,7 +87,7 @@ namespace NzbDrone.Common.Http
 
         public override string ToString()
         {
-            var result = string.Format("Res: [{0}] {1}: {2}.{3} ({4} bytes)", Request.Method, Request.Url, (int)StatusCode, StatusCode, ResponseData?.Length ?? 0);
+            var result = $"Res: HTTP/{Version} [{Request.Method}] {Request.Url}: {(int)StatusCode}.{StatusCode} ({ResponseData?.Length ?? 0} bytes)";
 
             if (HasHttpError && Headers.ContentType.IsNotNullOrWhiteSpace() && !Headers.ContentType.Equals("text/html", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -99,7 +102,7 @@ namespace NzbDrone.Common.Http
         where T : new()
     {
         public HttpResponse(HttpResponse response)
-            : base(response.Request, response.Headers, response.ResponseData, response.StatusCode)
+            : base(response.Request, response.Headers, response.ResponseData, response.StatusCode, response.Version)
         {
             Resource = Json.Deserialize<T>(response.Content);
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadApprovedReportsTests/DownloadApprovedFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -59,7 +60,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
         }
 
         [Test]
-        public void should_download_report_if_episode_was_not_already_downloaded()
+        public async Task should_download_report_if_episode_was_not_already_downloaded()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -67,12 +68,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             var decisions = new List<DownloadDecision>();
             decisions.Add(new DownloadDecision(remoteEpisode));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.IsAny<RemoteEpisode>(), null), Times.Once());
         }
 
         [Test]
-        public void should_only_download_episode_once()
+        public async Task should_only_download_episode_once()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -81,12 +82,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode));
             decisions.Add(new DownloadDecision(remoteEpisode));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.IsAny<RemoteEpisode>(), null), Times.Once());
         }
 
         [Test]
-        public void should_not_download_if_any_episode_was_already_downloaded()
+        public async Task should_not_download_if_any_episode_was_already_downloaded()
         {
             var remoteEpisode1 = GetRemoteEpisode(
                                                     new List<Episode> { GetEpisode(1) },
@@ -100,12 +101,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode1));
             decisions.Add(new DownloadDecision(remoteEpisode2));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.IsAny<RemoteEpisode>(), null), Times.Once());
         }
 
         [Test]
-        public void should_return_downloaded_reports()
+        public async Task should_return_downloaded_reports()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -113,11 +114,13 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             var decisions = new List<DownloadDecision>();
             decisions.Add(new DownloadDecision(remoteEpisode));
 
-            Subject.ProcessDecisions(decisions).Grabbed.Should().HaveCount(1);
+            var result = await Subject.ProcessDecisions(decisions);
+
+            result.Grabbed.Should().HaveCount(1);
         }
 
         [Test]
-        public void should_return_all_downloaded_reports()
+        public async Task should_return_all_downloaded_reports()
         {
             var remoteEpisode1 = GetRemoteEpisode(
                                                     new List<Episode> { GetEpisode(1) },
@@ -131,11 +134,13 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode1));
             decisions.Add(new DownloadDecision(remoteEpisode2));
 
-            Subject.ProcessDecisions(decisions).Grabbed.Should().HaveCount(2);
+            var result = await Subject.ProcessDecisions(decisions);
+
+            result.Grabbed.Should().HaveCount(2);
         }
 
         [Test]
-        public void should_only_return_downloaded_reports()
+        public async Task should_only_return_downloaded_reports()
         {
             var remoteEpisode1 = GetRemoteEpisode(
                                                     new List<Episode> { GetEpisode(1) },
@@ -154,11 +159,13 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode2));
             decisions.Add(new DownloadDecision(remoteEpisode3));
 
-            Subject.ProcessDecisions(decisions).Grabbed.Should().HaveCount(2);
+            var result = await Subject.ProcessDecisions(decisions);
+
+            result.Grabbed.Should().HaveCount(2);
         }
 
         [Test]
-        public void should_not_add_to_downloaded_list_when_download_fails()
+        public async Task should_not_add_to_downloaded_list_when_download_fails()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -167,7 +174,11 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode));
 
             Mocker.GetMock<IDownloadService>().Setup(s => s.DownloadReport(It.IsAny<RemoteEpisode>(), null)).Throws(new Exception());
-            Subject.ProcessDecisions(decisions).Grabbed.Should().BeEmpty();
+
+            var result = await Subject.ProcessDecisions(decisions);
+
+            result.Grabbed.Should().BeEmpty();
+
             ExceptionVerification.ExpectedWarns(1);
         }
 
@@ -182,7 +193,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
         }
 
         [Test]
-        public void should_not_grab_if_pending()
+        public async Task should_not_grab_if_pending()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -190,12 +201,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             var decisions = new List<DownloadDecision>();
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.IsAny<RemoteEpisode>(), null), Times.Never());
         }
 
         [Test]
-        public void should_not_add_to_pending_if_episode_was_grabbed()
+        public async Task should_not_add_to_pending_if_episode_was_grabbed()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -204,12 +215,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode));
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IPendingReleaseService>().Verify(v => v.AddMany(It.IsAny<List<Tuple<DownloadDecision, PendingReleaseReason>>>()), Times.Never());
         }
 
         [Test]
-        public void should_add_to_pending_even_if_already_added_to_pending()
+        public async Task should_add_to_pending_even_if_already_added_to_pending()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -218,12 +229,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
             decisions.Add(new DownloadDecision(remoteEpisode, new Rejection("Failure!", RejectionType.Temporary)));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IPendingReleaseService>().Verify(v => v.AddMany(It.IsAny<List<Tuple<DownloadDecision, PendingReleaseReason>>>()), Times.Once());
         }
 
         [Test]
-        public void should_add_to_failed_if_already_failed_for_that_protocol()
+        public async Task should_add_to_failed_if_already_failed_for_that_protocol()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -235,12 +246,12 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             Mocker.GetMock<IDownloadService>().Setup(s => s.DownloadReport(It.IsAny<RemoteEpisode>(), null))
                   .Throws(new DownloadClientUnavailableException("Download client failed"));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.IsAny<RemoteEpisode>(), null), Times.Once());
         }
 
         [Test]
-        public void should_not_add_to_failed_if_failed_for_a_different_protocol()
+        public async Task should_not_add_to_failed_if_failed_for_a_different_protocol()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p), DownloadProtocol.Usenet);
@@ -253,13 +264,13 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
             Mocker.GetMock<IDownloadService>().Setup(s => s.DownloadReport(It.Is<RemoteEpisode>(r => r.Release.DownloadProtocol == DownloadProtocol.Usenet), null))
                   .Throws(new DownloadClientUnavailableException("Download client failed"));
 
-            Subject.ProcessDecisions(decisions);
+            await Subject.ProcessDecisions(decisions);
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.Is<RemoteEpisode>(r => r.Release.DownloadProtocol == DownloadProtocol.Usenet), null), Times.Once());
             Mocker.GetMock<IDownloadService>().Verify(v => v.DownloadReport(It.Is<RemoteEpisode>(r => r.Release.DownloadProtocol == DownloadProtocol.Torrent), null), Times.Once());
         }
 
         [Test]
-        public void should_add_to_rejected_if_release_unavailable_on_indexer()
+        public async Task should_add_to_rejected_if_release_unavailable_on_indexer()
         {
             var episodes = new List<Episode> { GetEpisode(1) };
             var remoteEpisode = GetRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p));
@@ -271,7 +282,7 @@ namespace NzbDrone.Core.Test.Download.DownloadApprovedReportsTests
                   .Setup(s => s.DownloadReport(It.IsAny<RemoteEpisode>(), null))
                   .Throws(new ReleaseUnavailableException(remoteEpisode.Release, "That 404 Error is not just a Quirk"));
 
-            var result = Subject.ProcessDecisions(decisions);
+            var result = await Subject.ProcessDecisions(decisions);
 
             result.Grabbed.Should().BeEmpty();
             result.Rejected.Should().NotBeEmpty();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/UsenetBlackholeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/UsenetBlackholeFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -115,19 +116,19 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
         }
 
         [Test]
-        public void Download_should_download_file_if_it_doesnt_exist()
+        public async Task Download_should_download_file_if_it_doesnt_exist()
         {
             var remoteEpisode = CreateRemoteEpisode();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
-            Mocker.GetMock<IHttpClient>().Verify(c => c.Get(It.Is<HttpRequest>(v => v.Url.FullUri == _downloadUrl)), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.GetAsync(It.Is<HttpRequest>(v => v.Url.FullUri == _downloadUrl)), Times.Once());
             Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenWriteStream(_filePath), Times.Once());
-            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
         }
 
         [Test]
-        public void Download_should_replace_illegal_characters_in_title()
+        public async Task Download_should_replace_illegal_characters_in_title()
         {
             var illegalTitle = "Saturday Night Live - S38E08 - Jeremy Renner/Maroon 5 [SDTV]";
             var expectedFilename = Path.Combine(_blackholeFolder, "Saturday Night Live - S38E08 - Jeremy Renner+Maroon 5 [SDTV]" + Path.GetExtension(_filePath));
@@ -135,11 +136,11 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.Title = illegalTitle;
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
-            Mocker.GetMock<IHttpClient>().Verify(c => c.Get(It.Is<HttpRequest>(v => v.Url.FullUri == _downloadUrl)), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.GetAsync(It.Is<HttpRequest>(v => v.Url.FullUri == _downloadUrl)), Times.Once());
             Mocker.GetMock<IDiskProvider>().Verify(c => c.OpenWriteStream(expectedFilename), Times.Once());
-            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -200,26 +201,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
-        public void Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
+        public async Task Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = magnetUrl;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().Be(expectedHash);
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NLog;
@@ -37,8 +38,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
                 .Returns(() => CreateRemoteEpisode());
 
             Mocker.GetMock<IHttpClient>()
-                  .Setup(s => s.Get(It.IsAny<HttpRequest>()))
-                  .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>()));
+                  .Setup(s => s.GetAsync(It.IsAny<HttpRequest>()))
+                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>())));
 
             Mocker.GetMock<IRemotePathMappingService>()
                 .Setup(v => v.RemapRemoteToLocal(It.IsAny<string>(), It.IsAny<OsPath>()))

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/TorrentDownloadStationFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -373,7 +374,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public async Task Download_with_TvDirectory_should_force_directory()
         {
             GivenSerialNumber();
             GivenTvDirectory();
@@ -381,7 +382,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -390,7 +391,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_category_should_force_directory()
+        public async Task Download_with_category_should_force_directory()
         {
             GivenSerialNumber();
             GivenTvCategory();
@@ -398,7 +399,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -407,14 +408,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public async Task Download_without_TvDirectory_and_Category_should_use_default()
         {
             GivenSerialNumber();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -493,7 +494,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                   .Setup(s => s.GetSerialNumber(_settings))
                   .Throws(new ApplicationException("Some unknown exception, HttpException or DownloadClientException"));
 
-            Assert.Throws(Is.InstanceOf<Exception>(), () => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.ThrowsAsync(Is.InstanceOf<Exception>(), async () => await Subject.Download(remoteEpisode, CreateIndexer()));
 
             Mocker.GetMock<IDownloadStationTaskProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), null, _settings), Times.Never());

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadStationTests/UsenetDownloadStationFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -250,7 +251,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public async Task Download_with_TvDirectory_should_force_directory()
         {
             GivenSerialNumber();
             GivenTvDirectory();
@@ -258,7 +259,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -267,7 +268,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_with_category_should_force_directory()
+        public async Task Download_with_category_should_force_directory()
         {
             GivenSerialNumber();
             GivenTvCategory();
@@ -275,7 +276,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -284,14 +285,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public async Task Download_without_TvDirectory_and_Category_should_use_default()
         {
             GivenSerialNumber();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -370,7 +371,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DownloadStationTests
                   .Setup(s => s.GetSerialNumber(_settings))
                   .Throws(new ApplicationException("Some unknown exception, HttpException or DownloadClientException"));
 
-            Assert.Throws(Is.InstanceOf<Exception>(), () => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.ThrowsAsync(Is.InstanceOf<Exception>(), async () => await Subject.Download(remoteEpisode, CreateIndexer()));
 
             Mocker.GetMock<IDownloadStationTaskProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), null, _settings), Times.Never());

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/FreeboxDownloadTests/TorrentFreeboxDownloadFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -146,21 +147,21 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
         }
 
         [Test]
-        public void Download_with_DestinationDirectory_should_force_directory()
+        public async Task Download_with_DestinationDirectory_should_force_directory()
         {
             GivenDestinationDirectory();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDestinationDirectory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
-        public void Download_with_Category_should_force_directory()
+        public async Task Download_with_Category_should_force_directory()
         {
             GivenDownloadConfiguration();
             GivenCategory();
@@ -168,21 +169,21 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestinationAndCategory, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
         }
 
         [Test]
-        public void Download_without_DestinationDirectory_and_Category_should_use_default()
+        public async Task Download_without_DestinationDirectory_and_Category_should_use_default()
         {
             GivenDownloadConfiguration();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), _encodedDefaultDestination, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
@@ -190,7 +191,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
         [TestCase(false, false)]
         [TestCase(true, true)]
-        public void Download_should_pause_torrent_as_expected(bool addPausedSetting, bool toBePausedFlag)
+        public async Task Download_should_pause_torrent_as_expected(bool addPausedSetting, bool toBePausedFlag)
         {
             _settings.AddPaused = addPausedSetting;
 
@@ -199,7 +200,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), It.IsAny<string>(), toBePausedFlag, It.IsAny<bool>(), It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
@@ -213,7 +214,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
         [TestCase(15, (int)FreeboxDownloadPriority.Last, (int)FreeboxDownloadPriority.First, false)]
         [TestCase(15, (int)FreeboxDownloadPriority.First, (int)FreeboxDownloadPriority.Last, true)]
         [TestCase(15, (int)FreeboxDownloadPriority.Last, (int)FreeboxDownloadPriority.Last, false)]
-        public void Download_should_queue_torrent_first_as_expected(int ageDay, int olderPriority, int recentPriority, bool toBeQueuedFirstFlag)
+        public async Task Download_should_queue_torrent_first_as_expected(int ageDay, int olderPriority, int recentPriority, bool toBeQueuedFirstFlag)
         {
             _settings.OlderPriority = olderPriority;
             _settings.RecentPriority = recentPriority;
@@ -230,7 +231,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
             remoteEpisode.Episodes.Add(episode);
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), toBeQueuedFirstFlag, It.IsAny<double?>(), It.IsAny<FreeboxDownloadSettings>()), Times.Once());
@@ -238,7 +239,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
 
         [TestCase(0, 0)]
         [TestCase(1.5, 150)]
-        public void Download_should_define_seed_ratio_as_expected(double? providerSeedRatio, double? expectedSeedRatio)
+        public async Task Download_should_define_seed_ratio_as_expected(double? providerSeedRatio, double? expectedSeedRatio)
         {
             GivenDownloadConfiguration();
             GivenSuccessfulDownload();
@@ -248,7 +249,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.FreeboxDownloadTests
             remoteEpisode.SeedConfiguration = new TorrentSeedConfiguration();
             remoteEpisode.SeedConfiguration.Ratio = providerSeedRatio;
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IFreeboxDownloadProxy>()
                   .Verify(v => v.AddTaskFromUrl(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), expectedSeedRatio, It.IsAny<FreeboxDownloadSettings>()), Times.Once());

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -103,8 +104,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
         protected void GivenSuccessfulDownload()
         {
             Mocker.GetMock<IHttpClient>()
-                  .Setup(s => s.Get(It.IsAny<HttpRequest>()))
-                  .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), new byte[1000]));
+                  .Setup(s => s.GetAsync(It.IsAny<HttpRequest>()))
+                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), new byte[1000])));
 
             Mocker.GetMock<IHadoukenProxy>()
                 .Setup(s => s.AddTorrentUri(It.IsAny<HadoukenSettings>(), It.IsAny<string>()))
@@ -196,13 +197,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
@@ -277,7 +278,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
         }
 
         [Test]
-        public void Download_from_magnet_link_should_return_hash_uppercase()
+        public async Task Download_from_magnet_link_should_return_hash_uppercase()
         {
             var remoteEpisode = CreateRemoteEpisode();
 
@@ -286,13 +287,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
             Mocker.GetMock<IHadoukenProxy>()
                .Setup(v => v.AddTorrentUri(It.IsAny<HadoukenSettings>(), It.IsAny<string>()));
 
-            var result = Subject.Download(remoteEpisode, CreateIndexer());
+            var result = await Subject.Download(remoteEpisode, CreateIndexer());
 
             Assert.IsFalse(result.Any(c => char.IsLower(c)));
         }
 
         [Test]
-        public void Download_from_torrent_file_should_return_hash_uppercase()
+        public async Task Download_from_torrent_file_should_return_hash_uppercase()
         {
             var remoteEpisode = CreateRemoteEpisode();
 
@@ -300,7 +301,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
                .Setup(v => v.AddTorrentFile(It.IsAny<HadoukenSettings>(), It.IsAny<byte[]>()))
                .Returns("hash");
 
-            var result = Subject.Download(remoteEpisode, CreateIndexer());
+            var result = await Subject.Download(remoteEpisode, CreateIndexer());
 
             Assert.IsFalse(result.Any(c => char.IsLower(c)));
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbVortexTests/NzbVortexFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbVortexTests/NzbVortexFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -200,13 +201,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbVortexTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
@@ -218,7 +219,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbVortexTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Assert.Throws<DownloadClientException>(() => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.ThrowsAsync<DownloadClientException>(async () => await Subject.Download(remoteEpisode, CreateIndexer()));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/NzbgetTests/NzbgetFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -340,13 +341,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbgetTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
@@ -358,7 +359,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.NzbgetTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            Assert.Throws<DownloadClientRejectedReleaseException>(() => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.ThrowsAsync<DownloadClientRejectedReleaseException>(async () => await Subject.Download(remoteEpisode, CreateIndexer()));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/PneumaticProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/PneumaticProviderFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using Moq;
 using NLog;
@@ -66,15 +67,15 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
 
         private void WithFailedDownload()
         {
-            Mocker.GetMock<IHttpClient>().Setup(c => c.DownloadFile(It.IsAny<string>(), It.IsAny<string>())).Throws(new WebException());
+            Mocker.GetMock<IHttpClient>().Setup(c => c.DownloadFileAsync(It.IsAny<string>(), It.IsAny<string>())).Throws(new WebException());
         }
 
         [Test]
-        public void should_download_file_if_it_doesnt_exist()
+        public async Task should_download_file_if_it_doesnt_exist()
         {
-            Subject.Download(_remoteEpisode, _indexer);
+            await Subject.Download(_remoteEpisode, _indexer);
 
-            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFile(_nzbUrl, _nzbPath), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFileAsync(_nzbUrl, _nzbPath), Times.Once());
         }
 
         [Test]
@@ -82,7 +83,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
         {
             WithFailedDownload();
 
-            Assert.Throws<WebException>(() => Subject.Download(_remoteEpisode, _indexer));
+            Assert.ThrowsAsync<WebException>(async () => await Subject.Download(_remoteEpisode, _indexer));
         }
 
         [Test]
@@ -91,7 +92,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
             _remoteEpisode.Release.Title = "30 Rock - Season 1";
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
 
-            Assert.Throws<NotSupportedException>(() => Subject.Download(_remoteEpisode, _indexer));
+            Assert.ThrowsAsync<NotSupportedException>(async () => await Subject.Download(_remoteEpisode, _indexer));
         }
 
         [Test]
@@ -101,15 +102,15 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
         }
 
         [Test]
-        public void should_replace_illegal_characters_in_title()
+        public async Task should_replace_illegal_characters_in_title()
         {
             var illegalTitle = "Saturday Night Live - S38E08 - Jeremy Renner/Maroon 5 [SDTV]";
             var expectedFilename = Path.Combine(_pneumaticFolder, "Saturday Night Live - S38E08 - Jeremy Renner+Maroon 5 [SDTV].nzb");
             _remoteEpisode.Release.Title = illegalTitle;
 
-            Subject.Download(_remoteEpisode, _indexer);
+            await Subject.Download(_remoteEpisode, _indexer);
 
-            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFile(It.IsAny<string>(), expectedFilename), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(c => c.DownloadFileAsync(It.IsAny<string>(), expectedFilename), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -449,26 +450,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
-        public void Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
+        public async Task Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = magnetUrl;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().Be(expectedHash);
         }
@@ -483,7 +484,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = "magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR";
 
-            Assert.Throws<ReleaseDownloadException>(() => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.ThrowsAsync<ReleaseDownloadException>(async () => await Subject.Download(remoteEpisode, CreateIndexer()));
         }
 
         [Test]
@@ -496,28 +497,28 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = "magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp://abc";
 
-            Assert.DoesNotThrow(() => Subject.Download(remoteEpisode, CreateIndexer()));
+            Assert.DoesNotThrowAsync(async () => await Subject.Download(remoteEpisode, CreateIndexer()));
 
             Mocker.GetMock<IQBittorrentProxy>()
                   .Verify(s => s.AddTorrentFromUrl(It.IsAny<string>(), It.IsAny<TorrentSeedConfiguration>(), It.IsAny<QBittorrentSettings>()), Times.Once());
         }
 
         [Test]
-        public void Download_should_set_top_priority()
+        public async Task Download_should_set_top_priority()
         {
             GivenHighPriority();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<IQBittorrentProxy>()
                   .Verify(v => v.MoveTorrentToTopInQueue(It.IsAny<string>(), It.IsAny<QBittorrentSettings>()), Times.Once());
         }
 
         [Test]
-        public void Download_should_not_fail_if_top_priority_not_available()
+        public async Task Download_should_not_fail_if_top_priority_not_available()
         {
             GivenHighPriority();
             GivenSuccessfulDownload();
@@ -528,7 +529,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -555,27 +556,27 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
-        public void Download_should_handle_http_redirect_to_magnet()
+        public async Task Download_should_handle_http_redirect_to_magnet()
         {
             GivenRedirectToMagnet();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [Test]
-        public void Download_should_handle_http_redirect_to_torrent()
+        public async Task Download_should_handle_http_redirect_to_torrent()
         {
             GivenRedirectToTorrent();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/RTorrentTests/RTorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/RTorrentTests/RTorrentFixture.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -111,13 +112,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.RTorrentTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -300,27 +301,27 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
         }
 
         [TestCase("[ TOWN ]-[ http://www.town.ag ]-[ ANIME ]-[Usenet Provider >> http://www.ssl- <<] - [Commie] Aldnoah Zero 18 [234C8FC7]", "[ TOWN ]-[ http-++www.town.ag ]-[ ANIME ]-[Usenet Provider  http-++www.ssl- ] - [Commie] Aldnoah Zero 18 [234C8FC7].nzb")]
-        public void Download_should_use_clean_title(string title, string filename)
+        public async Task Download_should_use_clean_title(string title, string filename)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.Title = title;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<ISabnzbdProxy>()
                 .Verify(v => v.DownloadNzb(It.IsAny<byte[]>(), filename, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<SabnzbdSettings>()), Times.Once());
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
@@ -353,7 +354,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
         }
 
         [Test]
-        public void Download_should_use_sabRecentTvPriority_when_recentEpisode_is_true()
+        public async Task Download_should_use_sabRecentTvPriority_when_recentEpisode_is_true()
         {
             Mocker.GetMock<ISabnzbdProxy>()
                     .Setup(s => s.DownloadNzb(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), (int)SabnzbdPriority.High, It.IsAny<SabnzbdSettings>()))
@@ -366,7 +367,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
                                                       .Build()
                                                       .ToList();
 
-            Subject.Download(remoteEpisode, CreateIndexer());
+            await Subject.Download(remoteEpisode, CreateIndexer());
 
             Mocker.GetMock<ISabnzbdProxy>()
                   .Verify(v => v.DownloadNzb(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), (int)SabnzbdPriority.High, It.IsAny<SabnzbdSettings>()), Times.Once());

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -55,26 +56,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public async Task Download_with_TvDirectory_should_force_directory()
         {
             GivenTvDirectory();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -83,14 +84,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_with_category_should_force_directory()
+        public async Task Download_with_category_should_force_directory()
         {
             GivenTvCategory();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -99,7 +100,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_with_category_should_not_have_double_slashes()
+        public async Task Download_with_category_should_not_have_double_slashes()
         {
             GivenTvCategory();
             GivenSuccessfulDownload();
@@ -108,7 +109,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -117,13 +118,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public async Task Download_without_TvDirectory_and_Category_should_use_default()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -132,14 +133,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
-        public void Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
+        public async Task Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = magnetUrl;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().Be(expectedHash);
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/UTorrentTests/UTorrentFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -228,13 +229,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
@@ -252,14 +253,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
 
         // Proxy.GetTorrents does not return original url. So item has to be found via magnet url.
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
-        public void Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
+        public async Task Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = magnetUrl;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().Be(expectedHash);
         }
@@ -350,27 +351,27 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.UTorrentTests
         }
 
         [Test]
-        public void Download_should_handle_http_redirect_to_magnet()
+        public async Task Download_should_handle_http_redirect_to_magnet()
         {
             GivenRedirectToMagnet();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [Test]
-        public void Download_should_handle_http_redirect_to_torrent()
+        public async Task Download_should_handle_http_redirect_to_torrent()
         {
             GivenRedirectToTorrent();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -63,26 +64,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_should_return_unique_id()
+        public async Task Download_should_return_unique_id()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
         }
 
         [Test]
-        public void Download_with_TvDirectory_should_force_directory()
+        public async Task Download_with_TvDirectory_should_force_directory()
         {
             GivenTvDirectory();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -91,14 +92,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_with_category_should_force_directory()
+        public async Task Download_with_category_should_force_directory()
         {
             GivenTvCategory();
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -107,7 +108,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_with_category_should_not_have_double_slashes()
+        public async Task Download_with_category_should_not_have_double_slashes()
         {
             GivenTvCategory();
             GivenSuccessfulDownload();
@@ -116,7 +117,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -125,13 +126,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [Test]
-        public void Download_without_TvDirectory_and_Category_should_use_default()
+        public async Task Download_without_TvDirectory_and_Category_should_use_default()
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().NotBeNullOrEmpty();
 
@@ -140,14 +141,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         }
 
         [TestCase("magnet:?xt=urn:btih:ZPBPA2P6ROZPKRHK44D5OW6NHXU5Z6KR&tr=udp", "CBC2F069FE8BB2F544EAE707D75BCD3DE9DCF951")]
-        public void Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
+        public async Task Download_should_get_hash_from_magnet_url(string magnetUrl, string expectedHash)
         {
             GivenSuccessfulDownload();
 
             var remoteEpisode = CreateRemoteEpisode();
             remoteEpisode.Release.DownloadUrl = magnetUrl;
 
-            var id = Subject.Download(remoteEpisode, CreateIndexer());
+            var id = await Subject.Download(remoteEpisode, CreateIndexer());
 
             id.Should().Be(expectedHash);
         }

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -110,37 +111,37 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SingleEpisodeSearchCriteria>()))
                 .Callback<SingleEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SeasonSearchCriteria>()))
                 .Callback<SeasonSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<DailyEpisodeSearchCriteria>()))
                 .Callback<DailyEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<DailySeasonSearchCriteria>()))
                 .Callback<DailySeasonSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeEpisodeSearchCriteria>()))
                 .Callback<AnimeEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeSeasonSearchCriteria>()))
                 .Callback<AnimeSeasonSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SpecialEpisodeSearchCriteria>()))
                 .Callback<SpecialEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(new List<Parser.Model.ReleaseInfo>());
+                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
 
             return result;
         }
 
         [Test]
-        public void Tags_IndexerTags_SeriesNoTags_IndexerNotIncluded()
+        public async Task Tags_IndexerTags_SeriesNoTags_IndexerNotIncluded()
         {
             _mockIndexer.SetupGet(s => s.Definition).Returns(new IndexerDefinition
             {
@@ -152,7 +153,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
+            await Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
 
             var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
@@ -160,7 +161,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void Tags_IndexerNoTags_SeriesTags_IndexerIncluded()
+        public async Task Tags_IndexerNoTags_SeriesTags_IndexerIncluded()
         {
             _mockIndexer.SetupGet(s => s.Definition).Returns(new IndexerDefinition
             {
@@ -181,7 +182,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
+            await Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
 
             var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
@@ -189,7 +190,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void Tags_IndexerAndSeriesTagsMatch_IndexerIncluded()
+        public async Task Tags_IndexerAndSeriesTagsMatch_IndexerIncluded()
         {
             _mockIndexer.SetupGet(s => s.Definition).Returns(new IndexerDefinition
             {
@@ -211,7 +212,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
+            await Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
 
             var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
@@ -219,7 +220,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void Tags_IndexerAndSeriesTagsMismatch_IndexerNotIncluded()
+        public async Task Tags_IndexerAndSeriesTagsMismatch_IndexerNotIncluded()
         {
             _mockIndexer.SetupGet(s => s.Definition).Returns(new IndexerDefinition
             {
@@ -241,7 +242,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
+            await Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
 
             var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
@@ -249,13 +250,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void scene_episodesearch()
+        public async Task scene_episodesearch()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
+            await Subject.EpisodeSearch(_xemEpisodes.First(), true, false);
 
             var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
@@ -265,13 +266,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void scene_seasonsearch()
+        public async Task scene_seasonsearch()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
 
             var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
@@ -280,13 +281,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void scene_seasonsearch_should_search_multiple_seasons()
+        public async Task scene_seasonsearch_should_search_multiple_seasons()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 2, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 2, false, false, true, false);
 
             var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
@@ -296,13 +297,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void scene_seasonsearch_should_search_single_episode_if_possible()
+        public async Task scene_seasonsearch_should_search_single_episode_if_possible()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 4, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 4, false, false, true, false);
 
             var criteria1 = allCriteria.OfType<SeasonSearchCriteria>().ToList();
             var criteria2 = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
@@ -316,13 +317,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void scene_seasonsearch_should_use_seasonnumber_if_no_scene_number_is_available()
+        public async Task scene_seasonsearch_should_use_seasonnumber_if_no_scene_number_is_available()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
 
             var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
@@ -331,7 +332,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_search_for_each_monitored_episode()
+        public async Task season_search_for_anime_should_search_for_each_monitored_episode()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -340,7 +341,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
@@ -348,7 +349,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_unmonitored_episodes()
+        public async Task season_search_for_anime_should_not_search_for_unmonitored_episodes()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -358,7 +359,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, true, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, true, true, false);
 
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
@@ -366,7 +367,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_unaired_episodes()
+        public async Task season_search_for_anime_should_not_search_for_unaired_episodes()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -376,7 +377,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
@@ -384,7 +385,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_episodes_with_files()
+        public async Task season_search_for_anime_should_not_search_for_episodes_with_files()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -393,7 +394,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
@@ -401,7 +402,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_set_isSeasonSearch_flag()
+        public async Task season_search_for_anime_should_set_isSeasonSearch_flag()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -410,7 +411,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
@@ -419,7 +420,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_search_for_each_monitored_season()
+        public async Task season_search_for_anime_should_search_for_each_monitored_season()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -428,7 +429,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
@@ -437,7 +438,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_unmonitored_season()
+        public async Task season_search_for_anime_should_not_search_for_unmonitored_season()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -447,7 +448,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, true, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, true, true, false);
 
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
@@ -455,7 +456,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_unaired_season()
+        public async Task season_search_for_anime_should_not_search_for_unaired_season()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -465,7 +466,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, false, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
@@ -473,7 +474,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_anime_should_not_search_for_season_with_files()
+        public async Task season_search_for_anime_should_not_search_for_season_with_files()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -482,7 +483,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var seasonNumber = 1;
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
 
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
@@ -490,7 +491,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_daily_should_search_multiple_years()
+        public async Task season_search_for_daily_should_search_multiple_years()
         {
             WithEpisode(1, 1, null, null, "2005-12-30");
             WithEpisode(1, 2, null, null, "2005-12-31");
@@ -500,7 +501,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
 
             var criteria = allCriteria.OfType<DailySeasonSearchCriteria>().ToList();
 
@@ -510,7 +511,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_daily_should_search_single_episode_if_possible()
+        public async Task season_search_for_daily_should_search_single_episode_if_possible()
         {
             WithEpisode(1, 1, null, null, "2005-12-30");
             WithEpisode(1, 2, null, null, "2005-12-31");
@@ -519,7 +520,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
 
             var criteria1 = allCriteria.OfType<DailySeasonSearchCriteria>().ToList();
             var criteria2 = allCriteria.OfType<DailyEpisodeSearchCriteria>().ToList();
@@ -532,7 +533,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void season_search_for_daily_should_not_search_for_unmonitored_episodes()
+        public async Task season_search_for_daily_should_not_search_for_unmonitored_episodes()
         {
             WithEpisode(1, 1, null, null, "2005-12-30");
             WithEpisode(1, 2, null, null, "2005-12-31");
@@ -542,7 +543,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 1, false, true, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 1, false, true, true, false);
 
             var criteria1 = allCriteria.OfType<DailySeasonSearchCriteria>().ToList();
             var criteria2 = allCriteria.OfType<DailyEpisodeSearchCriteria>().ToList();
@@ -552,13 +553,13 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public void getscenenames_should_use_seasonnumber_if_no_scene_seasonnumber_is_available()
+        public async Task getscenenames_should_use_seasonnumber_if_no_scene_seasonnumber_is_available()
         {
             WithEpisodes();
 
             var allCriteria = WatchForSearchCriteria();
 
-            Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
+            await Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
 
             Mocker.GetMock<ISceneMappingService>()
                   .Verify(v => v.FindByTvdbId(_xemSeries.Id), Times.Once());

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -33,11 +34,11 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             Mocker.GetMock<ISearchForReleases>()
                   .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, false, true, false))
-                  .Returns(new List<DownloadDecision>());
+                  .Returns(Task.FromResult(new List<DownloadDecision>()));
 
             Mocker.GetMock<IProcessDownloadDecisions>()
                   .Setup(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
-                  .Returns(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>()));
+                  .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>())));
         }
 
         [Test]
@@ -69,7 +70,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             Mocker.GetMock<ISearchForReleases>()
                   .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false))
-                  .Returns(new List<DownloadDecision>())
+                  .Returns(Task.FromResult(new List<DownloadDecision>()))
                   .Callback<int, int, bool, bool, bool, bool>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch) => seasonOrder.Add(seasonNumber));
 
             Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });

--- a/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -25,15 +26,15 @@ namespace NzbDrone.Core.Test.IndexerTests.FanzubTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_fanzub()
+        public async Task should_parse_recent_feed_from_fanzub()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Fanzub/fanzub.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(3);
 

--- a/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -26,15 +27,15 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_FileList()
+        public async Task should_parse_recent_feed_from_FileList()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/FileList/RecentFeed.json");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
             releases.First().Should().BeOfType<TorrentInfo>();

--- a/src/NzbDrone.Core.Test/IndexerTests/HDBitsTests/HDBitsFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/HDBitsTests/HDBitsFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -30,15 +31,15 @@ namespace NzbDrone.Core.Test.IndexerTests.HDBitsTests
 
         [TestCase("Files/Indexers/HdBits/RecentFeedLongIDs.json")]
         [TestCase("Files/Indexers/HdBits/RecentFeedStringIDs.json")]
-        public void should_parse_recent_feed_from_HDBits(string fileName)
+        public async Task should_parse_recent_feed_from_HDBits(string fileName)
         {
             var responseJson = ReadAllText(fileName);
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Post)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), responseJson));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Post)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), responseJson)));
 
-            var torrents = Subject.FetchRecent();
+            var torrents = await Subject.FetchRecent();
 
             torrents.Should().HaveCount(2);
             torrents.First().Should().BeOfType<TorrentInfo>();
@@ -59,15 +60,15 @@ namespace NzbDrone.Core.Test.IndexerTests.HDBitsTests
         }
 
         [Test]
-        public void should_warn_on_wrong_passkey()
+        public async Task should_warn_on_wrong_passkey()
         {
             var responseJson = new { status = 5, message = "Invalid authentication credentials" }.ToJson();
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(v => v.Execute(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), Encoding.UTF8.GetBytes(responseJson)));
+                .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Encoding.UTF8.GetBytes(responseJson))));
 
-            var torrents = Subject.FetchRecent();
+            var torrents = await Subject.FetchRecent();
 
             torrents.Should().BeEmpty();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/IPTorrentsTests/IPTorrentsFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/IPTorrentsTests/IPTorrentsFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -84,15 +85,15 @@ namespace NzbDrone.Core.Test.IndexerTests.IPTorrentsTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_IPTorrents()
+        public async Task should_parse_recent_feed_from_IPTorrents()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/IPTorrents/IPTorrents.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -40,15 +41,15 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_newznab_nzb_su()
+        public async Task should_parse_recent_feed_from_newznab_nzb_su()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Newznab/newznab_nzb_su.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(100);
 
@@ -66,15 +67,15 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_newznab_animetosho()
+        public async Task should_parse_recent_feed_from_newznab_animetosho()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Torznab/torznab_animetosho.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(1);
 
@@ -112,7 +113,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_record_indexer_failure_if_caps_throw()
+        public async Task should_record_indexer_failure_if_caps_throw()
         {
             var request = new HttpRequest("http://my.indexer.com");
             var response = new HttpResponse(request, new HttpHeader(), Array.Empty<byte>(), (HttpStatusCode)429);
@@ -125,7 +126,9 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             _caps.MaxPageSize = 30;
             _caps.DefaultPageSize = 25;
 
-            Subject.FetchRecent().Should().BeEmpty();
+            var releases = await Subject.FetchRecent();
+
+            releases.Should().BeEmpty();
 
             Mocker.GetMock<IIndexerStatusService>()
                   .Verify(v => v.RecordFailure(It.IsAny<int>(), TimeSpan.FromMinutes(5.0)), Times.Once());

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -58,15 +59,15 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         }*/
 
         [Test]
-        public void should_parse_2021_recent_feed_from_Nyaa()
+        public async Task should_parse_2021_recent_feed_from_Nyaa()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Nyaa/Nyaa2021.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(3);
             releases.First().Should().BeOfType<TorrentInfo>();

--- a/src/NzbDrone.Core.Test/IndexerTests/SeasonSearchFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/SeasonSearchFixture.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
@@ -23,8 +24,8 @@ namespace NzbDrone.Core.Test.IndexerTests
             _series = Builder<Series>.CreateNew().Build();
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), "<xml></xml>"));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), "<xml></xml>")));
         }
 
         private void WithIndexer(bool paging, int resultCount)
@@ -67,7 +68,7 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             Subject.Fetch(new SeasonSearchCriteria { Series = _series, SceneTitles = new List<string> { _series.Title } });
 
-            Mocker.GetMock<IHttpClient>().Verify(v => v.Execute(It.IsAny<HttpRequest>()), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(v => v.ExecuteAsync(It.IsAny<HttpRequest>()), Times.Once());
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             Subject.Fetch(new SeasonSearchCriteria { Series = _series, SceneTitles = new List<string> { _series.Title } });
 
-            Mocker.GetMock<IHttpClient>().Verify(v => v.Execute(It.IsAny<HttpRequest>()), Times.Once());
+            Mocker.GetMock<IHttpClient>().Verify(v => v.ExecuteAsync(It.IsAny<HttpRequest>()), Times.Once());
         }
 
         [Test]
@@ -87,7 +88,7 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             Subject.Fetch(new SeasonSearchCriteria { Series = _series, SceneTitles = new List<string> { _series.Title } });
 
-            Mocker.GetMock<IHttpClient>().Verify(v => v.Execute(It.IsAny<HttpRequest>()), Times.Exactly(10));
+            Mocker.GetMock<IHttpClient>().Verify(v => v.ExecuteAsync(It.IsAny<HttpRequest>()), Times.Exactly(10));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TestTorrentRssIndexer.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TestTorrentRssIndexer.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         public List<ValidationFailure> TestPublic()
         {
             var result = new List<ValidationFailure>();
-            this.SetupNLog(); // Enable this to enable trace logging with nlog for debugging purposes
-            Test(result);
+            SetupNLog(); // Enable this to enable trace logging with nlog for debugging purposes
+            Test(result).GetAwaiter().GetResult();
             return result;
         }
 

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -35,16 +36,20 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
             var recentFeed = ReadAllText(@"Files/Indexers/" + rssXmlFile);
 
             Mocker.GetMock<IHttpClient>()
+                .Setup(o => o.ExecuteAsync(It.IsAny<HttpRequest>()))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+
+            Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.Execute(It.IsAny<HttpRequest>()))
                 .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
         }
 
         [Test]
-        public void should_parse_recent_feed_from_ImmortalSeed()
+        public async Task should_parse_recent_feed_from_ImmortalSeed()
         {
             GivenRecentFeedResponse("TorrentRss/ImmortalSeed.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(50);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -66,11 +71,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_Ezrss()
+        public async Task should_parse_recent_feed_from_Ezrss()
         {
             GivenRecentFeedResponse("TorrentRss/Ezrss.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(3);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -92,13 +97,13 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_ShowRSS_info()
+        public async Task should_parse_recent_feed_from_ShowRSS_info()
         {
             Subject.Definition.Settings.As<TorrentRssIndexerSettings>().AllowZeroSize = true;
 
             GivenRecentFeedResponse("TorrentRss/ShowRSS.info.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -120,13 +125,13 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_Doki()
+        public async Task should_parse_recent_feed_from_Doki()
         {
             Subject.Definition.Settings.As<TorrentRssIndexerSettings>().AllowZeroSize = true;
 
             GivenRecentFeedResponse("TorrentRss/Doki.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -148,11 +153,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_ExtraTorrents()
+        public async Task should_parse_recent_feed_from_ExtraTorrents()
         {
             GivenRecentFeedResponse("TorrentRss/ExtraTorrents.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -174,11 +179,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_LimeTorrents()
+        public async Task should_parse_recent_feed_from_LimeTorrents()
         {
             GivenRecentFeedResponse("TorrentRss/LimeTorrents.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -200,11 +205,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_AnimeTosho_without_size()
+        public async Task should_parse_recent_feed_from_AnimeTosho_without_size()
         {
             GivenRecentFeedResponse("TorrentRss/AnimeTosho_NoSize.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -226,11 +231,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_multi_enclosure_from_AnimeTosho()
+        public async Task should_parse_multi_enclosure_from_AnimeTosho()
         {
             GivenRecentFeedResponse("TorrentRss/AnimeTosho_NoSize.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
             releases.Last().Should().BeOfType<TorrentInfo>();
@@ -243,11 +248,11 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_AlphaRatio()
+        public async Task should_parse_recent_feed_from_AlphaRatio()
         {
             GivenRecentFeedResponse("TorrentRss/AlphaRatio.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
             releases.Last().Should().BeOfType<TorrentInfo>();
@@ -260,12 +265,12 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_EveolutionWorld_without_size()
+        public async Task should_parse_recent_feed_from_EveolutionWorld_without_size()
         {
             Subject.Definition.Settings.As<TorrentRssIndexerSettings>().AllowZeroSize = true;
             GivenRecentFeedResponse("TorrentRss/EvolutionWorld.xml");
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
             releases.First().Should().BeOfType<TorrentInfo>();
@@ -287,11 +292,13 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
         }
 
         [Test]
-        public void should_record_indexer_failure_if_unsupported_feed()
+        public async Task should_record_indexer_failure_if_unsupported_feed()
         {
             GivenRecentFeedResponse("TorrentRss/invalid/TorrentDay_NoPubDate.xml");
 
-            Subject.FetchRecent().Should().BeEmpty();
+            var releases = await Subject.FetchRecent();
+
+            releases.Should().BeEmpty();
 
             Mocker.GetMock<IIndexerStatusService>()
                   .Verify(v => v.RecordFailure(It.IsAny<int>(), TimeSpan.Zero), Times.Once());

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentleechTests/TorrentleechFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentleechTests/TorrentleechFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -26,15 +27,15 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentleechTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_Torrentleech()
+        public async Task should_parse_recent_feed_from_Torrentleech()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Torrentleech/Torrentleech.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
             releases.First().Should().BeOfType<TorrentInfo>();

--- a/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -44,15 +45,15 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_torznab_hdaccess_net()
+        public async Task should_parse_recent_feed_from_torznab_hdaccess_net()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Torznab/torznab_hdaccess_net.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
 
@@ -75,15 +76,15 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_torznab_tpb()
+        public async Task should_parse_recent_feed_from_torznab_tpb()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Torznab/torznab_tpb.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(5);
 
@@ -105,15 +106,15 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
         }
 
         [Test]
-        public void should_parse_recent_feed_from_torznab_animetosho()
+        public async Task should_parse_recent_feed_from_torznab_animetosho()
         {
             var recentFeed = ReadAllText(@"Files/Indexers/Torznab/torznab_animetosho.xml");
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
-            var releases = Subject.FetchRecent();
+            var releases = await Subject.FetchRecent();
 
             releases.Should().HaveCount(2);
 
@@ -173,8 +174,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
             (Subject.Definition.Settings as TorznabSettings).BaseUrl = baseUrl;
 
             Mocker.GetMock<IHttpClient>()
-                .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
             var result = new NzbDroneValidationResult(Subject.Test());
             result.IsValid.Should().BeTrue();
@@ -188,8 +189,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
             var recentFeed = ReadAllText(@"Files/Indexers/Torznab/torznab_tpb.xml");
 
             Mocker.GetMock<IHttpClient>()
-                  .Setup(o => o.Execute(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                  .Returns<HttpRequest>(r => new HttpResponse(r, new HttpHeader(), recentFeed));
+                  .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
+                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
 
             (Subject.Definition.Settings as TorznabSettings).ApiPath = apiPath;
 

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -32,7 +33,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
         public override DownloadProtocol Protocol => DownloadProtocol.Usenet;
 
-        public override string Download(RemoteEpisode remoteEpisode, IIndexer indexer)
+        public override async Task<string> Download(RemoteEpisode remoteEpisode, IIndexer indexer)
         {
             var url = remoteEpisode.Release.DownloadUrl;
             var title = remoteEpisode.Release.Title;
@@ -48,7 +49,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
             var nzbFile = Path.Combine(Settings.NzbFolder, title + ".nzb");
 
             _logger.Debug("Downloading NZB from: {0} to: {1}", url, nzbFile);
-            _httpClient.DownloadFile(url, nzbFile);
+            await _httpClient.DownloadFileAsync(url, nzbFile);
 
             _logger.Debug("NZB Download succeeded, saved to: {0}", nzbFile);
 

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -58,7 +59,7 @@ namespace NzbDrone.Core.Download
             get;
         }
 
-        public abstract string Download(RemoteEpisode remoteEpisode, IIndexer indexer);
+        public abstract Task<string> Download(RemoteEpisode remoteEpisode, IIndexer indexer);
         public abstract IEnumerable<DownloadClientItem> GetItems();
 
         public virtual DownloadClientItem GetImportItem(DownloadClientItem item, DownloadClientItem previousImportAttempt)

--- a/src/NzbDrone.Core/Download/IDownloadClient.cs
+++ b/src/NzbDrone.Core/Download/IDownloadClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.ThingiProvider;
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.Download
     public interface IDownloadClient : IProvider
     {
         DownloadProtocol Protocol { get; }
-        string Download(RemoteEpisode remoteEpisode, IIndexer indexer);
+        Task<string> Download(RemoteEpisode remoteEpisode, IIndexer indexer);
         IEnumerable<DownloadClientItem> GetItems();
         DownloadClientItem GetImportItem(DownloadClientItem item, DownloadClientItem previousImportAttempt);
         void RemoveItem(DownloadClientItem item, bool deleteData);

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download.Clients;
@@ -12,7 +13,7 @@ namespace NzbDrone.Core.Download
 {
     public interface IProcessDownloadDecisions
     {
-        ProcessedDecisions ProcessDecisions(List<DownloadDecision> decisions);
+        Task<ProcessedDecisions> ProcessDecisions(List<DownloadDecision> decisions);
     }
 
     public class ProcessDownloadDecisions : IProcessDownloadDecisions
@@ -33,7 +34,7 @@ namespace NzbDrone.Core.Download
             _logger = logger;
         }
 
-        public ProcessedDecisions ProcessDecisions(List<DownloadDecision> decisions)
+        public async Task<ProcessedDecisions> ProcessDecisions(List<DownloadDecision> decisions)
         {
             var qualifiedReports = GetQualifiedReports(decisions);
             var prioritizedDecisions = _prioritizeDownloadDecision.PrioritizeDecisions(qualifiedReports);
@@ -73,7 +74,7 @@ namespace NzbDrone.Core.Download
                 try
                 {
                     _logger.Trace("Grabbing from Indexer {0} at priority {1}.", remoteEpisode.Release.Indexer, remoteEpisode.Release.IndexerPriority);
-                    _downloadService.DownloadReport(remoteEpisode, null);
+                    await _downloadService.DownloadReport(remoteEpisode, null);
                     grabbed.Add(report);
                 }
                 catch (ReleaseUnavailableException)

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using MonoTorrent;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -41,7 +42,7 @@ namespace NzbDrone.Core.Download
         protected abstract string AddFromMagnetLink(RemoteEpisode remoteEpisode, string hash, string magnetLink);
         protected abstract string AddFromTorrentFile(RemoteEpisode remoteEpisode, string hash, string filename, byte[] fileContent);
 
-        public override string Download(RemoteEpisode remoteEpisode, IIndexer indexer)
+        public override async Task<string> Download(RemoteEpisode remoteEpisode, IIndexer indexer)
         {
             var torrentInfo = remoteEpisode.Release as TorrentInfo;
 
@@ -68,7 +69,7 @@ namespace NzbDrone.Core.Download
                 {
                     try
                     {
-                        return DownloadFromWebUrl(remoteEpisode, indexer, torrentUrl);
+                        return await DownloadFromWebUrl(remoteEpisode, indexer, torrentUrl);
                     }
                     catch (Exception ex)
                     {
@@ -114,14 +115,14 @@ namespace NzbDrone.Core.Download
 
                 if (torrentUrl.IsNotNullOrWhiteSpace())
                 {
-                    return DownloadFromWebUrl(remoteEpisode, indexer, torrentUrl);
+                    return await DownloadFromWebUrl(remoteEpisode, indexer, torrentUrl);
                 }
             }
 
             return null;
         }
 
-        private string DownloadFromWebUrl(RemoteEpisode remoteEpisode, IIndexer indexer, string torrentUrl)
+        private async Task<string> DownloadFromWebUrl(RemoteEpisode remoteEpisode, IIndexer indexer, string torrentUrl)
         {
             byte[] torrentFile = null;
 
@@ -132,7 +133,7 @@ namespace NzbDrone.Core.Download
                 request.Headers.Accept = "application/x-bittorrent";
                 request.AllowAutoRedirect = false;
 
-                var response = _httpClient.Get(request);
+                var response = await _httpClient.GetAsync(request);
 
                 if (response.StatusCode == HttpStatusCode.MovedPermanently ||
                     response.StatusCode == HttpStatusCode.Found ||
@@ -151,7 +152,7 @@ namespace NzbDrone.Core.Download
 
                         request.Url += new HttpUri(locationHeader);
 
-                        return DownloadFromWebUrl(remoteEpisode, indexer, request.Url.ToString());
+                        return await DownloadFromWebUrl(remoteEpisode, indexer, request.Url.ToString());
                     }
 
                     throw new WebException("Remote website tried to redirect without providing a location.");

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
@@ -34,7 +35,7 @@ namespace NzbDrone.Core.Download
 
         protected abstract string AddFromNzbFile(RemoteEpisode remoteEpisode, string filename, byte[] fileContent);
 
-        public override string Download(RemoteEpisode remoteEpisode, IIndexer indexer)
+        public override async Task<string> Download(RemoteEpisode remoteEpisode, IIndexer indexer)
         {
             var url = remoteEpisode.Release.DownloadUrl;
             var filename =  FileNameBuilder.CleanFileName(remoteEpisode.Release.Title) + ".nzb";
@@ -45,7 +46,10 @@ namespace NzbDrone.Core.Download
             {
                 var request = indexer?.GetDownloadRequest(url) ?? new HttpRequest(url);
                 request.RateLimitKey = remoteEpisode?.Release?.IndexerId.ToString();
-                nzbData = _httpClient.Get(request).ResponseData;
+
+                var response = await _httpClient.GetAsync(request);
+
+                nzbData = response.ResponseData;
 
                 _logger.Debug("Downloaded nzb for episode '{0}' finished ({1} bytes from {2})", remoteEpisode.Release.Title, nzbData.Length, url);
             }

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -22,8 +22,8 @@ namespace NzbDrone.Core.IndexerSearch
 
         public void Execute(SeasonSearchCommand message)
         {
-            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, false, true, message.Trigger == CommandTrigger.Manual, false);
-            var processed = _processDownloadDecisions.ProcessDecisions(decisions);
+            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, false, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
+            var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 
             _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
         }

--- a/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
@@ -49,8 +49,9 @@ namespace NzbDrone.Core.IndexerSearch
 
                 foreach (var episode in episodes)
                 {
-                    var decisions = _releaseSearchService.EpisodeSearch(episode, userInvokedSearch, false);
-                    downloadedCount += _processDownloadDecisions.ProcessDecisions(decisions).Grabbed.Count;
+                    var decisions = _releaseSearchService.EpisodeSearch(episode, userInvokedSearch, false).GetAwaiter().GetResult();
+                    var processDecisions = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+                    downloadedCount += processDecisions.Grabbed.Count;
                 }
             }
             else
@@ -63,8 +64,9 @@ namespace NzbDrone.Core.IndexerSearch
                         continue;
                     }
 
-                    var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, season.SeasonNumber, false, true, userInvokedSearch, false);
-                    downloadedCount += _processDownloadDecisions.ProcessDecisions(decisions).Grabbed.Count;
+                    var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, season.SeasonNumber, false, true, userInvokedSearch, false).GetAwaiter().GetResult();
+                    var processDecisions = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+                    downloadedCount += processDecisions.Grabbed.Count;
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/IIndexer.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -12,14 +13,14 @@ namespace NzbDrone.Core.Indexers
         bool SupportsSearch { get; }
         DownloadProtocol Protocol { get; }
 
-        IList<ReleaseInfo> FetchRecent();
-        IList<ReleaseInfo> Fetch(SeasonSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(SingleEpisodeSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(AnimeSeasonSearchCriteria searchCriteria);
-        IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> FetchRecent();
+        Task<IList<ReleaseInfo>> Fetch(SeasonSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(SingleEpisodeSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(DailyEpisodeSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(DailySeasonSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(AnimeSeasonSearchCriteria searchCriteria);
+        Task<IList<ReleaseInfo>> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
         HttpRequest GetDownloadRequest(string link);
     }
 }

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Http;
@@ -67,20 +68,19 @@ namespace NzbDrone.Core.Indexers
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 
-        public abstract IList<ReleaseInfo> FetchRecent();
-        public abstract IList<ReleaseInfo> Fetch(SeasonSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(SingleEpisodeSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(AnimeSeasonSearchCriteria searchCriteria);
-        public abstract IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> FetchRecent();
+        public abstract Task<IList<ReleaseInfo>> Fetch(SeasonSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(SingleEpisodeSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(DailyEpisodeSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(DailySeasonSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(AnimeSeasonSearchCriteria searchCriteria);
+        public abstract Task<IList<ReleaseInfo>> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
         public abstract HttpRequest GetDownloadRequest(string link);
 
         protected virtual IList<ReleaseInfo> CleanupReleases(IEnumerable<ReleaseInfo> releases)
         {
             var result = releases.DistinctBy(v => v.Guid).ToList();
-            var settings = Definition.Settings as IIndexerSettings;
 
             result.ForEach(c =>
             {
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Indexers
 
             try
             {
-                Test(failures);
+                Test(failures).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Indexers
             return new ValidationResult(failures);
         }
 
-        protected abstract void Test(List<ValidationFailure> failures);
+        protected abstract Task Test(List<ValidationFailure> failures);
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -98,9 +99,10 @@ namespace NzbDrone.Core.Indexers.Newznab
             return settings;
         }
 
-        protected override void Test(List<ValidationFailure> failures)
+        protected override async Task Test(List<ValidationFailure> failures)
         {
-            base.Test(failures);
+            await base.Test(failures);
+
             if (failures.HasErrors())
             {
                 return;

--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -91,9 +92,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             return settings;
         }
 
-        protected override void Test(List<ValidationFailure> failures)
+        protected override async Task Test(List<ValidationFailure> failures)
         {
-            base.Test(failures);
+            await base.Test(failures);
+
             if (failures.HasErrors())
             {
                 return;

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -155,7 +155,7 @@ namespace NzbDrone.Host
                     });
                     builder.ConfigureKestrel(serverOptions =>
                     {
-                        serverOptions.AllowSynchronousIO = true;
+                        serverOptions.AllowSynchronousIO = false;
                         serverOptions.Limits.MaxRequestBodySize = null;
                     });
                     builder.UseStartup<Startup>();

--- a/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
@@ -62,7 +62,7 @@ namespace Sonarr.Api.V3.Indexers
             lock (PushLock)
             {
                 decisions = _downloadDecisionMaker.GetRssDecision(new List<ReleaseInfo> { info });
-                _downloadDecisionProcessor.ProcessDecisions(decisions);
+                _downloadDecisionProcessor.ProcessDecisions(decisions).GetAwaiter().GetResult();
             }
 
             var firstDecision = decisions.FirstOrDefault();

--- a/src/Sonarr.Api.V3/Queue/QueueActionController.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueActionController.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Pending;
@@ -20,7 +21,7 @@ namespace Sonarr.Api.V3.Queue
         }
 
         [HttpPost("grab/{id:int}")]
-        public object Grab(int id)
+        public async Task<object> Grab(int id)
         {
             var pendingRelease = _pendingReleaseService.FindPendingQueueItem(id);
 
@@ -29,14 +30,14 @@ namespace Sonarr.Api.V3.Queue
                 throw new NotFoundException();
             }
 
-            _downloadService.DownloadReport(pendingRelease.RemoteEpisode, null);
+            await _downloadService.DownloadReport(pendingRelease.RemoteEpisode, null);
 
             return new { };
         }
 
         [HttpPost("grab/bulk")]
         [Consumes("application/json")]
-        public object Grab([FromBody] QueueBulkResource resource)
+        public async Task<object> Grab([FromBody] QueueBulkResource resource)
         {
             foreach (var id in resource.Ids)
             {
@@ -47,7 +48,7 @@ namespace Sonarr.Api.V3.Queue
                     throw new NotFoundException();
                 }
 
-                _downloadService.DownloadReport(pendingRelease.RemoteEpisode, null);
+                await _downloadService.DownloadReport(pendingRelease.RemoteEpisode, null);
             }
 
             return new { };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Releases/Indexer search changed to use the async requests
- Download/Grab releases changed to use the async requests
- Add async methods to RateLimitService
- Changed ProcessDownloadDecisions to be async
- Changed the default Request HTTP version to 2.0