### PR TITLE
Add max token length (including ellipsis) for some tokens

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ReverseFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ReverseFixture.cs
@@ -1,0 +1,17 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Common.Test.ExtensionTests.StringExtensionTests
+{
+    [TestFixture]
+    public class ReverseFixture
+    {
+        [TestCase("input", "tupni")]
+        [TestCase("racecar", "racecar")]
+        public void should_reverse_string(string input, string expected)
+        {
+            input.Reverse().Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -242,5 +242,14 @@ namespace NzbDrone.Common.Extensions
         {
             return input.Contains(':') ? $"[{input}]" : input;
         }
+
+        public static string Reverse(this string text)
+        {
+            var array = text.ToCharArray();
+
+            Array.Reverse(array);
+
+            return new string(array);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedReleaseGroupFixture.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class TruncatedReleaseGroupFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private List<Episode> _episodes;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .With(s => s.Title = "Series Title")
+                    .Build();
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.MultiEpisodeStyle = 0;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            _episodes = new List<Episode>
+                        {
+                            Builder<Episode>.CreateNew()
+                                            .With(e => e.Title = "Episode Title 1")
+                                            .With(e => e.SeasonNumber = 1)
+                                            .With(e => e.EpisodeNumber = 1)
+                                            .Build()
+                        };
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        private void GivenProper()
+        {
+            _episodeFile.Quality.Revision.Version = 2;
+        }
+
+        [Test]
+        public void should_truncate_from_beginning()
+        {
+            _series.Title = "The Fantastic Life of Mr. Sisko";
+
+            _episodeFile.Quality.Quality = Quality.Bluray1080p;
+            _episodeFile.ReleaseGroup = "IWishIWasALittleBitTallerIWishIWasABallerIWishIHadAGirlWhoLookedGoodIWouldCallHerIWishIHadARabbitInAHatWithABatAndASixFourImpala";
+            _episodes = _episodes.Take(1).ToList();
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}-{ReleaseGroup:12}";
+
+            var result = Subject.BuildFileName(_episodes, _series, _episodeFile, ".mkv");
+            result.Length.Should().BeLessOrEqualTo(255);
+            result.Should().Be("The Fantastic Life of Mr. Sisko - S01E01 - Episode Title 1 Bluray-1080p-IWishIWas....mkv");
+        }
+
+        [Test]
+        public void should_truncate_from_from_end()
+        {
+            _series.Title = "The Fantastic Life of Mr. Sisko";
+
+            _episodeFile.Quality.Quality = Quality.Bluray1080p;
+            _episodeFile.ReleaseGroup = "IWishIWasALittleBitTallerIWishIWasABallerIWishIHadAGirlWhoLookedGoodIWouldCallHerIWishIHadARabbitInAHatWithABatAndASixFourImpala";
+            _episodes = _episodes.Take(1).ToList();
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} - {Episode Title} {Quality Full}-{ReleaseGroup:-17}";
+
+            var result = Subject.BuildFileName(_episodes, _series, _episodeFile, ".mkv");
+            result.Length.Should().BeLessOrEqualTo(255);
+            result.Should().Be("The Fantastic Life of Mr. Sisko - S01E01 - Episode Title 1 Bluray-1080p-...ASixFourImpala.mkv");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedSeriesTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedSeriesTitleFixture.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class TruncatedSeriesTitleFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .With(s => s.Title = "Series Title")
+                    .Build();
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.MultiEpisodeStyle = 0;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [TestCase("{Series Title:16}", "The Fantastic...")]
+        [TestCase("{Series TitleThe:17}", "Fantastic Life...")]
+        [TestCase("{Series CleanTitle:-13}", "...Mr. Sisko")]
+        public void should_truncate_series_title(string format, string expected)
+        {
+            _series.Title = "The Fantastic Life of Mr. Sisko";
+            _namingConfig.SeriesFolderFormat = format;
+
+            var result = Subject.GetSeriesFolder(_series, _namingConfig);
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationInfoProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationInfoProxy.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Http;


### PR DESCRIPTION
#### Description

Adds `:##` to the end of series title, episode title and release group renaming tokens to allow truncation. Episode title truncation will behave as it does to truncate for file system limitations (middle truncating if including first/last). Series Title and Release Group truncation will allow truncation from the beginning: `My Series...` or the end `...Series Title`.

#### Issues Fixed or Closed by this PR
* Closes #6416

