### PR TITLE
Fixed: Recalculate Custom Format Score in Manual Import

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.js
+++ b/frontend/src/Activity/History/Details/HistoryDetails.js
@@ -7,7 +7,7 @@ import DescriptionListItemTitle from 'Components/DescriptionList/DescriptionList
 import Link from 'Components/Link/Link';
 import formatDateTime from 'Utilities/Date/formatDateTime';
 import formatAge from 'Utilities/Number/formatAge';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import styles from './HistoryDetails.css';
 
 function HistoryDetails(props) {
@@ -68,7 +68,7 @@ function HistoryDetails(props) {
           customFormatScore && customFormatScore !== '0' ?
             <DescriptionListItem
               title="Custom Format Score"
-              data={formatPreferredWordScore(customFormatScore)}
+              data={formatCustomFormatScore(customFormatScore)}
             /> :
             null
         }
@@ -200,7 +200,7 @@ function HistoryDetails(props) {
           customFormatScore && customFormatScore !== '0' ?
             <DescriptionListItem
               title="Custom Format Score"
-              data={formatPreferredWordScore(customFormatScore)}
+              data={formatCustomFormatScore(customFormatScore)}
             /> :
             null
         }
@@ -246,7 +246,7 @@ function HistoryDetails(props) {
           customFormatScore && customFormatScore !== '0' ?
             <DescriptionListItem
               title="Custom Format Score"
-              data={formatPreferredWordScore(customFormatScore)}
+              data={formatCustomFormatScore(customFormatScore)}
             /> :
             null
         }

--- a/frontend/src/Activity/History/HistoryRow.js
+++ b/frontend/src/Activity/History/HistoryRow.js
@@ -13,7 +13,7 @@ import EpisodeTitleLink from 'Episode/EpisodeTitleLink';
 import SeasonEpisodeNumber from 'Episode/SeasonEpisodeNumber';
 import { icons, tooltipPositions } from 'Helpers/Props';
 import SeriesTitleLink from 'Series/SeriesTitleLink';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import HistoryDetailsModal from './Details/HistoryDetailsModal';
 import HistoryEventTypeCell from './HistoryEventTypeCell';
 import styles from './HistoryRow.css';
@@ -212,7 +212,7 @@ class HistoryRow extends Component {
                   className={styles.customFormatScore}
                 >
                   <Tooltip
-                    anchor={formatPreferredWordScore(
+                    anchor={formatCustomFormatScore(
                       customFormatScore,
                       customFormats.length
                     )}

--- a/frontend/src/Activity/Queue/QueueRow.js
+++ b/frontend/src/Activity/Queue/QueueRow.js
@@ -18,7 +18,7 @@ import { icons, kinds, tooltipPositions } from 'Helpers/Props';
 import InteractiveImportModal from 'InteractiveImport/InteractiveImportModal';
 import SeriesTitleLink from 'Series/SeriesTitleLink';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import QueueStatusCell from './QueueStatusCell';
 import RemoveQueueItemModal from './RemoveQueueItemModal';
 import TimeleftCell from './TimeleftCell';
@@ -269,7 +269,7 @@ class QueueRow extends Component {
                   className={styles.customFormatScore}
                 >
                   <Tooltip
-                    anchor={formatPreferredWordScore(
+                    anchor={formatCustomFormatScore(
                       customFormatScore,
                       customFormats.length
                     )}

--- a/frontend/src/Episode/History/EpisodeHistoryRow.js
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.js
@@ -14,7 +14,7 @@ import EpisodeFormats from 'Episode/EpisodeFormats';
 import EpisodeLanguages from 'Episode/EpisodeLanguages';
 import EpisodeQuality from 'Episode/EpisodeQuality';
 import { icons, kinds, tooltipPositions } from 'Helpers/Props';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import styles from './EpisodeHistoryRow.css';
 
 function getTitle(eventType) {
@@ -126,7 +126,7 @@ class EpisodeHistoryRow extends Component {
         <TableRowCell className={styles.customFormatScore}>
           <Tooltip
             anchor={
-              formatPreferredWordScore(customFormatScore, customFormats.length)
+              formatCustomFormatScore(customFormatScore, customFormats.length)
             }
             tooltip={<EpisodeFormats formats={customFormats} />}
             position={tooltipPositions.BOTTOM}

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -431,7 +431,10 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
       <TableRowCell>
         {customFormats?.length ? (
           <Popover
-            anchor={formatCustomFormatScore(customFormatScore)}
+            anchor={formatCustomFormatScore(
+              customFormatScore,
+              customFormats.length
+            )}
             title={translate('CustomFormats')}
             body={
               <div className={styles.customFormatTooltip}>

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -30,7 +30,7 @@ import {
 import { SelectStateInputProps } from 'typings/props';
 import Rejection from 'typings/Rejection';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import translate from 'Utilities/String/translate';
 import InteractiveImportRowCellPlaceholder from './InteractiveImportRowCellPlaceholder';
 import styles from './InteractiveImportRow.css';
@@ -431,7 +431,7 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
       <TableRowCell>
         {customFormats?.length ? (
           <Popover
-            anchor={formatPreferredWordScore(customFormatScore)}
+            anchor={formatCustomFormatScore(customFormatScore)}
             title={translate('CustomFormats')}
             body={
               <div className={styles.customFormatTooltip}>

--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -19,7 +19,7 @@ import CustomFormat from 'typings/CustomFormat';
 import formatDateTime from 'Utilities/Date/formatDateTime';
 import formatAge from 'Utilities/Number/formatAge';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import OverrideMatchModal from './OverrideMatch/OverrideMatchModal';
 import Peers from './Peers';
 import ReleaseEpisode from './ReleaseEpisode';
@@ -236,7 +236,7 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
 
       <TableRowCell className={styles.customFormatScore}>
         <Tooltip
-          anchor={formatPreferredWordScore(
+          anchor={formatCustomFormatScore(
             customFormatScore,
             customFormats.length
           )}

--- a/frontend/src/Series/Details/EpisodeRow.js
+++ b/frontend/src/Series/Details/EpisodeRow.js
@@ -15,7 +15,7 @@ import MediaInfoConnector from 'EpisodeFile/MediaInfoConnector';
 import * as mediaInfoTypes from 'EpisodeFile/mediaInfoTypes';
 import { tooltipPositions } from 'Helpers/Props';
 import formatBytes from 'Utilities/Number/formatBytes';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import formatRuntime from 'Utilities/Number/formatRuntime';
 import styles from './EpisodeRow.css';
 
@@ -204,7 +204,7 @@ class EpisodeRow extends Component {
                   className={styles.customFormatScore}
                 >
                   <Tooltip
-                    anchor={formatPreferredWordScore(
+                    anchor={formatCustomFormatScore(
                       customFormatScore,
                       customFormats.length
                     )}

--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -16,7 +16,7 @@ import EpisodeNumber from 'Episode/EpisodeNumber';
 import EpisodeQuality from 'Episode/EpisodeQuality';
 import SeasonEpisodeNumber from 'Episode/SeasonEpisodeNumber';
 import { icons, kinds, tooltipPositions } from 'Helpers/Props';
-import formatPreferredWordScore from 'Utilities/Number/formatPreferredWordScore';
+import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import styles from './SeriesHistoryRow.css';
 
 function getTitle(eventType) {
@@ -146,7 +146,7 @@ class SeriesHistoryRow extends Component {
         <TableRowCell className={styles.customFormatScore}>
           <Tooltip
             anchor={
-              formatPreferredWordScore(customFormatScore, customFormats.length)
+              formatCustomFormatScore(customFormatScore, customFormats.length)
             }
             tooltip={<EpisodeFormats formats={customFormats} />}
             position={tooltipPositions.BOTTOM}

--- a/frontend/src/Utilities/Number/formatCustomFormatScore.ts
+++ b/frontend/src/Utilities/Number/formatCustomFormatScore.ts
@@ -1,5 +1,7 @@
-
-function formatPreferredWordScore(input, customFormatsLength = 0) {
+function formatCustomFormatScore(
+  input?: number,
+  customFormatsLength = 0
+): string {
   const score = Number(input);
 
   if (score > 0) {
@@ -7,10 +9,10 @@ function formatPreferredWordScore(input, customFormatsLength = 0) {
   }
 
   if (score < 0) {
-    return score;
+    return `${score}`;
   }
 
   return customFormatsLength > 0 ? '+0' : '';
 }
 
-export default formatPreferredWordScore;
+export default formatCustomFormatScore;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         public string ReleaseGroup { get; set; }
         public string DownloadId { get; set; }
         public List<CustomFormat> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
         public IEnumerable<Rejection> Rejections { get; set; }
 
         public ManualImportItem()

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -393,6 +393,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 item.Series = decision.LocalEpisode.Series;
 
                 item.CustomFormats = _formatCalculator.ParseCustomFormat(decision.LocalEpisode);
+                item.CustomFormatScore = item.Series.QualityProfile?.Value.CalculateCustomFormatScore(item.CustomFormats) ?? 0;
             }
 
             if (decision.LocalEpisode.Episodes.Any() && decision.LocalEpisode.Episodes.Select(c => c.SeasonNumber).Distinct().Count() == 1)

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
@@ -5,6 +5,7 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Manual;
 using NzbDrone.Core.Qualities;
+using Sonarr.Api.V3.CustomFormats;
 using Sonarr.Api.V3.Episodes;
 using Sonarr.Http;
 
@@ -43,6 +44,8 @@ namespace Sonarr.Api.V3.ManualImport
                 item.SeasonNumber = processedItem.SeasonNumber;
                 item.Episodes = processedItem.Episodes.ToResource();
                 item.Rejections = processedItem.Rejections;
+                item.CustomFormats = processedItem.CustomFormats.ToResource(false);
+                item.CustomFormatScore = processedItem.CustomFormatScore;
 
                 // Only set the language/quality if they're unknown and languages were returned.
                 // Languages won't be returned when reprocessing if the season/episode isn't filled in yet and we don't want to return no languages to the client.

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportReprocessResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportReprocessResource.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Qualities;
+using Sonarr.Api.V3.CustomFormats;
 using Sonarr.Api.V3.Episodes;
 using Sonarr.Http.REST;
 
@@ -18,7 +19,8 @@ namespace Sonarr.Api.V3.ManualImport
         public List<Language> Languages { get; set; }
         public string ReleaseGroup { get; set; }
         public string DownloadId { get; set; }
-
+        public List<CustomFormatResource> CustomFormats { get; set; }
+        public int CustomFormatScore { get; set; }
         public IEnumerable<Rejection> Rejections { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Sadly 972e1408993fc4656196087c6646f23d222e41f5 didn't consider that the resource can be reprocessed on changes of rls grp, quality, etc.
- Renamed `formatPreferredWordScore` to `formatCustomFormatScore`