### PR TITLE
Add DownloadStatus and DownloadStatusMessages to WebhookManualInteractionPayload

### DIFF
--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -178,6 +178,8 @@ namespace NzbDrone.Core.Notifications.Webhook
                 DownloadClient = message.DownloadClientInfo?.Name,
                 DownloadClientType = message.DownloadClientInfo?.Type,
                 DownloadId = message.DownloadId,
+                DownloadStatus = message.TrackedDownload.Status.ToString(),
+                DownloadStatusMessages = message.TrackedDownload.StatusMessages.Select(x => new WebhookDownloadStatusMessage(x)).ToList(),
                 CustomFormatInfo = new WebhookCustomFormatInfo(remoteEpisode.CustomFormats, remoteEpisode.CustomFormatScore),
                 Release = new WebhookGrabbedRelease(message.Release)
             };

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookDownloadStatusMessage.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookDownloadStatusMessage.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Download.TrackedDownloads;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookDownloadStatusMessage
+    {
+        public string Title { get; set; }
+        public List<string> Messages { get; set; }
+
+        public WebhookDownloadStatusMessage(TrackedDownloadStatusMessage statusMessage)
+        {
+            Title = statusMessage.Title;
+            Messages = statusMessage.Messages.ToList();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookManualInteractionPayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookManualInteractionPayload.cs
@@ -10,6 +10,8 @@ namespace NzbDrone.Core.Notifications.Webhook
         public string DownloadClient { get; set; }
         public string DownloadClientType { get; set; }
         public string DownloadId { get; set; }
+        public string DownloadStatus { get; set; }
+        public List<WebhookDownloadStatusMessage> DownloadStatusMessages { get; set; }
         public WebhookCustomFormatInfo CustomFormatInfo { get; set; }
         public WebhookGrabbedRelease Release { get; set; }
     }


### PR DESCRIPTION
#### Description

The current status and messages for the tracked download is important context needed to handle "Interaction Required" notifications.

- Add `WebhookDownloadStatusMessage` class
- Add `DownloadStatus` and `DownloadStatusMessages` fields to `WebhookManualInteractionPayload`
- Update `BuildManualInteractionRequiredPayload` with new fields