### PR TITLE
New: communication back from custom import script

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -267,7 +267,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
             Subject.Scan(_series);
 
             Mocker.GetMock<IDiskProvider>()
-                  .Verify(v => v.GetFiles(It.IsAny<string>(), It.IsAny<bool>()), Times.Once());
+                  .Verify(v => v.GetFiles(It.IsAny<string>(), It.IsAny<bool>()), Times.Exactly(2));
 
             Mocker.GetMock<IMakeImportDecision>()
                   .Verify(v => v.GetImportDecisions(It.Is<List<string>>(l => l.Count == 1), _series, false), Times.Once());

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using FizzWare.NBuilder;
 using FluentAssertions;
@@ -71,7 +72,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenFileExists();
             GivenSuccessfulScan();
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                   .Verify(v => v.GetMediaInfo(Path.Combine(_series.Path, "media.mkv")), Times.Exactly(2));
@@ -97,7 +98,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenFileExists();
             GivenSuccessfulScan();
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                   .Verify(v => v.GetMediaInfo(Path.Combine(_series.Path, "media.mkv")), Times.Exactly(2));
@@ -123,7 +124,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenFileExists();
             GivenSuccessfulScan();
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                   .Verify(v => v.GetMediaInfo(Path.Combine(_series.Path, "media.mkv")), Times.Exactly(3));
@@ -146,7 +147,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
 
             GivenSuccessfulScan();
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                   .Verify(v => v.GetMediaInfo("media.mkv"), Times.Never());
@@ -173,7 +174,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenSuccessfulScan();
             GivenFailedScan(Path.Combine(_series.Path, "media2.mkv"));
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                   .Verify(v => v.GetMediaInfo(Path.Combine(_series.Path, "media.mkv")), Times.Exactly(1));
@@ -203,7 +204,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenFileExists();
             GivenSuccessfulScan();
 
-            Subject.Handle(new SeriesScannedEvent(_series));
+            Subject.Handle(new SeriesScannedEvent(_series, new List<string>()));
 
             Mocker.GetMock<IVideoFileInfoReader>()
                 .Verify(v => v.GetMediaInfo(It.IsAny<string>()), Times.Never());

--- a/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Extras
 {
     public interface IExistingExtraFiles
     {
-        List<string> ImportFileList(Series series, List<string> possibleExtraFiles);
+        List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles);
     }
 
     public class ExistingExtraFileService : IExistingExtraFiles, IHandle<SeriesScannedEvent>
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Extras
             _logger = logger;
         }
 
-        public List<string> ImportFileList(Series series, List<string> possibleExtraFiles)
+        public List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles)
         {
             _logger.Debug("Looking for existing extra files in {0}", series.Path);
 
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Extras
 
             var possibleExtraFiles = message.PossibleExtraFiles;
 
-            var importedFiles = ImportFileList(series, possibleExtraFiles);
+            var importedFiles = ImportExtraFiles(series, possibleExtraFiles);
 
             _logger.Info("Found {0} possible extra files, imported {1} files.", possibleExtraFiles.Count, importedFiles.Count);
         }

--- a/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
@@ -44,9 +44,7 @@ namespace NzbDrone.Core.Extras
         public void Handle(SeriesScannedEvent message)
         {
             var series = message.Series;
-
             var possibleExtraFiles = message.PossibleExtraFiles;
-
             var importedFiles = ImportExtraFiles(series, possibleExtraFiles);
 
             _logger.Info("Found {0} possible extra files, imported {1} files.", possibleExtraFiles.Count, importedFiles.Count);

--- a/src/NzbDrone.Core/Extras/ExtraService.cs
+++ b/src/NzbDrone.Core/Extras/ExtraService.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Extras
 {
     public interface IExtraService
     {
+        void MoveFilesAfterRename(Series series, EpisodeFile episodeFile);
         void ImportEpisode(LocalEpisode localEpisode, EpisodeFile episodeFile, bool isReadOnly);
     }
 
@@ -136,6 +137,16 @@ namespace NzbDrone.Core.Extras
             foreach (var extraFileManager in _extraFileManagers)
             {
                 extraFileManager.CreateAfterEpisodeFolder(series, message.SeriesFolder, message.SeasonFolder);
+            }
+        }
+
+        public void MoveFilesAfterRename(Series series, EpisodeFile episodeFile)
+        {
+            var episodeFiles = new List<EpisodeFile> { episodeFile };
+
+            foreach (var extraFileManager in _extraFileManagers)
+            {
+                extraFileManager.MoveFilesAfterRename(series, episodeFiles);
             }
         }
 

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
 
                 CleanMediaFiles(series, new List<string>());
-                CompletedScanning(series);
+                CompletedScanning(series, new List<string>());
 
                 return;
             }
@@ -174,8 +174,11 @@ namespace NzbDrone.Core.MediaFiles
             fileInfoStopwatch.Stop();
             _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
 
+            var filesOnDisk = GetNonVideoFiles(series.Path);
+            var possibleExtraFiles = FilterPaths(series.Path, filesOnDisk);
+
             RemoveEmptySeriesFolder(series.Path);
-            CompletedScanning(series);
+            CompletedScanning(series, possibleExtraFiles);
         }
 
         private void CleanMediaFiles(Series series, List<string> mediaFileList)
@@ -184,10 +187,10 @@ namespace NzbDrone.Core.MediaFiles
             _mediaFileTableCleanupService.Clean(series, mediaFileList);
         }
 
