### PR TITLE
New: Improve All Series call by using dictionary for stats iteration

### DIFF
--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -113,7 +113,7 @@ namespace Sonarr.Api.V3.Series
             }
 
             MapCoversToLocal(seriesResources.ToArray());
-            LinkSeriesStatistics(seriesResources, seriesStats);
+            LinkSeriesStatistics(seriesResources, seriesStats.ToDictionary(x => x.SeriesId));
             PopulateAlternateTitles(seriesResources);
             seriesResources.ForEach(LinkRootFolderPath);
 
@@ -229,17 +229,14 @@ namespace Sonarr.Api.V3.Series
             LinkSeriesStatistics(resource, _seriesStatisticsService.SeriesStatistics(resource.Id));
         }
 
-        private void LinkSeriesStatistics(List<SeriesResource> resources, List<SeriesStatistics> seriesStatistics)
+        private void LinkSeriesStatistics(List<SeriesResource> resources, Dictionary<int, SeriesStatistics> seriesStatistics)
         {
             foreach (var series in resources)
             {
-                var stats = seriesStatistics.SingleOrDefault(ss => ss.SeriesId == series.Id);
-                if (stats == null)
+                if (seriesStatistics.TryGetValue(series.Id, out var stats))
                 {
-                    continue;
+                    LinkSeriesStatistics(series, stats);
                 }
-
-                LinkSeriesStatistics(series, stats);
             }
         }
 


### PR DESCRIPTION
#### Description
Iterating list of stats for every series is costly, this significantly improves response time for All Series call for large libraries by converting stats object to a dictionary for value search prior to linking. 

The effects of this are exponential, an extreme example from Radarr testing is below:

Library - 263,000 Items
Current Code - 26 Min to link
Proposed Code - 22 Sec to link

Due to the double iteration it's not near as substantial on a smaller library, but can have some impact. 
