### PR TITLE
New: Add ValueHash for hidden API keys via the API

### DIFF
--- a/src/Sonarr.Http/ClientSchema/Field.cs
+++ b/src/Sonarr.Http/ClientSchema/Field.cs
@@ -13,6 +13,7 @@ namespace Sonarr.Http.ClientSchema
         public string HelpTextWarning { get; set; }
         public string HelpLink { get; set; }
         public object Value { get; set; }
+        public string ValueHash { get; set; }
         public string Type { get; set; }
         public bool Advanced { get; set; }
         public List<SelectOption> SelectOptions { get; set; }

--- a/src/Sonarr.Http/ClientSchema/SchemaBuilder.cs
+++ b/src/Sonarr.Http/ClientSchema/SchemaBuilder.cs
@@ -7,6 +7,7 @@ using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Reflection;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core;
 using NzbDrone.Core.Annotations;
 
 namespace Sonarr.Http.ClientSchema
@@ -30,8 +31,13 @@ namespace Sonarr.Http.ClientSchema
                 field.Value = mapping.GetterFunc(model);
 
                 if (field.Value != null && !field.Value.Equals(string.Empty) &&
-                    (field.Privacy == PrivacyLevel.ApiKey || field.Privacy == PrivacyLevel.Password))
+                    field.Privacy is PrivacyLevel.ApiKey or PrivacyLevel.Password)
                 {
+                    if (field.Privacy == PrivacyLevel.ApiKey)
+                    {
+                        field.ValueHash = field.Value.ToString()?.SHA256Hash()?.AsSpan(0, 6).ToString();
+                    }
+
                     field.Value = PRIVATE_VALUE;
                 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Looks like 570be882154e73f8ad1de5b16b957bcb964697fd is breaking the applications sync from Prowlarr making it see the remote indexer always changed due to mismatch between Prowlarr's apikey and `********` thus triggering a new indexer sync every 6 hours or when sync apps is manually triggered. So I'm adding the value hash to have something to compare.