### PR TITLE
New: Ignore language in split episode title

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeEpisodeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeEpisodeTitleFixture.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class NormalizeEpisodeTitleFixture : CoreTest
+    {
+        [TestCase("Episode Title", "episode title")]
+        [TestCase("A.B,C;", "a b c")]
+        [TestCase("Episode  Title", "episode title")]
+        [TestCase("French Title (1)", "french title")]
+        [TestCase("Series.Title.S01.Special.Episode.Title.720p.HDTV.x264-Sonarr", "episode title")]
+        [TestCase("Series.Title.S01E00.Episode.Title.720p.HDTV.x264-Sonarr", "episode title")]
+        public void should_normalize_episode_title(string input, string expected)
+        {
+            var result = Parser.Parser.NormalizeEpisodeTitle(input);
+
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeSeriesTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeSeriesTitleFixture.cs
@@ -6,7 +6,7 @@ using NzbDrone.Core.Test.Framework;
 namespace NzbDrone.Core.Test.ParserTests
 {
     [TestFixture]
-    public class NormalizeTitleFixture : CoreTest
+    public class NormalizeSeriesTitleFixture : CoreTest
     {
         [TestCase("Series", "series")]
         [TestCase("Series (2009)", "series2009")]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -541,6 +541,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex TitleComponentsRegex = new Regex(@"^(?:(?<title>.+?) \((?<title>.+?)\)|(?<title>.+?) \| (?<title>.+?))$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+        private static readonly Regex PartRegex = new Regex(@"\(\d+\)$", RegexOptions.Compiled);
         private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
         private static readonly Regex ArticleWordRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -792,6 +793,7 @@ namespace NzbDrone.Core.Parser
             // Disabled, Until we run into specific testcases for the removal of these words.
             // title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
 
+            title = PartRegex.Replace(title, "");
             title = PunctuationRegex.Replace(title, " ");
             title = DuplicateSpacesRegex.Replace(title, " ");
 


### PR DESCRIPTION
#### Description

Split episode titles weren't properly getting normalized which allowed for languages in the split title to be treated as the audio language.