### PR TITLE
New: Add Download Client validation for indexers

### DIFF
--- a/src/NzbDrone.Core.Test/Profiles/QualityProfileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/QualityProfileServiceFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.Profiles
 
             Subject.Handle(new ApplicationStartedEvent());
 
-            Mocker.GetMock<IProfileRepository>()
+            Mocker.GetMock<IQualityProfileRepository>()
                 .Verify(v => v.Insert(It.IsAny<QualityProfile>()), Times.Exactly(6));
         }
 
@@ -42,13 +42,13 @@ namespace NzbDrone.Core.Test.Profiles
         // We don't want to keep adding them back if a user deleted them on purpose.
         public void Init_should_skip_if_any_profiles_already_exist()
         {
-            Mocker.GetMock<IProfileRepository>()
+            Mocker.GetMock<IQualityProfileRepository>()
                   .Setup(s => s.All())
                   .Returns(Builder<QualityProfile>.CreateListOfSize(2).Build().ToList());
 
             Subject.Handle(new ApplicationStartedEvent());
 
-            Mocker.GetMock<IProfileRepository>()
+            Mocker.GetMock<IQualityProfileRepository>()
                 .Verify(v => v.Insert(It.IsAny<QualityProfile>()), Times.Never());
         }
 
@@ -65,11 +65,11 @@ namespace NzbDrone.Core.Test.Profiles
                                             .Build().ToList();
 
             Mocker.GetMock<ISeriesService>().Setup(c => c.GetAllSeries()).Returns(seriesList);
-            Mocker.GetMock<IProfileRepository>().Setup(c => c.Get(profile.Id)).Returns(profile);
+            Mocker.GetMock<IQualityProfileRepository>().Setup(c => c.Get(profile.Id)).Returns(profile);
 
             Assert.Throws<QualityProfileInUseException>(() => Subject.Delete(profile.Id));
 
-            Mocker.GetMock<IProfileRepository>().Verify(c => c.Delete(It.IsAny<int>()), Times.Never());
+            Mocker.GetMock<IQualityProfileRepository>().Verify(c => c.Delete(It.IsAny<int>()), Times.Never());
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.Profiles
 
             Subject.Delete(1);
 
-            Mocker.GetMock<IProfileRepository>().Verify(c => c.Delete(1), Times.Once());
+            Mocker.GetMock<IQualityProfileRepository>().Verify(c => c.Delete(1), Times.Once());
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.Profiles
                                                            .Random(1)
                                                            .Build().ToList();
 
-            Mocker.GetMock<IProfileRepository>().Setup(c => c.Get(profile.Id)).Returns(profile);
+            Mocker.GetMock<IQualityProfileRepository>().Setup(c => c.Get(profile.Id)).Returns(profile);
             Mocker.GetMock<ISeriesService>().Setup(c => c.GetAllSeries()).Returns(seriesList);
 
             Mocker.GetMock<IImportListFactory>()
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.Profiles
 
             Assert.Throws<QualityProfileInUseException>(() => Subject.Delete(1));
 
