### PR TITLE
Fix: return '#' as first character for non alphanumeric

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
@@ -36,8 +36,11 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("The Mist", "M\\The Mist")]
         [TestCase("A", "A\\A")]
         [TestCase("30 Rock", "3\\30 Rock")]
-        [TestCase("The '80s Greatest", "_\\The '80s Greatest")]
+        [TestCase("The '80s Greatest", "8\\The '80s Greatest")]
         [TestCase("좀비버스", "좀\\좀비버스")]
+        [TestCase("¡Mucha Lucha!", "M\\¡Mucha Lucha!")]
+        [TestCase(".hack", "H\\hack")]
+        [TestCase("Ütopya", "Ü\\Ütopya")]
 
         public void should_get_expected_folder_name_back(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
@@ -36,7 +36,8 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("The Mist", "M\\The Mist")]
         [TestCase("A", "A\\A")]
         [TestCase("30 Rock", "3\\30 Rock")]
-        [TestCase("The '80s Greatest", "#\\The '80s Greatest")]
+        [TestCase("The '80s Greatest", "_\\The '80s Greatest")]
+        [TestCase("좀비버스", "좀\\좀비버스")]
 
         public void should_get_expected_folder_name_back(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("좀비버스", "좀\\좀비버스")]
         [TestCase("¡Mucha Lucha!", "M\\¡Mucha Lucha!")]
         [TestCase(".hack", "H\\hack")]
-        [TestCase("Ütopya", "Ü\\Ütopya")]
+        [TestCase("Ütopya", "U\\Ütopya")]
 
         public void should_get_expected_folder_name_back(string title, string expected)
         {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
@@ -36,6 +36,8 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("The Mist", "M\\The Mist")]
         [TestCase("A", "A\\A")]
         [TestCase("30 Rock", "3\\30 Rock")]
+        [TestCase("The '80s Greatest", "#\\The '80s Greatest")]
+
         public void should_get_expected_folder_name_back(string title, string expected)
         {
             _series.Title = title;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -381,9 +381,16 @@ namespace NzbDrone.Core.Organizer
         {
             if (char.IsLetterOrDigit(title[0]))
             {
-                return title.Substring(0, 1).FirstCharToUpper();
+                return title.Substring(0, 1).ToUpper();
             }
 
+            // try the second character if the first was non alphanumeric
+            if (char.IsLetterOrDigit(title[1]))
+            {
+                return title.Substring(1, 1).ToUpper();
+            }
+
+            // default to "_" if no alphanumeric character can be found in the first 2 positions
             return "_";
         }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -384,7 +384,7 @@ namespace NzbDrone.Core.Organizer
                 return title.Substring(0, 1).ToUpper().RemoveAccent();
             }
 
-            // try the second character if the first was non alphanumeric
+            // Try the second character if the first was non alphanumeric
             if (char.IsLetterOrDigit(title[1]))
             {
                 return title.Substring(1, 1).ToUpper().RemoveAccent();

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -381,13 +381,13 @@ namespace NzbDrone.Core.Organizer
         {
             if (char.IsLetterOrDigit(title[0]))
             {
-                return title.Substring(0, 1).ToUpper();
+                return title.Substring(0, 1).ToUpper().RemoveAccent();
             }
 
             // try the second character if the first was non alphanumeric
             if (char.IsLetterOrDigit(title[1]))
             {
-                return title.Substring(1, 1).ToUpper();
+                return title.Substring(1, 1).ToUpper().RemoveAccent();
             }
 
             // default to "_" if no alphanumeric character can be found in the first 2 positions

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -379,15 +379,12 @@ namespace NzbDrone.Core.Organizer
 
         public static string TitleFirstCharacter(string title)
         {
-            title = ScenifyReplaceChars.Replace(title, " ");
-            title = ScenifyRemoveChars.Replace(title, string.Empty);
-
             if (char.IsLetterOrDigit(title[0]))
             {
                 return title.Substring(0, 1).FirstCharToUpper();
             }
 
-            return "#";
+            return "_";
         }
 
         public static string CleanFileName(string name)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -377,6 +377,19 @@ namespace NzbDrone.Core.Organizer
             return title;
         }
 
+        public static string TitleFirstCharacter(string title)
+        {
+            title = ScenifyReplaceChars.Replace(title, " ");
+            title = ScenifyRemoveChars.Replace(title, string.Empty);
+
+            if (char.IsLetterOrDigit(title[0]))
+            {
+                return title.Substring(0, 1).FirstCharToUpper();
+            }
+
+            return "#";
+        }
+
         public static string CleanFileName(string name)
         {
             return CleanFileName(name, NamingConfig.Default);
@@ -452,7 +465,7 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Series TitleWithoutYear}"] = m => TitleWithoutYear(series.Title);
             tokenHandlers["{Series TitleTheYear}"] = m => TitleYear(TitleThe(series.Title), series.Year);
             tokenHandlers["{Series TitleTheWithoutYear}"] = m => TitleWithoutYear(TitleThe(series.Title));
-            tokenHandlers["{Series TitleFirstCharacter}"] = m => TitleThe(series.Title).Substring(0, 1).FirstCharToUpper();
+            tokenHandlers["{Series TitleFirstCharacter}"] = m => TitleFirstCharacter(TitleThe(series.Title));
             tokenHandlers["{Series Year}"] = m => series.Year.ToString();
         }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -390,7 +390,7 @@ namespace NzbDrone.Core.Organizer
                 return title.Substring(1, 1).ToUpper().RemoveAccent();
             }
 
-            // default to "_" if no alphanumeric character can be found in the first 2 positions
+            // Default to "_" if no alphanumeric character can be found in the first 2 positions
             return "_";
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This returns '#' as the first character to use in the `{Series TitleFirstCharacter}` token when that character is not alphanumeric

#### Todos
- [X] Tests

#### Issues Fixed or Closed by this PR

* fixes #6055 6055
