### PR TITLE
Separate publishing of test results for PRs from forks

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -79,10 +79,8 @@ runs:
       shell: bash
       run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger trx --results-directory "${{ env.RESULTS_NAME }}"
 
-    - name: Publish Test Results
-      if: ${{ !cancelled() }}
-      uses: phoenix-actions/test-reporting@v12
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.RESULTS_NAME }}
+        name: results-${{ env.RESULTS_NAME }}
         path: ${{ env.RESULTS_NAME }}/*.trx
-        reporter: dotnet-trx

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -80,6 +80,7 @@ runs:
       run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger trx --results-directory "${{ env.RESULTS_NAME }}"
 
     - name: Upload Test Results
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: results-${{ env.RESULTS_NAME }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,24 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ['Build']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish Test Results
+      uses: phoenix-actions/test-reporting@v12
+      with:
+        artifact: /results-(.*)/
+        name: '$1'
+        path: '*.trx'
+        reporter: dotnet-trx


### PR DESCRIPTION
#### Description
This should address PRs from forks failing with `Resource not accessible by integration` per https://github.com/phoenix-actions/test-reporting#recommended-setup-for-public-repositories