### PR TITLE
New: Add support for Jellyfin's "enddate" tag when generating the xbmc metadata nfo file.

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     }
 
                     // Add support for Jellyfin's "enddate" tag
-                    if (series.Status.Equals(SeriesStatusType.Ended) && series.LastAired.HasValue)
+                    if (series.Status == SeriesStatusType.Ended && series.LastAired.HasValue)
                     {
                         tvShow.Add(new XElement("enddate", series.LastAired.Value.ToString("yyyy-MM-dd")));
                     }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -198,6 +198,12 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         tvShow.Add(new XElement("premiered", series.FirstAired.Value.ToString("yyyy-MM-dd")));
                     }
 
+                    // Add support for Jellyfin's "enddate" tag
+                    if (series.Status.Equals(SeriesStatusType.Ended) && series.LastAired.HasValue)
+                    {
+                        tvShow.Add(new XElement("enddate", series.LastAired.Value.ToString("yyyy-MM-dd")));
+                    }
+
                     tvShow.Add(new XElement("studio", series.Network));
 
                     foreach (var actor in series.Actors)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add support for Jellyfin's "enddate" tag when generating the xbmc metadata nfo file. When the series has ended, enddate tag will be added to the nfo file.
#### Todos

#### Issues Fixed or Closed by this PR

* 
