### PR TITLE
New: Added some extra pixels to grouped calendar events

### DIFF
--- a/frontend/src/Calendar/Events/CalendarEventGroup.css
+++ b/frontend/src/Calendar/Events/CalendarEventGroup.css
@@ -43,6 +43,7 @@
 .expandContainer,
 .collapseContainer {
   display: flex;
+  align-items: center;
   justify-content: center;
 }
 

--- a/frontend/src/Calendar/Events/CalendarEventGroup.js
+++ b/frontend/src/Calendar/Events/CalendarEventGroup.js
@@ -224,16 +224,19 @@ class CalendarEventGroup extends Component {
         </div>
 
         {
-          showEpisodeInformation &&
+          showEpisodeInformation ?
             <Link
               className={styles.expandContainer}
               component="div"
               onPress={this.onExpandPress}
             >
+              &nbsp;
               <Icon
                 name={icons.EXPAND}
               />
-            </Link>
+              &nbsp;
+            </Link> :
+            null
         }
       </div>
     );


### PR DESCRIPTION
#### Description

Uses a non-breaking space before/after the expand icon to change the row height and centers the icon vertically, this results in the height being the same for grouped and ungrouped events without needing to hardcode a height.


#### Issues Fixed or Closed by this PR
* Closes #6395

