### PR TITLE
Fixed: Monitor last season only if there's at least one future monitored episode

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -314,6 +314,22 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
         }
 
         [Test]
+        public void should_not_monitor_last_season_for_future_episodes_if_all_episodes_already_aired()
+        {
+            _episodes.ForEach(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-7));
+
+            var monitoringOptions = new MonitoringOptions
+            {
+                Monitor = MonitorTypes.Future
+            };
+
+            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
+
+            VerifySeasonNotMonitored(n => n.SeasonNumber > 0);
+            VerifyNotMonitored(n => n.SeasonNumber > 0);
+        }
+
+        [Test]
         public void should_monitor_any_recent_and_future_episodes_if_all_episodes_aired_within_90_days()
         {
             _series.Seasons = Builder<Season>.CreateListOfSize(1)

--- a/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
@@ -135,11 +135,12 @@ namespace NzbDrone.Core.Tv
                 // Monitor the last season when:
                 // - Not specials
                 // - The latest season
-                // - Set to monitor all or future episodes
+                // - Set to monitor all episodes
+                // - Set to monitor future episodes and series is continuing or not yet aired
                 if (seasonNumber > 0 &&
                     seasonNumber == lastSeason &&
                     (monitoringOptions.Monitor == MonitorTypes.All ||
-                    monitoringOptions.Monitor == MonitorTypes.Future))
+                     (monitoringOptions.Monitor == MonitorTypes.Future && series.Status is SeriesStatusType.Continuing or SeriesStatusType.Upcoming)))
                 {
                     season.Monitored = true;
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix for last season monitored with no future episodes when applying monitor future episodes.