### PR TITLE
Fixed: Error trying to notify user when process not UserInteractive

### DIFF
--- a/src/NzbDrone/WindowsApp.cs
+++ b/src/NzbDrone/WindowsApp.cs
@@ -32,7 +32,11 @@ namespace NzbDrone
             {
                 Logger.Fatal(e, "EPIC FAIL");
                 var message = string.Format("{0}: {1}", e.GetType().Name, e.ToString());
-                MessageBox.Show($"{e.GetType().Name}: {e.Message}", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error, caption: "Epic Fail!");
+
+                if (RuntimeInfo.IsUserInteractive)
+                {
+                    MessageBox.Show($"{e.GetType().Name}: {e.Message}", buttons: MessageBoxButtons.OK, icon: MessageBoxIcon.Error, caption: "Epic Fail!");
+                }
             }
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently in certain cases MessageBox.Show fails with below. Likely from users trying to run tray app as a service. This will avoid tossing error on message box if environment is not UserInteractive

```
System.InvalidOperationException: Showing a modal dialog box or form when the application is not running in UserInteractive mode is not a valid operation. Specify the ServiceNotification or DefaultDesktopOnly style to display a notification from a service application.
  ?, in MB MessageBox.GetMessageBoxStyle(IWin32Window owner, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, MessageBoxOptions options, bool showHelp)
  ?, in DialogResult MessageBox.ShowCore(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton, MessageBoxOptions options, bool showHelp)
  ?, in DialogResult MessageBox.Show(string text, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
  File "./Sonarr/WindowsApp.cs", line 35, col 17, in void WindowsApp.Main(string[] args)
```
