### PR TITLE
Avoid blocklisted by title query for releases with InfoHash

### DIFF
--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -36,30 +36,28 @@ namespace NzbDrone.Core.Blocklisting
 
         public bool Blocklisted(int seriesId, ReleaseInfo release)
         {
-            var blocklistedByTitle = _blocklistRepository.BlocklistedByTitle(seriesId, release.Title);
-
             if (release.DownloadProtocol == DownloadProtocol.Torrent)
             {
-                var torrentInfo = release as TorrentInfo;
-
-                if (torrentInfo == null)
+                if (release is not TorrentInfo torrentInfo)
                 {
                     return false;
                 }
 
-                if (torrentInfo.InfoHash.IsNullOrWhiteSpace())
+                if (torrentInfo.InfoHash.IsNotNullOrWhiteSpace())
                 {
-                    return blocklistedByTitle.Where(b => b.Protocol == DownloadProtocol.Torrent)
-                                             .Any(b => SameTorrent(b, torrentInfo));
+                    var blocklistedByTorrentInfohash = _blocklistRepository.BlocklistedByTorrentInfoHash(seriesId, torrentInfo.InfoHash);
+
+                    return blocklistedByTorrentInfohash.Any(b => SameTorrent(b, torrentInfo));
                 }
 
-                var blocklistedByTorrentInfohash = _blocklistRepository.BlocklistedByTorrentInfoHash(seriesId, torrentInfo.InfoHash);
-
-                return blocklistedByTorrentInfohash.Any(b => SameTorrent(b, torrentInfo));
+                return _blocklistRepository.BlocklistedByTitle(seriesId, release.Title)
+                    .Where(b => b.Protocol == DownloadProtocol.Torrent)
+                    .Any(b => SameTorrent(b, torrentInfo));
             }
 
-            return blocklistedByTitle.Where(b => b.Protocol == DownloadProtocol.Usenet)
-                                     .Any(b => SameNzb(b, release));
+            return _blocklistRepository.BlocklistedByTitle(seriesId, release.Title)
+                .Where(b => b.Protocol == DownloadProtocol.Usenet)
+                .Any(b => SameNzb(b, release));
         }
 
         public bool BlocklistedTorrentHash(int seriesId, string hash)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This change simply avoids running `BlocklistedByTitle` (which is a `LIKE` query with wildcards) if the release has an infohash and the result isn't used anyways. 