### PR TITLE
Drop commands table content before altering tables

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/188_postgres_update_timestamp_columns_to_with_timezone.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/188_postgres_update_timestamp_columns_to_with_timezone.cs
@@ -8,6 +8,8 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
+            Delete.FromTable("Commands").AllRows();
+
             Alter.Table("Blocklist").AlterColumn("Date").AsDateTimeOffset().NotNullable();
             Alter.Table("Blocklist").AlterColumn("PublishedDate").AsDateTimeOffset().Nullable();
             Alter.Table("Commands").AlterColumn("QueuedAt").AsDateTimeOffset().NotNullable();


### PR DESCRIPTION
#### Description
Avoid a common migration error:

```[Error] FluentMigrator.Runner.MigrationRunner: database disk image is malformed
database disk image is malformed
While Processing:
"INSERT INTO "Commands_temp" ("Id", "Name", "Body", "Priority", "Status", "QueuedAt", "StartedAt", "EndedAt", "Duration", "Exception", "Trigger", "Result") SELECT "Id", "Name", "Body", "Priority", "Status", "QueuedAt", "StartedAt", "EndedAt", "Duration", "Exception", "Trigger", "Result" FROM "Commands""
```


#### Database Migration
YES - 188 (existing)

