### PR TITLE
Clean branch name to remove slashes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   FRAMEWORK: net6.0
-  BRANCH: ${{ github.head_ref || github.ref_name }}
+  RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   SONARR_MAJOR_VERSION: 4
   VERSION: 4.0.1
 
@@ -48,6 +48,8 @@ jobs:
 
         echo "SDK_PATH=${{ env.DOTNET_ROOT }}/sdk/${DOTNET_VERSION}" >> "$GITHUB_ENV"
         echo "SONARR_VERSION=$SONARR_VERSION" >> "$GITHUB_ENV"
+        echo "BRANCH=${RAW_BRANCH_NAME/\//-}" >> "$GITHUB_ENV"
+
         echo "framework=${{ env.FRAMEWORK }}" >> "$GITHUB_OUTPUT"
         echo "major_version=${{ env.SONARR_MAJOR_VERSION }}" >> "$GITHUB_OUTPUT"
         echo "version=$SONARR_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
#### Description

Branch names with slashes cause issues with builds so replace them with dashes.