### PR TITLE
Fixed: Don't add series from import list with no matched TVDB ID

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -33,7 +33,6 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             var item1 = new ImportListItemInfo()
             {
-                TvdbId = 12345,
                 Title = "Breaking Bad"
             };
 
@@ -121,6 +120,17 @@ namespace NzbDrone.Core.Test.ImportListTests
         private void WithImdbId()
         {
             _list1Series.First().ImdbId = "tt0496424";
+
+            Mocker.GetMock<ISearchForNewSeries>()
+                .Setup(s => s.SearchForNewSeriesByImdbId(_list1Series.First().ImdbId))
+                .Returns(
+                    Builder<Series>
+                        .CreateListOfSize(1)
+                        .All()
+                        .With(s => s.Title = "Breaking Bad")
+                        .With(s => s.TvdbId = 81189)
+                        .Build()
+                        .ToList());
         }
 
         private void WithExistingSeries()
@@ -343,6 +353,7 @@ namespace NzbDrone.Core.Test.ImportListTests
         public void should_add_new_series_from_single_list_to_library()
         {
             _importListFetch.Series.ForEach(m => m.ImportListId = 1);
+            WithTvdbId();
             WithList(1, true);
             WithCleanLevel(ListSyncLevelType.Disabled);
 
@@ -359,6 +370,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             _importListFetch.Series.ForEach(m => m.ImportListId = 1);
             _importListFetch.Series.AddRange(_list2Series);
 
+            WithTvdbId();
             WithList(1, true);
             WithList(2, true);
 
@@ -377,6 +389,7 @@ namespace NzbDrone.Core.Test.ImportListTests
             _importListFetch.Series.ForEach(m => m.ImportListId = 1);
             _importListFetch.Series.AddRange(_list2Series);
 
+            WithTvdbId();
             WithList(1, true);
             WithList(2, false);
 
@@ -422,18 +435,18 @@ namespace NzbDrone.Core.Test.ImportListTests
         [Test]
         public void should_search_by_imdb_if_series_title_and_series_imdb()
         {
-            _importListFetch.Series.ForEach(m =>
-            {
-                m.ImportListId = 1;
-                m.TvdbId = 0;
-            });
+            _importListFetch.Series.ForEach(m => m.ImportListId = 1);
 
             WithList(1, true);
             WithImdbId();
+
             Subject.Execute(_commandAll);
 
             Mocker.GetMock<ISearchForNewSeries>()
                   .Verify(v => v.SearchForNewSeriesByImdbId(It.IsAny<string>()), Times.Once());
+
+            Mocker.GetMock<IAddSeriesService>()
+                .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 1), It.IsAny<bool>()));
         }
 
         [Test]
@@ -503,6 +516,19 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             Mocker.GetMock<IImportListExclusionService>()
                 .Verify(v => v.All(), Times.Never);
+        }
+
+        [Test]
+        public void should_not_add_if_tvdbid_is_0()
+        {
+            _importListFetch.Series.ForEach(m => m.ImportListId = 1);
+            WithList(1, true);
+            WithExcludedSeries();
+
+            Subject.Execute(_commandAll);
+
+            Mocker.GetMock<IAddSeriesService>()
+                .Verify(v => v.AddSeries(It.Is<List<Series>>(t => t.Count == 0), It.IsAny<bool>()));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListSyncServiceFixture.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             var item1 = new ImportListItemInfo()
             {
+                TvdbId = 12345,
                 Title = "Breaking Bad"
             };
 
@@ -421,7 +422,12 @@ namespace NzbDrone.Core.Test.ImportListTests
         [Test]
         public void should_search_by_imdb_if_series_title_and_series_imdb()
         {
-            _importListFetch.Series.ForEach(m => m.ImportListId = 1);
+            _importListFetch.Series.ForEach(m =>
+            {
+                m.ImportListId = 1;
+                m.TvdbId = 0;
+            });
+
             WithList(1, true);
             WithImdbId();
             Subject.Execute(_commandAll);

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -190,6 +190,12 @@ namespace NzbDrone.Core.ImportLists
                     item.Title = mappedSeries.Title;
                 }
 
+                if (item.TvdbId == 0)
+                {
+                    _logger.Debug("[{0}] Rejected, unable to find TVDB ID", item.Title);
+                    continue;
+                }
+
                 // Check to see if series excluded
                 var excludedSeries = listExclusions.Where(s => s.TvdbId == item.TvdbId).SingleOrDefault();
 
@@ -202,7 +208,7 @@ namespace NzbDrone.Core.ImportLists
                 // Break if Series Exists in DB
                 if (existingTvdbIds.Any(x => x == item.TvdbId))
                 {
-                    _logger.Debug("{0} [{1}] Rejected, Series Exists in DB", item.TvdbId, item.Title);
+                    _logger.Debug("{0} [{1}] Rejected, series exists in database", item.TvdbId, item.Title);
                     continue;
                 }
 

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexParser.cs
@@ -39,7 +39,6 @@ namespace NzbDrone.Core.ImportLists.Plex
                 int.TryParse(tvdbIdString, out var tvdbId);
                 int.TryParse(tmdbIdString, out var tmdbId);
 
-
                 series.Add(new ImportListItemInfo
                 {
                     TvdbId = tvdbId,

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexParser.cs
@@ -39,6 +39,7 @@ namespace NzbDrone.Core.ImportLists.Plex
                 int.TryParse(tvdbIdString, out var tvdbId);
                 int.TryParse(tmdbIdString, out var tmdbId);
 
+
                 series.Add(new ImportListItemInfo
                 {
                     TvdbId = tvdbId,


### PR DESCRIPTION
#### Description

Plex Watchlist isn't returning any IDs, but series with TVDB ID of 0 were attempting to be added.

