### PR TITLE
Fixed: Grouped calendar events not correctly showing as downloading

### DIFF
--- a/frontend/src/Calendar/Events/CalendarEventGroupConnector.js
+++ b/frontend/src/Calendar/Events/CalendarEventGroupConnector.js
@@ -10,7 +10,7 @@ function createIsDownloadingSelector() {
     (state) => state.queue.details,
     (episodeIds, details) => {
       return details.items.some((item) => {
-        return item.episode && episodeIds.includes(item.episode.id);
+        return !!(item.episodeId && episodeIds.includes(item.episodeId));
       });
     }
   );


### PR DESCRIPTION
#### Description

`episode` no longer exists with the request we're making so we need to use `episodeId` instead of `episode.id`.


#### Issues Fixed or Closed by this PR
* Closes #6441

