### PR TITLE
Update action and add merge conflict labeler

### DIFF
--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -21,3 +21,4 @@ jobs:
         with:
           dirtyLabel: 'merge-conflict'
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          

--- a/.github/workflows/conflict_labeler.yml
+++ b/.github/workflows/conflict_labeler.yml
@@ -1,0 +1,23 @@
+name: Merge Conflict Labeler
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request_target:
+  issue_comment:
+
+permissions: {}
+
+jobs:
+  label:
+    name: Labeling
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Sonarr/Sonarr' }}
+    steps:
+      - name: Apply label
+        uses: eps1lon/actions-label-merge-conflict@v3
+        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request_target'}}
+        with:
+          dirtyLabel: 'merge-conflict'
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Description
Added a merge conflict labeler workflow for all the PR when a merge conflict is detected so people can resolve it when commit on develop branch is made

`merge-conflict` label need to be made before merging this PR

Update action version to remove the warning and adapt parameters on labeler