### PR TITLE
Prevent NullRef in naming when truncating a null Release Group

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -1168,6 +1168,11 @@ namespace NzbDrone.Core.Organizer
 
         private string Truncate(string input, string formatter)
         {
+            if (input.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
             var maxLength = GetMaxLengthFromFormatter(formatter);
 
             if (maxLength == 0 || input.Length <= Math.Abs(maxLength))

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -1170,7 +1170,7 @@ namespace NzbDrone.Core.Organizer
         {
             if (input.IsNullOrWhiteSpace())
             {
-                return null;
+                return string.Empty;
             }
 
             var maxLength = GetMaxLengthFromFormatter(formatter);


### PR DESCRIPTION
#### Description
Fix for https://discord.com/channels/383686866005917708/383688189941907459/1215276558424743997 when using truncate with a null value.

