### PR TITLE
Fixed: Multi-word genres in Auto Tags

### DIFF
--- a/frontend/src/Components/Form/TextTagInputConnector.js
+++ b/frontend/src/Components/Form/TextTagInputConnector.js
@@ -91,6 +91,7 @@ class TextTagInputConnector extends Component {
   render() {
     return (
       <TagInput
+        delimiters={['Tab', 'Enter', ',']}
         tagList={[]}
         onTagAdd={this.onTagAdd}
         onTagDelete={this.onTagDelete}


### PR DESCRIPTION
#### Description
This changes all text tags to allow space within them, which is what tag fields from the backend utilize.

#### Issues Fixed or Closed by this PR
* Closes #6488

