### PR TITLE
Fixed: Don't store seasons from import list items in database

### DIFF
--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -82,7 +82,8 @@ namespace NzbDrone.Core.Datastore
                   .Ignore(i => i.Enable);
 
             Mapper.Entity<ImportListItemInfo>("ImportListItems").RegisterModel()
-                   .Ignore(i => i.ImportList);
+                   .Ignore(i => i.ImportList)
+                   .Ignore(i => i.Seasons);
 
             Mapper.Entity<NotificationDefinition>("Notifications").RegisterModel()
                   .Ignore(x => x.ImplementationName)


### PR DESCRIPTION
#### Description
Seasons should have been ignored because we don't store other monitoring info and now store information about each item in the DB.

#### Issues Fixed or Closed by this PR
* Closes #6555

