### PR TITLE
Fixed: Replace docker detection for cgroup v2

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -78,8 +78,8 @@ namespace NzbDrone.Common.EnvironmentInfo
             }
 
             if (IsLinux &&
-                ((File.Exists("/proc/1/cgroup") && File.ReadAllText("/proc/1/cgroup").Contains("/docker/")) ||
-                 (File.Exists("/proc/1/mountinfo") && File.ReadAllText("/proc/1/mountinfo").Contains("/docker/"))))
+                (File.Exists("/.dockerenv") ||
+                 (File.Exists("/proc/1/cgroup") && File.ReadAllText("/proc/1/cgroup").Contains("/docker/"))))
             {
                 IsDocker = true;
             }


### PR DESCRIPTION
`/proc/1/mountinfo` doesn't seem a reliable source of truth.