### PR TITLE
Fixed: Don't clone indexer API Key

### DIFF
--- a/frontend/src/Store/Actions/Settings/indexers.js
+++ b/frontend/src/Store/Actions/Settings/indexers.js
@@ -149,7 +149,13 @@ export default {
       delete selectedSchema.name;
 
       selectedSchema.fields = selectedSchema.fields.map((field) => {
-        return { ...field };
+        const newField = { ...field };
+
+        if (newField.privacy === 'apiKey' || newField.privacy === 'password') {
+          newField.value = '';
+        }
+
+        return newField;
       });
 
       newState.selectedSchema = selectedSchema;


### PR DESCRIPTION
#### Description

No longer clone `********` as the indexer API key, instead clear it out.

#### Issues Fixed or Closed by this PR
* Closes #6265

