### PR TITLE
New: Year custom filter in Series Index

### DIFF
--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -348,6 +348,11 @@ export const filterBuilderProps = [
     name: 'hasMissingSeason',
     label: () => translate('HasMissingSeason'),
     type: filterBuilderTypes.EXACT
+  },
+  {
+    name: 'year',
+    label: () => translate('Year'),
+    type: filterBuilderTypes.NUMBER
   }
 ];
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the option to create a custom filter based on year show began airing

#### Todos

#### Issues Fixed or Closed by this PR

* 
