### PR TITLE
Fix bug in which Minimum retention was not being considered for qBittorrent client test

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -388,19 +388,18 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
             }
 
-            var minimumRetention = GetMinimumRetention();
-
             return new DownloadClientInfo
             {
                 IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, destDir) },
-                RemovesCompletedDownloads = (config.MaxRatioEnabled || (config.MaxSeedingTimeEnabled && config.MaxSeedingTime < minimumRetention)) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles)
+                RemovesCompletedDownloads = RemovesCompletedDownloads(config)
             };
         }
 
-        private int GetMinimumRetention()
+        private int RemovesCompletedDownloads(QBittorrentPreferences config)
         {
-            return 60 * 24 * 14; // 14 days in minutes
+            var minimumRetention = 60 * 24 * 14; // 14 days in minutes
+            return (config.MaxRatioEnabled || (config.MaxSeedingTimeEnabled && config.MaxSeedingTime < minimumRetention)) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles);
         }
 
         protected override void Test(List<ValidationFailure> failures)
@@ -453,8 +452,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Complain if qBittorrent is configured to remove torrents on max ratio
                 var config = Proxy.GetConfig(Settings);
-                var minimumRetention = GetMinimumRetention();
-                if ((config.MaxRatioEnabled || (config.MaxSeedingTimeEnabled && config.MaxSeedingTime < minimumRetention)) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles))
+                if (RemovesCompletedDownloads(config))
                 {
                     return new NzbDroneValidationFailure(string.Empty, _localizationService.GetLocalizedString("DownloadClientQbittorrentValidationRemovesAtRatioLimit"))
                     {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -396,7 +396,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             };
         }
 
-        private int RemovesCompletedDownloads(QBittorrentPreferences config)
+        private bool RemovesCompletedDownloads(QBittorrentPreferences config)
         {
             var minimumRetention = 60 * 24 * 14; // 14 days in minutes
             return (config.MaxRatioEnabled || (config.MaxSeedingTimeEnabled && config.MaxSeedingTime < minimumRetention)) && (config.MaxRatioAction == QBittorrentMaxRatioAction.Remove || config.MaxRatioAction == QBittorrentMaxRatioAction.DeleteFiles);


### PR DESCRIPTION
#### Description
The validation added on #6050 was not included in the code for the connection Test between Sonarr and the qBittorrent client. This means that even with a correctly configured client, sonarr would complain that torrents could be deleted before they were imported. This PR fixes this issue by including the same validation on the Test function
