### PR TITLE
Fixed: Correctly handle Migration when PG Host has ".db"

### DIFF
--- a/src/NzbDrone.Core/Datastore/DbFactory.cs
+++ b/src/NzbDrone.Core/Datastore/DbFactory.cs
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Datastore
                 case MigrationType.Main:
                     {
                         connectionInfo = _connectionStringFactory.MainDbConnection;
-                        CreateMain(connectionInfo.ConnectionString, migrationContext);
+                        CreateMain(connectionInfo.ConnectionString, migrationContext, connectionInfo.DatabaseType);
 
                         break;
                     }
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Datastore
                 case MigrationType.Log:
                     {
                         connectionInfo = _connectionStringFactory.LogDbConnection;
-                        CreateLog(connectionInfo.ConnectionString, migrationContext);
+                        CreateLog(connectionInfo.ConnectionString, migrationContext, connectionInfo.DatabaseType);
 
                         break;
                     }
@@ -108,12 +108,12 @@ namespace NzbDrone.Core.Datastore
             return db;
         }
 
-        private void CreateMain(string connectionString, MigrationContext migrationContext)
+        private void CreateMain(string connectionString, MigrationContext migrationContext, DatabaseType databaseType)
         {
             try
             {
                 _restoreDatabaseService.Restore();
-                _migrationController.Migrate(connectionString, migrationContext);
+                _migrationController.Migrate(connectionString, migrationContext, databaseType);
             }
             catch (SQLiteException e)
             {
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Datastore
 
                         try
                         {
-                            _migrationController.Migrate(connectionString, migrationContext);
+                            _migrationController.Migrate(connectionString, migrationContext, databaseType);
                             return;
                         }
                         catch (Exception ex)
@@ -165,11 +165,11 @@ namespace NzbDrone.Core.Datastore
             }
         }
 
-        private void CreateLog(string connectionString, MigrationContext migrationContext)
+        private void CreateLog(string connectionString, MigrationContext migrationContext, DatabaseType databaseType)
         {
             try
             {
-                _migrationController.Migrate(connectionString, migrationContext);
+                _migrationController.Migrate(connectionString, migrationContext, databaseType);
             }
             catch (SQLiteException e)
             {
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.Datastore
                     Logger.Error("Unable to recreate logging database automatically. It will need to be removed manually.");
                 }
 
-                _migrationController.Migrate(connectionString, migrationContext);
+                _migrationController.Migrate(connectionString, migrationContext, databaseType);
             }
             catch (Exception e)
             {

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Reflection;
 using FluentMigrator.Runner;
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 {
     public interface IMigrationController
     {
-        void Migrate(string connectionString, MigrationContext migrationContext);
+        void Migrate(string connectionString, MigrationContext migrationContext, DatabaseType databaseType);
     }
 
     public class MigrationController : IMigrationController
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             _migrationLoggerProvider = migrationLoggerProvider;
         }
 
-        public void Migrate(string connectionString, MigrationContext migrationContext)
+        public void Migrate(string connectionString, MigrationContext migrationContext, DatabaseType databaseType)
         {
             var sw = Stopwatch.StartNew();
 
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             ServiceProvider serviceProvider;
 
-            var db = connectionString.Contains(".db") ? "sqlite" : "postgres";
+            var db = databaseType == DatabaseType.SQLite ? "sqlite" : "postgres";
 
             serviceProvider = new ServiceCollection()
                 .AddLogging(b => b.AddNLog())


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use the database type from connection string factory for migration to prevent issues when postgres host contains ".db"


#### Issues Fixed or Closed by this PR

* Fixes #6225 
