### PR TITLE
Fixed: Ensure failing providers are marked as failed when testing all

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientFactory.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientFactory.cs
@@ -74,9 +74,18 @@ namespace NzbDrone.Core.Download
         {
             var result = base.Test(definition);
 
-            if ((result == null || result.IsValid) && definition.Id != 0)
+            if (definition.Id == 0)
+            {
+                return result;
+            }
+
+            if (result == null || result.IsValid)
             {
                 _downloadClientStatusService.RecordSuccess(definition.Id);
+            }
+            else
+            {
+                _downloadClientStatusService.RecordFailure(definition.Id);
             }
 
             return result;

--- a/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
@@ -75,9 +75,18 @@ namespace NzbDrone.Core.ImportLists
         {
             var result = base.Test(definition);
 
-            if ((result == null || result.IsValid) && definition.Id != 0)
+            if (definition.Id == 0)
+            {
+                return result;
+            }
+
+            if (result == null || result.IsValid)
             {
                 _importListStatusService.RecordSuccess(definition.Id);
+            }
+            else
+            {
+                _importListStatusService.RecordFailure(definition.Id);
             }
 
             return result;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Similar to b407eba61284d5fb855df6a2868805853aa6f448, this seems to affect all providers.