### PR TITLE
New: Add Watched filter type to Trakt User Import List

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
@@ -26,24 +26,24 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
                 return listItems;
             }
 
-            var jsonResponse = new List<TraktSeriesResource>();
+            var traktSeries = new List<TraktSeriesResource>();
 
             if (_settings.TraktListType == (int)TraktPopularListType.Popular)
             {
-                jsonResponse = STJson.Deserialize<List<TraktSeriesResource>>(_importResponse.Content);
+                traktSeries = STJson.Deserialize<List<TraktSeriesResource>>(_importResponse.Content);
             }
             else
             {
-                jsonResponse = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
+                traktSeries = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
             }
 
-            // no movies were return
-            if (jsonResponse == null)
+            // no series were returned
+            if (traktSeries == null)
             {
                 return listItems;
             }
 
-            foreach (var series in jsonResponse)
+            foreach (var series in traktSeries)
             {
                 listItems.AddIfNotNull(new ImportListItemInfo()
                 {

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktAPI.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktAPI.cs
@@ -1,4 +1,5 @@
-using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace NzbDrone.Core.ImportLists.Trakt
 {
@@ -16,6 +17,8 @@ namespace NzbDrone.Core.ImportLists.Trakt
         public string Title { get; set; }
         public int? Year { get; set; }
         public TraktSeriesIdsResource Ids { get; set; }
+        [JsonPropertyName("aired_episodes")]
+        public int AiredEpisodes { get; set; }
     }
 
     public class TraktResponse
@@ -23,13 +26,29 @@ namespace NzbDrone.Core.ImportLists.Trakt
         public TraktSeriesResource Show { get; set; }
     }
 
+    public class TraktWatchedEpisodeResource
+    {
+        public int? Plays { get; set; }
+    }
+
+    public class TraktWatchedSeasonResource
+    {
+        public int? Number { get; set; }
+        public List<TraktWatchedEpisodeResource> Episodes { get; set; }
+    }
+
+    public class TraktWatchedResponse : TraktResponse
+    {
+        public List<TraktWatchedSeasonResource> Seasons { get; set; }
+    }
+
     public class RefreshRequestResponse
     {
-        [JsonProperty("access_token")]
+        [JsonPropertyName("access_token")]
         public string AccessToken { get; set; }
-        [JsonProperty("expires_in")]
+        [JsonPropertyName("expires_in")]
         public int ExpiresIn { get; set; }
-        [JsonProperty("refresh_token")]
+        [JsonPropertyName("refresh_token")]
         public string RefreshToken { get; set; }
     }
 

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktParser.cs
@@ -22,20 +22,20 @@ namespace NzbDrone.Core.ImportLists.Trakt
                 return series;
             }
 
-            var jsonResponse = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content);
+            var traktResponses = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content);
 
-            // no series were return
-            if (jsonResponse == null)
+            // no series were returned
+            if (traktResponses == null)
             {
                 return series;
             }
 
-            foreach (var show in jsonResponse)
+            foreach (var traktResponse in traktResponses)
             {
                 series.AddIfNotNull(new ImportListItemInfo()
                 {
-                    Title = show.Show.Title,
-                    TvdbId = show.Show.Ids.Tvdb.GetValueOrDefault()
+                    Title = traktResponse.Show.Title,
+                    TvdbId = traktResponse.Show.Ids.Tvdb.GetValueOrDefault()
                 });
             }
 

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserImport.cs
@@ -19,6 +19,11 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
 
         public override string Name => "Trakt User";
 
+        public override IParseImportListResponse GetParser()
+        {
+            return new TraktUserParser(Settings);
+        }
+
         public override IImportListRequestGenerator GetRequestGenerator()
         {
             return new TraktUserRequestGenerator()

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserParser.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.Trakt.User
+{
+    public class TraktUserParser : TraktParser
+    {
+        private readonly TraktUserSettings _settings;
+        private ImportListResponse _importResponse;
+
+        public TraktUserParser(TraktUserSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public override IList<ImportListItemInfo> ParseResponse(ImportListResponse importResponse)
+        {
+            _importResponse = importResponse;
+
+            var listItems = new List<ImportListItemInfo>();
+
+            if (!PreProcess(_importResponse))
+            {
+                return listItems;
+            }
+
+            var jsonResponse = new List<TraktSeriesResource>();
+
+            if (_settings.TraktListType == (int)TraktUserListType.UserWatchedList)
+            {
+                var jsonWatchedResponse = STJson.Deserialize<List<TraktWatchedResponse>>(_importResponse.Content);
+                switch (_settings.TraktWatchedListType)
+                {
+                    case (int)TraktUserWatchedListType.InProgress:
+                        jsonResponse = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) < c.Show.AiredEpisodes).SelectList(c => c.Show);
+                        break;
+                    case (int)TraktUserWatchedListType.CompletelyWatched:
+                        jsonResponse = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) == c.Show.AiredEpisodes).SelectList(c => c.Show);
+                        break;
+                    default:
+                        jsonResponse = jsonWatchedResponse.SelectList(c => c.Show);
+                        break;
+                }
+            }
+            else
+            {
+                jsonResponse = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
+            }
+
+            // no series were return
+            if (jsonResponse == null)
+            {
+                return listItems;
+            }
+
+            foreach (var series in jsonResponse)
+            {
+                listItems.AddIfNotNull(new ImportListItemInfo()
+                {
+                    Title = series.Title,
+                    TvdbId = series.Ids.Tvdb.GetValueOrDefault(),
+                });
+            }
+
+            return listItems;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserParser.cs
@@ -27,36 +27,37 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
                 return listItems;
             }
 
