### PR TITLE
Fixed: Deleted episodes not being unmonitored when series folder has been deleted

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -174,10 +174,16 @@ namespace NzbDrone.Core.MediaFiles
             fileInfoStopwatch.Stop();
             _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
 
-            var filesOnDisk = GetNonVideoFiles(series.Path);
-            var possibleExtraFiles = FilterPaths(series.Path, filesOnDisk);
-
             RemoveEmptySeriesFolder(series.Path);
+
+            var possibleExtraFiles = new List<string>();
+
+            if (_diskProvider.FolderExists(series.Path))
+            {
+                var extraFiles = GetNonVideoFiles(series.Path);
+                possibleExtraFiles = FilterPaths(series.Path, extraFiles);
+            }
+
             CompletedScanning(series, possibleExtraFiles);
         }
 


### PR DESCRIPTION
#### Description

Series folders were being deleted mid-processing when they were empty, which resulted in the extra files scan failing and the unmonitoring of deleted files not being triggered.

#### Issues Fixed or Closed by this PR
* Closes #6678

