### PR TITLE
New: set relative path as Initial Sort order on Manual Import

### DIFF
--- a/frontend/src/InteractiveImport/InteractiveImportModal.tsx
+++ b/frontend/src/InteractiveImport/InteractiveImportModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import Modal from 'Components/Modal/Modal';
 import usePrevious from 'Helpers/Hooks/usePrevious';
-import { sizes, sortDirections } from 'Helpers/Props';
+import { sizes } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
 import InteractiveImportSelectFolderModalContent from './Folder/InteractiveImportSelectFolderModalContent';
 import InteractiveImportModalContent from './Interactive/InteractiveImportModalContent';
@@ -58,8 +58,6 @@ function InteractiveImportModal(props: InteractiveImportModalProps) {
           downloadId={downloadId}
           modalTitle={modalTitle}
           onModalClose={onModalClose}
-          initialSortKey="relativePath"
-          initialSortDirection={sortDirections.ASCENDING}
         />
       ) : (
         <InteractiveImportSelectFolderModalContent

--- a/frontend/src/InteractiveImport/InteractiveImportModal.tsx
+++ b/frontend/src/InteractiveImport/InteractiveImportModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import Modal from 'Components/Modal/Modal';
 import usePrevious from 'Helpers/Hooks/usePrevious';
-import { sizes } from 'Helpers/Props';
+import { sizes, sortDirections } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
 import InteractiveImportSelectFolderModalContent from './Folder/InteractiveImportSelectFolderModalContent';
 import InteractiveImportModalContent from './Interactive/InteractiveImportModalContent';
@@ -58,6 +58,8 @@ function InteractiveImportModal(props: InteractiveImportModalProps) {
           downloadId={downloadId}
           modalTitle={modalTitle}
           onModalClose={onModalClose}
+          initialSortKey="relativePath"
+          initialSortDirection={sortDirections.ASCENDING}
         />
       ) : (
         <InteractiveImportSelectFolderModalContent

--- a/frontend/src/Store/Actions/interactiveImportActions.js
+++ b/frontend/src/Store/Actions/interactiveImportActions.js
@@ -28,8 +28,8 @@ export const defaultState = {
   error: null,
   items: [],
   originalItems: [],
-  sortKey: 'quality',
-  sortDirection: sortDirections.DESCENDING,
+  sortKey: 'relativePath',
+  sortDirection: sortDirections.ASCENDING,
   recentFolders: [],
   importMode: 'chooseImportMode',
   sortPredicates: {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
sets the default sort order of manual imports to ascending relative path, so the episodes (most likely) appear in order.

#### Todos

#### Issues Fixed or Closed by this PR

* 
