### PR TITLE
Fixed: Clear pending season releases to prevent stale results

### DIFF
--- a/frontend/src/Episode/EpisodeDetailsModalContentConnector.js
+++ b/frontend/src/Episode/EpisodeDetailsModalContentConnector.js
@@ -63,7 +63,7 @@ class EpisodeDetailsModalContentConnector extends Component {
   // Lifecycle
 
   componentWillUnmount() {
-    // Clear pending releases here so we can reshow the search
+    // Clear pending releases here, so we can reshow the search
     // results even after switching tabs.
 
     this.props.dispatchCancelFetchReleases();
@@ -75,6 +75,7 @@ class EpisodeDetailsModalContentConnector extends Component {
 
   render() {
     const {
+      dispatchCancelFetchReleases,
       dispatchClearReleases,
       ...otherProps
     } = this.props;

--- a/frontend/src/Series/Search/SeasonInteractiveSearchModalConnector.js
+++ b/frontend/src/Series/Search/SeasonInteractiveSearchModalConnector.js
@@ -1,9 +1,19 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { cancelFetchReleases, clearReleases } from 'Store/Actions/releaseActions';
 import SeasonInteractiveSearchModal from './SeasonInteractiveSearchModal';
 
 function createMapDispatchToProps(dispatch, props) {
   return {
+    dispatchCancelFetchReleases() {
+      dispatch(cancelFetchReleases());
+    },
+
+    dispatchClearReleases() {
+      dispatch(clearReleases());
+    },
+
     onModalClose() {
       dispatch(cancelFetchReleases());
       dispatch(clearReleases());
@@ -12,4 +22,38 @@ function createMapDispatchToProps(dispatch, props) {
   };
 }
 
-export default connect(null, createMapDispatchToProps)(SeasonInteractiveSearchModal);
+class SeasonInteractiveSearchModalConnector extends Component {
+
+  //
+  // Lifecycle
+
+  componentWillUnmount() {
+    this.props.dispatchCancelFetchReleases();
+    this.props.dispatchClearReleases();
+  }
+
+  //
+  // Render
+
+  render() {
+    const {
+      dispatchCancelFetchReleases,
+      dispatchClearReleases,
+      ...otherProps
+    } = this.props;
+
+    return (
+      <SeasonInteractiveSearchModal
+        {...otherProps}
+      />
+    );
+  }
+}
+
+SeasonInteractiveSearchModalConnector.propTypes = {
+  ...SeasonInteractiveSearchModal.propTypes,
+  dispatchCancelFetchReleases: PropTypes.func.isRequired,
+  dispatchClearReleases: PropTypes.func.isRequired
+};
+
+export default connect(null, createMapDispatchToProps)(SeasonInteractiveSearchModalConnector);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When using the browser's back button after searching for a season in one series and going to another, we would see the results for the previous series in the new series season search.