### PR TITLE
Properly type validation errors/warnings

### DIFF
--- a/frontend/src/typings/pending.ts
+++ b/frontend/src/typings/pending.ts
@@ -1,7 +1,21 @@
+export interface ValidationFailure {
+  propertyName: string;
+  errorMessage: string;
+  severity: 'error' | 'warning';
+}
+
+export interface ValidationError extends ValidationFailure {
+  isWarning: false;
+}
+
+export interface ValidationWarning extends ValidationFailure {
+  isWarning: true;
+}
+
 export interface Pending<T> {
   value: T;
-  errors: any[];
-  warnings: any[];
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
 }
 
 export type PendingSection<T> = {


### PR DESCRIPTION
#### Description

Will stop GHA from writing the warnings as annotations in the summary.

