### PR TITLE
Fix: validation logic of DownloadStation output path ref #6421

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -211,40 +211,36 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             try
             {
-                var downloadDir = GetDefaultDir();
+                var downloadDir = GetDownloadDirectory();
 
                 if (downloadDir == null)
                 {
-                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), "DownloadClientDownloadStationValidationNoDefaultDestination")
+                    return new NzbDroneValidationFailure(nameof(Settings.TvDirectory), _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationNoDefaultDestination"))
                     {
                         DetailedDescription = _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationNoDefaultDestinationDetail", new Dictionary<string, object> { { "username", Settings.Username } })
                     };
                 }
 
-                downloadDir = GetDownloadDirectory();
+                var sharedFolder = downloadDir.Split('\\', '/')[0];
+                var fieldName = Settings.TvDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.TvDirectory) : nameof(Settings.TvCategory);
 
-                if (downloadDir != null)
+                var folderInfo = _fileStationProxy.GetInfoFileOrDirectory($"/{downloadDir}", Settings);
+
+                if (folderInfo.Additional == null)
                 {
-                    var sharedFolder = downloadDir.Split('\\', '/')[0];
-                    var fieldName = Settings.TvDirectory.IsNotNullOrWhiteSpace() ? nameof(Settings.TvDirectory) : nameof(Settings.TvCategory);
-
-                    var folderInfo = _fileStationProxy.GetInfoFileOrDirectory($"/{downloadDir}", Settings);
-
-                    if (folderInfo.Additional == null)
+                    return new NzbDroneValidationFailure(fieldName, _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationSharedFolderMissing"))
                     {
-                        return new NzbDroneValidationFailure(fieldName, _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationSharedFolderMissing"))
-                        {
-                            DetailedDescription = _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationSharedFolderMissingDetail", new Dictionary<string, object> { { "sharedFolder", sharedFolder } })
-                        };
-                    }
+                        DetailedDescription = _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationSharedFolderMissingDetail",
+                            new Dictionary<string, object> { { "sharedFolder", sharedFolder } })
+                    };
+                }
 
-                    if (!folderInfo.IsDir)
+                if (!folderInfo.IsDir)
+                {
+                    return new NzbDroneValidationFailure(fieldName, _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationFolderMissing"))
                     {
-                        return new NzbDroneValidationFailure(fieldName, _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationFolderMissing"))
-                        {
-                            DetailedDescription = _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationFolderMissingDetail", new Dictionary<string, object> { { "downloadDir", downloadDir }, { "sharedFolder", sharedFolder } })
-                        };
-                    }
+                        DetailedDescription = _localizationService.GetLocalizedString("DownloadClientDownloadStationValidationFolderMissingDetail", new Dictionary<string, object> { { "downloadDir", downloadDir }, { "sharedFolder", sharedFolder } })
+                    };
                 }
 
                 return null;
@@ -439,7 +435,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             var destDir = GetDefaultDir();
 
-            if (Settings.TvCategory.IsNotNullOrWhiteSpace())
+            if (destDir.IsNotNullOrWhiteSpace() && Settings.TvCategory.IsNotNullOrWhiteSpace())
             {
                 return $"{destDir.TrimEnd('/')}/{Settings.TvCategory}";
             }


### PR DESCRIPTION
#### Description

Currently the validation of a downloadstation client fails if no `default_dir` is set in downloadstation, however it should pass if a user has set an alternative download path in the settings.
By adjusting the call we will gather the download path that the client would use during operation and validate against that.

A few sentences describing the overall goals of the pull request's commits.

#### Issues Fixed or Closed by this PR
* Closes #6421 

