### PR TITLE
New: Show successful grabs in Interactive Search with different color

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -42,6 +42,18 @@ function getDownloadIcon(
   return icons.DOWNLOAD;
 }
 
+function getDownloadKind(isGrabbed: boolean, grabError?: string) {
+  if (isGrabbed) {
+    return kinds.SUCCESS;
+  }
+
+  if (grabError) {
+    return kinds.DANGER;
+  }
+
+  return kinds.DEFAULT;
+}
+
 function getDownloadTooltip(
   isGrabbing: boolean,
   isGrabbed: boolean,
@@ -265,7 +277,7 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
       <TableRowCell className={styles.download}>
         <SpinnerIconButton
           name={getDownloadIcon(isGrabbing, isGrabbed, grabError)}
-          kind={grabError ? kinds.DANGER : kinds.DEFAULT}
+          kind={getDownloadKind(isGrabbed, grabError)}
           title={getDownloadTooltip(isGrabbing, isGrabbed, grabError)}
           isSpinning={isGrabbing}
           onPress={onGrabPressWrapper}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Before
![before](https://github.com/Sonarr/Sonarr/assets/707714/c7ece6dc-d26e-4193-baa5-429cb051429c)

After
![after](https://github.com/Sonarr/Sonarr/assets/707714/c0eebe25-4411-48f7-bac6-51b35166398d)
