### PR TITLE
Update API docs page to clarify v3/v4 independence

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -99,7 +99,7 @@ namespace NzbDrone.Host
                 {
                     Version = "3.0.0",
                     Title = "Sonarr",
-                    Description = "Sonarr API docs",
+                    Description = "Sonarr API docs - The v3 API docs apply to both v3 and v4 versions of Sonarr. Some functionality may only be available in v4 of the Sonarr application.",
                     License = new OpenApiLicense
                     {
                         Name = "GPL-3.0",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Expand the description on the swagger UI page to state that the API docs are for API v3 for the v4 frontend
