### PR TITLE
Better Test Result Publishing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -203,6 +203,7 @@ dotnet_diagnostic.CA1819.severity = suggestion
 dotnet_diagnostic.CA1822.severity = suggestion
 dotnet_diagnostic.CA1823.severity = suggestion
 dotnet_diagnostic.CA1824.severity = suggestion
+dotnet_diagnostic.CA1825.severity = suggestion
 dotnet_diagnostic.CA2000.severity = suggestion
 dotnet_diagnostic.CA2002.severity = suggestion
 dotnet_diagnostic.CA2007.severity = suggestion

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -79,9 +79,13 @@ runs:
       shell: bash
       run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger trx --results-directory "${{ env.RESULTS_NAME }}"
 
-    - name: Upload Test Results
+    - name: Publish Test Results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v4
+      uses: EnricoMi/publish-unit-test-result-action/composite@v2
       with:
-        name: results-${{ env.RESULTS_NAME }}
-        path: ${{ env.RESULTS_NAME }}/*.trx
+        check_run: false
+        check_run_annotations: none
+        comment_mode: off
+        comment_title: ${{ env.RESULTS_NAME }} Test Results
+        large_files: true
+        files: ${{ env.RESULTS_NAME }}/*.trx

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -79,6 +79,13 @@ runs:
       shell: bash
       run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger trx --results-directory "${{ env.RESULTS_NAME }}"
 
+    - name: Upload Test Results
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: results-${{ env.RESULTS_NAME }}
+        path: ${{ env.RESULTS_NAME }}/*.trx
+
     - name: Publish Test Results
       if: ${{ !cancelled() }}
       uses: EnricoMi/publish-unit-test-result-action/composite@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
             binary_path: osx-x64/${{ needs.backend.outputs.framework }}/Sonarr
           - os: windows-latest
             artifact: tests-win-x64
-            filter: TestCategory!=ManualTest&TestCategory=WINDOWS&TestCategory=IntegrationTest
+            filter: TestCategory!=ManualTest&TestCategory!=LINUX&TestCategory=IntegrationTest
             binary_artifact: build_windows
             binary_path: win-x64/${{ needs.backend.outputs.framework }}/Sonarr
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,13 +207,13 @@ jobs:
         binary_artifact: ${{ matrix.binary_artifact }}
         binary_path: ${{ matrix.binary_path }}
 
-  deploy:
-    if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
-    needs: [backend, unit_test, unit_test_postgres, integration_test]
-    secrets: inherit
-    uses: ./.github/workflows/deploy.yml
-    with:
-      framework: ${{ needs.backend.outputs.framework }}
-      branch: ${{ github.ref_name }}
-      major_version: ${{ needs.backend.outputs.major_version }}
-      version: ${{ needs.backend.outputs.version }}
+  # deploy:
+  #   if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
+  #   needs: [backend, unit_test, unit_test_postgres, integration_test]
+  #   secrets: inherit
+  #   uses: ./.github/workflows/deploy.yml
+  #   with:
+  #     framework: ${{ needs.backend.outputs.framework }}
+  #     branch: ${{ github.ref_name }}
+  #     major_version: ${{ needs.backend.outputs.major_version }}
+  #     version: ${{ needs.backend.outputs.version }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -13,12 +13,19 @@ permissions:
 
 jobs:
   report:
+    if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     steps:
+    - name: Download Test Reports
+      uses: actions/download-artifact@v4
+      with:
+        name: results-*
+        path: test-results
+        merge-multiple: true
+
     - name: Publish Test Results
       uses: phoenix-actions/test-reporting@v12
       with:
-        artifact: /results-(.*)/
-        name: '$1'
-        path: '*.trx'
+        name: 'Test Results'
+        path: 'test-results/*.trx'
         reporter: dotnet-trx

--- a/src/NzbDrone.Mono.Test/EnvironmentInfo/VersionAdapters/MacOsVersionAdapterFixture.cs
+++ b/src/NzbDrone.Mono.Test/EnvironmentInfo/VersionAdapters/MacOsVersionAdapterFixture.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Mono.Test.EnvironmentInfo.VersionAdapters
             versionName.FullName.Should().Be("macOS " + versionString);
         }
 
-        [TestCase]
+        [Test]
         public void should_detect_server()
         {
             var fileContent = File.ReadAllText(GetTestPath("Files/macOS/SystemVersion.plist"));
@@ -63,7 +63,7 @@ namespace NzbDrone.Mono.Test.EnvironmentInfo.VersionAdapters
             versionName.Name.Should().Be("macOS Server");
         }
 
-        [TestCase]
+        [Test]
         public void should_return_null_if_folder_doesnt_exist()
         {
             Mocker.GetMock<IDiskProvider>()


### PR DESCRIPTION
#### Description
The separate workflow doesn't work correctly with upload-artifact@v4, which can be worked around, but a separate check with the results isn't really necessary.

https://github.com/marketplace/actions/publish-test-results looks like a possibly better solution as check publishing can be disabled and has the option for PR comments, but disabled them for now to avoid the need for special permissions.

