### PR TITLE
New: Add remaining CleanTitle tokens and re-order options

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -82,13 +82,16 @@ const fileNameTokens = [
 const seriesTokens = [
   { token: '{Series Title}', example: 'The Series Title\'s!' },
   { token: '{Series CleanTitle}', example: 'The Series Title\'s!' },
-  { token: '{Series CleanTitleYear}', example: 'The Series Titles! 2010' },
+  { token: '{Series TitleYear}', example: 'The Series Title\'s! (2010)' },
+  { token: '{Series CleanTitleYear}', example: 'The Series Title\'s! 2010' },
+  { token: '{Series TitleWithoutYear}', example: 'The Series Title\'s!' },
   { token: '{Series CleanTitleWithoutYear}', example: 'The Series Title\'s!' },
   { token: '{Series TitleThe}', example: 'Series Title\'s!, The' },
+  { token: '{Series CleanTitleThe}', example: 'Series Title\'s!, The' },
   { token: '{Series TitleTheYear}', example: 'Series Title\'s!, The (2010)' },
+  { token: '{Series CleanTitleTheYear}', example: 'Series Title\'s!, The 2010' },
   { token: '{Series TitleTheWithoutYear}', example: 'Series Title\'s!, The' },
-  { token: '{Series TitleYear}', example: 'The Series Title\'s! (2010)' },
-  { token: '{Series TitleWithoutYear}', example: 'Series Title\'s!' },
+  { token: '{Series CleanTitleTheWithoutYear}', example: 'Series Title\'s!, The' },
   { token: '{Series TitleFirstCharacter}', example: 'S' },
   { token: '{Series Year}', example: '2010' }
 ];

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheFixture.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class CleanTitleTheFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", "Mist, The")]
+        [TestCase("A Place to Call Home", "Place to Call Home, A")]
+        [TestCase("An Adventure in Space and Time", "Adventure in Space and Time, An")]
+        [TestCase("The Flash (2010)", "Flash, The 2010")]
+        [TestCase("A League Of Their Own (AU)", "League Of Their Own, A AU")]
+        [TestCase("The Fixer (ZH) (2015)", "Fixer, The ZH 2015")]
+        [TestCase("The Sixth Sense 2 (Thai)", "Sixth Sense 2, The Thai")]
+        [TestCase("The Amazing Race (Latin America)", "Amazing Race, The Latin America")]
+        [TestCase("The Rat Pack (A&E)", "Rat Pack, The AandE")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", "Climax I Almost Got Away With It, The 2016")]
+        public void should_get_expected_title_back(string title, string expected)
+        {
+            _series.Title = title;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleThe}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("A")]
+        [TestCase("Anne")]
+        [TestCase("Theodore")]
+        [TestCase("3%")]
+        public void should_not_change_title(string title)
+        {
+            _series.Title = title;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleThe}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(title);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheWithoutYearFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheWithoutYearFixture.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class CleanTitleTheWithoutYearFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", 2018, "Mist, The")]
+        [TestCase("The Rat Pack (A&E)", 1999, "Rat Pack, The AandE")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 2016, "Climax I Almost Got Away With It, The")]
+        [TestCase("A", 2017, "A")]
+        public void should_get_expected_title_back(string title, int year, string expected)
+        {
+            _series.Title = title;
+            _series.Year = year;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleTheWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [Test]
+        public void should_not_include_0_for_year()
+        {
+            _series.Title = "The Alienist";
+            _series.Year = 0;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleTheWithoutYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be("Alienist, The");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheYearFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleTheYearFixture.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+    public class CleanTitleTheYearFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("The Mist", 2018, "Mist, The 2018")]
+        [TestCase("The Rat Pack (A&E)", 1999, "Rat Pack, The AandE 1999")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 2016, "Climax I Almost Got Away With It, The 2016")]
+        [TestCase("The Climax: I (Almost) Got Away With It (2016)", 0, "Climax I Almost Got Away With It, The 2016")]
+        [TestCase("The Climax: I (Almost) Got Away With It", 0, "Climax I Almost Got Away With It, The")]
+        [TestCase("A", 2017, "A 2017")]
+        public void should_get_expected_title_back(string title, int year, string expected)
+        {
+            _series.Title = title;
+            _series.Year = year;
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitleTheYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be(expected);
+        }
+
+        [Test]
+        public void should_not_include_0_for_year()
+        {
+            _series.Title = "The Alienist";
+            _series.Year = 0;
+            _namingConfig.StandardEpisodeFormat = "{Series TitleTheYear}";
+
+            Subject.BuildFileName(new List<Episode> { _episode }, _series, _episodeFile)
+                   .Should().Be("Alienist, The");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -353,6 +353,17 @@ namespace NzbDrone.Core.Organizer
             return TitlePrefixRegex.Replace(title, "$2, $1$3");
         }
 
