### PR TITLE
Fixed: Path parsing incorrectly treating series title as episode number

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
@@ -31,6 +31,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase(@"C:\Test\Series\Season 1\2 Honor Thy Developer (1080p HD).m4v", 1, 2)]
         [TestCase(@"C:\Test\Series\Season 2 - Total Series Action\01. Total Series Action - Episode 1 - Monster Cash.mkv", 2, 1)]
         [TestCase(@"C:\Test\Series\Season 2\01. Total Series Action - Episode 1 - Monster Cash.mkv", 2, 1)]
+        [TestCase(@"C:\Test\Series\Season 1\02.04.24 - S01E01 - The Rabbit Hole", 1, 1)]
+        [TestCase(@"C:\Test\Series\Season 1\8 Series Rules - S01E01 - Pilot", 1, 1)]
 
         // [TestCase(@"C:\series.state.S02E04.720p.WEB-DL.DD5.1.H.264\73696S02-04.mkv", 2, 4)] //Gets treated as S01E04 (because it gets parsed as anime); 2020-01 broken test case: Expected result.EpisodeNumbers to contain 1 item(s), but found 0
         public void should_parse_from_path(string path, int season, int episode)

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Parser.Model
         public bool IsMultiSeason { get; set; }
         public bool IsSeasonExtra { get; set; }
         public bool IsSplitEpisode { get; set; }
+        public bool IsMiniSeries { get; set; }
         public bool Special { get; set; }
         public string ReleaseGroup { get; set; }
         public string ReleaseHash { get; set; }


### PR DESCRIPTION
#### Description

A file with a series title that starts with a number could be treated as the episode number and result in mis-parsing.