### PR TITLE
Fix: Removal of paused Qbittorrent torrents with global max ratio

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -620,7 +620,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             }
             else if (torrent.RatioLimit == -2 && config.MaxRatioEnabled)
             {
-                if (torrent.Ratio >= config.MaxRatio)
+                if (Math.Round(torrent.Ratio, 2) >= config.MaxRatio)
                 {
                     return true;
                 }


### PR DESCRIPTION
#### Description
qBittorrent rounds of its ratio when deciding to pause a torrent, but then provides in its API response a full double which we store as float. 
When a paused torrent is then Global Max ratio it can be under the ratio (`0.99999 < 1`) which results in a paused torrent not being removed even though it is presented in qbit ui as Paused with a ratio of 1.0

By rounding off the seeded ratio when checking for removal candidates we can avoid these edge cases hanging in qbit.

