### PR TITLE
Fix import list exclusion props

### DIFF
--- a/frontend/src/App/State/AppSectionState.ts
+++ b/frontend/src/App/State/AppSectionState.ts
@@ -19,6 +19,7 @@ export interface AppSectionSaveState {
 
 export interface PagedAppSectionState {
   pageSize: number;
+  totalRecords?: number;
 }
 
 export interface AppSectionFilterState<T> {

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
 import FieldSet from 'Components/FieldSet';
@@ -41,11 +42,6 @@ const COLUMNS = [
   },
 ];
 
-interface ImportListExclusionsProps {
-  useCurrentPage: number;
-  totalRecords: number;
-}
-
 function createImportListExlucionsSelector() {
   return createSelector(
     (state: AppState) => state.settings.importListExclusions,
@@ -57,8 +53,9 @@ function createImportListExlucionsSelector() {
   );
 }
 
-function ImportListExclusions(props: ImportListExclusionsProps) {
-  const { useCurrentPage, totalRecords } = props;
+function ImportListExclusions() {
+  const history = useHistory();
+  const useCurrentPage = history.action === 'POP';
 
   const dispatch = useDispatch();
 
@@ -155,6 +152,7 @@ function ImportListExclusions(props: ImportListExclusionsProps) {
     sortKey,
     error,
     sortDirection,
+    totalRecords,
     ...otherProps
   } = selected;
 


### PR DESCRIPTION
#### Description

Fixes a problem with the import list exclusion props declaring `useCurrentPage` and `totalRecords` but not actually being passed them. This removes those props and makes it so `totalRecords` is selected from the app state, and `useCurrentPage` is calculated from the `useHistory()` hook.

