### PR TITLE
Fixed: Release push with only Magnet URL

### DIFF
--- a/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
@@ -41,7 +41,8 @@ namespace Sonarr.Api.V3.Indexers
             _logger = logger;
 
             PostValidator.RuleFor(s => s.Title).NotEmpty();
-            PostValidator.RuleFor(s => s.DownloadUrl).NotEmpty();
+            PostValidator.RuleFor(s => s.DownloadUrl).NotEmpty().When(s => s.MagnetUrl.IsNullOrWhiteSpace());
+            PostValidator.RuleFor(s => s.MagnetUrl).NotEmpty().When(s => s.DownloadUrl.IsNullOrWhiteSpace());
             PostValidator.RuleFor(s => s.Protocol).NotEmpty();
             PostValidator.RuleFor(s => s.PublishDate).NotEmpty();
         }
@@ -50,7 +51,7 @@ namespace Sonarr.Api.V3.Indexers
         [Consumes("application/json")]
         public ActionResult<List<ReleaseResource>> Create(ReleaseResource release)
         {
-            _logger.Info("Release pushed: {0} - {1}", release.Title, release.DownloadUrl);
+            _logger.Info("Release pushed: {0} - {1}", release.Title, release.DownloadUrl ?? release.MagnetUrl);
 
             ValidateResource(release);
 


### PR DESCRIPTION
#### Description
Allows `MagnetUrl` without `DownloadUrl` and vice versa.

#### Issues Fixed or Closed by this PR
* Closes #6622

