### PR TITLE
Fixed: Subtitle title migration when original title is null

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/198_parse_titles_from_existing_subtitle_filesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/198_parse_titles_from_existing_subtitle_filesFixture.cs
@@ -62,7 +62,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
                     Id = 1,
                     SeriesId = 1,
                     RelativePath = episodePath,
-                    OriginalFilePath = string.Empty,
                     Quality = new { }.ToJson(),
                     Size = 0,
                     DateAdded = now,

--- a/src/NzbDrone.Core/Datastore/Migration/198_parse_titles_from_existing_subtitle_files.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/198_parse_titles_from_existing_subtitle_files.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     var id = reader.GetInt32(0);
                     var relativePath = reader.GetString(1);
                     var episodeFileRelativePath = reader.GetString(2);
-                    var episodeFileOriginalFilePath = reader.GetString(3);
+                    var episodeFileOriginalFilePath = reader[3] as string;
 
                     var subtitleTitleInfo = CleanSubtitleTitleInfo(episodeFileRelativePath, episodeFileOriginalFilePath, relativePath);
 


### PR DESCRIPTION
#### Description

Fixes migration 198 when the Original File Path is null.

