### PR TITLE
Translate Frontend Store (default name for copied specs or profiles)

### DIFF
--- a/frontend/src/Store/Actions/Settings/autoTaggingSpecifications.js
+++ b/frontend/src/Store/Actions/Settings/autoTaggingSpecifications.js
@@ -10,6 +10,7 @@ import getProviderState from 'Utilities/State/getProviderState';
 import getSectionState from 'Utilities/State/getSectionState';
 import selectProviderSchema from 'Utilities/State/selectProviderSchema';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 import { removeItem, set, update, updateItem } from '../baseActions';
 
 //
@@ -176,7 +177,7 @@ export default {
       const newItem = {
         ...item,
         id: newId,
-        name: `${item.name} - Copy`
+        name: translate('DefaultNameCopiedSpecification', { name: item.name })
       };
       newState.items = [...items, newItem];
       newState.itemMap[newId] = newState.items.length - 1;

--- a/frontend/src/Store/Actions/Settings/autoTaggings.js
+++ b/frontend/src/Store/Actions/Settings/autoTaggings.js
@@ -7,6 +7,7 @@ import createSetSettingValueReducer from 'Store/Actions/Creators/Reducers/create
 import { createThunk } from 'Store/thunks';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 
 //
 // Variables
@@ -99,7 +100,7 @@ export default {
       const pendingChanges = { ...item, id: 0 };
       delete pendingChanges.id;
 
-      pendingChanges.name = `${pendingChanges.name} - Copy`;
+      pendingChanges.name = translate('DefaultNameCopiedProfile', { name: pendingChanges.name });
       newState.pendingChanges = pendingChanges;
 
       return updateSectionState(state, section, newState);

--- a/frontend/src/Store/Actions/Settings/customFormatSpecifications.js
+++ b/frontend/src/Store/Actions/Settings/customFormatSpecifications.js
@@ -10,6 +10,7 @@ import getProviderState from 'Utilities/State/getProviderState';
 import getSectionState from 'Utilities/State/getSectionState';
 import selectProviderSchema from 'Utilities/State/selectProviderSchema';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 import { removeItem, set, update, updateItem } from '../baseActions';
 
 //
@@ -176,7 +177,7 @@ export default {
       const newItem = {
         ...item,
         id: newId,
-        name: `${item.name} - Copy`
+        name: translate('DefaultNameCopiedSpecification', { name: item.name })
       };
       newState.items = [...items, newItem];
       newState.itemMap[newId] = newState.items.length - 1;

--- a/frontend/src/Store/Actions/Settings/customFormats.js
+++ b/frontend/src/Store/Actions/Settings/customFormats.js
@@ -6,6 +6,7 @@ import createSetSettingValueReducer from 'Store/Actions/Creators/Reducers/create
 import { createThunk } from 'Store/thunks';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 import { set } from '../baseActions';
 
 //
@@ -98,7 +99,7 @@ export default {
       const pendingChanges = { ...item, id: 0 };
       delete pendingChanges.id;
 
-      pendingChanges.name = `${pendingChanges.name} - Copy`;
+      pendingChanges.name = translate('DefaultNameCopiedProfile', { name: pendingChanges.name });
       newState.pendingChanges = pendingChanges;
 
       return updateSectionState(state, section, newState);

--- a/frontend/src/Store/Actions/Settings/indexers.js
+++ b/frontend/src/Store/Actions/Settings/indexers.js
@@ -13,6 +13,7 @@ import { createThunk } from 'Store/thunks';
 import getSectionState from 'Utilities/State/getSectionState';
 import selectProviderSchema from 'Utilities/State/selectProviderSchema';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 
 //
 // Variables
@@ -149,7 +150,7 @@ export default {
 
       // Set the name in pendingChanges
       newState.pendingChanges = {
-        name: `${item.name} - Copy`
+        name: translate('DefaultNameCopiedSpecification', { name: item.name })
       };
 
       return updateSectionState(state, section, newState);

--- a/frontend/src/Store/Actions/Settings/qualityProfiles.js
+++ b/frontend/src/Store/Actions/Settings/qualityProfiles.js
@@ -7,6 +7,7 @@ import createSetSettingValueReducer from 'Store/Actions/Creators/Reducers/create
 import { createThunk } from 'Store/thunks';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
+import translate from 'Utilities/String/translate';
 
 //
 // Variables
@@ -87,7 +88,7 @@ export default {
       const pendingChanges = { ...item, id: 0 };
       delete pendingChanges.id;
 
-      pendingChanges.name = `${pendingChanges.name} - Copy`;
+      pendingChanges.name = translate('DefaultNameCopiedProfile', { name: pendingChanges.name });
       newState.pendingChanges = pendingChanges;
 
       return updateSectionState(state, section, newState);

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -253,6 +253,8 @@
   "Default": "Default",
   "DefaultCase": "Default Case",
   "DefaultDelayProfile": "This is the default profile. It applies to all series that don't have an explicit profile.",
+  "DefaultNameCopiedProfile": "{name} - Copy",
+  "DefaultNameCopiedSpecification": "{name} - Copy",
   "DefaultNotFoundMessage": "You must be lost, nothing to see here.",
   "DelayMinutes": "{delay} Minutes",
   "DelayProfile": "Delay Profile",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Translate Frontend Store
only additions that were needed were to the default names of copied profiles or specs within a profile.

#### Todos


#### Issues Fixed or Closed by this PR

* 
