### PR TITLE
New: Show CF Score in episode row

### DIFF
--- a/frontend/src/Series/Details/EpisodeRow.css
+++ b/frontend/src/Series/Details/EpisodeRow.css
@@ -56,3 +56,9 @@
 
   width: 120px;
 }
+
+.customFormatScore {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+
+  width: 55px;
+}

--- a/frontend/src/Series/Details/EpisodeRow.css.d.ts
+++ b/frontend/src/Series/Details/EpisodeRow.css.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'audio': string;
   'audioLanguages': string;
+  'customFormatScore': string;
   'episodeNumber': string;
   'episodeNumberAnime': string;
   'languages': string;

--- a/frontend/src/Series/Details/EpisodeRow.js
+++ b/frontend/src/Series/Details/EpisodeRow.js
@@ -4,6 +4,7 @@ import MonitorToggleButton from 'Components/MonitorToggleButton';
 import RelativeDateCellConnector from 'Components/Table/Cells/RelativeDateCellConnector';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
+import Tooltip from 'Components/Tooltip/Tooltip';
 import EpisodeFormats from 'Episode/EpisodeFormats';
 import EpisodeNumber from 'Episode/EpisodeNumber';
 import EpisodeSearchCellConnector from 'Episode/EpisodeSearchCellConnector';
@@ -12,6 +13,7 @@ import EpisodeTitleLink from 'Episode/EpisodeTitleLink';
 import EpisodeFileLanguageConnector from 'EpisodeFile/EpisodeFileLanguageConnector';
 import MediaInfoConnector from 'EpisodeFile/MediaInfoConnector';
 import * as mediaInfoTypes from 'EpisodeFile/mediaInfoTypes';
+import { tooltipPositions } from 'Helpers/Props';
 import formatBytes from 'Utilities/Number/formatBytes';
 import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
 import formatRuntime from 'Utilities/Number/formatRuntime';
@@ -201,7 +203,14 @@ class EpisodeRow extends Component {
                   key={name}
                   className={styles.customFormatScore}
                 >
-                  {formatPreferredWordScore(customFormatScore)}
+                  <Tooltip
+                    anchor={formatPreferredWordScore(
+                      customFormatScore,
+                      customFormats.length
+                    )}
+                    tooltip={<EpisodeFormats formats={customFormats} />}
+                    position={tooltipPositions.BOTTOM}
+                  />
                 </TableRowCell>
               );
             }

--- a/frontend/src/Series/Details/EpisodeRow.js
+++ b/frontend/src/Series/Details/EpisodeRow.js
@@ -13,6 +13,7 @@ import EpisodeFileLanguageConnector from 'EpisodeFile/EpisodeFileLanguageConnect
 import MediaInfoConnector from 'EpisodeFile/MediaInfoConnector';
 import * as mediaInfoTypes from 'EpisodeFile/mediaInfoTypes';
 import formatBytes from 'Utilities/Number/formatBytes';
+import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
 import formatRuntime from 'Utilities/Number/formatRuntime';
 import styles from './EpisodeRow.css';
 
@@ -72,6 +73,7 @@ class EpisodeRow extends Component {
       episodeFileSize,
       releaseGroup,
       customFormats,
+      customFormatScore,
       alternateTitles,
       columns
     } = this.props;
@@ -189,6 +191,17 @@ class EpisodeRow extends Component {
                   <EpisodeFormats
                     formats={customFormats}
                   />
+                </TableRowCell>
+              );
+            }
+
+            if (name === 'customFormatScore') {
+              return (
+                <TableRowCell
+                  key={name}
+                  className={styles.customFormatScore}
+                >
+                  {formatPreferredWordScore(customFormatScore)}
                 </TableRowCell>
               );
             }
@@ -355,6 +368,7 @@ EpisodeRow.propTypes = {
   episodeFileSize: PropTypes.number,
   releaseGroup: PropTypes.string,
   customFormats: PropTypes.arrayOf(PropTypes.object),
+  customFormatScore: PropTypes.number.isRequired,
   mediaInfo: PropTypes.object,
   alternateTitles: PropTypes.arrayOf(PropTypes.object).isRequired,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Series/Details/EpisodeRowConnector.js
+++ b/frontend/src/Series/Details/EpisodeRowConnector.js
@@ -19,6 +19,7 @@ function createMapStateToProps() {
         episodeFileSize: episodeFile ? episodeFile.size : null,
         releaseGroup: episodeFile ? episodeFile.releaseGroup : null,
         customFormats: episodeFile ? episodeFile.customFormats : [],
+        customFormatScore: episodeFile ? episodeFile.customFormatScore : 0,
         alternateTitles: series.alternateTitles
       };
     }