-            var jsonResponse = new List<TraktSeriesResource>();
+            var traktSeries = new List<TraktSeriesResource>();
 
             if (_settings.TraktListType == (int)TraktUserListType.UserWatchedList)
             {
                 var jsonWatchedResponse = STJson.Deserialize<List<TraktWatchedResponse>>(_importResponse.Content);
+
                 switch (_settings.TraktWatchedListType)
                 {
                     case (int)TraktUserWatchedListType.InProgress:
-                        jsonResponse = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) < c.Show.AiredEpisodes).SelectList(c => c.Show);
+                        traktSeries = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) < c.Show.AiredEpisodes).SelectList(c => c.Show);
                         break;
                     case (int)TraktUserWatchedListType.CompletelyWatched:
-                        jsonResponse = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) == c.Show.AiredEpisodes).SelectList(c => c.Show);
+                        traktSeries = jsonWatchedResponse.Where(c => c.Seasons.Where(s => s.Number > 0).Sum(s => s.Episodes.Count) == c.Show.AiredEpisodes).SelectList(c => c.Show);
                         break;
                     default:
-                        jsonResponse = jsonWatchedResponse.SelectList(c => c.Show);
+                        traktSeries = jsonWatchedResponse.SelectList(c => c.Show);
                         break;
                 }
             }
             else
             {
-                jsonResponse = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
+                traktSeries = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
             }
 
-            // no series were return
-            if (jsonResponse == null)
+            // no series were returned
+            if (traktSeries == null)
             {
                 return listItems;
             }
 
-            foreach (var series in jsonResponse)
+            foreach (var series in traktSeries)
             {
                 listItems.AddIfNotNull(new ImportListItemInfo()
                 {

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
                     link += $"/users/{userName}/watchlist/shows?limit={Settings.Limit}";
                     break;
                 case (int)TraktUserListType.UserWatchedList:
-                    link += $"/users/{userName}/watched/shows?limit={Settings.Limit}";
+                    link += $"/users/{userName}/watched/shows?extended=full&limit={Settings.Limit}";
                     break;
                 case (int)TraktUserListType.UserCollectionList:
                     link += $"/users/{userName}/collection/shows?limit={Settings.Limit}";

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserSettings.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
         : base()
         {
             RuleFor(c => c.TraktListType).NotNull();
+            RuleFor(c => c.TraktWatchedListType).NotNull();
             RuleFor(c => c.AuthUser).NotEmpty();
         }
     }
@@ -20,12 +21,16 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
         public TraktUserSettings()
         {
             TraktListType = (int)TraktUserListType.UserWatchList;
+            TraktWatchedListType = (int)TraktUserWatchedListType.All;
         }
 
         [FieldDefinition(1, Label = "List Type", Type = FieldType.Select, SelectOptions = typeof(TraktUserListType), HelpText = "Type of list you're seeking to import from")]
         public int TraktListType { get; set; }
 
-        [FieldDefinition(2, Label = "Username", HelpText = "Username for the List to import from (empty to use Auth User)")]
+        [FieldDefinition(2, Label = "Watched List Filter", Type = FieldType.Select, SelectOptions = typeof(TraktUserWatchedListType), HelpText = "If List Type is Watched. Series do you want to import from")]
+        public int TraktWatchedListType { get; set; }
+
+        [FieldDefinition(3, Label = "Username", HelpText = "Username for the List to import from (empty to use Auth User)")]
         public string Username { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserWatchedListType.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserWatchedListType.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+
+namespace NzbDrone.Core.ImportLists.Trakt.User
+{
+    public enum TraktUserWatchedListType
+    {
+        [EnumMember(Value = "All")]
+        All = 0,
+        [EnumMember(Value = "In Progress")]
+        InProgress = 1,
+        [EnumMember(Value = "100% Watched")]
+        CompletelyWatched = 2
+    }
+}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In Sonarr there is no way to import those series that are in progress on Trakt.

- Watchlist only brings you those that you have not started to see.
- Watched brings you both the ones you have in progress and the ones you have finished.

From the Trakt API they warn that there is no specific endpoint to bring you this information and you have to do calculations locally. After much asking and searching, we have agreed that the easiest way is to compare the total number of episodes in a series and the number of episodes seen without counting the rewatches.

I have included a selector in the import list configuration to be able to select if you want to bring Everything, In Progress, Completed.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
