### PR TITLE
Fixed: Reprocessing release type for items in Manual Import

### DIFF
--- a/frontend/src/InteractiveImport/InteractiveImport.ts
+++ b/frontend/src/InteractiveImport/InteractiveImport.ts
@@ -1,5 +1,6 @@
 import ModelBase from 'App/ModelBase';
 import Episode from 'Episode/Episode';
+import ReleaseType from 'InteractiveImport/ReleaseType';
 import Language from 'Language/Language';
 import { QualityModel } from 'Quality/Quality';
 import Series from 'Series/Series';
@@ -33,6 +34,7 @@ interface InteractiveImport extends ModelBase {
   qualityWeight: number;
   customFormats: object[];
   indexerFlags: number;
+  releaseType: ReleaseType;
   rejections: Rejection[];
   episodeFileId?: number;
 }

--- a/frontend/src/InteractiveImport/ReleaseType.ts
+++ b/frontend/src/InteractiveImport/ReleaseType.ts
@@ -1,0 +1,3 @@
+type ReleaseType = 'unknown' | 'singleEpisode' | 'multiEpisode' | 'seasonPack';
+
+export default ReleaseType;

--- a/frontend/src/Store/Actions/interactiveImportActions.js
+++ b/frontend/src/Store/Actions/interactiveImportActions.js
@@ -163,6 +163,7 @@ export const actionHandlers = handleThunks({
         languages: item.languages,
         releaseGroup: item.releaseGroup,
         indexerFlags: item.indexerFlags,
+        releaseType: item.releaseType,
         downloadId: item.downloadId
       };
     });

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
@@ -39,7 +39,7 @@ namespace Sonarr.Api.V3.ManualImport
         {
             foreach (var item in items)
             {
-                var processedItem = _manualImportService.ReprocessItem(item.Path, item.DownloadId, item.SeriesId, item.SeasonNumber, item.EpisodeIds ?? new List<int>(), item.ReleaseGroup, item.Quality, item.Languages, item.IndexerFlags);
+                var processedItem = _manualImportService.ReprocessItem(item.Path, item.DownloadId, item.SeriesId, item.SeasonNumber, item.EpisodeIds ?? new List<int>(), item.ReleaseGroup, item.Quality, item.Languages, item.IndexerFlags, item.ReleaseType);
 
                 item.SeasonNumber = processedItem.SeasonNumber;
                 item.Episodes = processedItem.Episodes.ToResource();

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportReprocessResource.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportReprocessResource.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 using Sonarr.Api.V3.CustomFormats;
 using Sonarr.Api.V3.Episodes;
@@ -22,6 +23,7 @@ namespace Sonarr.Api.V3.ManualImport
         public List<CustomFormatResource> CustomFormats { get; set; }
         public int CustomFormatScore { get; set; }
         public int IndexerFlags { get; set; }
+        public ReleaseType ReleaseType { get; set; }
         public IEnumerable<Rejection> Rejections { get; set; }
     }
 }


### PR DESCRIPTION
#### Description
Reuse `releaseType` when reprocessing items in manual import.
