### PR TITLE
Apple WebApp on login.html

### DIFF
--- a/frontend/src/login.html
+++ b/frontend/src/login.html
@@ -3,13 +3,16 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <!-- Chrome, Opera, and Firefox OS -->
     <meta name="theme-color" content="#3a3f51" />
     <!-- Windows Phone -->
     <meta name="msapplication-navbutton-color" content="#3a3f51" />
+    <!-- Android/Apple Phone -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="format-detection" content="telephone=no">
 
     <meta name="description" content="Sonarr" />
 


### PR DESCRIPTION
New iPhones need different meta tags to see an app as a web-app. This should address those missing tags on login.html, namely Status Bar.