### PR TITLE
Fixed: Showing already imported episodes as downloading in Series index

### DIFF
--- a/frontend/src/App/State/QueueAppState.ts
+++ b/frontend/src/App/State/QueueAppState.ts
@@ -1,41 +1,9 @@
-import ModelBase from 'App/ModelBase';
-import Language from 'Language/Language';
-import { QualityModel } from 'Quality/Quality';
-import CustomFormat from 'typings/CustomFormat';
+import Queue from 'typings/Queue';
 import AppSectionState, {
   AppSectionFilterState,
   AppSectionItemState,
   Error,
 } from './AppSectionState';
-
-export interface StatusMessage {
-  title: string;
-  messages: string[];
-}
-
-export interface Queue extends ModelBase {
-  languages: Language[];
-  quality: QualityModel;
-  customFormats: CustomFormat[];
-  size: number;
-  title: string;
-  sizeleft: number;
-  timeleft: string;
-  estimatedCompletionTime: string;
-  status: string;
-  trackedDownloadStatus: string;
-  trackedDownloadState: string;
-  statusMessages: StatusMessage[];
-  errorMessage: string;
-  downloadId: string;
-  protocol: string;
-  downloadClient: string;
-  outputPath: string;
-  episodeHasFile: boolean;
-  seriesId?: number;
-  episodeId?: number;
-  seasonNumber?: number;
-}
 
 export interface QueueDetailsAppState extends AppSectionState<Queue> {
   params: unknown;

--- a/frontend/src/Series/Index/createSeriesQueueDetailsSelector.ts
+++ b/frontend/src/Series/Index/createSeriesQueueDetailsSelector.ts
@@ -15,7 +15,10 @@ function createSeriesQueueDetailsSelector(
     (queueItems) => {
       return queueItems.reduce(
         (acc: SeriesQueueDetails, item) => {
-          if (item.seriesId !== seriesId) {
+          if (
+            item.trackedDownloadState === 'imported' ||
+            item.seriesId !== seriesId
+          ) {
             return acc;
           }
 

--- a/frontend/src/typings/Queue.ts
+++ b/frontend/src/typings/Queue.ts
@@ -1,0 +1,46 @@
+import ModelBase from 'App/ModelBase';
+import Language from 'Language/Language';
+import { QualityModel } from 'Quality/Quality';
+import CustomFormat from 'typings/CustomFormat';
+
+export type QueueTrackedDownloadStatus = 'ok' | 'warning' | 'error';
+
+export type QueueTrackedDownloadState =
+  | 'downloading'
+  | 'importPending'
+  | 'importing'
+  | 'imported'
+  | 'failedPending'
+  | 'failed'
+  | 'ignored';
+
+export interface StatusMessage {
+  title: string;
+  messages: string[];
+}
+
+interface Queue extends ModelBase {
+  languages: Language[];
+  quality: QualityModel;
+  customFormats: CustomFormat[];
+  size: number;
+  title: string;
+  sizeleft: number;
+  timeleft: string;
+  estimatedCompletionTime: string;
+  status: string;
+  trackedDownloadStatus: QueueTrackedDownloadStatus;
+  trackedDownloadState: QueueTrackedDownloadState;
+  statusMessages: StatusMessage[];
+  errorMessage: string;
+  downloadId: string;
+  protocol: string;
+  downloadClient: string;
+  outputPath: string;
+  episodeHasFile: boolean;
+  seriesId?: number;
+  episodeId?: number;
+  seasonNumber?: number;
+}
+
+export default Queue;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Avoid already imported episodes to be shown as downloading in the SeriesIndexProgressBar component.

https://github.com/Radarr/Radarr/issues/9367
