### PR TITLE
fix: searching with incorrect absolute episode number in multiple-season anime

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -350,7 +350,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             searchSpec.SeasonNumber = episode.SceneSeasonNumber ?? episode.SeasonNumber;
             searchSpec.EpisodeNumber = episode.SceneEpisodeNumber ?? episode.EpisodeNumber;
-            searchSpec.AbsoluteEpisodeNumber = episode.SceneAbsoluteEpisodeNumber ?? episode.AbsoluteEpisodeNumber ?? 0;
+            searchSpec.AbsoluteEpisodeNumber = episode.AbsoluteEpisodeNumber ?? episode.SceneAbsoluteEpisodeNumber ?? 0;
 
             return await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
  When I searched for S02E18 of jujutsu-kaisen , most of the results are S01E18. Sonarr sent queries including "S02E18", "S2 18", "18", but not "42". I believe it is correct to use 42 instead of 18 as absolute episode number here. After switching the `SceneAbsoluteEpisodeNumber` and `AbsoluteEpisodeNumber`, now sonarr can search properly with correct responses.
  Let me know if there is anything needs to be changed.

#### Todos
- [ ] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

may be related to #1604 

