### PR TITLE
Fix: update Spanish release episode parser

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -161,6 +161,9 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series-S07E12-31st_Century_Fox-[Bluray-1080p].mkv", "Series", 7, 12)]
         [TestCase("TheTitle-S12E13-3_Acts_of_God.mkv", "TheTitle", 12, 13)]
         [TestCase("Series Title - Temporada 2 [HDTV 720p][Cap.408]", "Series Title", 4, 8)]
+        [TestCase("Ahsoka [HDTV][Cap.104](wolfmax4k.com).avi", "Ahsoka", 1, 4)]
+        [TestCase("Sex Education [HDTV][Cap.402](wolfmax4k.com).avi", "Sex Education", 4, 2)]
+        [TestCase("The Walking Dead Daryl Dixon [HDTV 720p][Cap.101](wolfmax4k.com).mkv", "The Walking Dead Daryl Dixon", 1, 1)]
 
         // [TestCase("", "", 0, 0)]
         public void should_parse_single_episode(string postTitle, string title, int seasonNumber, int episodeNumber)

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -161,9 +161,9 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series-S07E12-31st_Century_Fox-[Bluray-1080p].mkv", "Series", 7, 12)]
         [TestCase("TheTitle-S12E13-3_Acts_of_God.mkv", "TheTitle", 12, 13)]
         [TestCase("Series Title - Temporada 2 [HDTV 720p][Cap.408]", "Series Title", 4, 8)]
-        [TestCase("Ahsoka [HDTV][Cap.104](wolfmax4k.com).avi", "Ahsoka", 1, 4)]
-        [TestCase("Sex Education [HDTV][Cap.402](wolfmax4k.com).avi", "Sex Education", 4, 2)]
-        [TestCase("The Walking Dead Daryl Dixon [HDTV 720p][Cap.101](wolfmax4k.com).mkv", "The Walking Dead Daryl Dixon", 1, 1)]
+        [TestCase("Series Title [HDTV][Cap.104](website.com).avi", "Series Title", 1, 4)]
+        [TestCase("Series Title [HDTV][Cap.402](website.com).avi", "Series Title", 4, 2)]
+        [TestCase("Series Title [HDTV 720p][Cap.101](website.com).mkv", "Series Title", 1, 1)]
 
         // [TestCase("", "", 0, 0)]
         public void should_parse_single_episode(string postTitle, string title, int seasonNumber, int episodeNumber)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -363,7 +363,7 @@ namespace NzbDrone.Core.Parser
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 // Spanish tracker releases
-                new Regex(@"^(?<title>.+?)(?:[-_. ]+?Temporada.+?\[Cap[-_.])(?<season>(?<!\d+)\d{1,2})(?<episode>(?<!e|x)(?:[1-9][0-9]|[0][1-9]))(?:\])",
+                new Regex(@"^(?<title>.+?)(?:(?:[-_. ]+?Temporada.+?|\[.+?\])\[Cap[-_.])(?<season>(?<!\d+)\d{1,2})(?<episode>(?<!e|x)(?:[1-9][0-9]|[0][1-9]))(?:\])",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
                 // Anime Range - Title Absolute Episode Number (ep01-12)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Aparantly spanish indexers aren't using the `Temporada #` part of their release title anymore, this was brough to attention on discord, and the regex is updated with this PR

Thanks to Ivory: https://discord.com/channels/383686866005917708/383688189941907459/1154205181270044772
#### Todos


#### Issues Fixed or Closed by this PR

* 
