### PR TITLE
Fixed: Ignore SceneTitle for Custom Format Title Parsing

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -166,12 +166,7 @@ namespace NzbDrone.Core.CustomFormats
         {
             var releaseTitle = string.Empty;
 
-            if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
-            {
-                _logger.Trace("Using scene name for release title: {0}", episodeFile.SceneName);
-                releaseTitle = episodeFile.SceneName;
-            }
-            else if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
+            if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
             {
                 _logger.Trace("Using original file path for release title: {0}", Path.GetFileName(episodeFile.OriginalFilePath));
                 releaseTitle = Path.GetFileName(episodeFile.OriginalFilePath);


### PR DESCRIPTION
#### Description
Use file name not scenetitle dude to numerous issues with parsing and download loops. I.e. SceneTitle reports the wrong hdr type or audio type

Ref https://github.com/Sonarr/Sonarr/issues/5598
https://github.com/Radarr/Radarr/issues/9542