### PR TITLE
New: Add CustomFormat field types to Discord OnGrab Notification

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -101,6 +101,14 @@ namespace NzbDrone.Core.Notifications.Discord
                         discordField.Name = "Links";
                         discordField.Value = GetLinksString(series);
                         break;
+                    case DiscordGrabFieldType.CustomFormats:
+                        discordField.Name = "Custom Formats";
+                        discordField.Value = string.Join("|", message.Episode.Release.CustomFormats);
+                        break;
+                    case DiscordGrabFieldType.CustomFormatScore:
+                        discordField.Name = "Custom Format Score";
+                        discordField.Value = message.Episode.Release.CustomFormatScore.ToString();
+                        break;
                     case DiscordGrabFieldType.Indexer:
                         discordField.Name = "Indexer";
                         discordField.Value = message.Episode.Release.Indexer;

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -103,11 +103,11 @@ namespace NzbDrone.Core.Notifications.Discord
                         break;
                     case DiscordGrabFieldType.CustomFormats:
                         discordField.Name = "Custom Formats";
-                        discordField.Value = string.Join("|", message.Episode.Release.CustomFormats);
+                        discordField.Value = string.Join("|", message.Episode.CustomFormats);
                         break;
                     case DiscordGrabFieldType.CustomFormatScore:
                         discordField.Name = "Custom Format Score";
-                        discordField.Value = message.Episode.Release.CustomFormatScore.ToString();
+                        discordField.Value = message.Episode.CustomFormatScore.ToString();
                         break;
                     case DiscordGrabFieldType.Indexer:
                         discordField.Name = "Indexer";

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordFieldType.cs
@@ -12,6 +12,8 @@ namespace NzbDrone.Core.Notifications.Discord
         Release,
         Poster,
         Fanart,
+        CustomFormats,
+        CustomFormatScore,
         Indexer
     }
 

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Discord
         public DiscordSettings()
         {
             // Set Default Fields
-            GrabFields = new[] { 0, 1, 2, 3, 5, 6, 7, 8, 9 };
+            GrabFields = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
             ImportFields = new[] { 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12 };
             ManualInteractionFields = new[] { 0, 1, 2, 3, 5, 6, 7, 8, 9 };
         }


### PR DESCRIPTION
Similar to Radarr, adds the ability to include parsed custom formats and CF score in the Discord webhook notification.
Are there even more options that could be included here?
Database Migration

NO
Description

See https://github.com/Sonarr/Sonarr/issues/5769.
Similar in nature to PR https://github.com/Sonarr/Sonarr/pull/5493
Todos

Tests (How?)

    Wiki Updates (None, except all the possible field types listed somewhere would be nice. Might open a PR for the wiki at some point)

Issues Fixed or Closed by this PR

Closes https://github.com/Sonarr/Sonarr/issues/5769