### PR TITLE
Set busy timeout for SQLite

### DIFF
--- a/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
+++ b/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
@@ -44,11 +44,12 @@ namespace NzbDrone.Core.Datastore
             var connectionBuilder = new SQLiteConnectionStringBuilder
             {
                 DataSource = dbPath,
-                CacheSize = (int)-10000,
+                CacheSize = (int)-20000,
                 DateTimeKind = DateTimeKind.Utc,
                 JournalMode = OsInfo.IsOsx ? SQLiteJournalModeEnum.Truncate : SQLiteJournalModeEnum.Wal,
                 Pooling = true,
-                Version = 3
+                Version = 3,
+                BusyTimeout = 100
             };
 
             if (OsInfo.IsOsx)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adding a busy timeout in order to avoid db locks. I used 100 for more than week and 0 db locks since. 

https://www.sqlite.org/c3ref/busy_timeout.html