### PR TITLE
New: Use Torznab minimum seed and ratio when available

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
@@ -73,6 +73,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
             releaseInfo.InfoHash.Should().Be("63e07ff523710ca268567dad344ce1e0e6b7e8a3");
             releaseInfo.Seeders.Should().Be(7);
             releaseInfo.Peers.Should().Be(7);
+            releaseInfo.MinimumRatio.Should().Be(1.0);
+            releaseInfo.MinimumSeedTime.Should().Be(172800);
         }
 
         [Test]
@@ -103,6 +105,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
             releaseInfo.InfoHash.Should().Be("9fb267cff5ae5603f07a347676ec3bf3e35f75e1");
             releaseInfo.Seeders.Should().Be(34128);
             releaseInfo.Peers.Should().Be(36724);
+            releaseInfo.MinimumRatio.Should().Be(1.0);
+            releaseInfo.MinimumSeedTime.Should().Be(172800);
         }
 
         [Test]
@@ -134,6 +138,8 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
             releaseInfo.InfoHash.Should().Be("2d69a861bef5a9f2cdf791b7328e37b7953205e1");
             releaseInfo.Seeders.Should().BeNull();
             releaseInfo.Peers.Should().BeNull();
+            releaseInfo.MinimumRatio.Should().BeNull();
+            releaseInfo.MinimumSeedTime.Should().BeNull();
         }
 
         [Test]

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -1,5 +1,6 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using NzbDrone.Common.Extensions;
@@ -80,8 +81,32 @@ namespace NzbDrone.Core.Indexers.Torznab
 
             torrentInfo.TvdbId = GetTvdbId(item);
             torrentInfo.TvRageId = GetTvRageId(item);
+            torrentInfo.MinimumSeedTime = GetMinimumSeedTime(item);
+            torrentInfo.MinimumRatio = GetMinimumRatio(item);
 
             return torrentInfo;
+        }
+
+        protected virtual long? GetMinimumSeedTime(XElement item)
+        {
+            var seedTimeString = TryGetTorznabAttribute(item, "minimumseedtime", null);
+            if (long.TryParse(seedTimeString, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        protected virtual double? GetMinimumRatio(XElement item)
+        {
+            var ratioString = TryGetTorznabAttribute(item, "minimumratio", null);
+            if (double.TryParse(ratioString, NumberStyles.Float, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            return null;
         }
 
         protected override string GetInfoUrl(XElement item)

--- a/src/NzbDrone.Core/Parser/Model/TorrentInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/TorrentInfo.cs
@@ -8,6 +8,8 @@ namespace NzbDrone.Core.Parser.Model
         public string InfoHash { get; set; }
         public int? Seeders { get; set; }
         public int? Peers { get; set; }
+        public long? MinimumSeedTime { get; set; } // torznab provides it in seconds
+        public double? MinimumRatio { get; set; }
 
         public static int? GetSeeders(ReleaseInfo release)
         {


### PR DESCRIPTION
Prefer indexer seed configuration if it is available otherwise fallback to Torznab when available

#### Database Migration
NO

#### Description
This change will make Sonarr use `minimumseedtime` and `minimumratio`  from torznab indexers that supply it as long a the indexers haven't been manually configured with a Ratio or Seedtime. This is especially useful for example AnimeBytes where the seed time is based on the size of the torrent and Prowlarr does this calculation but Sonarr isn't using it.

#### Todos
- [x] Tests
- [ ] Wiki Updates


#### Issues Fixed or Closed by this PR

* None to my knowledge, since I didn't make one just looked into implementing it.
