### PR TITLE
No error uneccessary custom import rename

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -129,17 +129,18 @@ namespace NzbDrone.Core.MediaFiles
             {
                 var scriptImportDecision = _scriptImportDecider.TryImport(episodeFilePath, destinationFilePath, localEpisode, episodeFile, mode);
 
-                switch (scriptImportDecision)
+                transfer = scriptImportDecision == ScriptImportDecision.DeferMove;
+
+                if (scriptImportDecision == ScriptImportDecision.RenameRequested)
                 {
-                    case ScriptImportDecision.DeferMove:
-                        break;
-                    case ScriptImportDecision.RenameRequested:
+                    try
+                    {
                         MoveEpisodeFile(episodeFile, series, episodeFile.Episodes);
-                        transfer = false;
-                        break;
-                    case ScriptImportDecision.MoveComplete:
-                        transfer = false;
-                        break;
+                    }
+                    catch (SameFilenameException)
+                    {
+                        _logger.Debug("No rename was required. File already exists at destination.");
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Minor oversight for custom import scripts. When requesting a rename that is not required, an error is thrown because the file would be moved to the location it is already in. In that case we can simply catch the error and ignore it.

#### Issues Fixed or Closed by this PR

* 
