### PR TITLE
Prevent health checks warnings for disabled notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -35,6 +35,11 @@ namespace NzbDrone.Core.Notifications
             _logger = logger;
         }
 
+        protected override List<NotificationDefinition> Active()
+        {
+            return base.Active().Where(c => c.Enable).ToList();
+        }
+
         public List<INotification> OnGrabEnabled(bool filterBlockedNotifications = true)
         {
             if (filterBlockedNotifications)


### PR DESCRIPTION
If you disable a blocked connection by status it won't disappear from the health status because there's no filter for enabled notifications only.