### PR TITLE
Fix: Fallback to English translations if invalid UI language in config

### DIFF
--- a/frontend/src/Settings/UI/UISettings.js
+++ b/frontend/src/Settings/UI/UISettings.js
@@ -220,6 +220,13 @@ class UISettings extends Component {
                       helpTextWarning={translate('BrowserReloadRequired')}
                       onChange={onInputChange}
                       {...settings.uiLanguage}
+                      errors={
+                        languages.some((language) => language.key === settings.uiLanguage.value) ?
+                          settings.uiLanguage.errors :
+                          [
+                            ...settings.uiLanguage.errors,
+                            { message: translate('InvalidUILanguage') }
+                          ]}
                     />
                   </FormGroup>
                 </FieldSet>

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -612,6 +612,7 @@
   "InteractiveSearchResultsFailedErrorMessage": "Search failed because its {message}. Try refreshing the series info and verify the necessary information is present before searching again.",
   "Interval": "Interval",
   "InvalidFormat": "Invalid Format",
+  "InvalidUILanguage": "Your UI is set to an invalid language, correct it and save your settings",
   "KeyboardShortcuts": "Keyboard Shortcuts",
   "KeyboardShortcutsCloseModal": "Close Current Modal",
   "KeyboardShortcutsConfirmModal": "Accept Confirmation Modal",

--- a/src/NzbDrone.Core/Localization/LocalizationService.cs
+++ b/src/NzbDrone.Core/Localization/LocalizationService.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Localization
 
         public string GetLanguageIdentifier()
         {
-            var isoLanguage = IsoLanguages.Get((Language)_configService.UILanguage);
+            var isoLanguage = IsoLanguages.Get((Language)_configService.UILanguage) ?? IsoLanguages.Get(Language.English);
             var language = isoLanguage.TwoLetterCode;
 
             if (isoLanguage.CountryCode.IsNotNullOrWhiteSpace())

--- a/src/Sonarr.Api.V3/Config/UiConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/UiConfigController.cs
@@ -1,7 +1,9 @@
 using System.Linq;
 using System.Reflection;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Languages;
 using Sonarr.Http;
 using Sonarr.Http.REST.Attributes;
 
@@ -16,6 +18,17 @@ namespace Sonarr.Api.V3.Config
             : base(configService)
         {
             _configFileProvider = configFileProvider;
+            SharedValidator.RuleFor(c => c.UILanguage).Custom((value, context) =>
+            {
+                if (!Language.All.Any(o => o.Id == value))
+                {
+                    context.AddFailure("Invalid UI Language value");
+                }
+            });
+
+            SharedValidator.RuleFor(c => c.UILanguage)
+                           .GreaterThanOrEqualTo(1)
+                           .WithMessage("The UI Language value cannot be less than 1");
         }
 
         [RestPutById]


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
We saw on Discord that it was possible for someone to have -2 as an original language, which resulted in translations failing.
This falls back to English if an invalid Language is returned during evaluating what language the UI should be in.

#### Todos


#### Issues Fixed or Closed by this PR

* 
