### PR TITLE
New: Additional one minute back-off level

### DIFF
--- a/src/NzbDrone.Core.Test/ThingiProviderTests/ProviderStatusServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ThingiProviderTests/ProviderStatusServiceFixture.cs
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Test.ThingiProviderTests
             var status = Subject.GetBlockedProviders().FirstOrDefault();
             status.Should().NotBeNull();
             status.DisabledTill.Should().HaveValue();
-            status.DisabledTill.Value.Should().BeCloseTo(_epoch + TimeSpan.FromMinutes(5), _disabledTillPrecision);
+            status.DisabledTill.Value.Should().BeCloseTo(_epoch + TimeSpan.FromMinutes(1), _disabledTillPrecision);
         }
 
         [Test]
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Test.ThingiProviderTests
             var status = Subject.GetBlockedProviders().FirstOrDefault();
             status.Should().NotBeNull();
             status.DisabledTill.Should().HaveValue();
-            status.DisabledTill.Value.Should().BeCloseTo(_epoch + TimeSpan.FromMinutes(15), _disabledTillPrecision);
+            status.DisabledTill.Value.Should().BeCloseTo(_epoch + TimeSpan.FromMinutes(5), _disabledTillPrecision);
         }
 
         [Test]

--- a/src/NzbDrone.Core/ThingiProvider/Status/EscalationBackOff.cs
+++ b/src/NzbDrone.Core/ThingiProvider/Status/EscalationBackOff.cs
@@ -1,10 +1,11 @@
-﻿namespace NzbDrone.Core.ThingiProvider.Status
+namespace NzbDrone.Core.ThingiProvider.Status
 {
     public static class EscalationBackOff
     {
         public static readonly int[] Periods =
         {
             0,
+            60,
             5 * 60,
             15 * 60,
             30 * 60,

--- a/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusServiceBase.cs
+++ b/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusServiceBase.cs
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.ThingiProvider.Status
 
                 if (inStartupGracePeriod && minimumBackOff == TimeSpan.Zero && status.DisabledTill.HasValue)
                 {
-                    var maximumDisabledTill = now + TimeSpan.FromSeconds(EscalationBackOff.Periods[1]);
+                    var maximumDisabledTill = now + TimeSpan.FromSeconds(EscalationBackOff.Periods[2]);
                     if (maximumDisabledTill < status.DisabledTill)
                     {
                         status.DisabledTill = maximumDisabledTill;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In [Prowlarr](https://github.com/Prowlarr/Prowlarr/commit/5cc044aa8fbc7ba62d9c32442d8125b9b347d28a) we had to add an additional back-off level of one minute to deal with a few indexers rate limiting per minute. Adding an additional one minute back-off level should help with not having the indexers marked as failed for too long than it's needed.