### PR TITLE
Prevent NullRef for cases when media covers have nullable urls

### DIFF
--- a/src/NzbDrone.Core/MediaCover/MediaCoverProxy.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverProxy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using NzbDrone.Common.Cache;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 
@@ -31,6 +32,11 @@ namespace NzbDrone.Core.MediaCover
 
         public string RegisterUrl(string url)
         {
+            if (url.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
             var hash = url.SHA256Hash();
 
             _cache.Set(hash, url, TimeSpan.FromHours(24));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Noticed in Radarr, but it seems like when people mess around with downgrading and upgrading it can lead to issues with null values for RemoteUrl in Media Covers.

```
[v5.0.3.8107] System.ArgumentNullException: String reference not set to an instance of a String. (Parameter 's')
   at System.Text.Encoding.GetBytes(String s)
   at NzbDrone.Core.Hashing.SHA256Hash(String input) in ./Radarr.Core/Hashing.cs:line 14
   at NzbDrone.Core.MediaCover.MediaCoverProxy.RegisterUrl(String url) in ./Radarr.Core/MediaCover/MediaCoverProxy.cs:line 34
   at NzbDrone.Core.MediaCover.MediaCoverService.ConvertToLocalUrls(Int32 movieId, IEnumerable`1 covers, Dictionary`2 fileInfos) in ./Radarr.Core/MediaCover/MediaCoverService.cs:line 96
   at NzbDrone.Core.MediaCover.MediaCoverService.ConvertToLocalUrls(IEnumerable`1 items, Dictionary`2 coverFileInfos) in ./Radarr.Core/MediaCover/MediaCoverService.cs:line 135
```