### PR TITLE
Fixed: Task progress messages in the UI

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -522,7 +522,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             var reports = batch.SelectMany(x => x).ToList();
 
-            _logger.Debug("Total of {0} reports were found for {1} from {2} indexers", reports.Count, criteriaBase, indexers.Count);
+            _logger.ProgressDebug("Total of {0} reports were found for {1} from {2} indexers", reports.Count, criteriaBase, indexers.Count);
 
             // Update the last search time for all episodes if at least 1 indexer was searched.
             if (indexers.Any())

--- a/src/NzbDrone.Core/Indexers/RssSyncCommand.cs
+++ b/src/NzbDrone.Core/Indexers/RssSyncCommand.cs
@@ -5,7 +5,6 @@ namespace NzbDrone.Core.Indexers
     public class RssSyncCommand : Command
     {
         public override bool SendUpdatesToClient => true;
-
         public override bool IsLongRunning => true;
     }
 }

--- a/src/NzbDrone.Core/Messaging/Commands/Command.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/Command.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Messaging.Commands
         }
 
         public virtual bool UpdateScheduledTask => true;
-        public virtual string CompletionMessage => "Completed";
+        public virtual string CompletionMessage => null;
         public virtual bool RequiresDiskAccess => false;
         public virtual bool IsExclusive => false;
         public virtual bool IsLongRunning => false;

--- a/src/NzbDrone.Core/ProgressMessaging/ProgressMessageContext.cs
+++ b/src/NzbDrone.Core/ProgressMessaging/ProgressMessageContext.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
+using System.Threading;
 using NzbDrone.Core.Messaging.Commands;
 
 namespace NzbDrone.Core.ProgressMessaging
 {
     public static class ProgressMessageContext
     {
+        private static AsyncLocal<CommandModel> _commandModelAsync = new AsyncLocal<CommandModel>();
+
         [ThreadStatic]
         private static CommandModel _commandModel;
 
@@ -13,8 +16,15 @@ namespace NzbDrone.Core.ProgressMessaging
 
         public static CommandModel CommandModel
         {
-            get { return _commandModel; }
-            set { _commandModel = value; }
+            get
+            {
+                return _commandModel ?? _commandModelAsync.Value;
+            }
+            set
+            {
+                _commandModel = value;
+                _commandModelAsync.Value = value;
+            }
         }
 
         public static bool LockReentrancy()

--- a/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
+++ b/src/NzbDrone.Core/Tv/Commands/RefreshSeriesCommand.cs
@@ -39,5 +39,7 @@ namespace NzbDrone.Core.Tv.Commands
         public override bool UpdateScheduledTask => SeriesIds.Empty();
 
         public override bool IsLongRunning => true;
+
+        public override string CompletionMessage => "Completed";
     }
 }

--- a/src/NzbDrone.Core/Update/Commands/ApplicationUpdateCommand.cs
+++ b/src/NzbDrone.Core/Update/Commands/ApplicationUpdateCommand.cs
@@ -6,7 +6,5 @@ namespace NzbDrone.Core.Update.Commands
     {
         public override bool SendUpdatesToClient => true;
         public override bool IsExclusive => true;
-
-        public override string CompletionMessage => null;
     }
 }


### PR DESCRIPTION
#### Description
Async tasks lack the `ThreadStatic` context, using `AsyncLocal` adds that context back. Also changed the default completion message to be the last received message.

#### Issues Fixed or Closed by this PR
* Closes #6632

