### PR TITLE
Add DevContainer and VSCode config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+  "name": "Sonarr",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:1-6.0",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "nodeGypDependencies": true,
+      "version": "16",
+      "nvmVersion": "latest"
+    }
+  },
+  "forwardPorts": [8989],
+  "customizations": {
+    "vscode": {
+      "extensions": ["esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ coverage*.xml
 coverage*.json
 setup/Output/
 *.~is
+.mono
 
 #VS outout folders
 bin

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-dotnettools.csdevkit",
+    "ms-vscode-remote.remote-containers"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Use IntelliSense to find out which attributes exist for C# debugging
+      // Use hover for the description of the existing attributes
+      // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+      "name": "Run Sonarr",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build dotnet",
+      // If you have changed target frameworks, make sure to update the program path.
+      "program": "${workspaceFolder}/_output/net6.0/Sonarr",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+      "console": "integratedTerminal",
+      "stopAtEntry": false
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,44 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build dotnet",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "msbuild",
+        "-restore",
+        "${workspaceFolder}/src/Sonarr.sln",
+        "-p:GenerateFullPaths=true",
+        "-p:Configuration=Debug",
+        "-p:Platform=Posix",
+        "-consoleloggerparameters:NoSummary;ForceNoAlign"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "publish",
+        "${workspaceFolder}/src/Sonarr.sln",
+        "-property:GenerateFullPaths=true",
+        "-consoleloggerparameters:NoSummary;ForceNoAlign"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "watch",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "watch",
+        "run",
+        "--project",
+        "${workspaceFolder}/src/Sonarr.sln"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -175,16 +175,46 @@
     </Otherwise>
   </Choose>
 
+  <!--
+       Set architecture to RuntimeInformation.ProcessArchitecture if not specified -->
+  <Choose>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X64'">
+      <PropertyGroup>
+        <Architecture>x64</Architecture>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'X86'">
+      <PropertyGroup>
+        <Architecture>x86</Architecture>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm64'">
+      <PropertyGroup>
+        <Architecture>arm64</Architecture>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)' == 'Arm'">
+      <PropertyGroup>
+        <Architecture>arm</Architecture>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Architecture></Architecture>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <PropertyGroup Condition="'$(IsWindows)' == 'true' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-$(Architecture)</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsLinux)' == 'true' and
                             '$(RuntimeIdentifier)' == ''">
     <_UsingDefaultRuntimeIdentifier>true</_UsingDefaultRuntimeIdentifier>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>linux-$(Architecture)</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsOSX)' == 'true' and


### PR DESCRIPTION
#### Description

This makes it possible to develop Sonarr in a DevContainer with VSCode (which is useful for running this easily on a Mac).

On an M1/M2 Mac, I found that the default linux-x64 runtime identifier
is not valid for the aarch64 docker image that will be used by default.
So instead of hardcoding the runtime identifier, I've added a check to
set the architecture based on the current process architecture.

#### Testing

Tested working on an M2 Mac with Docker Desktop not using Rosetta.

1. Install docker desktop (or your preferred flavor of docker)
2. Open the repo in VSCode and accept the suggestion to reload into the DevContainer
3. Run the npm: install and npm: build tasks 
4. Run | Run without Debugging
5. Click button to load in browser

<img width="1145" alt="image" src="https://github.com/Sonarr/Sonarr/assets/381361/0ef8166d-d1b6-4d78-902e-3bc3844ac058">

#### Background on the architecture issue

The existing code specifies `linux-x64` for the architecture, and it's not possible to pass `-p:RuntimeIdentifier` (note singular property name, not plural) to the `dotnet msbuild command`. When the incorrect runtime identifier is used, the software builds, but when run cannot find a file in `/lib64` (which doesn't exist on arm64 / aarch64 docker containers). Using an x64 image instead of an arm64 image is much slower for pretty much everything.

I'd guess there's possibly a more correct way to do this (perhaps using Platform / PlatformTarget), but I'm not familiar with exactly how these should be used (and how the customization in Sonarr effect these props).