### PR TITLE
New: Log warning if less than 1 GB free space during update

### DIFF
--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -107,6 +107,11 @@ namespace NzbDrone.Core.Update
 
             var updateSandboxFolder = _appFolderInfo.GetUpdateSandboxFolder();
 
+            if (_diskProvider.GetTotalSize(updateSandboxFolder) < 1.Gigabytes())
+            {
+                _logger.Warn("Temporary location '{0}' has less than 1 GB free space, Sonarr may not be able to update itself.", updateSandboxFolder);
+            }
+
             var packageDestination = Path.Combine(updateSandboxFolder, updatePackage.FileName);
 
             if (_diskProvider.FolderExists(updateSandboxFolder))


### PR DESCRIPTION
#### Description
With the fact that `/tmp` can change rather quickly, I don't see a lot of value in a health check for this, but checking just before updating that there is 1GB free space (which is more than Sonarr needs) and logging a warning if it's lower will improve the current behaviour.


#### Issues Fixed or Closed by this PR
* Closes #6385

