### PR TITLE
Specify widely supported display mode for PWA

### DIFF
--- a/frontend/src/Content/Images/Icons/manifest.json
+++ b/frontend/src/Content/Images/Icons/manifest.json
@@ -15,5 +15,5 @@
     "start_url": "../../../../",
     "theme_color": "#3a3f51",
     "background_color": "#3a3f51",
-    "display": "minimal-ui"
+    "display": "standalone"
 }


### PR DESCRIPTION
#### Description
With the changes from #6231 by changing `display` to `minimal-ui` it broke Progressive Web App behavior on iOS.
Instead of opening the *arr application as a standalone (PWA) instance it opens a new tab in Safari.

By looking at [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/Manifest/display#browser_compatibility) of `display` in **manifest.json**, you can see that `minimal-ui` is not supported on iOS.
![image](https://github.com/Sonarr/Sonarr/assets/2996147/797d429f-6b81-458f-8ede-166db7f95b9b)

Reverting these changes made to **manifest.json** the *arr application will properly open a standalone (PWA) instance on iOS.

#### Screenshots for UI Changes
In this video you can see the difference between current (4.0.2.1183) and fixed behavior on iOS.

https://github.com/Sonarr/Sonarr/assets/2996147/273b7c4c-049a-496a-867e-23e0f80edbcd


#### Database Migration
NO


