### PR TITLE
Update name for RSS only indexers

### DIFF
--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrents.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrents.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
 {
     public class IPTorrents : HttpIndexerBase<IPTorrentsSettings>
     {
-        public override string Name => "IP Torrents";
+        public override string Name => "IP Torrents RSS";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override bool SupportsSearch => false;
@@ -21,12 +21,12 @@ namespace NzbDrone.Core.Indexers.IPTorrents
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new IPTorrentsRequestGenerator() { Settings = Settings };
+            return new IPTorrentsRequestGenerator { Settings = Settings };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new TorrentRssParser() { ParseSizeInDescription = true };
+            return new TorrentRssParser { ParseSizeInDescription = true };
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Torrentleech/Torrentleech.cs
+++ b/src/NzbDrone.Core/Indexers/Torrentleech/Torrentleech.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.Indexers.Torrentleech
 {
     public class Torrentleech : HttpIndexerBase<TorrentleechSettings>
     {
-        public override string Name => "TorrentLeech";
+        public override string Name => "TorrentLeech RSS";
 
         public override DownloadProtocol Protocol => DownloadProtocol.Torrent;
         public override bool SupportsSearch => false;
@@ -21,12 +21,12 @@ namespace NzbDrone.Core.Indexers.Torrentleech
 
         public override IIndexerRequestGenerator GetRequestGenerator()
         {
-            return new TorrentleechRequestGenerator() { Settings = Settings };
+            return new TorrentleechRequestGenerator { Settings = Settings };
         }
 
         public override IParseIndexerResponse GetParser()
         {
-            return new TorrentRssParser() { UseGuidInfoUrl = true, ParseSeedersInDescription = true };
+            return new TorrentRssParser { UseGuidInfoUrl = true, ParseSeedersInDescription = true };
         }
     }
 }


### PR DESCRIPTION
#### Description
Some users are confusing these indexers being search capable so I think would be better to indicate that's RSS only in the naming.