### PR TITLE
Fixed: Allow `noChange` as value in QualityProfileSelect

### DIFF
--- a/frontend/src/Components/Form/QualityProfileSelectInputConnector.js
+++ b/frontend/src/Components/Form/QualityProfileSelectInputConnector.js
@@ -69,7 +69,7 @@ class QualityProfileSelectInputConnector extends Component {
   // Listeners
 
   onChange = ({ name, value }) => {
-    this.props.onChange({ name, value: parseInt(value) });
+    this.props.onChange({ name, value: value === 'noChange' ? value : parseInt(value) });
   };
 
   //


### PR DESCRIPTION
#### Database Migration
NO

#### Description
As described on #development channel, allowing `noChange` as value for quality profile select.

```
Warning: Received NaN for the `value` attribute. If this is expected, cast the value to a string.
select
SelectInput@webpack-internal:///10453:13:5
```