### PR TITLE
Cache busting for CSS files

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -91,7 +91,8 @@ module.exports = (env) => {
       }),
 
       new MiniCssExtractPlugin({
-        filename: 'Content/styles.css'
+        filename: 'Content/styles.css',
+        chunkFilename: 'Content/[id]-[chunkhash].css'
       }),
 
       new HtmlWebpackPlugin({


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Seems like the CSS files need a cache busting too. On iOS without clear all cache I can't make it see the new style. 