### PR TITLE
Fixed: Importing Plex RSS lists with invalid items

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportParser.cs
@@ -3,18 +3,19 @@ using System.Xml.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.ImportLists.Rss.Plex
 {
     public class PlexRssImportParser : RssImportBaseParser
     {
+        private readonly Logger _logger;
         private static readonly Regex ImdbIdRegex = new (@"(tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public PlexRssImportParser(Logger logger)
             : base(logger)
         {
+            _logger = logger;
         }
 
         protected override ImportListItemInfo ProcessItem(XElement item)
@@ -53,7 +54,9 @@ namespace NzbDrone.Core.ImportLists.Rss.Plex
 
             if (info.ImdbId.IsNullOrWhiteSpace() && info.TvdbId == 0 && info.TmdbId == 0)
             {
-                throw new UnsupportedFeedException("Each item in the RSS feed must have a guid element with a IMDB ID, TVDB ID or TMDB ID");
+                _logger.Warn("Each item in the RSS feed must have a guid element with a IMDB ID, TVDB ID or TMDB ID: '{0}'", info.Title);
+
+                return null;
             }
 
             return info;


### PR DESCRIPTION
#### Description
It may happen that some items to have the GUID missing and would break the whole import.