### PR TITLE
Fixed: qBittorent history retention to allow at least 14 days seeding

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -378,11 +378,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
             }
 
+            var minimumRetention = 60 * 24 * 14;
+
             return new DownloadClientInfo
             {
                 IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, destDir) },
-                RemovesCompletedDownloads = (config.MaxRatioEnabled || config.MaxSeedingTimeEnabled) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles)
+                RemovesCompletedDownloads = (config.MaxRatioEnabled || (config.MaxSeedingTimeEnabled && config.MaxSeedingTime < minimumRetention)) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles)
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
don't raise RemovesCompletedDownloads health check if qBittorrent removes torrents after 14 days seeding.

Health Check is popped when:
```
 downloads are set to remove or remove+delete, and
     1) ratio box is checked, or
     2) seeding time box is checked and is set to less than 14d
```

#### Todos

#### Issues Fixed or Closed by this PR

* 
