### PR TITLE
Fixed: Enforce validation warnings when testing providers

### DIFF
--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -74,7 +74,7 @@ namespace Sonarr.Api.V3
 
             if (providerDefinition.Enable)
             {
-                Test(providerDefinition, false);
+                Test(providerDefinition, !forceSave);
             }
 
             providerDefinition = _providerFactory.Create(providerDefinition);
@@ -92,7 +92,7 @@ namespace Sonarr.Api.V3
             // Only test existing definitions if it is enabled and forceSave isn't set.
             if (providerDefinition.Enable && !forceSave)
             {
-                Test(providerDefinition, false);
+                Test(providerDefinition, true);
             }
 
             _providerFactory.Update(providerDefinition);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Currently it seems like the warnings from `TestConnection` are shown only using the test endpoint, and I think it would better to show them on create/update as well.