### PR TITLE
Fixed: History retention for Newsbin

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/SabnzbdTests/SabnzbdFixture.cs
@@ -454,6 +454,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.SabnzbdTests
 
         [TestCase("0")]
         [TestCase("15d")]
+        [TestCase("")]
+        [TestCase(null)]
         public void should_set_history_removes_completed_downloads_false(string historyRetention)
         {
             _config.Misc.history_retention = historyRetention;

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -278,7 +278,11 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                 status.OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, category.FullPath) };
             }
 
-            if (config.Misc.history_retention.IsNotNullOrWhiteSpace() && config.Misc.history_retention.EndsWith("d"))
+            if (config.Misc.history_retention.IsNullOrWhiteSpace())
+            {
+                status.RemovesCompletedDownloads = false;
+            }
+            else if (config.Misc.history_retention.EndsWith("d"))
             {
                 int.TryParse(config.Misc.history_retention.AsSpan(0, config.Misc.history_retention.Length - 1),
                     out var daysRetention);


### PR DESCRIPTION
#### Description
A few sentences describing the overall goals of the pull request's commits.

Newsbin fakes the SAB API, but doesn't return `history_retention`, treating null/empty retaining is safe for SAB's current behaviour.

> -1 is do not keep, 0 keep all. then n/d is for max number or max days.

