### PR TITLE
New: Log database engine version on startup

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -7,7 +7,7 @@ using NzbDrone.Common.Instrumentation;
 namespace NzbDrone.Core.Datastore.Migration
 {
     [Maintenance(MigrationStage.BeforeAll, TransactionBehavior.None)]
-    public class DatabaseEngineversionCheck : FluentMigrator.Migration
+    public class DatabaseEngineVersionCheck : FluentMigrator.Migration
     {
         protected readonly Logger _logger;
 

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -1,0 +1,69 @@
+using System.Data;
+using System.Text.RegularExpressions;
+using FluentMigrator;
+using NLog;
+using NzbDrone.Common.Instrumentation;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Maintenance(MigrationStage.BeforeAll, TransactionBehavior.None)]
+    public class DatabaseEngineversionCheck : FluentMigrator.Migration
+    {
+        protected readonly Logger _logger;
+
+        public DatabaseEngineversionCheck()
+        {
+            _logger = NzbDroneLogger.GetLogger(this);
+        }
+
+        public override void Up()
+        {
+            IfDatabase("sqlite").Execute.WithConnection(LogSqliteVersion);
+            IfDatabase("postgres").Execute.WithConnection(LogPostgresVersion);
+        }
+
+        public override void Down()
+        {
+            // No-op
+        }
+
+        private void LogSqliteVersion(IDbConnection conn, IDbTransaction tran)
+        {
+            using (var versionCmd = conn.CreateCommand())
+            {
+                versionCmd.Transaction = tran;
+                versionCmd.CommandText = "SELECT sqlite_version();";
+
+                using (var reader = versionCmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        var version = reader.GetString(0);
+
+                        _logger.Info("SQLite {0}", version);
+                    }
+                }
+            }
+        }
+
+        private void LogPostgresVersion(IDbConnection conn, IDbTransaction tran)
+        {
+            using (var versionCmd = conn.CreateCommand())
+            {
+                versionCmd.Transaction = tran;
+                versionCmd.CommandText = "SHOW server_version";
+
+                using (var reader = versionCmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        var version = reader.GetString(0);
+                        var cleanVersion = Regex.Replace(version, @"\(.*?\)", "");
+
+                        _logger.Info("Postgres {0}", cleanVersion);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected readonly Logger _logger;
 
-        public DatabaseEngineversionCheck()
+        public DatabaseEngineVersionCheck()
         {
             _logger = NzbDroneLogger.GetLogger(this);
         }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -42,12 +42,13 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             serviceProvider = new ServiceCollection()
                 .AddLogging(b => b.AddNLog())
                 .AddFluentMigratorCore()
+                .Configure<RunnerOptions>(cfg => cfg.IncludeUntaggedMaintenances = true)
                 .ConfigureRunner(
                     builder => builder
                     .AddPostgres()
                     .AddNzbDroneSQLite()
                     .WithGlobalConnectionString(connectionString)
-                    .WithMigrationsIn(Assembly.GetExecutingAssembly()))
+                    .ScanIn(Assembly.GetExecutingAssembly()).For.All())
                 .Configure<TypeFilterOptions>(opt => opt.Namespace = "NzbDrone.Core.Datastore.Migration")
                 .Configure<ProcessorOptions>(opt =>
                 {


### PR DESCRIPTION
#### Description
Some users are running OAF versions of SQLite that don't work for all migrations, this will give us a little more information when troubleshooting those issues.

The DB engine version will be logged once for each database being migrated on every startup.

Console logs look like this:
```
[Info] DatabaseEngineversionCheck: SQLite 3.36.0
[Info] DatabaseEngineversionCheck: Postgres 14.8
````


#### Database Migration
Not really, it's a "maintenance" migration that doesn't change the DB and runs every time Sonarr starts up

