### PR TITLE
add zhtw and yue as Chinese language

### DIFF
--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -64,7 +64,9 @@ namespace NzbDrone.Core.Parser
             { "cze", Language.Czech },
             { "dut", Language.Dutch },
             { "mac", Language.Macedonian },
-            { "rum", Language.Romanian }
+            { "rum", Language.Romanian },
+            { "yue", Language.Chinese },
+            { "zhtw", Language.Chinese }
         };
 
         public static IsoLanguage Find(string isoCode)
@@ -86,6 +88,10 @@ namespace NzbDrone.Core.Parser
 
                 return isoLanguages.FirstOrDefault();
             }
+            else if (AlternateIsoCodeMappings.TryGetValue(isoCode, out var alternateLanguage))
+            {
+                return Get(alternateLanguage);
+            }
             else if (langCode.Length == 3)
             {
                 // Lookup ISO639-2T code
@@ -95,10 +101,6 @@ namespace NzbDrone.Core.Parser
                 }
 
                 return All.FirstOrDefault(l => l.ThreeLetterCode == langCode);
-            }
-            else if (AlternateIsoCodeMappings.TryGetValue(isoCode, out var alternateLanguage))
-            {
-                return Get(alternateLanguage);
             }
 
             return null;


### PR DESCRIPTION
#### Description
add zhtw and yue as alternative codes for Chinese language.

order of check rearranged in `Find`in `IsoLanguages.cs` - otherwise the dictionary of AlternativeIsoCodeMappings is never used for three character codes.

#### Issues Fixed or Closed by this PR
* Closes #6363 

