### PR TITLE
Fixed: Calculate reached seeding time in seconds for qBittorrent

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -634,7 +634,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
                 .Returns(new QBittorrentTorrentProperties
                 {
                     Hash = "HASH",
-                    SeedingTime = seedingTime
+                    SeedingTime = seedingTime * 60
                 });
 
             return torrent;

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -626,11 +626,11 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             if (torrent.SeedingTimeLimit >= 0)
             {
-                seedingTimeLimit = torrent.SeedingTimeLimit;
+                seedingTimeLimit = torrent.SeedingTimeLimit * 60;
             }
             else if (torrent.SeedingTimeLimit == -2 && config.MaxSeedingTimeEnabled)
             {
-                seedingTimeLimit = config.MaxSeedingTime;
+                seedingTimeLimit = config.MaxSeedingTime * 60;
             }
             else
             {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public float RatioLimit { get; set; } = -2;
 
         [JsonProperty(PropertyName = "seeding_time")]
-        public long? SeedingTime { get; set; } // Torrent seeding time (not provided by the list api)
+        public long? SeedingTime { get; set; } // Torrent seeding time (in seconds, not provided by the list api)
 
         [JsonProperty(PropertyName = "seeding_time_limit")] // Per torrent seeding time limit (-2 = use global, -1 = unlimited)
         public long SeedingTimeLimit { get; set; } = -2;
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         public string SavePath { get; set; }
 
         [JsonProperty(PropertyName = "seeding_time")]
-        public long SeedingTime { get; set; } // Torrent seeding time
+        public long SeedingTime { get; set; } // Torrent seeding time (in seconds)
     }
 
     public class QBittorrentTorrentFile


### PR DESCRIPTION
#### Database Migration
NO

#### Description
https://github.com/Radarr/Radarr/issues/9126

Ignoring the mistakes from the API docs, `seeding_time` seems to be seconds while `seeding_time_limit` and `max_seeding_time` in minutes. 

#### Todos
- [x] Tests
- [ ] Wiki Updates
