### PR TITLE
Fix showing Grab ID in history details modal

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.js
+++ b/frontend/src/Activity/History/Details/HistoryDetails.js
@@ -16,6 +16,7 @@ function HistoryDetails(props) {
     eventType,
     sourceTitle,
     data,
+    downloadId,
     shortDateFormat,
     timeFormat
   } = props;
@@ -29,7 +30,6 @@ function HistoryDetails(props) {
       nzbInfoUrl,
       downloadClient,
       downloadClientName,
-      downloadId,
       age,
       ageHours,
       ageMinutes,
@@ -149,6 +149,15 @@ function HistoryDetails(props) {
           title={translate('Name')}
           data={sourceTitle}
         />
+
+        {
+          downloadId ?
+            <DescriptionListItem
+              title={translate('GrabId')}
+              data={downloadId}
+            /> :
+            null
+        }
 
         {
           message ?
@@ -302,6 +311,15 @@ function HistoryDetails(props) {
         />
 
         {
+          downloadId ?
+            <DescriptionListItem
+              title={translate('GrabId')}
+              data={downloadId}
+            /> :
+            null
+        }
+
+        {
           message ?
             <DescriptionListItem
               title={translate('Message')}
@@ -328,6 +346,7 @@ HistoryDetails.propTypes = {
   eventType: PropTypes.string.isRequired,
   sourceTitle: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  downloadId: PropTypes.string,
   shortDateFormat: PropTypes.string.isRequired,
   timeFormat: PropTypes.string.isRequired
 };

--- a/frontend/src/Activity/History/Details/HistoryDetailsModal.js
+++ b/frontend/src/Activity/History/Details/HistoryDetailsModal.js
@@ -37,6 +37,7 @@ function HistoryDetailsModal(props) {
     eventType,
     sourceTitle,
     data,
+    downloadId,
     isMarkingAsFailed,
     shortDateFormat,
     timeFormat,
@@ -59,6 +60,7 @@ function HistoryDetailsModal(props) {
             eventType={eventType}
             sourceTitle={sourceTitle}
             data={data}
+            downloadId={downloadId}
             shortDateFormat={shortDateFormat}
             timeFormat={timeFormat}
           />
@@ -93,6 +95,7 @@ HistoryDetailsModal.propTypes = {
   eventType: PropTypes.string.isRequired,
   sourceTitle: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  downloadId: PropTypes.string,
   isMarkingAsFailed: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
   timeFormat: PropTypes.string.isRequired,

--- a/frontend/src/Activity/History/HistoryRow.js
+++ b/frontend/src/Activity/History/HistoryRow.js
@@ -69,6 +69,7 @@ class HistoryRow extends Component {
       sourceTitle,
       date,
       data,
+      downloadId,
       isMarkingAsFailed,
       columns,
       shortDateFormat,
@@ -269,6 +270,7 @@ class HistoryRow extends Component {
           eventType={eventType}
           sourceTitle={sourceTitle}
           data={data}
+          downloadId={downloadId}
           isMarkingAsFailed={isMarkingAsFailed}
           shortDateFormat={shortDateFormat}
           timeFormat={timeFormat}
@@ -294,6 +296,7 @@ HistoryRow.propTypes = {
   sourceTitle: PropTypes.string.isRequired,
   date: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  downloadId: PropTypes.string,
   isMarkingAsFailed: PropTypes.bool,
   markAsFailedError: PropTypes.object,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Episode/History/EpisodeHistoryRow.js
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.js
@@ -72,7 +72,8 @@ class EpisodeHistoryRow extends Component {
       customFormats,
       customFormatScore,
       date,
-      data
+      data,
+      downloadId
     } = this.props;
 
     const {
@@ -118,6 +119,7 @@ class EpisodeHistoryRow extends Component {
                 eventType={eventType}
                 sourceTitle={sourceTitle}
                 data={data}
+                downloadId={downloadId}
               />
             }
             position={tooltipPositions.LEFT}
@@ -170,6 +172,7 @@ EpisodeHistoryRow.propTypes = {
   customFormatScore: PropTypes.number.isRequired,
   date: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  downloadId: PropTypes.string,
   onMarkAsFailedPress: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -73,6 +73,7 @@ class SeriesHistoryRow extends Component {
       customFormats,
       date,
       data,
+      downloadId,
       fullSeries,
       series,
       episode,
@@ -137,6 +138,7 @@ class SeriesHistoryRow extends Component {
                 eventType={eventType}
                 sourceTitle={sourceTitle}
                 data={data}
+                downloadId={downloadId}
               />
             }
             position={tooltipPositions.LEFT}
@@ -188,6 +190,7 @@ SeriesHistoryRow.propTypes = {
   customFormats: PropTypes.arrayOf(PropTypes.object),
   date: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  downloadId: PropTypes.string,
   fullSeries: PropTypes.bool.isRequired,
   series: PropTypes.object.isRequired,
   episode: PropTypes.object.isRequired,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
`DownloadId` has a separate column, not a part of data.