-            Mocker.GetMock<IProfileRepository>().Verify(c => c.Delete(It.IsAny<int>()), Times.Never());
+            Mocker.GetMock<IQualityProfileRepository>().Verify(c => c.Delete(It.IsAny<int>()), Times.Never());
         }
     }
 }

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRepository.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRepository.cs
@@ -6,12 +6,12 @@ using NzbDrone.Core.Messaging.Events;
 
 namespace NzbDrone.Core.Profiles.Qualities
 {
-    public interface IProfileRepository : IBasicRepository<QualityProfile>
+    public interface IQualityProfileRepository : IBasicRepository<QualityProfile>
     {
         bool Exists(int id);
     }
 
-    public class QualityProfileRepository : BasicRepository<QualityProfile>, IProfileRepository
+    public class QualityProfileRepository : BasicRepository<QualityProfile>, IQualityProfileRepository
     {
         private readonly ICustomFormatService _customFormatService;
 

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
@@ -28,19 +28,19 @@ namespace NzbDrone.Core.Profiles.Qualities
                                          IHandle<CustomFormatAddedEvent>,
                                          IHandle<CustomFormatDeletedEvent>
     {
-        private readonly IProfileRepository _profileRepository;
+        private readonly IQualityProfileRepository _qualityProfileRepository;
         private readonly IImportListFactory _importListFactory;
         private readonly ICustomFormatService _formatService;
         private readonly ISeriesService _seriesService;
         private readonly Logger _logger;
 
-        public QualityProfileService(IProfileRepository profileRepository,
+        public QualityProfileService(IQualityProfileRepository qualityProfileRepository,
                                      IImportListFactory importListFactory,
                                      ICustomFormatService formatService,
                                      ISeriesService seriesService,
                                      Logger logger)
         {
-            _profileRepository = profileRepository;
+            _qualityProfileRepository = qualityProfileRepository;
             _importListFactory = importListFactory;
             _formatService = formatService;
             _seriesService = seriesService;
@@ -49,38 +49,38 @@ namespace NzbDrone.Core.Profiles.Qualities
 
         public QualityProfile Add(QualityProfile profile)
         {
-            return _profileRepository.Insert(profile);
+            return _qualityProfileRepository.Insert(profile);
         }
 
         public void Update(QualityProfile profile)
         {
-            _profileRepository.Update(profile);
+            _qualityProfileRepository.Update(profile);
         }
 
         public void Delete(int id)
         {
             if (_seriesService.GetAllSeries().Any(c => c.QualityProfileId == id) || _importListFactory.All().Any(c => c.QualityProfileId == id))
             {
-                var profile = _profileRepository.Get(id);
+                var profile = _qualityProfileRepository.Get(id);
                 throw new QualityProfileInUseException(profile.Name);
             }
 
-            _profileRepository.Delete(id);
+            _qualityProfileRepository.Delete(id);
         }
 
         public List<QualityProfile> All()
         {
-            return _profileRepository.All().ToList();
+            return _qualityProfileRepository.All().ToList();
         }
 
         public QualityProfile Get(int id)
         {
-            return _profileRepository.Get(id);
+            return _qualityProfileRepository.Get(id);
         }
 
         public bool Exists(int id)
         {
-            return _profileRepository.Exists(id);
+            return _qualityProfileRepository.Exists(id);
         }
 
         public void Handle(ApplicationStartedEvent message)

--- a/src/NzbDrone.Core/Validation/DownloadClientExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/DownloadClientExistsValidator.cs
@@ -1,0 +1,27 @@
+﻿using FluentValidation.Validators;
+using NzbDrone.Core.Download;
+
+namespace NzbDrone.Core.Validation
+{
+    public class DownloadClientExistsValidator : PropertyValidator
+    {
+        private readonly IDownloadClientFactory _downloadClientFactory;
+
+        public DownloadClientExistsValidator(IDownloadClientFactory downloadClientFactory)
+        {
+            _downloadClientFactory = downloadClientFactory;
+        }
+
+        protected override string GetDefaultMessageTemplate() => "Download Client does not exist";
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            if (context?.PropertyValue == null || (int)context.PropertyValue == 0)
+            {
+                return true;
+            }
+
+            return _downloadClientFactory.Exists((int)context.PropertyValue);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Validation
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
-            if (context.PropertyValue == null)
+            if (context?.PropertyValue == null || (int)context.PropertyValue == 0)
             {
                 return true;
             }

--- a/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/QualityProfileExistsValidator.cs
@@ -3,16 +3,16 @@ using NzbDrone.Core.Profiles.Qualities;
 
 namespace NzbDrone.Core.Validation
 {
-    public class ProfileExistsValidator : PropertyValidator
+    public class QualityProfileExistsValidator : PropertyValidator
     {
         private readonly IQualityProfileService _qualityProfileService;
 
-        public ProfileExistsValidator(IQualityProfileService qualityProfileService)
+        public QualityProfileExistsValidator(IQualityProfileService qualityProfileService)
         {
             _qualityProfileService = qualityProfileService;
         }
 
-        protected override string GetDefaultMessageTemplate() => "QualityProfile does not exist";
+        protected override string GetDefaultMessageTemplate() => "Quality Profile does not exist";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {

--- a/src/NzbDrone.Integration.Test/ApiTests/SeriesEditorFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/SeriesEditorFixture.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Integration.Test.ApiTests
     {
         private void GivenExistingSeries()
         {
-            WaitForCompletion(() => Profiles.All().Count > 0);
+            WaitForCompletion(() => QualityProfiles.All().Count > 0);
 
             foreach (var title in new[] { "90210", "Dexter" })
             {

--- a/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/WantedTests/CutoffUnmetFixture.cs
@@ -12,7 +12,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         [Order(1)]
         public void cutoff_should_have_monitored_items()
         {
-            EnsureProfileCutoff(1, Quality.HDTV720p, true);
+            EnsureQualityProfileCutoff(1, Quality.HDTV720p, true);
             var series = EnsureSeries(266189, "The Blacklist", true);
             EnsureEpisodeFile(series, 1, 1, Quality.SDTV);
 
@@ -25,7 +25,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         [Order(1)]
         public void cutoff_should_not_have_unmonitored_items()
         {
-            EnsureProfileCutoff(1, Quality.HDTV720p, true);
+            EnsureQualityProfileCutoff(1, Quality.HDTV720p, true);
             var series = EnsureSeries(266189, "The Blacklist", false);
             EnsureEpisodeFile(series, 1, 1, Quality.SDTV);
 
@@ -38,7 +38,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         [Order(1)]
         public void cutoff_should_have_series()
         {
-            EnsureProfileCutoff(1, Quality.HDTV720p, true);
+            EnsureQualityProfileCutoff(1, Quality.HDTV720p, true);
             var series = EnsureSeries(266189, "The Blacklist", true);
             EnsureEpisodeFile(series, 1, 1, Quality.SDTV);
 
@@ -52,7 +52,7 @@ namespace NzbDrone.Integration.Test.ApiTests.WantedTests
         [Order(2)]
         public void cutoff_should_have_unmonitored_items()
         {
-            EnsureProfileCutoff(1, Quality.HDTV720p, true);
+            EnsureQualityProfileCutoff(1, Quality.HDTV720p, true);
             var series = EnsureSeries(266189, "The Blacklist", false);
             EnsureEpisodeFile(series, 1, 1, Quality.SDTV);
 

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Integration.Test
         public LogsClient Logs;
         public ClientBase<NamingConfigResource> NamingConfig;
         public NotificationClient Notifications;
-        public ClientBase<QualityProfileResource> Profiles;
+        public ClientBase<QualityProfileResource> QualityProfiles;
         public ReleaseClient Releases;
         public ReleasePushClient ReleasePush;
         public ClientBase<RootFolderResource> RootFolders;
@@ -113,7 +113,7 @@ namespace NzbDrone.Integration.Test
             Logs = new LogsClient(RestClient, ApiKey);
             NamingConfig = new ClientBase<NamingConfigResource>(RestClient, ApiKey, "config/naming");
             Notifications = new NotificationClient(RestClient, ApiKey);
-            Profiles = new ClientBase<QualityProfileResource>(RestClient, ApiKey);
+            QualityProfiles = new ClientBase<QualityProfileResource>(RestClient, ApiKey);
             Releases = new ReleaseClient(RestClient, ApiKey);
             ReleasePush = new ReleasePushClient(RestClient, ApiKey);
             RootFolders = new ClientBase<RootFolderResource>(RestClient, ApiKey);
@@ -317,10 +317,10 @@ namespace NzbDrone.Integration.Test
             return result.EpisodeFile;
         }
 
-        public QualityProfileResource EnsureProfileCutoff(int profileId, Quality cutoff, bool upgradeAllowed)
+        public QualityProfileResource EnsureQualityProfileCutoff(int profileId, Quality cutoff, bool upgradeAllowed)
         {
             var needsUpdate = false;
-            var profile = Profiles.Get(profileId);
+            var profile = QualityProfiles.Get(profileId);
 
             if (profile.Cutoff != cutoff.Id)
             {
@@ -336,7 +336,7 @@ namespace NzbDrone.Integration.Test
 
             if (needsUpdate)
             {
-                profile = Profiles.Put(profile);
+                profile = QualityProfiles.Put(profile);
             }
 
             return profile;

--- a/src/Sonarr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Sonarr.Api.V3/ImportLists/ImportListController.cs
@@ -11,13 +11,13 @@ namespace Sonarr.Api.V3.ImportLists
         public static readonly ImportListResourceMapper ResourceMapper = new ();
         public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
 
-        public ImportListController(IImportListFactory importListFactory, ProfileExistsValidator profileExistsValidator)
+        public ImportListController(IImportListFactory importListFactory, QualityProfileExistsValidator qualityProfileExistsValidator)
             : base(importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
         {
             Http.Validation.RuleBuilderExtensions.ValidId(SharedValidator.RuleFor(s => s.QualityProfileId));
 
             SharedValidator.RuleFor(c => c.RootFolderPath).IsValidPath();
-            SharedValidator.RuleFor(c => c.QualityProfileId).SetValidator(profileExistsValidator);
+            SharedValidator.RuleFor(c => c.QualityProfileId).SetValidator(qualityProfileExistsValidator);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Sonarr.Api.V3/Indexers/IndexerController.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Validation;
 using Sonarr.Http;
 
 namespace Sonarr.Api.V3.Indexers
@@ -9,9 +10,10 @@ namespace Sonarr.Api.V3.Indexers
         public static readonly IndexerResourceMapper ResourceMapper = new ();
         public static readonly IndexerBulkResourceMapper BulkResourceMapper = new ();
 
-        public IndexerController(IndexerFactory indexerFactory)
+        public IndexerController(IndexerFactory indexerFactory, DownloadClientExistsValidator downloadClientExistsValidator)
             : base(indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
         {
+            SharedValidator.RuleFor(c => c.DownloadClientId).SetValidator(downloadClientExistsValidator);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -58,7 +58,7 @@ namespace Sonarr.Api.V3.Series
                             SeriesExistsValidator seriesExistsValidator,
                             SeriesAncestorValidator seriesAncestorValidator,
                             SystemFolderValidator systemFolderValidator,
-                            ProfileExistsValidator profileExistsValidator,
+                            QualityProfileExistsValidator qualityProfileExistsValidator,
                             SeriesFolderAsRootFolderValidator seriesFolderAsRootFolderValidator)
             : base(signalRBroadcaster)
         {
@@ -83,7 +83,7 @@ namespace Sonarr.Api.V3.Series
                            .SetValidator(systemFolderValidator)
                            .When(s => !s.Path.IsNullOrWhiteSpace());
 
-            SharedValidator.RuleFor(s => s.QualityProfileId).SetValidator(profileExistsValidator);
+            SharedValidator.RuleFor(s => s.QualityProfileId).SetValidator(qualityProfileExistsValidator);
 
             PostValidator.RuleFor(s => s.Path).IsValidPath().When(s => s.RootFolderPath.IsNullOrWhiteSpace());
             PostValidator.RuleFor(s => s.RootFolderPath)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Renamed a few instances of Profile to QualityProfile
- Added Download Client validation for indexers
- Fixed validation logic in QualityProfileExistsValidator to allow 0 as valid choice for optional fields. For mandatory `ValidId` is to be used too.