### PR TITLE
Fix translation for GrabReleaseMessageText

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearchRow.tsx
@@ -309,7 +309,7 @@ function InteractiveSearchRow(props: InteractiveSearchRowProps) {
         isOpen={isConfirmGrabModalOpen}
         kind={kinds.WARNING}
         title={translate('GrabRelease')}
-        message={translate('GrabReleaseMessageText', { title })}
+        message={translate('GrabReleaseMessageText', { title, appName: 'Sonarr' })}
         confirmLabel={translate('Grab')}
         onConfirm={onGrabConfirm}
         onCancel={onGrabCancel}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Translation uses `appName` but this parameter was not being passed.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* 
