### PR TITLE
New: Add root folder select to EditSeriesModal

### DIFF
--- a/frontend/src/Series/Edit/EditSeriesModalConnector.js
+++ b/frontend/src/Series/Edit/EditSeriesModalConnector.js
@@ -2,13 +2,21 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { clearPendingChanges } from 'Store/Actions/baseActions';
+import { fetchRootFolders } from 'Store/Actions/rootFolderActions';
 import EditSeriesModal from './EditSeriesModal';
 
 const mapDispatchToProps = {
-  clearPendingChanges
+  clearPendingChanges,
+  fetchRootFolders
 };
 
 class EditSeriesModalConnector extends Component {
+
+  //
+  // Lifecycle
+  componentDidMount() {
+    this.props.fetchRootFolders();
+  }
 
   //
   // Listeners
@@ -34,7 +42,8 @@ class EditSeriesModalConnector extends Component {
 EditSeriesModalConnector.propTypes = {
   ...EditSeriesModal.propTypes,
   onModalClose: PropTypes.func.isRequired,
-  clearPendingChanges: PropTypes.func.isRequired
+  clearPendingChanges: PropTypes.func.isRequired,
+  fetchRootFolders: PropTypes.func.isRequired
 };
 
 export default connect(undefined, mapDispatchToProps)(EditSeriesModalConnector);

--- a/frontend/src/Series/Edit/EditSeriesModalContent.js
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.js
@@ -77,6 +77,7 @@ class EditSeriesModalContent extends Component {
       qualityProfileId,
       seriesType,
       path,
+      rootFolderPath,
       tags
     } = item;
 
@@ -144,6 +145,23 @@ class EditSeriesModalContent extends Component {
                 type={inputTypes.PATH}
                 name="path"
                 {...path}
+                onChange={onInputChange}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <FormLabel>{translate('Root Folder')}</FormLabel>
+
+              <FormInputGroup
+                type={inputTypes.ROOT_FOLDER_SELECT}
+                name="rootFolderPath"
+                {...rootFolderPath}
+                includeNoChange={true}
+                includeNoChangeDisabled={false}
+                selectedValueOptions={{ includeFreeSpace: false }}
+                helpText={translate(
+                  'Moving series to the same root folder can be used to rename series folders to match updated title or naming format'
+                )}
                 onChange={onInputChange}
               />
             </FormGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Simply added the root folder select to the edit series modal. Changing the root folder also changes the series path accordingly.

#### Todos
- [ ] Tests
- [ ] Wiki Updates

#### Screenshot (if UI related)
![root-folder1](https://github.com/Sonarr/Sonarr/assets/80476005/86fa54cb-fe85-4f8d-a1c9-8b05df34993f)
![root-folder2](https://github.com/Sonarr/Sonarr/assets/80476005/99a70595-2eef-47c9-87ec-248b1a45267c)

#### Issues Fixed or Closed by this PR

* Closes #5544 
