### PR TITLE
Bind shortcut for pending changes confirmation only when it's shown

### DIFF
--- a/frontend/src/Settings/PendingChangesModal.js
+++ b/frontend/src/Settings/PendingChangesModal.js
@@ -15,12 +15,17 @@ function PendingChangesModal(props) {
     isOpen,
     onConfirm,
     onCancel,
-    bindShortcut
+    bindShortcut,
+    unbindShortcut
   } = props;
 
   useEffect(() => {
-    bindShortcut('enter', onConfirm);
-  }, [bindShortcut, onConfirm]);
+    if (isOpen) {
+      bindShortcut('enter', onConfirm);
+
+      return () => unbindShortcut('enter', onConfirm);
+    }
+  }, [bindShortcut, unbindShortcut, isOpen, onConfirm]);
 
   return (
     <Modal
@@ -61,7 +66,8 @@ PendingChangesModal.propTypes = {
   kind: PropTypes.oneOf(kinds.all),
   onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  bindShortcut: PropTypes.func.isRequired
+  bindShortcut: PropTypes.func.isRequired,
+  unbindShortcut: PropTypes.func.isRequired
 };
 
 PendingChangesModal.defaultProps = {


### PR DESCRIPTION
#### Description
This seems to be executed as well when using Enter in a `ConfirmModal` and throws an undefined for `nextLocation`.

https://github.com/Sonarr/Sonarr/blob/70807a9dcf0fbbd39768779ec8b416c78e6804f8/frontend/src/Settings/SettingsToolbarConnector.js#L86