### PR TITLE
Fixed: Only match via TV Rage ID if TheTVDB ID is not available

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -191,10 +191,21 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         {
             GivenParseResultSeriesDoesntMatchSearchCriteria();
 
-            Subject.Map(_parsedEpisodeInfo, 10, 10, _singleEpisodeSearchCriteria);
+            Subject.Map(_parsedEpisodeInfo, 0, 10, _singleEpisodeSearchCriteria);
 
             Mocker.GetMock<ISeriesService>()
                   .Verify(v => v.FindByTvRageId(It.IsAny<int>()), Times.Once());
+        }
+
+        [Test]
+        public void should_not_FindByTvRageId_when_search_criteria_and_FindByTitle_matching_fails_and_tvdb_id_is_specified()
+        {
+            GivenParseResultSeriesDoesntMatchSearchCriteria();
+
+            Subject.Map(_parsedEpisodeInfo, 10, 10, _singleEpisodeSearchCriteria);
+
+            Mocker.GetMock<ISeriesService>()
+                .Verify(v => v.FindByTvRageId(It.IsAny<int>()), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -396,7 +396,7 @@ namespace NzbDrone.Core.Parser
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Id);
                 }
 
-                if (tvRageId > 0 && tvRageId == searchCriteria.Series.TvRageId)
+                if (tvRageId > 0 && tvRageId == searchCriteria.Series.TvRageId && tvdbId <= 0)
                 {
                     _logger.Debug()
                            .Message("Found matching series by TVRage ID {0}, an alias may be needed for: {1}", tvRageId, parsedEpisodeInfo.SeriesTitle)
@@ -446,7 +446,7 @@ namespace NzbDrone.Core.Parser
                 }
             }
 
-            if (series == null && tvRageId > 0)
+            if (series == null && tvRageId > 0 && tvdbId <= 0)
             {
                 series = _seriesService.FindByTvRageId(tvRageId);
 


### PR DESCRIPTION
#### Description

Skip TV Rage ID lookup when release has TVDB ID.

#### Issues Fixed or Closed by this PR
* Closes #6517

