### PR TITLE
Avoid returning null in static resource mapper Task

### DIFF
--- a/src/Sonarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Sonarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -50,7 +50,7 @@ namespace Sonarr.Http.Frontend.Mappers
 
             _logger.Warn("File {0} not found", filePath);
 
-            return null;
+            return Task.FromResult<IActionResult>(null);
         }
 
         protected virtual Stream GetContentStream(string filePath)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Missed this in ad1f185330a30a2a9d27c9d3f18d384e66727c2a.