### PR TITLE
Improve release notes for main releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
 
   deploy:
     if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
-    needs: [backend, unit_test, unit_test_postgres, integration_test]
+    needs: [backend, frontend, unit_test, unit_test_postgres, integration_test]
     secrets: inherit
     uses: ./.github/workflows/deploy.yml
     with:
@@ -228,7 +228,7 @@ jobs:
 
   notify:
     name: Discord Notification
-    needs: [backend, unit_test, unit_test_postgres, integration_test]
+    needs: [backend, frontend, unit_test, unit_test_postgres, integration_test, deploy]
     if: ${{ !cancelled() && (github.ref_name == 'develop' || github.ref_name == 'main') }}
     env:
       STATUS: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,12 +69,38 @@ jobs:
         pattern: release_*
         merge-multiple: true
 
+    - name: Get Previous Release
+      id: previous-release
+      uses: cardinalby/git-get-release-action@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        latest: true
+        prerelease: ${{ inputs.branch != 'main' }}
+
+    - name: Generate Release Notes
+      id: generate-release-notes
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ github.token }}
+        result-encoding: string
+        script: |
+          const { data } = await github.rest.repos.generateReleaseNotes({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: 'v${{ inputs.version }}',
+            target_commitish: '${{ github.sha }}',
+            previous_tag_name: '${{ steps.previous-release.outputs.tag_name }}',
+          })
+          return data.body
+
     - name: Create release
       uses: ncipollo/release-action@v1
       with:
         artifacts: _artifacts/Sonarr.*
         commit: ${{ github.sha }}
-        generateReleaseNotes: true
+        generateReleaseNotes: false
+        body: ${{ steps.generate-release-notes.outputs.result }}
         name: ${{ inputs.version }}
         prerelease: ${{ inputs.branch != 'main' }}
         skipIfReleaseExists: true


### PR DESCRIPTION
#### Description

For all main releases release notes will be generated off the previous main release, instead of off of develop, this will provide a much more accurate list of actual changes in these releases. For develop releases the releases will be built off the previous develop release (though the impact this is much lower).