### PR TITLE
Bump dotnet to 6.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fortawesome/free-solid-svg-icons": "6.4.0",
     "@fortawesome/react-fontawesome": "0.2.0",
     "@juggle/resize-observer": "3.4.0",
-    "@microsoft/signalr": "6.0.16",
+    "@microsoft/signalr": "6.0.21",
     "@sentry/browser": "7.51.2",
     "@sentry/integrations": "7.51.2",
     "@types/node": "18.16.8",

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -4,7 +4,7 @@
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">ISMUSL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="5.3.4" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -13,13 +13,13 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
     <PackageReference Include="Sentry" Version="3.23.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Text.Json" Version="6.0.7" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="EnsureThat\Resources\ExceptionMessages.Designer.cs">

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="MailKit" Version="3.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.21" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.2.106" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
@@ -20,7 +20,7 @@
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
-    <PackageReference Include="System.Text.Json" Version="6.0.7" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Sonarr.Common.csproj" />

--- a/src/NzbDrone.Host/Sonarr.Host.csproj
+++ b/src/NzbDrone.Host/Sonarr.Host.csproj
@@ -4,13 +4,13 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="6.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="6.0.21" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />
-    <PackageReference Include="DryIoc.dll" Version="5.3.4" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.1" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Sonarr.Common.csproj" />

--- a/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Sonarr.Test.Common.csproj" />

--- a/src/NzbDrone.Update/Sonarr.Update.csproj
+++ b/src/NzbDrone.Update/Sonarr.Update.csproj
@@ -4,8 +4,8 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="5.3.4" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.1" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
     <PackageReference Include="NLog" Version="4.7.14" />
   </ItemGroup>
   <ItemGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,10 +1185,10 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@microsoft/signalr@6.0.16":
-  version "6.0.16"
-  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-6.0.16.tgz#d36498a9b16bf11c0e9213d77d24c0ad8ebffa47"
-  integrity sha512-wekzRtt2Ti38Ja0OQwLE0EKN0Zm7RI9VilrungwHe5Eej1IwnRYuhpauAqNtwwP3CY2j7uFT4XUk74E2vythTQ==
+"@microsoft/signalr@6.0.21":
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-6.0.21.tgz#b45f335df7011abba831cb3d7974b58da7e725c7"
+  integrity sha512-3MWhSUE7AxkQs3QBuJ/spJJpg1mAHo0/6yRGhs5+Hew3Z+iqYrHVfo0yTElC7W2bVA9t3fW3jliQ9rBN0OvJLA==
   dependencies:
     abort-controller "^3.0.0"
     eventsource "^1.0.7"


### PR DESCRIPTION
- [ ] Needs dotnet-bsd 6.0.21 to be released
- [ ] The bump actually must be done in the builder to actually use the new version.