### PR TITLE
Use Diacritical.Net library for TitleFirstCharacter token

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/SeriesTitleFirstCharacterFixture.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("¡Mucha Lucha!", "M\\¡Mucha Lucha!")]
         [TestCase(".hack", "H\\hack")]
         [TestCase("Ütopya", "U\\Ütopya")]
+        [TestCase("Æon Flux", "A\\Æon Flux")]
 
         public void should_get_expected_folder_name_back(string title, string expected)
         {

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Diacritical;
+using DryIoc.ImTools;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
@@ -411,13 +413,13 @@ namespace NzbDrone.Core.Organizer
         {
             if (char.IsLetterOrDigit(title[0]))
             {
-                return title.Substring(0, 1).ToUpper().RemoveAccent();
+                return title.Substring(0, 1).ToUpper().RemoveDiacritics()[0].ToString();
             }
 
             // Try the second character if the first was non alphanumeric
             if (char.IsLetterOrDigit(title[1]))
             {
-                return title.Substring(1, 1).ToUpper().RemoveAccent();
+                return title.Substring(1, 1).ToUpper().RemoveDiacritics()[0].ToString();
             }
 
             // Default to "_" if no alphanumeric character can be found in the first 2 positions

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="MailKit" Version="3.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.21" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use [Diacritical.Net ](https://www.nuget.org/packages/Diacritical.Net)library when determining the TitleFirstCharacter token for simpler sorting

#### Todos


#### Issues Fixed or Closed by this PR

* 
