### PR TITLE
Fixed: Handle DownloadClientInfo as nullable in ManualInteractionRequiredMessage

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -351,8 +351,8 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_Series_OriginalLanguage", IsoLanguages.Get(series.OriginalLanguage).ThreeLetterCode);
             environmentVariables.Add("Sonarr_Series_Genres", string.Join("|", series.Genres));
             environmentVariables.Add("Sonarr_Series_Tags", string.Join("|", series.Tags.Select(t => _tagRepository.Get(t).Label)));
-            environmentVariables.Add("Sonarr_Download_Client", message.DownloadClientName ?? string.Empty);
-            environmentVariables.Add("Sonarr_Download_Client_Type", message.DownloadClientType ?? string.Empty);
+            environmentVariables.Add("Sonarr_Download_Client", message.DownloadClientInfo?.Name ?? string.Empty);
+            environmentVariables.Add("Sonarr_Download_Client_Type", message.DownloadClientInfo?.Type ?? string.Empty);
             environmentVariables.Add("Sonarr_Download_Id", message.DownloadId ?? string.Empty);
             environmentVariables.Add("Sonarr_Download_Size", message.TrackedDownload.DownloadItem.TotalSize.ToString());
             environmentVariables.Add("Sonarr_Download_Title", message.TrackedDownload.DownloadItem.Title);

--- a/src/NzbDrone.Core/Notifications/ManualInteractionRequiredMessage.cs
+++ b/src/NzbDrone.Core/Notifications/ManualInteractionRequiredMessage.cs
@@ -1,3 +1,4 @@
+using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
@@ -12,8 +13,7 @@ namespace NzbDrone.Core.Notifications
         public RemoteEpisode Episode { get; set; }
         public TrackedDownload TrackedDownload { get; set; }
         public QualityModel Quality { get; set; }
-        public string DownloadClientType { get; set; }
-        public string DownloadClientName { get; set; }
+        public DownloadClientItemClientInfo DownloadClientInfo { get; set; }
         public string DownloadId { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
 

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -240,8 +240,7 @@ namespace NzbDrone.Core.Notifications
                 Quality = message.Episode.ParsedEpisodeInfo.Quality,
                 Episode = message.Episode,
                 TrackedDownload = message.TrackedDownload,
-                DownloadClientType = message.TrackedDownload.DownloadItem.DownloadClientInfo.Type,
-                DownloadClientName = message.TrackedDownload.DownloadItem.DownloadClientInfo.Name,
+                DownloadClientInfo = message.TrackedDownload.DownloadItem.DownloadClientInfo,
                 DownloadId = message.TrackedDownload.DownloadItem.DownloadId,
                 Release = message.Release
             };

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -175,8 +175,8 @@ namespace NzbDrone.Core.Notifications.Webhook
                 Series = new WebhookSeries(message.Series),
                 Episodes = remoteEpisode.Episodes.ConvertAll(x => new WebhookEpisode(x)),
                 DownloadInfo = new WebhookDownloadClientItem(quality, message.TrackedDownload.DownloadItem),
-                DownloadClient = message.DownloadClientName,
-                DownloadClientType = message.DownloadClientType,
+                DownloadClient = message.DownloadClientInfo?.Name,
+                DownloadClientType = message.DownloadClientInfo?.Type,
                 DownloadId = message.DownloadId,
                 CustomFormatInfo = new WebhookCustomFormatInfo(remoteEpisode.CustomFormats, remoteEpisode.CustomFormatScore),
                 Release = new WebhookGrabbedRelease(message.Release)


### PR DESCRIPTION
#### Description
Cherry pick from Radarr for the same issue.


#### Issues Fixed or Closed by this PR
* Closes #6558

