### PR TITLE
AnimeStandardFormatSearch option also looks for season packs

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubRequestGeneratorFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Test.IndexerTests.FanzubTests
     {
         private SeasonSearchCriteria _seasonSearchCriteria;
         private AnimeEpisodeSearchCriteria _animeSearchCriteria;
+        private AnimeSeasonSearchCriteria _animeSeasonSearchCriteria;
 
         [SetUp]
         public void SetUp()
@@ -33,6 +34,12 @@ namespace NzbDrone.Core.Test.IndexerTests.FanzubTests
                 AbsoluteEpisodeNumber = 9,
                 SeasonNumber = 1,
                 EpisodeNumber = 9
+            };
+
+            _animeSeasonSearchCriteria = new AnimeSeasonSearchCriteria()
+            {
+                SceneTitles = new List<string>() { "Naruto Shippuuden" },
+                SeasonNumber = 3,
             };
         }
 
@@ -80,6 +87,19 @@ namespace NzbDrone.Core.Test.IndexerTests.FanzubTests
             var page = results.GetAllTiers().First().First();
 
             page.Url.FullUri.Should().Contain("q=\"Naruto+Shippuuden%2009\"|\"Naruto+Shippuuden%20-%2009\"|\"Naruto+Shippuuden%20S01E09\"|\"Naruto+Shippuuden%20-%20S01E09\"");
+        }
+
+        [Test]
+        public void should_search_by_standard_season_number()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetAllTiers().Should().HaveCount(1);
+
+            var page = results.GetAllTiers().First().First();
+
+            page.Url.FullUri.Should().Contain("q=\"Naruto+Shippuuden%20S03\"|\"Naruto+Shippuuden%20-%20S03\"");
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         private SingleEpisodeSearchCriteria _singleEpisodeSearchCriteria;
         private SeasonSearchCriteria _seasonSearchCriteria;
         private AnimeEpisodeSearchCriteria _animeSearchCriteria;
+        private AnimeSeasonSearchCriteria _animeSeasonSearchCriteria;
         private NewznabCapabilities _capabilities;
 
         [SetUp]
@@ -49,6 +50,13 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
                 AbsoluteEpisodeNumber = 100,
                 SeasonNumber = 5,
                 EpisodeNumber = 4
+            };
+
+            _animeSeasonSearchCriteria = new AnimeSeasonSearchCriteria()
+            {
+                Series = new Tv.Series { TvRageId = 10, TvdbId = 20, TvMazeId = 30, ImdbId = "t40" },
+                SceneTitles = new List<string> { "Monkey Island" },
+                SeasonNumber = 3,
             };
 
             _capabilities = new NewznabCapabilities();
@@ -160,6 +168,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             pages[1].Url.FullUri.Should().Contain("rid=10&season=5&ep=4");
             pages[2].Url.FullUri.Should().Contain("q=Monkey%20Island+100");
             pages[3].Url.FullUri.Should().Contain("q=Monkey%20Island&season=5&ep=4");
+        }
+
+        [Test]
+        public void should_search_by_standard_season_number()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetTier(0).Should().HaveCount(2);
+            var pages = results.GetTier(0).Select(t => t.First()).ToList();
+
+            pages[0].Url.FullUri.Should().Contain("rid=10&season=3");
+            pages[1].Url.FullUri.Should().Contain("q=Monkey%20Island&season=3");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
     {
         private SeasonSearchCriteria _seasonSearchCriteria;
         private AnimeEpisodeSearchCriteria _animeSearchCriteria;
+        private AnimeSeasonSearchCriteria _animeSeasonSearchCriteria;
 
         [SetUp]
         public void SetUp()
@@ -33,6 +34,12 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
                 AbsoluteEpisodeNumber = 9,
                 SeasonNumber = 1,
                 EpisodeNumber = 9
+            };
+
+            _animeSeasonSearchCriteria = new AnimeSeasonSearchCriteria()
+            {
+                SceneTitles = new List<string>() { "Naruto Shippuuden" },
+                SeasonNumber = 3
             };
         }
 
@@ -81,6 +88,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
             pages[0].Url.FullUri.Should().Contain("term=Naruto+Shippuuden+9");
             pages[1].Url.FullUri.Should().Contain("term=Naruto+Shippuuden+09");
             pages[2].Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s01e09");
