### PR TITLE
Fixed: Show correct error on unauthorized caps call

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
@@ -7,6 +7,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Indexers.Exceptions;
 
 namespace NzbDrone.Core.Indexers.Newznab
 {
@@ -71,6 +72,13 @@ namespace NzbDrone.Core.Indexers.Newznab
                 ex.WithData(response, 128 * 1024);
                 _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
                 _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}", indexerSettings.BaseUrl);
+                throw;
+            }
+            catch (ApiKeyException ex)
+            {
+                ex.WithData(response, 128 * 1024);
+                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
+                _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}, invalid key", indexerSettings.BaseUrl);
                 throw;
             }
             catch (Exception ex)

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 ex.WithData(response, 128 * 1024);
                 _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
-                _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}, invalid key", indexerSettings.BaseUrl);
+                _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}, invalid API key", indexerSettings.BaseUrl);
                 throw;
             }
             catch (Exception ex)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently CapabilitiesProvider doesn't throw on APIKey error, thus default categories are returned resulting in confusing messaging to the user. This change catches and throws the ApiKeyException that is generated instead of handling it with other exceptions

![image](https://github.com/Sonarr/Sonarr/assets/376117/04b09cb1-4f1f-43b7-8e1a-746c723e4433)
