### PR TITLE
Adjust reporting of torrents with relative path in rTorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -139,13 +139,13 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 // Ignore torrents with an empty path
                 if (torrent.Path.IsNullOrWhiteSpace())
                 {
-                    _logger.Warn($"Torrent '{torrent.Name}' has an empty download path and will not be processed. Adjust this to an absolute path in rTorrent");
+                    _logger.Warn("Torrent '{0}' has an empty download path and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
                     continue;
                 }
 
                 if (torrent.Path.StartsWith("."))
                 {
-                    _logger.Warn($"Torrent '{torrent.Name}' has a download path starting with '.' and will not be processed. Adjust this to an absolute path in rTorrent");
+                    _logger.Warn("Torrent '{0}' has a download path starting with '.' and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -139,12 +139,14 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 // Ignore torrents with an empty path
                 if (torrent.Path.IsNullOrWhiteSpace())
                 {
+                    _logger.Warn($"Torrent '{torrent.Name}' has an empty download path and will not be processed. Adjust this to an absolute path in rTorrent");
                     continue;
                 }
 
                 if (torrent.Path.StartsWith("."))
                 {
-                    throw new DownloadClientException("Download paths must be absolute. Please specify variable \"directory\" in rTorrent.");
+                    _logger.Warn($"Torrent '{torrent.Name}' has a download path starting with '.' and will not be processed. Adjust this to an absolute path in rTorrent");
+                    continue;
                 }
 
                 var item = new DownloadClientItem();


### PR DESCRIPTION
#### Description
Prevents the exiting of torrent processing due to a single torrent having a relative path.
Now warns user and processes remaining torrents
