### PR TITLE
Usenet sorting

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                             .Build();
         }
 
-        private RemoteEpisode GivenRemoteEpisode(List<Episode> episodes, QualityModel quality, Language language, int age = 0, long size = 0, DownloadProtocol downloadProtocol = DownloadProtocol.Usenet, int indexerPriority = 25)
+        private RemoteEpisode GivenRemoteEpisode(List<Episode> episodes, QualityModel quality, Language language, int age = 0, long size = 0, DownloadProtocol downloadProtocol = DownloadProtocol.Usenet, int indexerPriority = 25, string releaseTitle = null)
         {
             var remoteEpisode = new RemoteEpisode();
             remoteEpisode.ParsedEpisodeInfo = new ParsedEpisodeInfo();
@@ -62,6 +62,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             remoteEpisode.Release.Size = size;
             remoteEpisode.Release.DownloadProtocol = downloadProtocol;
             remoteEpisode.Release.IndexerPriority = indexerPriority;
+            remoteEpisode.Release.Title = releaseTitle;
 
             remoteEpisode.Series = Builder<Series>.CreateNew()
                                                   .With(e => e.Runtime = 60)
@@ -157,10 +158,10 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_order_by_age_then_largest_rounded_to_200mb()
         {
-            var remoteEpisodeSd = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.SDTV), Language.English, size: 100.Megabytes(), age: 1);
-            var remoteEpisodeHdSmallOld = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1200.Megabytes(), age: 1000);
-            var remoteEpisodeSmallYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1250.Megabytes(), age: 10);
-            var remoteEpisodeHdLargeYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 1);
+            var remoteEpisodeSd = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.SDTV), Language.English, size: 100.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisodeHdSmallOld = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1200.Megabytes(), age: 1000, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisodeSmallYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1250.Megabytes(), age: 10, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisodeHdLargeYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
 
             var decisions = new List<DownloadDecision>();
             decisions.Add(new DownloadDecision(remoteEpisodeSd));

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -174,6 +174,26 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         }
 
         [Test]
+        public void should_order_by_age_for_equal_usenet_releases()
+        {
+            var remoteEpisode1 = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.SDTV), Language.English, size: 100.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisode2 = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3300.Megabytes(), age: 1000, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisode3 = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 2750.Megabytes(), age: 10, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisode4 = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisode5 = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 2, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-OTHERGRP");
+
+            var decisions = new List<DownloadDecision>();
+            decisions.Add(new DownloadDecision(remoteEpisode1));
+            decisions.Add(new DownloadDecision(remoteEpisode2));
+            decisions.Add(new DownloadDecision(remoteEpisode3));
+            decisions.Add(new DownloadDecision(remoteEpisode4));
+            decisions.Add(new DownloadDecision(remoteEpisode5));
+
+            var qualifiedReports = Subject.PrioritizeDecisions(decisions);
+            qualifiedReports.First().RemoteEpisode.Should().Be(remoteEpisode4);
+        }
+
+        [Test]
         public void should_order_by_closest_to_preferred_size_if_both_under()
         {
             // 200 MB/Min * 60 Min Runtime = 12000 MB

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -158,10 +158,10 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_order_by_age_then_largest_rounded_to_200mb()
         {
-            var remoteEpisodeSd = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.SDTV), Language.English, size: 100.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
-            var remoteEpisodeHdSmallOld = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1200.Megabytes(), age: 1000, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
-            var remoteEpisodeSmallYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1250.Megabytes(), age: 10, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
-            var remoteEpisodeHdLargeYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 1, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisodeSd = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.SDTV), Language.English, size: 100.Megabytes(), age: 1, downloadProtocol: DownloadProtocol.Torrent);
+            var remoteEpisodeHdSmallOld = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1200.Megabytes(), age: 1000, downloadProtocol: DownloadProtocol.Torrent);
+            var remoteEpisodeSmallYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 1250.Megabytes(), age: 10, downloadProtocol: DownloadProtocol.Usenet, releaseTitle: "Series.Title.S01E01.Pilot.1080p.WEB-DL-RLSGRP");
+            var remoteEpisodeHdLargeYoung = GivenRemoteEpisode(new List<Episode> { GivenEpisode(1) }, new QualityModel(Quality.HDTV720p), Language.English, size: 3000.Megabytes(), age: 1, downloadProtocol: DownloadProtocol.Torrent);
 
             var decisions = new List<DownloadDecision>();
             decisions.Add(new DownloadDecision(remoteEpisodeSd));

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -224,9 +224,7 @@ namespace NzbDrone.Core.DecisionEngine
         {
             var roundingRules = new List<(long threshold, long roundTo)>
                 {
-                    (1.5.Gigabytes(), 200.Megabytes()),
-                    (3.5.Gigabytes(), 300.Megabytes()),
-                    (6.Gigabytes(), 450.Megabytes()),
+                    (2.5.Gigabytes(), 300.Megabytes()),
                     (15.Gigabytes(), 800.Megabytes()),
                     (30.Gigabytes(), 1600.Megabytes())
                 };

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -12,6 +12,8 @@ namespace NzbDrone.Core.DecisionEngine
 {
     public class DownloadDecisionComparer : IComparer<DownloadDecision>
     {
+        private static readonly string[] IgnoredStrings = new string[] { "-xpost" };
+
         private readonly IConfigService _configService;
         private readonly IDelayProfileService _delayProfileService;
         private readonly IQualityDefinitionService _qualityDefinitionService;
@@ -242,9 +244,7 @@ namespace NzbDrone.Core.DecisionEngine
         {
             // some indexers add strings like -xpost to the release which can be ignored (it's not a release group)
 
-            var ignoredStrings = new string[] { "-xpost" };
-
-            foreach (var ignoredString in ignoredStrings)
+            foreach (var ignoredString in IgnoredStrings)
             {
                 if (releaseName.EndsWith(ignoredString, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.DecisionEngine
             }
             else
             {
-                // use original sorting logic if the releases are not equal
+                // Use original sorting logic if the releases are not equal
                 return CompareBy(x.RemoteEpisode, y.RemoteEpisode, remoteEpisode =>
                 {
                     var ageHours = remoteEpisode.Release.AgeHours;
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.DecisionEngine
 
         private string SanitizeReleaseName(string releaseName)
         {
-            // some indexers add strings like -xpost to the release which can be ignored (it's not a release group)
+            // Some indexers add strings like -xpost to the release which can be ignored
 
             foreach (var ignoredString in IgnoredStrings)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Usenet releases with the same name and size are now sorted by age in ascending order. This solves the issue of block accounts being used when there is no need. It also saves time and bandwith as older uploads are more often missing articles.

Before:
![grafik](https://github.com/Sonarr/Sonarr/assets/377223/dcb6bc5e-a8fc-47cf-8783-906fd05e3ce9)
After:
![grafik](https://github.com/PCJones/Sonarr-Enhanced/assets/377223/808fa57b-5b5c-4623-80a1-657ec4ef5a44)


#### Issues Fixed or Closed by this PR

* #6057 

#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
