### PR TITLE
Add info box to custom formats modal

### DIFF
--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
@@ -151,6 +151,11 @@ class EditCustomFormatModalContent extends Component {
                   </Form>
 
                   <FieldSet legend={translate('Conditions')}>
+                    <Alert kind={kinds.INFO}>
+                      <div>
+                        {translate('CustomFormatsSettingsTriggerInfo')}
+                      </div>
+                    </Alert>
                     <div className={styles.customFormats}>
                       {
                         specifications.map((tag) => {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -278,6 +278,7 @@
   "CustomFormats": "Custom Formats",
   "CustomFormatsLoadError": "Unable to load Custom Formats",
   "CustomFormatsSettings": "Custom Formats Settings",
+  "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied when the release name or file name matches at least one of each of the different condition types chosen.",
   "CustomFormatsSettingsSummary": "Custom Formats and Settings",
   "CustomFormatsSpecificationFlag": "Flag",
   "CustomFormatsSpecificationLanguage": "Language",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -278,7 +278,7 @@
   "CustomFormats": "Custom Formats",
   "CustomFormatsLoadError": "Unable to load Custom Formats",
   "CustomFormatsSettings": "Custom Formats Settings",
-  "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied when the release name or file name matches at least one of each of the different condition types chosen.",
+  "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied to a release or file when it matches at least one of each of the different condition types chosen.",
   "CustomFormatsSettingsSummary": "Custom Formats and Settings",
   "CustomFormatsSpecificationFlag": "Flag",
   "CustomFormatsSpecificationLanguage": "Language",


### PR DESCRIPTION
#### Description
Add a small info box to the custom formats modal, clarifying how CFs are applied when multiple specs are chosen.

#### Screenshots for UI Changes

![image](https://github.com/Sonarr/Sonarr/assets/1117625/d1da1606-afbc-47cd-9e85-ed99ec307d10)