+        public static string CleanTitleThe(string title)
+        {
+            if (TitlePrefixRegex.IsMatch(title))
+            {
+                var splitResult = TitlePrefixRegex.Split(title);
+                return $"{CleanTitle(splitResult[2]).Trim()}, {splitResult[1]}{CleanTitle(splitResult[3])}";
+            }
+
+            return CleanTitle(title);
+        }
+
         public static string TitleYear(string title, int year)
         {
             // Don't use 0 for the year.
@@ -368,6 +379,25 @@ namespace NzbDrone.Core.Organizer
             }
 
             return $"{title} ({year})";
+        }
+
+        public static string CleanTitleTheYear(string title, int year)
+        {
+            // Don't use 0 for the year.
+            if (year == 0)
+            {
+                return CleanTitleThe(title);
+            }
+
+            // Regex match incase the year in the title doesn't match the year, for whatever reason.
+            if (YearRegex.IsMatch(title))
+            {
+                var splitReturn = YearRegex.Split(title);
+                var yearMatch = YearRegex.Match(title);
+                return $"{CleanTitleThe(splitReturn[0].Trim())} {yearMatch.Value[1..5]}";
+            }
+
+            return $"{CleanTitleThe(title)} {year}";
         }
 
         public static string TitleWithoutYear(string title)
@@ -462,13 +492,16 @@ namespace NzbDrone.Core.Organizer
         {
             tokenHandlers["{Series Title}"] = m => series.Title;
             tokenHandlers["{Series CleanTitle}"] = m => CleanTitle(series.Title);
+            tokenHandlers["{Series TitleYear}"] = m => TitleYear(series.Title, series.Year);
             tokenHandlers["{Series CleanTitleYear}"] = m => CleanTitle(TitleYear(series.Title, series.Year));
+            tokenHandlers["{Series TitleWithoutYear}"] = m => TitleWithoutYear(series.Title);
             tokenHandlers["{Series CleanTitleWithoutYear}"] = m => CleanTitle(TitleWithoutYear(series.Title));
             tokenHandlers["{Series TitleThe}"] = m => TitleThe(series.Title);
-            tokenHandlers["{Series TitleYear}"] = m => TitleYear(series.Title, series.Year);
-            tokenHandlers["{Series TitleWithoutYear}"] = m => TitleWithoutYear(series.Title);
+            tokenHandlers["{Series CleanTitleThe}"] = m => CleanTitleThe(series.Title);
             tokenHandlers["{Series TitleTheYear}"] = m => TitleYear(TitleThe(series.Title), series.Year);
+            tokenHandlers["{Series CleanTitleTheYear}"] = m => CleanTitleTheYear(series.Title, series.Year);
             tokenHandlers["{Series TitleTheWithoutYear}"] = m => TitleWithoutYear(TitleThe(series.Title));
+            tokenHandlers["{Series CleanTitleTheWithoutYear}"] = m => CleanTitleThe(TitleWithoutYear(series.Title));
             tokenHandlers["{Series TitleFirstCharacter}"] = m => TitleFirstCharacter(TitleThe(series.Title));
             tokenHandlers["{Series Year}"] = m => series.Year.ToString();
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the remaining CleanTitle naming tokens and tests to cover them.
Also took the opportunity to reorder them so normal and clean line up properly in the with each other:

![image](https://github.com/Sonarr/Sonarr/assets/1117625/6cb42ba8-bfed-4886-8345-225c3a8ae34a)

Question: Do we want the `,` the be prepended with `The` in Clean filenames? I.e. should it be `Series Name, The` or `Series Name The`

#### Todos
- [X] Tests


#### Issues Fixed or Closed by this PR

* Fixes #6066 