-        private void CompletedScanning(Series series)
+        private void CompletedScanning(Series series, List<string> possibleExtraFiles)
         {
             _logger.Info("Completed scanning disk for {0}", series.Title);
-            _eventAggregator.PublishEvent(new SeriesScannedEvent(series));
+            _eventAggregator.PublishEvent(new SeriesScannedEvent(series, possibleExtraFiles));
         }
 
         public string[] GetVideoFiles(string path, bool allDirectories = true)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -130,6 +130,7 @@ namespace NzbDrone.Core.MediaFiles
                     try
                     {
                         MoveEpisodeFile(episodeFile, series, episodeFile.Episodes);
+                        localEpisode.ImportRenamed = true;
                     }
                     catch (SameFilenameException)
                     {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.MediaFiles
                     try
                     {
                         MoveEpisodeFile(episodeFile, series, episodeFile.Episodes);
-                        localEpisode.ImportRenamed = true;
+                        localEpisode.FileRenamedAfterScriptImport = true;
                     }
                     catch (SameFilenameException)
                     {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -135,9 +135,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     {
                         if (localEpisode.ScriptImported)
                         {
-                            _existingExtraFiles.ImportFileList(localEpisode.Series, localEpisode.PossibleExtraFiles);
+                            _existingExtraFiles.ImportExtraFiles(localEpisode.Series, localEpisode.PossibleExtraFiles);
 
-                            if (localEpisode.ImportRenamed)
+                            if (localEpisode.FileRenamedAfterScriptImport)
                             {
                                 _extraService.MoveFilesAfterRename(localEpisode.Series, episodeFile);
                             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -142,7 +142,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                                 _extraService.MoveFilesAfterRename(localEpisode.Series, episodeFile);
                             }
                         }
-                        else
+
+                        if (!localEpisode.ScriptImported || localEpisode.ShouldImportExtras)
                         {
                             _extraService.ImportEpisode(localEpisode, episodeFile, copyOnly);
                         }

--- a/src/NzbDrone.Core/MediaFiles/Events/SeriesScannedEvent.cs
+++ b/src/NzbDrone.Core/MediaFiles/Events/SeriesScannedEvent.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Common.Messaging;
+﻿using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MediaFiles.Events
@@ -6,10 +7,12 @@ namespace NzbDrone.Core.MediaFiles.Events
     public class SeriesScannedEvent : IEvent
     {
         public Series Series { get; private set; }
+        public List<string> PossibleExtraFiles { get; set; }
 
-        public SeriesScannedEvent(Series series)
+        public SeriesScannedEvent(Series series, List<string> possibleExtraFiles)
         {
             Series = series;
+            PossibleExtraFiles = possibleExtraFiles;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
@@ -187,7 +187,12 @@ namespace NzbDrone.Core.MediaFiles
             episodeFile.RelativePath = series.Path.GetRelativePath(destinationFilePath);
             episodeFile.Path = destinationFilePath;
 
-            switch (processOutput.ExitCode)
+            if ((processOutput.ExitCode & 0x4) == 0x4)
+            {
+                localEpisode.ShouldImportExtras = true;
+            }
+
+            switch (processOutput.ExitCode & 0x3)
             {
                 case 0: // Copy complete
                     localEpisode.ScriptImported = true;

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportInfo.cs
@@ -6,11 +6,15 @@ namespace NzbDrone.Core.MediaFiles
     {
         public List<string> PossibleExtraFiles { get; set; }
         public string MediaFile { get; set; }
+        public ScriptImportDecision Decision { get; set; }
+        public bool ImportExtraFiles { get; set; }
 
-        public ScriptImportInfo(List<string> possibleExtraFiles, string mediaFile)
+        public ScriptImportInfo(List<string> possibleExtraFiles, string mediaFile, ScriptImportDecision decision, bool importExtraFiles)
         {
             PossibleExtraFiles = possibleExtraFiles;
             MediaFile = mediaFile;
+            Decision = decision;
+            ImportExtraFiles = importExtraFiles;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportInfo.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.MediaFiles
+{
+    public struct ScriptImportInfo
+    {
+        public List<string> PossibleExtraFiles { get; set; }
+        public string MediaFile { get; set; }
+
+        public ScriptImportInfo(List<string> possibleExtraFiles, string mediaFile)
+        {
+            PossibleExtraFiles = possibleExtraFiles;
+            MediaFile = mediaFile;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Parser.Model
         public int CustomFormatScore { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
         public bool ScriptImported { get; set; }
-        public bool ImportRenamed { get; set; }
+        public bool FileRenamedAfterScriptImport { get; set; }
         public bool ShouldImportExtras { get; set; }
         public List<string> PossibleExtraFiles { get; set; }
 

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -40,6 +40,9 @@ namespace NzbDrone.Core.Parser.Model
         public List<CustomFormat> CustomFormats { get; set; }
         public int CustomFormatScore { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
+        public bool ScriptImported { get; set; }
+        public bool ImportRenamed { get; set; }
+        public List<string> PossibleExtraFiles { get; set; }
 
         public int SeasonNumber
         {

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.Parser.Model
         public GrabbedReleaseInfo Release { get; set; }
         public bool ScriptImported { get; set; }
         public bool ImportRenamed { get; set; }
+        public bool ShouldImportExtras { get; set; }
         public List<string> PossibleExtraFiles { get; set; }
 
         public int SeasonNumber


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There are a few cases that were not handled for custom import scripts yet:

* Custom import scripts that generate additional extra files to be imported.
* Custom import scripts that remux the original media file to a different container, such that its extension must change
* Wanting to import extra files via a custom import script(as deferred to a later date in the original #5538)

All of these use cases are addressed as follows: A custom import script can now communicate back to Sonarr by means of a temporary file, the path to which is passed as an environment variable. This avoids parsing a potentially polluted stdout, however I am open to changes in this respect. This communication is used in order to inform Sonarr of: The potentially changed name of the media file, and which extras have been imported, or equivalently generated, by the custom import script.

Still a WIP as I haven't really tested this yet and am just leaving it for initial feedback.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
