### PR TITLE
Fixed: Sending ntfy.sh notifications with unicode characters

### DIFF
--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -2,12 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
-using NzbDrone.Core.Download.Clients.FreeboxDownload;
 using NzbDrone.Core.Localization;
 
 namespace NzbDrone.Core.Notifications.Ntfy
@@ -153,11 +151,6 @@ namespace NzbDrone.Core.Notifications.Ntfy
 
                 throw new NtfyException("Unable to send text message: {0}", ex, ex.Message);
             }
-        }
-
-        private string GetBase64EncodedValue(string input)
-        {
-            return $"=?UTF-8?B?{input.EncodeBase64()}?=";
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -7,6 +7,7 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Download.Clients.FreeboxDownload;
 using NzbDrone.Core.Localization;
 
 namespace NzbDrone.Core.Notifications.Ntfy
@@ -115,18 +116,18 @@ namespace NzbDrone.Core.Notifications.Ntfy
         {
             try
             {
-                requestBuilder.Headers.Add("X-Title", title);
-                requestBuilder.Headers.Add("X-Message", message);
-                requestBuilder.Headers.Add("X-Priority", settings.Priority.ToString());
+                requestBuilder.AddQueryParam("title", title);
+                requestBuilder.AddQueryParam("message", message);
+                requestBuilder.AddQueryParam("priority", settings.Priority.ToString());
 
                 if (settings.Tags.Any())
                 {
-                    requestBuilder.Headers.Add("X-Tags", settings.Tags.Join(","));
+                    requestBuilder.AddQueryParam("tags", settings.Tags.Join(","));
                 }
 
                 if (!settings.ClickUrl.IsNullOrWhiteSpace())
                 {
-                    requestBuilder.Headers.Add("X-Click", settings.ClickUrl);
+                    requestBuilder.AddQueryParam("click", settings.ClickUrl);
                 }
 
                 if (!settings.AccessToken.IsNullOrWhiteSpace())
@@ -152,6 +153,11 @@ namespace NzbDrone.Core.Notifications.Ntfy
 
                 throw new NtfyException("Unable to send text message: {0}", ex, ex.Message);
             }
+        }
+
+        private string GetBase64EncodedValue(string input)
+        {
+            return $"=?UTF-8?B?{input.EncodeBase64()}?=";
         }
     }
 }


### PR DESCRIPTION
#### Description

Switched to query string params instead of headers for ntfy.sh parameters which handles unicode characters properly.

#### Issues Fixed or Closed by this PR
* Closes #6679

