### PR TITLE
Fix: translate for empty appName token

### DIFF
--- a/frontend/src/Utilities/String/translate.ts
+++ b/frontend/src/Utilities/String/translate.ts
@@ -25,15 +25,13 @@ export async function fetchTranslations(): Promise<boolean> {
 
 export default function translate(
   key: string,
-  tokens: Record<string, string | number | boolean> = { appName: 'Sonarr' }
+  tokens: Record<string, string | number | boolean> = {}
 ) {
   const translation = translations[key] || key;
 
-  if (tokens) {
-    return translation.replace(/\{([a-z0-9]+?)\}/gi, (match, tokenMatch) =>
-      String(tokens[tokenMatch] ?? match)
-    );
-  }
+  tokens.appName = 'Sonarr';
 
-  return translation;
+  return translation.replace(/\{([a-z0-9]+?)\}/gi, (match, tokenMatch) =>
+    String(tokens[tokenMatch] ?? match)
+  );
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
when there tokens are passed to translate function appName is not added to the list, thus is skipped in multiple translation strings.
translate() function now defaults to it (when no tokens are passed) and adds it when tokens are passed.

#### Todos

#### Issues Fixed or Closed by this PR

* #6155
