### PR TITLE
revert translations on defaultProps for QueueStatus.js

### DIFF
--- a/frontend/src/Activity/Queue/QueueStatus.js
+++ b/frontend/src/Activity/Queue/QueueStatus.js
@@ -154,8 +154,8 @@ QueueStatus.propTypes = {
 };
 
 QueueStatus.defaultProps = {
-  trackedDownloadStatus: translate('Ok'),
-  trackedDownloadState: translate('Downloading'),
+  trackedDownloadStatus: 'Ok',
+  trackedDownloadState: 'Downloading',
   canFlip: false
 };
 

--- a/frontend/src/Activity/Queue/QueueStatus.js
+++ b/frontend/src/Activity/Queue/QueueStatus.js
@@ -154,8 +154,8 @@ QueueStatus.propTypes = {
 };
 
 QueueStatus.defaultProps = {
-  trackedDownloadStatus: 'Ok',
-  trackedDownloadState: 'Downloading',
+  trackedDownloadStatus: 'ok',
+  trackedDownloadState: 'downloading',
   canFlip: false
 };
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
revert translations on defaultProps for QueueStatus.js
This wasn't required

#### Todos


#### Issues Fixed or Closed by this PR

* 
