### PR TITLE
Use build version for macOS

### DIFF
--- a/distribution/macOS/Sonarr.app/Contents/Info.plist
+++ b/distribution/macOS/Sonarr.app/Contents/Info.plist
@@ -23,11 +23,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0</string>
+	<string>10.0.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>xmmd</string>
 	<key>CFBundleVersion</key>
-	<string>4.0</string>
+	<string>10.0.0.0</string>
 	<key>NSAppleScriptEnabled</key>
 	<string>YES</string>
 </dict>


### PR DESCRIPTION
#### Description
Use the version generated by the build as version for the macOS app.

https://github.com/Sonarr/Sonarr/blob/6b92b556bb6506ba95df64932b5db2db88f0b52f/build.sh#L27

#### Issues Fixed or Closed by this PR
* Resolves #6294

