### PR TITLE
Include preferred size in quality definition reset

### DIFF
--- a/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
@@ -121,6 +121,7 @@ namespace NzbDrone.Core.Qualities
 
                 existing.MinSize = definition.MinSize;
                 existing.MaxSize = definition.MaxSize;
+                existing.PreferredSize = definition.PreferredSize;
                 existing.Title = message.ResetTitles ? definition.Title : existing.Title;
 
                 updateList.Add(existing);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When resetting the quality definitions to their default value using the "Reset Definitions" button

#### Todos
- [ ] Tests (there are none for this feature as far as I can tell)
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

None
