### PR TITLE
Fix: reduce Series Title on SeriesDetails when on small screen

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -156,6 +156,12 @@
   .headerContent {
     padding: 15px;
   }
+
+  .title {
+    font-weight: 300;
+    font-size: 30px;
+    line-height: 30px;
+  }
 }
 
 @media only screen and (max-width: $breakpointLarge) {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
To avoid long titles taking up a lot of screen real estate, title font size is reduced for smaller screens

#### Todos



#### Issues Fixed or Closed by this PR

* Closes #6087 
