### PR TITLE
Fixed: Renaming episodes for a series

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -122,7 +122,11 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             episodeFile.RelativePath = series.Path.GetRelativePath(destinationFilePath);
-            localEpisode.FileNameBeforeRename = episodeFile.RelativePath;
+
+            if (localEpisode is not null)
+            {
+                localEpisode.FileNameBeforeRename = episodeFile.RelativePath;
+            }
 
             if (localEpisode is not null && _scriptImportDecider.TryImport(episodeFilePath, destinationFilePath, localEpisode, episodeFile, mode) is var scriptImportDecision && scriptImportDecision != ScriptImportDecision.DeferMove)
             {


### PR DESCRIPTION
#### Description
Fixes a regression introduced in #6640 where localEpisode can be null when using Organize & Rename under a series.

- Fixes #6704