### PR TITLE
New: Expand seasons with all episodes having missing air dates

### DIFF
--- a/frontend/src/Series/Details/SeriesDetailsSeason.js
+++ b/frontend/src/Series/Details/SeriesDetailsSeason.js
@@ -129,10 +129,8 @@ class SeriesDetailsSeason extends Component {
       items
     } = this.props;
 
-    const expand = _.some(items, (item) => {
-      return isAfter(item.airDateUtc) ||
-             isAfter(item.airDateUtc, { days: -30 });
-    });
+    const expand = _.some(items, (item) => isAfter(item.airDateUtc) || isAfter(item.airDateUtc, { days: -30 })) ||
+      items.every((item) => !item.airDateUtc);
 
     onExpandPress(seasonNumber, expand && seasonNumber > 0);
   }


### PR DESCRIPTION
#### Description
Expand by default seasons where the episodes, usually TBA, have the air date missing. 

Should make it easier to not get scared that you missed a whole season, when it's actually TBA. 😄 

#### Screenshots for UI Changes
![Screenshot](https://github.com/Sonarr/Sonarr/assets/707714/81e379a0-4e6c-434e-8210-cf3b7ff32f0e)

