### PR TITLE
Fixed: Prevent anime search with ep/season if not supported

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -402,7 +402,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                                                        searchCriteria.SeasonNumber > 0 &&
                                                        searchCriteria.EpisodeNumber > 0;
 
-                if (includeAnimeStandardFormatSearch)
+                if (includeAnimeStandardFormatSearch && SupportsEpisodeSearch)
                 {
                     AddTvIdPageableRequests(pageableRequests,
                         Settings.AnimeCategories,
@@ -419,7 +419,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                         "search",
                         $"&q={NewsnabifyTitle(queryTitle)}+{searchCriteria.AbsoluteEpisodeNumber:00}"));
 
-                    if (includeAnimeStandardFormatSearch)
+                    if (includeAnimeStandardFormatSearch && SupportsEpisodeSearch)
                     {
                         pageableRequests.Add(GetPagedRequests(MaxPages,
                             Settings.AnimeCategories,


### PR DESCRIPTION
#### Description
Don't use Ep/Season parameters if the indexer doesn't support it (MOE)

