### PR TITLE
Search for new series rather than going to first suggestion

### DIFF
--- a/frontend/src/Components/Page/Header/SeriesSearchInput.js
+++ b/frontend/src/Components/Page/Header/SeriesSearchInput.js
@@ -161,13 +161,12 @@ class SeriesSearchInput extends Component {
       return;
     }
 
-    // If an suggestion is not selected go to the first series,
-    // otherwise go to the selected series.
-
-    if (highlightedSuggestionIndex == null) {
-      this.goToSeries(suggestions[0]);
-    } else {
+    // If a suggestion is highlighted, go to that movie
+    // otherwise search for a new movie
+    if (highlightedSuggestionIndex) {
       this.goToSeries(suggestions[highlightedSuggestionIndex]);
+    } else {
+      this.props.onGoToAddNewSeries(value);
     }
 
     this._autosuggest.input.blur();

--- a/frontend/src/Components/Page/Header/SeriesSearchInput.js
+++ b/frontend/src/Components/Page/Header/SeriesSearchInput.js
@@ -161,12 +161,12 @@ class SeriesSearchInput extends Component {
       return;
     }
 
-    // If a suggestion is highlighted, go to that series
-    // otherwise search for a new series
-    if (highlightedSuggestionIndex) {
-      this.goToSeries(suggestions[highlightedSuggestionIndex]);
-    } else {
+    // If no suggestion is highlighted, search for a new series
+    // otherwise go to that suggestion
+    if (highlightedSuggestionIndex == null) {
       this.props.onGoToAddNewSeries(value);
+    } else {
+      this.goToSeries(suggestions[highlightedSuggestionIndex]);
     }
 
     this._autosuggest.input.blur();

--- a/frontend/src/Components/Page/Header/SeriesSearchInput.js
+++ b/frontend/src/Components/Page/Header/SeriesSearchInput.js
@@ -161,8 +161,8 @@ class SeriesSearchInput extends Component {
       return;
     }
 
-    // If a suggestion is highlighted, go to that movie
-    // otherwise search for a new movie
+    // If a suggestion is highlighted, go to that series
+    // otherwise search for a new series
     if (highlightedSuggestionIndex) {
       this.goToSeries(suggestions[highlightedSuggestionIndex]);
     } else {


### PR DESCRIPTION
#### Description
Most search engines do not select the first suggestion upon pressing enter, they perform a search for your term. Sonarr will currently do this when there are no existing series that match the search term, but it will go to the first matching existing series if one exists.

Update the Sonarr search to look for a new series upon pressing Tab or Enter instead of selecting the first existing series if there is one. The behaviour for no matching existing series remains the same. It will navigate to the highlighted selection if selected.

#### Screenshots for UI Changes
Behavioural change rather than visual change.

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
N/A

#### Other info
[Corresponding PR for Radarr](https://github.com/Radarr/Radarr/pull/9786)