+        }
+
+        [Test]
+        public void should_search_by_standard_season_number()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetAllTiers().Should().HaveCount(1);
+
+            var page = results.GetAllTiers().First().First();
+
+            page.Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeEpisodeSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeEpisodeSearchCriteria.cs
@@ -1,4 +1,4 @@
-﻿namespace NzbDrone.Core.IndexerSearch.Definitions
+namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public class AnimeEpisodeSearchCriteria : SearchCriteriaBase
     {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
@@ -1,0 +1,12 @@
+namespace NzbDrone.Core.IndexerSearch.Definitions
+{
+    public class AnimeSeasonSearchCriteria : SearchCriteriaBase
+    {
+        public int SeasonNumber { get; set; }
+
+        public override string ToString()
+        {
+            return $"[{Series.Title} : S{SeasonNumber:00}]";
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -42,8 +42,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public virtual IndexerPageableRequestChain GetSearchRequests(SingleEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 foreach (var episode in searchCriteria.Episodes)
@@ -63,8 +63,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public virtual IndexerPageableRequestChain GetSearchRequests(SeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 foreach (var seasonNumber in searchCriteria.Episodes.Select(v => v.SeasonNumber).Distinct())
@@ -89,8 +89,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public virtual IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 parameters.Category = "Episode";
@@ -117,8 +117,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 parameters.Category = "Episode";
@@ -145,8 +145,8 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 foreach (var episode in searchCriteria.Episodes)
@@ -173,11 +173,37 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+            var parameters = new BroadcastheNetTorrentQuery();
+
+            if (AddSeriesSearchParameters(parameters, searchCriteria))
+            {
+                foreach (var seasonNumber in searchCriteria.Episodes.Select(v => v.SeasonNumber).Distinct())
+                {
+                    parameters.Category = "Season";
+                    parameters.Name = string.Format("Season {0}%", seasonNumber);
+
+                    pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
+
+                    parameters = parameters.Clone();
+
+                    parameters.Category = "Episode";
+                    parameters.Name = string.Format("S{0:00}E%", seasonNumber);
+
+                    pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
+                }
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var parameters = new BroadcastheNetTorrentQuery();
+
             if (AddSeriesSearchParameters(parameters, searchCriteria))
             {
                 var episodeQueryTitle = searchCriteria.Episodes.Where(e => !string.IsNullOrWhiteSpace(e.Title))

--- a/src/NzbDrone.Core/Indexers/Fanzub/FanzubRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Fanzub/FanzubRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -69,6 +69,19 @@ namespace NzbDrone.Core.Indexers.Fanzub
             }
 
             pageableRequests.Add(GetPagedRequests(string.Join("|", searchTitles)));
+
+            return pageableRequests;
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+            {
+                var searchTitles = searchCriteria.CleanSceneTitles.SelectMany(v => GetSeasonSearchStrings(v, searchCriteria.SeasonNumber)).ToList();
+                pageableRequests.Add(GetPagedRequests(string.Join("|", searchTitles)));
+            }
 
             return pageableRequests;
         }

--- a/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
@@ -103,6 +103,17 @@ namespace NzbDrone.Core.Indexers.FileList
             return pageableRequests;
         }
 
+        public IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            AddImdbRequests(pageableRequests, searchCriteria, "search-torrents", Settings.AnimeCategories, $"&season={searchCriteria.SeasonNumber}");
+            pageableRequests.AddTier();
+            AddNameRequests(pageableRequests, searchCriteria, "search-torrents", Settings.AnimeCategories, $"&season={searchCriteria.SeasonNumber}");
+
+            return pageableRequests;
+        }
+
         public IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsRequestGenerator.cs
@@ -24,8 +24,8 @@ namespace NzbDrone.Core.Indexers.HDBits
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var queryBase = new TorrentQuery();
+
             if (TryAddSearchParameters(queryBase, searchCriteria))
             {
                 foreach (var episode in searchCriteria.Episodes)
@@ -40,6 +40,26 @@ namespace NzbDrone.Core.Indexers.HDBits
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+            var queryBase = new TorrentQuery();
+
+            if (TryAddSearchParameters(queryBase, searchCriteria))
+            {
+                foreach (var seasonNumber in searchCriteria.Episodes.Select(e => e.SeasonNumber).Distinct())
+                {
+                    var query = queryBase.Clone();
+
+                    query.TvdbInfo.Season = seasonNumber;
+
+                    pageableRequests.Add(GetRequest(query));
+                }
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
@@ -48,8 +68,8 @@ namespace NzbDrone.Core.Indexers.HDBits
         public virtual IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var query = new TorrentQuery();
+
             if (TryAddSearchParameters(query, searchCriteria))
             {
                 query.Search = string.Format("{0:yyyy}-{0:MM}-{0:dd}", searchCriteria.AirDate);
@@ -63,8 +83,8 @@ namespace NzbDrone.Core.Indexers.HDBits
         public virtual IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var query = new TorrentQuery();
+
             if (TryAddSearchParameters(query, searchCriteria))
             {
                 query.Search = string.Format("{0}-", searchCriteria.Year);
@@ -78,8 +98,8 @@ namespace NzbDrone.Core.Indexers.HDBits
         public virtual IndexerPageableRequestChain GetSearchRequests(SeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var queryBase = new TorrentQuery();
+
             if (TryAddSearchParameters(queryBase, searchCriteria))
             {
                 foreach (var seasonNumber in searchCriteria.Episodes.Select(e => e.SeasonNumber).Distinct())
@@ -98,8 +118,8 @@ namespace NzbDrone.Core.Indexers.HDBits
         public virtual IndexerPageableRequestChain GetSearchRequests(SingleEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
             var queryBase = new TorrentQuery();
+
             if (TryAddSearchParameters(queryBase, searchCriteria))
             {
                 foreach (var episode in searchCriteria.Episodes)

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -100,6 +100,16 @@ namespace NzbDrone.Core.Indexers
             return FetchReleases(g => g.GetSearchRequests(searchCriteria));
         }
 
+        public override IList<ReleaseInfo> Fetch(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            if (!SupportsSearch)
+            {
+                return Array.Empty<ReleaseInfo>();
+            }
+
+            return FetchReleases(g => g.GetSearchRequests(searchCriteria));
+        }
+
         public override IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria)
         {
             if (!SupportsSearch)

--- a/src/NzbDrone.Core/Indexers/IIndexer.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexer.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Indexers
         IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
+        IList<ReleaseInfo> Fetch(AnimeSeasonSearchCriteria searchCriteria);
         IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
         HttpRequest GetDownloadRequest(string link);
     }

--- a/src/NzbDrone.Core/Indexers/IIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/IIndexerRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.IndexerSearch.Definitions;
 
 namespace NzbDrone.Core.Indexers
 {
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Indexers
         IndexerPageableRequestChain GetSearchRequests(DailyEpisodeSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(DailySeasonSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria);
+        IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria);
         IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria);
     }
 }

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
 
@@ -38,6 +38,11 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -73,6 +73,7 @@ namespace NzbDrone.Core.Indexers
         public abstract IList<ReleaseInfo> Fetch(DailyEpisodeSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(DailySeasonSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(AnimeEpisodeSearchCriteria searchCriteria);
+        public abstract IList<ReleaseInfo> Fetch(AnimeSeasonSearchCriteria searchCriteria);
         public abstract IList<ReleaseInfo> Fetch(SpecialEpisodeSearchCriteria searchCriteria);
         public abstract HttpRequest GetDownloadRequest(string link);
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -430,6 +430,31 @@ namespace NzbDrone.Core.Indexers.Newznab
             return pageableRequests;
         }
 
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            if (SupportsSearch && Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+            {
+                AddTvIdPageableRequests(pageableRequests,
+                    Settings.AnimeCategories,
+                    searchCriteria,
+                    $"&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}");
+
+                var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
+
+                foreach (var queryTitle in queryTitles)
+                {
+                    pageableRequests.Add(GetPagedRequests(MaxPages,
+                        Settings.AnimeCategories,
+                        "tvsearch",
+                        $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
+                }
+            }
+
+            return pageableRequests;
+        }
+
         public virtual IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -86,6 +86,21 @@ namespace NzbDrone.Core.Indexers.Nyaa
                 if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0 && searchCriteria.EpisodeNumber > 0)
                 {
                     pageableRequests.Add(GetPagedRequests(MaxPages, $"{searchTitle}+s{searchCriteria.SeasonNumber:00}e{searchCriteria.EpisodeNumber:00}"));
+                }
+            }
+
+            return pageableRequests;
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
+            {
+                if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+                {
+                    pageableRequests.Add(GetPagedRequests(MaxPages, $"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/RssIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/RssIndexerRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using NzbDrone.Common.Http;
+using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
 
 namespace NzbDrone.Core.Indexers
@@ -42,6 +42,11 @@ namespace NzbDrone.Core.Indexers
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -39,6 +39,11 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }

--- a/src/NzbDrone.Core/Indexers/Torrentleech/TorrentleechRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Torrentleech/TorrentleechRequestGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.IndexerSearch.Definitions;
 
@@ -38,6 +38,11 @@ namespace NzbDrone.Core.Indexers.Torrentleech
         }
 
         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchCriteria searchCriteria)
+        {
+            return new IndexerPageableRequestChain();
+        }
+
+        public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
         {
             return new IndexerPageableRequestChain();
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Implemented the new search criteria object, `AnimeSeasonSearchCriteria`, and applied it where it might be needed throughout the codebase. Generally paired with wherever `AnimeEpisodeSearchCriteria` is referenced. Added some minor tests that are similar to the already existing tests. Now, when the `AnimeStandardFormatSearch` option is enabled in the indexer settings, season packs will also be found in addition to its original function.


#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* https://github.com/Sonarr/Sonarr/issues/5616
