### PR TITLE
Fixed: Re-testing edited providers will forcibly test them

### DIFF
--- a/frontend/src/Store/Actions/Creators/createTestProviderHandler.js
+++ b/frontend/src/Store/Actions/Creators/createTestProviderHandler.js
@@ -1,8 +1,11 @@
+import $ from 'jquery';
+import _ from 'lodash';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import getProviderState from 'Utilities/State/getProviderState';
 import { set } from '../baseActions';
 
 const abortCurrentRequests = {};
+let lastTestData = null;
 
 export function createCancelTestProviderHandler(section) {
   return function(getState, payload, dispatch) {
@@ -17,10 +20,25 @@ function createTestProviderHandler(section, url) {
   return function(getState, payload, dispatch) {
     dispatch(set({ section, isTesting: true }));
 
-    const testData = getProviderState(payload, getState, section);
+    const {
+      queryParams = {},
+      ...otherPayload
+    } = payload;
+
+    const testData = getProviderState({ ...otherPayload }, getState, section);
+    const params = { ...queryParams };
+
+    // If the user is re-testing the same provider without changes
+    // force it to be tested.
+
+    if (_.isEqual(testData, lastTestData)) {
+      params.forceTest = true;
+    }
+
+    lastTestData = testData;
 
     const ajaxOptions = {
-      url: `${url}/test`,
+      url: `${url}/test?${$.param(params, true)}`,
       method: 'POST',
       contentType: 'application/json',
       dataType: 'json',
@@ -32,6 +50,8 @@ function createTestProviderHandler(section, url) {
     abortCurrentRequests[section] = abortRequest;
 
     request.done((data) => {
+      lastTestData = null;
+
       dispatch(set({
         section,
         isTesting: false,

--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -205,10 +205,10 @@ namespace Sonarr.Api.V3
         [SkipValidation(true, false)]
         [HttpPost("test")]
         [Consumes("application/json")]
-        public object Test([FromBody] TProviderResource providerResource)
+        public object Test([FromBody] TProviderResource providerResource, [FromQuery] bool forceTest = false)
         {
             var existingDefinition = providerResource.Id > 0 ? _providerFactory.Find(providerResource.Id) : null;
-            var providerDefinition = GetDefinition(providerResource, existingDefinition, true, true, true);
+            var providerDefinition = GetDefinition(providerResource, existingDefinition, true, !forceTest, true);
 
             Test(providerDefinition, true);
 


### PR DESCRIPTION
#### Description
Same as with force saving, re-testing will exclude warnings.
