### PR TITLE
Fix: Wrap routeableipv4 in try catch

### DIFF
--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -270,7 +270,7 @@ namespace NzbDrone.Common.Http.Dispatchers
             }
             catch (Exception e)
             {
-                _logger.Debug(e, "Caught exception while GetAllNetworkInterfaces assuming IPv4 connectivity" + e.Message);
+                _logger.Debug(e, "Caught exception while GetAllNetworkInterfaces assuming IPv4 connectivity: {0}", e.Message);
                 return true;
             }
         }

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http.Proxy;
@@ -30,11 +31,14 @@ namespace NzbDrone.Common.Http.Dispatchers
         private readonly ICached<System.Net.Http.HttpClient> _httpClientCache;
         private readonly ICached<CredentialCache> _credentialCache;
 
+        private readonly Logger _logger;
+
         public ManagedHttpDispatcher(IHttpProxySettingsProvider proxySettingsProvider,
             ICreateManagedWebProxy createManagedWebProxy,
             ICertificateValidationService certificateValidationService,
             IUserAgentBuilder userAgentBuilder,
-            ICacheManager cacheManager)
+            ICacheManager cacheManager,
+            Logger logger)
         {
             _proxySettingsProvider = proxySettingsProvider;
             _createManagedWebProxy = createManagedWebProxy;
@@ -43,6 +47,8 @@ namespace NzbDrone.Common.Http.Dispatchers
 
             _httpClientCache = cacheManager.GetCache<System.Net.Http.HttpClient>(typeof(ManagedHttpDispatcher));
             _credentialCache = cacheManager.GetCache<CredentialCache>(typeof(ManagedHttpDispatcher), "credentialcache");
+
+            _logger = logger;
         }
 
         public async Task<HttpResponse> GetResponseAsync(HttpRequest request, CookieContainer cookies)
@@ -249,19 +255,27 @@ namespace NzbDrone.Common.Http.Dispatchers
             return _credentialCache.Get("credentialCache", () => new CredentialCache());
         }
 
-        private static bool HasRoutableIPv4Address()
+        private bool HasRoutableIPv4Address()
         {
             // Get all IPv4 addresses from all interfaces and return true if there are any with non-loopback addresses
-            var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
+            try
+            {
+                var networkInterfaces = NetworkInterface.GetAllNetworkInterfaces();
 
-            return networkInterfaces.Any(ni =>
-                ni.OperationalStatus == OperationalStatus.Up &&
-                ni.GetIPProperties().UnicastAddresses.Any(ip =>
-                    ip.Address.AddressFamily == AddressFamily.InterNetwork &&
-                    !IPAddress.IsLoopback(ip.Address)));
+                return networkInterfaces.Any(ni =>
+                    ni.OperationalStatus == OperationalStatus.Up &&
+                    ni.GetIPProperties().UnicastAddresses.Any(ip =>
+                        ip.Address.AddressFamily == AddressFamily.InterNetwork &&
+                        !IPAddress.IsLoopback(ip.Address)));
+            }
+            catch (Exception e)
+            {
+                _logger.Debug(e, "Caught exception while GetAllNetworkInterfaces assuming IPv4 connectivity" + e.Message);
+                return true;
+            }
         }
 
-        private static async ValueTask<Stream> onConnect(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+        private async ValueTask<Stream> onConnect(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
         {
             // Until .NET supports an implementation of Happy Eyeballs (https://tools.ietf.org/html/rfc8305#section-2), let's make IPv4 fallback work in a simple way.
             // This issue is being tracked at https://github.com/dotnet/runtime/issues/26177 and expected to be fixed in .NET 6.
@@ -285,7 +299,9 @@ namespace NzbDrone.Common.Http.Dispatchers
                 catch
                 {
                     // Do not retry IPv6 if a routable IPv4 address is available, otherwise continue to attempt IPv6 connections.
-                    useIPv6 = !HasRoutableIPv4Address();
+                    var routableIPv4 = HasRoutableIPv4Address();
+                    _logger.Info("IPv4 is available: {0}, IPv6 will be {1}", routableIPv4, routableIPv4 ? "disabled" : "left enabled");
+                    useIPv6 = !routableIPv4;
                 }
                 finally
                 {

--- a/src/NzbDrone.Core.Test/Framework/CoreTest.cs
+++ b/src/NzbDrone.Core.Test/Framework/CoreTest.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Test.Framework
             Mocker.SetConstant<IHttpProxySettingsProvider>(new HttpProxySettingsProvider(Mocker.Resolve<ConfigService>()));
             Mocker.SetConstant<ICreateManagedWebProxy>(new ManagedWebProxyFactory(Mocker.Resolve<CacheManager>()));
             Mocker.SetConstant<ICertificateValidationService>(new X509CertificateValidationService(Mocker.Resolve<ConfigService>(), TestLogger));
-            Mocker.SetConstant<IHttpDispatcher>(new ManagedHttpDispatcher(Mocker.Resolve<IHttpProxySettingsProvider>(), Mocker.Resolve<ICreateManagedWebProxy>(), Mocker.Resolve<ICertificateValidationService>(), Mocker.Resolve<UserAgentBuilder>(), Mocker.Resolve<CacheManager>()));
+            Mocker.SetConstant<IHttpDispatcher>(new ManagedHttpDispatcher(Mocker.Resolve<IHttpProxySettingsProvider>(), Mocker.Resolve<ICreateManagedWebProxy>(), Mocker.Resolve<ICertificateValidationService>(), Mocker.Resolve<UserAgentBuilder>(), Mocker.Resolve<CacheManager>(), TestLogger));
             Mocker.SetConstant<IHttpClient>(new HttpClient(Array.Empty<IHttpRequestInterceptor>(), Mocker.Resolve<CacheManager>(), Mocker.Resolve<RateLimitService>(), Mocker.Resolve<IHttpDispatcher>(), TestLogger));
             Mocker.SetConstant<ISonarrCloudRequestBuilder>(new SonarrCloudRequestBuilder());
         }


### PR DESCRIPTION
#### Description
Wrap NetworkInterface.GetAllNetworkInterfaces in try catch to solve race condition on aarch64

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
* Closes #
https://github.com/Prowlarr/Prowlarr/issues/2076
