### PR TITLE
Use 'paths-ignore' instead of 'path' with only negative matches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - develop
       - main
-    paths:
-      - '!src/Sonarr.Api.*/openapi.json'
+    paths-ignore:
+      - 'src/Sonarr.Api.*/openapi.json'
   pull_request:
     branches:
       - develop
-    paths:
-      - '!src/NzbDrone.Core/Localization/Core/**'
-      - '!src/Sonarr.Api.*/openapi.json'
+    paths-ignore:
+      - 'src/NzbDrone.Core/Localization/Core/**'
+      - 'src/Sonarr.Api.*/openapi.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
#### Description

`paths` cannot only contain paths to exclude, at least one path to include must be present or you need to use `paths-ignore`

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
