### PR TITLE
Fixed: Redirecting after login

### DIFF
--- a/src/Sonarr.Http/Authentication/AuthenticationController.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 
@@ -46,7 +47,17 @@ namespace Sonarr.Http.Authentication
 
             await HttpContext.SignInAsync(AuthenticationType.Forms.ToString(), new ClaimsPrincipal(new ClaimsIdentity(claims, "Cookies", "user", "identifier")), authProperties);
 
-            return Redirect(_configFileProvider.UrlBase + "/");
+            if (returnUrl.IsNullOrWhiteSpace())
+            {
+                return Redirect(_configFileProvider.UrlBase + "/");
+            }
+
+            if (_configFileProvider.UrlBase.IsNullOrWhiteSpace() || returnUrl.StartsWith(_configFileProvider.UrlBase))
+            {
+                return Redirect(returnUrl);
+            }
+
+            return Redirect(_configFileProvider.UrlBase + returnUrl);
         }
 
         [HttpGet("logout")]


### PR DESCRIPTION
#### Description
We weren't correctly returning to the return URL and also noticed that redirecting when URL base is set, but URL base is not included in the original URL results in failed redirects.

#### Issues Fixed or Closed by this PR
* Closes #6454

