### PR TITLE
New: Add CF Score to import modal

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
@@ -131,7 +131,7 @@ const COLUMNS = [
       name: icons.INTERACTIVE,
       title: 'Custom Format',
     }),
-    isSortable: true,
+    isSortable: false,
     isVisible: true,
   },
   {

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
@@ -131,7 +131,7 @@ const COLUMNS = [
       name: icons.INTERACTIVE,
       title: 'Custom Format',
     }),
-    isSortable: false,
+    isSortable: true,
     isVisible: true,
   },
   {

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -30,6 +30,8 @@ import {
 import { SelectStateInputProps } from 'typings/props';
 import Rejection from 'typings/Rejection';
 import formatBytes from 'Utilities/Number/formatBytes';
+import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import translate from 'Utilities/String/translate';
 import InteractiveImportRowCellPlaceholder from './InteractiveImportRowCellPlaceholder';
 import styles from './InteractiveImportRow.css';
 
@@ -57,6 +59,7 @@ interface InteractiveImportRowProps {
   languages?: Language[];
   size: number;
   customFormats?: object[];
+  customFormatScore?: number;
   rejections: Rejection[];
   columns: Column[];
   episodeFileId?: number;
@@ -80,6 +83,7 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
     releaseGroup,
     size,
     customFormats,
+    customFormatScore,
     rejections,
     isReprocessing,
     isSelected,
@@ -427,8 +431,8 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
       <TableRowCell>
         {customFormats?.length ? (
           <Popover
-            anchor={<Icon name={icons.INTERACTIVE} />}
-            title="Formats"
+            anchor={formatPreferredWordScore(customFormatScore)}
+            title={translate('CustomFormats')}
             body={
               <div className={styles.customFormatTooltip}>
                 <EpisodeFormats formats={customFormats} />

--- a/frontend/src/Store/Actions/interactiveImportActions.js
+++ b/frontend/src/Store/Actions/interactiveImportActions.js
@@ -47,6 +47,10 @@ export const defaultState = {
 
     quality: function(item, direction) {
       return item.qualityWeight || 0;
+    },
+
+    customFormats: function(item, direction) {
+      return item.customFormatScore;
     }
   }
 };

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -43,7 +43,7 @@ namespace Sonarr.Api.V3.ManualImport
             }
 
             var customFormats = model.CustomFormats;
-            var customFormatScore = model.Series?.QualityProfile.Value.CalculateCustomFormatScore(customFormats) ?? 0;
+            var customFormatScore = model.Series?.QualityProfile?.Value?.CalculateCustomFormatScore(customFormats) ?? 0;
 
             return new ManualImportResource
             {

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportResource.cs
@@ -29,6 +29,7 @@ namespace Sonarr.Api.V3.ManualImport
         public int QualityWeight { get; set; }
         public string DownloadId { get; set; }
         public List<CustomFormatResource> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
         public IEnumerable<Rejection> Rejections { get; set; }
     }
 
@@ -40,6 +41,9 @@ namespace Sonarr.Api.V3.ManualImport
             {
                 return null;
             }
+
+            var customFormats = model.CustomFormats;
+            var customFormatScore = model.Series?.QualityProfile.Value.CalculateCustomFormatScore(customFormats) ?? 0;
 
             return new ManualImportResource
             {
@@ -56,7 +60,8 @@ namespace Sonarr.Api.V3.ManualImport
                 ReleaseGroup = model.ReleaseGroup,
                 Quality = model.Quality,
                 Languages = model.Languages,
-                CustomFormats = model.CustomFormats.ToResource(false),
+                CustomFormats = customFormats.ToResource(false),
+                CustomFormatScore = customFormatScore,
 
                 // QualityWeight
                 DownloadId = model.DownloadId,


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
This PR adds custom format score information in the Manual Import modal and consequenctly manage series episodes modal.

This is part of my ongong effort to include CF Score data where-ever custom formats are shown/returned by the API

I am more than open to alternative approaches.
![image](https://github.com/Sonarr/Sonarr/assets/62065280/d2af33b5-99a9-4c3c-9ef5-ccb5e723ea7a)

I think the UI on this one could use some tweaking. Perhaps keeping the icon next to the score number.
I also couldn't get sorting by CF column working. I think it should sort by the score value. 
#### Todos
- [ ] Tests (None?)
- [ ] Wiki Updates (N/A)


#### Issues Fixed or Closed by this PR

* 
