### PR TITLE
Fix: hasMissingSeason filter function

### DIFF
--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -168,9 +168,10 @@ export const filterPredicates = {
   },
 
   hasMissingSeason: function(item, filterValue, type) {
+    const predicate = filterTypePredicates[type];
     const { seasons = [] } = item;
 
-    return seasons.some((season) => {
+    const hasMissingSeason = seasons.some((season) => {
       const {
         seasonNumber,
         statistics = {}
@@ -189,6 +190,8 @@ export const filterPredicates = {
         episodeFileCount === 0
       );
     });
+
+    return predicate(hasMissingSeason, filterValue);
   }
 };
 
@@ -347,7 +350,8 @@ export const filterBuilderProps = [
   {
     name: 'hasMissingSeason',
     label: () => translate('HasMissingSeason'),
-    type: filterBuilderTypes.EXACT
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.BOOL
   },
   {
     name: 'year',


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The current hasMissingSeason filter returns all shows with missing seasons no matter what the filter is set to.
This enables the filter to be used as a boolean so that it can also be used for shows that don't have a full missing season.


#### Todos

#### Issues Fixed or Closed by this PR

* 
