### PR TITLE
Fixed: FolderWritable check for CIFS shares mounted in Unix

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
@@ -11,6 +11,16 @@ namespace NzbDrone.Common.Test.DiskTests
         where TSubject : class, IDiskProvider
     {
         [Test]
+        public void writealltext_should_truncate_existing()
+        {
+            var file = GetTempFilePath();
+
+            Subject.WriteAllText(file, "A pretty long string");
+            Subject.WriteAllText(file, "A short string");
+            Subject.ReadAllText(file).Should().Be("A short string");
+        }
+
+        [Test]
         [Retry(5)]
         public void directory_exist_should_be_able_to_find_existing_folder()
         {


### PR DESCRIPTION
cherry picked from commit 96384521c59233dab5bd8289e7c84043f75b84a2

#### Description

bring in change from Radarr to potentially fix cifs mounts in unix.

#### Issues Fixed or Closed by this PR
* Closes #6425 

