### PR TITLE
extend InlineMarkdown to handle code blocks in backticks

### DIFF
--- a/frontend/src/Components/Markdown/InlineMarkdown.js
+++ b/frontend/src/Components/Markdown/InlineMarkdown.js
@@ -10,7 +10,8 @@ class InlineMarkdown extends Component {
   render() {
     const {
       className,
-      data
+      data,
+      code
     } = this.props;
 
     // For now only replace links
@@ -33,13 +34,28 @@ class InlineMarkdown extends Component {
       }
     }
 
+    // replace blocks in the string surrounded in backticks with <code>
+    // if the first character is a backtick then we ignore the first split and start directly with a code block
+    if (code) {
+      const codeSplit = code.split('`');
+      const startIndex = (code.startsWith('`') === true) ? 1 : 0;
+
+      for (let index = startIndex; index < codeSplit.length; index++) {
+        if (index % 2 === 1) {
+          markdownBlocks.push(<code>{codeSplit[index]}</code>);
+        } else {
+          markdownBlocks.push(codeSplit[index]);
+        }
+      }
+    }
     return <span className={className}>{markdownBlocks}</span>;
   }
 }
 
 InlineMarkdown.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.string
+  data: PropTypes.string,
+  code: PropTypes.string
 };
 
 export default InlineMarkdown;

--- a/frontend/src/Components/Markdown/InlineMarkdown.js
+++ b/frontend/src/Components/Markdown/InlineMarkdown.js
@@ -20,10 +20,12 @@ class InlineMarkdown extends Component {
 
       let endIndex = 0;
       let match = null;
+
       while ((match = linkRegex.exec(data)) !== null) {
         if (match.index > endIndex) {
           markdownBlocks.push(data.substr(endIndex, match.index - endIndex));
         }
+
         markdownBlocks.push(<Link key={match.index} to={match[2]}>{match[1]}</Link>);
         endIndex = match.index + match[0].length;
       }
@@ -37,12 +39,15 @@ class InlineMarkdown extends Component {
       endIndex = 0;
       match = null;
       let matchedCode = false;
+
       while ((match = codeRegex.exec(data)) !== null) {
         matchedCode = true;
+
         if (match.index > endIndex) {
           markdownBlocks.push(data.substr(endIndex, match.index - endIndex));
         }
-        markdownBlocks.push(<code key={match.index}>{match[0].substring(1, match[0].length - 1)}</code>);
+
+        markdownBlocks.push(<code key={`code-${match.index}`}>{match[0].substring(1, match[0].length - 1)}</code>);
         endIndex = match.index + match[0].length;
       }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I wanted to make use of this during translations to properly present translation strings that contain codeblocks

Initally I used it for one code block found [here](https://github.com/stevietv/Sonarr/blob/80850ac976a3841be28fae3132240251893c5b93/frontend/src/Settings/MediaManagement/Naming/NamingModal.js#L511)

To translate this string and present it properly:

```
"MediaInfoFootNote": "MediaInfo Full/AudioLanguages/SubtitleLanguages support a `:EN+DE` suffix allowing you to filter the languages included in the filename. Use `-DE` to exclude specific languages. Appending `+` (eg `:EN+`) will output `[EN]`/`[EN+--]`/`[--]` depending on excluded languages. For example `{MediaInfo Full:EN+DE}`.",
```

There are two cases to handle during the split, one if the code passed to it begins with a ` and one if it doesn't

Not sure if I tackled this one the right way, at least it presents correctly in the UI :)
Open to suggestions!

#### Todos

*

#### Issues Fixed or Closed by this PR

* 