--- a/frontend/src/Store/Actions/episodeActions.js
+++ b/frontend/src/Store/Actions/episodeActions.js
@@ -7,6 +7,7 @@ import episodeEntities from 'Episode/episodeEntities';
 import { icons, sortDirections } from 'Helpers/Props';
 import { createThunk, handleThunks } from 'Store/thunks';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
+import translate from 'Utilities/String/translate';
 import { updateItem } from './baseActions';
 import createFetchHandler from './Creators/createFetchHandler';
 import createHandleActions from './Creators/createHandleActions';

--- a/frontend/src/Store/Actions/episodeActions.js
+++ b/frontend/src/Store/Actions/episodeActions.js
@@ -1,8 +1,10 @@
 import _ from 'lodash';
+import React from 'react';
 import { createAction } from 'redux-actions';
 import { batchActions } from 'redux-batched-actions';
+import Icon from 'Components/Icon';
 import episodeEntities from 'Episode/episodeEntities';
-import { sortDirections } from 'Helpers/Props';
+import { icons, sortDirections } from 'Helpers/Props';
 import { createThunk, handleThunks } from 'Store/thunks';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import { updateItem } from './baseActions';
@@ -107,6 +109,15 @@ export const defaultState = {
     {
       name: 'customFormats',
       label: 'Formats',
+      isVisible: false
+    },
+    {
+      name: 'customFormatScore',
+      columnLabel: 'Custom Format Score',
+      label: React.createElement(Icon, {
+        name: icons.SCORE,
+        title: 'Custom format score'
+      }),
       isVisible: false
     },
     {

--- a/frontend/src/Store/Actions/episodeActions.js
+++ b/frontend/src/Store/Actions/episodeActions.js
@@ -113,10 +113,10 @@ export const defaultState = {
     },
     {
       name: 'customFormatScore',
-      columnLabel: 'Custom Format Score',
+      columnLabel: translate('CustomFormatScore'),
       label: React.createElement(Icon, {
         name: icons.SCORE,
-        title: 'Custom format score'
+        title: translate('CustomFormatScore')
       }),
       isVisible: false
     },

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -25,6 +25,7 @@
   "CountImportListsSelected": "{count} import list(s) selected",
   "CountIndexersSelected": "{count} indexer(s) selected",
   "CountSeasons": "{count} seasons",
+  "CustomFormatScore": "Custom Format Score",
   "Delete": "Delete",
   "DeleteCondition": "Delete Condition",
   "DeleteConditionMessageText": "Are you sure you want to delete the condition '{0}'?",

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -69,7 +69,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
 
             model.Series = series;
             var customFormats = formatCalculationService?.ParseCustomFormat(model, model.Series);
-            var customFormatScore = series?.QualityProfile.Value.CalculateCustomFormatScore(customFormats) ?? 0;
+            var customFormatScore = series?.QualityProfile?.Value?.CalculateCustomFormatScore(customFormats) ?? 0;
 
             return new EpisodeFileResource
             {

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileResource.cs
@@ -24,6 +24,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
         public List<Language> Languages { get; set; }
         public QualityModel Quality { get; set; }
         public List<CustomFormatResource> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
         public MediaInfoResource MediaInfo { get; set; }
 
         public bool QualityCutoffNotMet { get; set; }
@@ -67,6 +68,8 @@ namespace Sonarr.Api.V3.EpisodeFiles
             }
 
             model.Series = series;
+            var customFormats = formatCalculationService?.ParseCustomFormat(model, model.Series);
+            var customFormatScore = series?.QualityProfile.Value.CalculateCustomFormatScore(customFormats) ?? 0;
 
             return new EpisodeFileResource
             {
@@ -84,7 +87,8 @@ namespace Sonarr.Api.V3.EpisodeFiles
                 Quality = model.Quality,
                 MediaInfo = model.MediaInfo.ToResource(model.SceneName),
                 QualityCutoffNotMet = upgradableSpecification.QualityCutoffNotMet(series.QualityProfile.Value, model.Quality),
-                CustomFormats = formatCalculationService.ParseCustomFormat(model).ToResource(false)
+                CustomFormats = customFormats.ToResource(false),
+                CustomFormatScore = customFormatScore
             };
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This commit adds the Custom Format column in the series episode row view. This is to be consistent with fields available in 
History, Queue, Search, etc.. This is something I wanted for my personal use at least

![image](https://github.com/Sonarr/Sonarr/assets/62065280/7541c8ff-12f3-4316-b9e6-799e4fdf532c)

Disclaimer: I am not a React Developer and am hacking this together from existing code. If there is a better way to integrate all table views with consistent column view options, I am completely open to redesigning.

#### Todos
- [ ] Tests (None?)
- [x] Wiki Updates (N/A)


#### Issues Fixed or Closed by this PR

* 
