### PR TITLE
New: Bypass archived history for failed downloads in SABnzbd

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -205,11 +205,11 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     DeleteItemData(item);
                 }
 
-                _proxy.RemoveFrom("history", item.DownloadId, deleteData, Settings);
+                _proxy.RemoveFromHistory(item.DownloadId, deleteData, item.Status == DownloadItemStatus.Failed, Settings);
             }
             else
             {
-                _proxy.RemoveFrom("queue", item.DownloadId, deleteData, Settings);
+                _proxy.RemoveFromQueue(item.DownloadId, deleteData, Settings);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
@@ -14,7 +14,8 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
     {
         string GetBaseUrl(SabnzbdSettings settings, string relativePath = null);
         SabnzbdAddResponse DownloadNzb(byte[] nzbData, string filename, string category, int priority, SabnzbdSettings settings);
-        void RemoveFrom(string source, string id, bool deleteData, SabnzbdSettings settings);
+        void RemoveFromQueue(string id, bool deleteData, SabnzbdSettings settings);
+        void RemoveFromHistory(string id, bool deleteData, bool deletePermanently, SabnzbdSettings settings);
         string GetVersion(SabnzbdSettings settings);
         SabnzbdConfig GetConfig(SabnzbdSettings settings);
         SabnzbdFullStatus GetFullStatus(SabnzbdSettings settings);
@@ -60,12 +61,23 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
             return response;
         }
 
-        public void RemoveFrom(string source, string id, bool deleteData, SabnzbdSettings settings)
+        public void RemoveFromQueue(string id, bool deleteData, SabnzbdSettings settings)
         {
-            var request = BuildRequest(source, settings);
+            var request = BuildRequest("queue", settings);
             request.AddQueryParam("name", "delete");
             request.AddQueryParam("del_files", deleteData ? 1 : 0);
             request.AddQueryParam("value", id);
+
+            ProcessRequest(request, settings);
+        }
+
+        public void RemoveFromHistory(string id, bool deleteData, bool deletePermanently, SabnzbdSettings settings)
+        {
+            var request = BuildRequest("history", settings);
+            request.AddQueryParam("name", "delete");
+            request.AddQueryParam("del_files", deleteData ? 1 : 0);
+            request.AddQueryParam("value", id);
+            request.AddQueryParam("archive", deletePermanently ? 0 : 1);
 
             ProcessRequest(request, settings);
         }


### PR DESCRIPTION
#### Description

SABnzbd is adding a history archive, so deletions will end up in the archive instead of deleted permanently. For failed downloads we want to skip the archiving and allow Sonarr to find a replacement without dupe checking getting in the way.