### PR TITLE
`{Custom Format:Format}` Rename Token

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -150,7 +150,8 @@ const mediaInfoTokens = [
 
 const otherTokens = [
   { token: '{Release Group}', example: 'Rls Grp' },
-  { token: '{Custom Formats}', example: 'iNTERNAL' }
+  { token: '{Custom Formats}', example: 'iNTERNAL' },
+  { token: '{Custom Format:FormatName}', example: 'AMZN' }
 ];
 
 const originalTokens = [

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CustomFormatsFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CustomFormatsFixture.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class CustomFormatsFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode1;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        private List<CustomFormat> _customFormats;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .With(s => s.Title = "South Park")
+                    .Build();
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            _episode1 = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            _customFormats = new List<CustomFormat>()
+            {
+                new CustomFormat()
+                {
+                    Name = "INTERNAL",
+                    IncludeCustomFormatWhenRenaming = true
+                },
+                new CustomFormat()
+                {
+                    Name = "AMZN",
+                    IncludeCustomFormatWhenRenaming = true
+                },
+                new CustomFormat()
+                {
+                    Name = "NAME WITH SPACES",
+                    IncludeCustomFormatWhenRenaming = true
+                },
+                new CustomFormat()
+                {
+                    Name = "NotIncludedFormat",
+                    IncludeCustomFormatWhenRenaming = false
+                }
+            };
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+        }
+
+        [TestCase("{Custom Formats}", "INTERNAL AMZN NAME WITH SPACES")]
+        public void should_replace_custom_formats(string format, string expected)
+        {
+            _namingConfig.StandardEpisodeFormat = format;
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile, customFormats: _customFormats)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("{Custom Formats}", "")]
+        public void should_replace_custom_formats_with_no_custom_formats(string format, string expected)
+        {
+            _namingConfig.StandardEpisodeFormat = format;
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile, customFormats: new List<CustomFormat>())
+                   .Should().Be(expected);
+        }
+
+        [TestCase("{Custom Format}", "")]
+        [TestCase("{Custom Format:INTERNAL}", "INTERNAL")]
+        [TestCase("{Custom Format:AMZN}", "AMZN")]
+        [TestCase("{Custom Format:NAME WITH SPACES}", "NAME WITH SPACES")]
+        [TestCase("{Custom Format:DOESNOTEXIST}", "")]
+        [TestCase("{Custom Format:INTERNAL} - {Custom Format:AMZN}", "INTERNAL - AMZN")]
+        [TestCase("{Custom Format:AMZN} - {Custom Format:INTERNAL}", "AMZN - INTERNAL")]
+        public void should_replace_custom_format(string format, string expected)
+        {
+            _namingConfig.StandardEpisodeFormat = format;
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile, customFormats: _customFormats)
+                   .Should().Be(expected);
+        }
+
+        [TestCase("{Custom Format}", "")]
+        [TestCase("{Custom Format:INTERNAL}", "")]
+        [TestCase("{Custom Format:AMZN}", "")]
+        public void should_replace_custom_format_with_no_custom_formats(string format, string expected)
+        {
+            _namingConfig.StandardEpisodeFormat = format;
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile, customFormats: new List<CustomFormat>())
+                   .Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/CustomFormat.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Core.Datastore;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -705,7 +705,7 @@ namespace NzbDrone.Core.Organizer
                     return string.Empty;
                 }
 
-                return string.Join(" ", customFormats.Where(x => x.IncludeCustomFormatWhenRenaming && x.Name == m.CustomFormat));
+                return customFormats.Where(x => x.IncludeCustomFormatWhenRenaming && x.Name == m.CustomFormat).FirstOrDefault()?.ToString() ?? string.Empty;
             };
         }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -698,6 +698,15 @@ namespace NzbDrone.Core.Organizer
             }
 
             tokenHandlers["{Custom Formats}"] = m => string.Join(" ", customFormats.Where(x => x.IncludeCustomFormatWhenRenaming));
+            tokenHandlers["{Custom Format}"] = m =>
+            {
+                if (m.CustomFormat.IsNullOrWhiteSpace())
+                {
+                    return string.Empty;
+                }
+
+                return string.Join(" ", customFormats.Where(x => x.IncludeCustomFormatWhenRenaming && x.Name == m.CustomFormat));
+            };
         }
 
         private void AddIdTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Series series)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Organizer
         private readonly ICached<bool> _patternHasEpisodeIdentifierCache;
         private readonly Logger _logger;
 
-        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?:[ ]+)?(?<customFormat>[ a-z0-9+-]+(?<!-| )))?(?<suffix>[- ._)\]]*)\}",
+        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ a-z0-9+-]+(?<![- ])))?(?<suffix>[- ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         private static readonly Regex EpisodeRegex = new Regex(@"(?<episode>\{episode(?:\:0+)?})",

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Organizer
         private readonly ICached<bool> _patternHasEpisodeIdentifierCache;
         private readonly Logger _logger;
 
-        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[a-z0-9+-]+(?<!-)))?(?<suffix>[- ._)\]]*)\}",
+        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?:[ ]+)?(?<customFormat>[ a-z0-9+-]+(?<!-| )))?(?<suffix>[- ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         private static readonly Regex EpisodeRegex = new Regex(@"(?<episode>\{episode(?:\:0+)?})",


### PR DESCRIPTION
#### Description
Implementing the `{Custom Format:Format}` rename token to allow position of Custom Formats when renaming.

This re-implements #4453 for Custom Formats, and would satisfy [Radarr/Radarr#6801](https://github.com/Radarr/Radarr/issues/6801) if it gets cherry-picked to over there.

It is a smaller change because it's really just allowing exact placement of the Format Name instead of the old Preferred Words implementation that replaced with the matched values.

#### Database Migration
NO


#### Issues Fixed or Closed by this PR
* #6431 - It doesn't close this issue, but is related.

