### PR TITLE
Fixed: Disable SSL on start if certificate path is not set

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -346,8 +346,8 @@ namespace NzbDrone.Core.Configuration
                 return;
             }
 
-            // If SSL is enabled and a cert hash is still in the config file disable SSL
-            if (EnableSsl && GetValue("SslCertHash", null).IsNotNullOrWhiteSpace())
+            // If SSL is enabled and a cert hash is still in the config file or cert path is empty disable SSL
+            if (EnableSsl && (GetValue("SslCertHash", null).IsNotNullOrWhiteSpace() || SslCertPath.IsNullOrWhiteSpace()))
             {
                 SetValue("EnableSsl", false);
             }


### PR DESCRIPTION
Sometimes people have SSL enabled from before, but a hash was not set which results in the config not being fixed automatically.