### PR TITLE
New: Speed up Series Add by reworking SeriesPathValidator

### DIFF
--- a/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using FluentValidation.Validators;
 using NzbDrone.Core.Tv;
 
@@ -24,7 +25,7 @@ namespace NzbDrone.Core.Validation.Paths
 
             var tvdbId = Convert.ToInt32(context.PropertyValue.ToString());
 
-            return !_seriesService.GetAllSeries().Exists(s => s.TvdbId == tvdbId);
+            return !_seriesService.AllSeriesTvdbIds().Any(s => s == tvdbId);
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation.Validators;
+using System.Linq;
+using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
 
@@ -27,7 +28,7 @@ namespace NzbDrone.Core.Validation.Paths
             dynamic instance = context.ParentContext.InstanceToValidate;
             var instanceId = (int)instance.Id;
 
-            return !_seriesService.GetAllSeries().Exists(s => s.Path.PathEquals(context.PropertyValue.ToString()) && s.Id != instanceId);
+            return !_seriesService.GetAllSeriesPaths().Any(s => s.Value.PathEquals(context.PropertyValue.ToString()) && s.Key != instanceId);
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
GetAllSeries is expensive due to deserialization of multiple json objects. Use GetAllSeriesPaths in SeriesPathValidator instead to speed up Series adds. 

#### Todos
- [ ] Tests

