### PR TITLE
Fixed: Task with removed series causing error

### DIFF
--- a/frontend/src/Store/Selectors/createMultiSeriesSelector.ts
+++ b/frontend/src/Store/Selectors/createMultiSeriesSelector.ts
@@ -1,12 +1,21 @@
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
+import Series from 'Series/Series';
 
 function createMultiSeriesSelector(seriesIds: number[]) {
   return createSelector(
     (state: AppState) => state.series.itemMap,
     (state: AppState) => state.series.items,
     (itemMap, allSeries) => {
-      return seriesIds.map((seriesId) => allSeries[itemMap[seriesId]]);
+      return seriesIds.reduce((acc: Series[], seriesId) => {
+        const series = allSeries[itemMap[seriesId]];
+
+        if (series) {
+          acc.push(series);
+        }
+
+        return acc;
+      }, []);
     }
   );
 }


### PR DESCRIPTION
#### Description

Tasks without a matching series would get undefined and fail, the selector will now skip unknown series.