### PR TITLE
Fixed: Add dedupe releases rule based on indexer priority

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -548,9 +548,10 @@ namespace NzbDrone.Core.IndexerSearch
 
         private List<DownloadDecision> DeDupeDecisions(List<DownloadDecision> decisions)
         {
-            // De-dupe reports by guid so duplicate results aren't returned. Pick the one with the least rejections.
-
-            return decisions.GroupBy(d => d.RemoteEpisode.Release.Guid).Select(d => d.OrderBy(v => v.Rejections.Count()).First()).ToList();
+            // De-dupe reports by guid so duplicate results aren't returned. Pick the one with the least rejections and higher indexer priority.
+            return decisions.GroupBy(d => d.RemoteEpisode.Release.Guid)
+                .Select(d => d.OrderBy(v => v.Rejections.Count()).ThenBy(v => v.RemoteEpisode?.Release?.IndexerPriority ?? IndexerDefinition.DefaultPriority).First())
+                .ToList();
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
@@ -4,6 +4,13 @@ namespace NzbDrone.Core.Indexers
 {
     public class IndexerDefinition : ProviderDefinition
     {
+        public const int DefaultPriority = 25;
+
+        public IndexerDefinition()
+        {
+            Priority = DefaultPriority;
+        }
+
         public bool EnableRss { get; set; }
         public bool EnableAutomaticSearch { get; set; }
         public bool EnableInteractiveSearch { get; set; }
@@ -11,7 +18,7 @@ namespace NzbDrone.Core.Indexers
         public DownloadProtocol Protocol { get; set; }
         public bool SupportsRss { get; set; }
         public bool SupportsSearch { get; set; }
-        public int Priority { get; set; } = 25;
+        public int Priority { get; set; }
         public int SeasonSearchMaximumSingleEpisodeAge { get; set; }
 
         public override bool Enable => EnableRss || EnableAutomaticSearch || EnableInteractiveSearch;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This comes handy when you're using two instances of the same indexer (eg. one freeleech and the other normal), and would rather show the FL releases first based on the indexer priority.