### PR TITLE
Add info box under health messages

### DIFF
--- a/frontend/src/System/Status/Health/Health.js
+++ b/frontend/src/System/Status/Health/Health.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Alert from 'Components/Alert';
 import FieldSet from 'Components/FieldSet';
 import Icon from 'Components/Icon';
 import IconButton from 'Components/Link/IconButton';
 import SpinnerIconButton from 'Components/Link/SpinnerIconButton';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
@@ -204,7 +206,7 @@ class Health extends Component {
 
                           {
                             !!testLink &&
-                              testLink
+                            testLink
                           }
                         </TableRowCell>
                       </TableRow>
@@ -213,6 +215,12 @@ class Health extends Component {
                 }
               </TableBody>
             </Table>
+        }
+        {
+          healthIssues &&
+            <Alert kind={kinds.INFO}>
+              <InlineMarkdown data={translate('HealthMessagesInfoBox', { link: '/system/logs/files' })} />
+            </Alert>
         }
       </FieldSet>
     );

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -509,6 +509,7 @@
   "HardlinkCopyFiles": "Hardlink/Copy Files",
   "HasMissingSeason": "Has Missing Season",
   "Health": "Health",
+  "HealthMessagesInfoBox": "You can find more information about the cause of these health check messages by clicking the wiki link at the end of the row, or by checking your [logs]({link}). If you have difficultly interpreting these messages then you can reach out to our support, at the links below.",
   "Here": "here",
   "HiddenClickToShow": "Hidden, click to show",
   "HideAdvanced": "Hide Advanced",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -509,7 +509,7 @@
   "HardlinkCopyFiles": "Hardlink/Copy Files",
   "HasMissingSeason": "Has Missing Season",
   "Health": "Health",
-  "HealthMessagesInfoBox": "You can find more information about the cause of these health check messages by clicking the wiki link at the end of the row, or by checking your [logs]({link}). If you have difficultly interpreting these messages then you can reach out to our support, at the links below.",
+  "HealthMessagesInfoBox": "You can find more information about the cause of these health check messages by clicking the wiki link (book icon) at the end of the row, or by checking your [logs]({link}). If you have difficulty interpreting these messages then you can reach out to our support, at the links below.",
   "Here": "here",
   "HiddenClickToShow": "Hidden, click to show",
   "HideAdvanced": "Hide Advanced",


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Adds an info box under the health messages when there are health checks reminding users to:
* check the wiki link on the message row 
* check their logs
* or come to support for help

#### Todos


#### Issues Fixed or Closed by this PR

* closes #5958 
