### PR TITLE
Fixed: Disabled select option still selectable

### DIFF
--- a/frontend/src/Components/Form/MonitorEpisodesSelectInput.js
+++ b/frontend/src/Components/Form/MonitorEpisodesSelectInput.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import monitorOptions from 'Utilities/Series/monitorOptions';
 import translate from 'Utilities/String/translate';
-import SelectInput from './SelectInput';
+import EnhancedSelectInput from './EnhancedSelectInput';
 
 function MonitorEpisodesSelectInput(props) {
   const {
@@ -19,7 +19,7 @@ function MonitorEpisodesSelectInput(props) {
       get value() {
         return translate('NoChange');
       },
-      disabled: true
+      isDisabled: true
     });
   }
 
@@ -29,12 +29,12 @@ function MonitorEpisodesSelectInput(props) {
       get value() {
         return `(${translate('Mixed')})`;
       },
-      disabled: true
+      isDisabled: true
     });
   }
 
   return (
-    <SelectInput
+    <EnhancedSelectInput
       values={values}
       {...otherProps}
     />

--- a/frontend/src/Components/Form/MonitorNewItemsSelectInput.js
+++ b/frontend/src/Components/Form/MonitorNewItemsSelectInput.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import monitorNewItemsOptions from 'Utilities/Series/monitorNewItemsOptions';
-import SelectInput from './SelectInput';
+import EnhancedSelectInput from './EnhancedSelectInput';
 
 function MonitorNewItemsSelectInput(props) {
   const {
@@ -16,7 +16,7 @@ function MonitorNewItemsSelectInput(props) {
     values.unshift({
       key: 'noChange',
       value: 'No Change',
-      disabled: true
+      isDisabled: true
     });
   }
 
@@ -24,12 +24,12 @@ function MonitorNewItemsSelectInput(props) {
     values.unshift({
       key: 'mixed',
       value: '(Mixed)',
-      disabled: true
+      isDisabled: true
     });
   }
 
   return (
-    <SelectInput
+    <EnhancedSelectInput
       values={values}
       {...otherProps}
     />

--- a/frontend/src/Components/Form/QualityProfileSelectInputConnector.js
+++ b/frontend/src/Components/Form/QualityProfileSelectInputConnector.js
@@ -28,7 +28,7 @@ function createMapStateToProps() {
           get value() {
             return translate('NoChange');
           },
-          disabled: includeNoChangeDisabled
+          isDisabled: includeNoChangeDisabled
         });
       }
 
@@ -38,7 +38,7 @@ function createMapStateToProps() {
           get value() {
             return `(${translate('Mixed')})`;
           },
-          disabled: true
+          isDisabled: true
         });
       }
 

--- a/frontend/src/Components/Form/SeriesTypeSelectInput.tsx
+++ b/frontend/src/Components/Form/SeriesTypeSelectInput.tsx
@@ -15,7 +15,7 @@ interface ISeriesTypeOption {
   key: string;
   value: string;
   format?: string;
-  disabled?: boolean;
+  isDisabled?: boolean;
 }
 
 const seriesTypeOptions: ISeriesTypeOption[] = [
@@ -55,7 +55,7 @@ function SeriesTypeSelectInput(props: SeriesTypeSelectInputProps) {
     values.unshift({
       key: 'noChange',
       value: translate('NoChange'),
-      disabled: includeNoChangeDisabled,
+      isDisabled: includeNoChangeDisabled,
     });
   }
 
@@ -63,7 +63,7 @@ function SeriesTypeSelectInput(props: SeriesTypeSelectInputProps) {
     values.unshift({
       key: 'mixed',
       value: `(${translate('Mixed')})`,
-      disabled: true,
+      isDisabled: true,
     });
   }
 

--- a/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
+++ b/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
@@ -36,7 +36,7 @@ const monitoredOptions = [
     get value() {
       return translate('NoChange');
     },
-    disabled: true,
+    isDisabled: true,
   },
   {
     key: 'monitored',
@@ -58,7 +58,7 @@ const seasonFolderOptions = [
     get value() {
       return translate('NoChange');
     },
-    disabled: true,
+    isDisabled: true,
   },
   {
     key: 'yes',

--- a/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Edit/ManageDownloadClientsEditModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Edit/ManageDownloadClientsEditModalContent.tsx
@@ -32,7 +32,7 @@ const enableOptions = [
     get value() {
       return translate('NoChange');
     },
-    disabled: true,
+    isDisabled: true,
   },
   {
     key: 'enabled',

--- a/frontend/src/Settings/ImportLists/ImportLists/Manage/Edit/ManageImportListsEditModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportLists/Manage/Edit/ManageImportListsEditModalContent.tsx
@@ -31,7 +31,7 @@ const autoAddOptions = [
     get value() {
       return translate('NoChange');
     },
-    disabled: true,
+    isDisabled: true,
   },
   {
     key: 'enabled',

--- a/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
@@ -32,7 +32,7 @@ const enableOptions = [
     get value() {
       return translate('NoChange');
     },
-    disabled: true,
+    isDisabled: true,
   },
   {
     key: 'enabled',


### PR DESCRIPTION
#### Description

Came up on Discord today, `disabled != isDisabled` for `EnhancedSelectInput`, also converted a couple `SelectInput` usages in to `EnhancedSelectInput` for consistency in forms.

