### PR TITLE
Translations update from Servarr Weblate

### DIFF
--- a/src/NzbDrone.Core/Localization/Core/es.json
+++ b/src/NzbDrone.Core/Localization/Core/es.json
@@ -2066,5 +2066,8 @@
     "ReleaseGroupFootNote": "Opcionalmente controla el truncamiento hasta un número máximo de bytes, incluyendo elipsis (`...`). Está soportado truncar tanto desde el final (p. ej. `{Grupo de lanzamiento:30}`) como desde el principio (p. ej. `{Grupo de lanzamiento:-30}`).",
     "SelectReleaseType": "Seleccionar tipo de lanzamiento",
     "SeriesFootNote": "Opcionalmente controla el truncamiento hasta un número máximo de bytes, incluyendo elipsis (`...`). Está soportado truncar tanto desde el final (p. ej. `{Título de serie:30}`) como desde el principio (p. ej. `{Título de serie:-30}`).",
-    "EpisodeTitleFootNote": "Opcionalmente controla el truncamiento hasta un número máximo de bytes, incluyendo elipsis (`...`). Está soportado truncar tanto desde el final (p. ej. `{Título de episodio:30}`) como desde el principio (p. ej. `{Título de episodio:-30}`). Los títulos de episodio serán truncados automáticamente acorde a las limitaciones del sistema de archivos si es necesario."
+    "EpisodeTitleFootNote": "Opcionalmente controla el truncamiento hasta un número máximo de bytes, incluyendo elipsis (`...`). Está soportado truncar tanto desde el final (p. ej. `{Título de episodio:30}`) como desde el principio (p. ej. `{Título de episodio:-30}`). Los títulos de episodio serán truncados automáticamente acorde a las limitaciones del sistema de archivos si es necesario.",
+    "AutoTaggingSpecificationTag": "Etiqueta",
+    "NotificationsTelegramSettingsIncludeAppName": "Incluir {appName} en el título",
+    "NotificationsTelegramSettingsIncludeAppNameHelpText": "Prefija opcionalmente el título de mensaje con {appName} para diferenciar notificaciones de aplicaciones diferentes"
 }

--- a/src/NzbDrone.Core/Localization/Core/pt_BR.json
+++ b/src/NzbDrone.Core/Localization/Core/pt_BR.json
@@ -989,7 +989,7 @@
     "AgeWhenGrabbed": "Tempo de vida (quando obtido)",
     "DelayingDownloadUntil": "Atrasando o download até {date} às {time}",
     "DeletedReasonEpisodeMissingFromDisk": "O {appName} não conseguiu encontrar o arquivo no disco, então o arquivo foi desvinculado do episódio no banco de dados",
-    "DeletedReasonManual": "O arquivo foi excluído por meio da IU",
+    "DeletedReasonManual": "O arquivo foi excluído usando {appName} manualmente ou por outra ferramenta por meio da API",
     "DownloadFailed": "Download Falhou",
     "DestinationRelativePath": "Caminho Relativo de Destino",
     "DownloadIgnoredEpisodeTooltip": "Download do Episódio Ignorado",
@@ -2061,5 +2061,12 @@
     "ImportListsMyAnimeListSettingsAuthenticateWithMyAnimeList": "Autenticar com MyAnimeList",
     "ImportListsMyAnimeListSettingsListStatus": "Status da Lista",
     "ImportListsMyAnimeListSettingsListStatusHelpText": "Tipo de lista da qual você deseja importar, defina como 'Todas' para todas as listas",
-    "CustomFormatsSettingsTriggerInfo": "Um formato personalizado será aplicado a um lançamento ou arquivo quando corresponder a pelo menos um de cada um dos diferentes tipos de condição escolhidos."
+    "CustomFormatsSettingsTriggerInfo": "Um formato personalizado será aplicado a um lançamento ou arquivo quando corresponder a pelo menos um de cada um dos diferentes tipos de condição escolhidos.",
+    "EpisodeTitleFootNote": "Opcionalmente, controle o truncamento para um número máximo de bytes, incluindo reticências (`...`). Truncar do final (por exemplo, `{Episode Title:30}`) ou do início (por exemplo, `{Episode Title:-30}`) é suportado. Os títulos dos episódios serão automaticamente truncados de acordo com as limitações do sistema de arquivos, se necessário.",
+    "NotificationsTelegramSettingsIncludeAppNameHelpText": "Opcionalmente, prefixe o título da mensagem com {appName} para diferenciar notificações de diferentes aplicativos",
+    "ReleaseGroupFootNote": "Opcionalmente, controle o truncamento para um número máximo de bytes, incluindo reticências (`...`). Truncar do final (por exemplo, `{Release Group:30}`) ou do início (por exemplo, `{Release Group:-30}`) é suportado.`).",
+    "ClickToChangeReleaseType": "Clique para alterar o tipo de lançamento",
+    "NotificationsTelegramSettingsIncludeAppName": "Incluir {appName} no Título",
+    "SelectReleaseType": "Selecionar o Tipo de Lançamento",
+    "SeriesFootNote": "Opcionalmente, controle o truncamento para um número máximo de bytes, incluindo reticências (`...`). Truncar do final (por exemplo, `{Series Title:30}`) ou do início (por exemplo, `{Series Title:-30}`) é suportado."
 }

--- a/src/NzbDrone.Core/Localization/Core/zh_CN.json
+++ b/src/NzbDrone.Core/Localization/Core/zh_CN.json
@@ -588,7 +588,6 @@
     "DownloadIgnored": "忽略下载",
     "DownloadIgnoredEpisodeTooltip": "集下载被忽略",
     "EditAutoTag": "编辑自动标签",
-    "AddAutoTagError": "无法添加新的自动标签，请重试。",
     "AddImportListExclusionError": "无法添加新排除列表，请再试一次。",
     "AddIndexer": "添加索引器",
     "AddImportList": "添加导入列表",


### PR DESCRIPTION
Translations update from [Servarr Weblate](https://translate.servarr.com) for [Servarr/Sonarr](https://translate.servarr.com/projects/servarr/sonarr/).



Current translation status:

![Weblate translation status](https://translate.servarr.com/widgets/servarr/-/sonarr/horizontal-auto.svg)