### PR TITLE
Fix removing completed qBitorrent torrents that use inactive seeding time

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentPreferences.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentPreferences.cs
@@ -28,6 +28,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [JsonProperty(PropertyName = "max_seeding_time")]
         public long MaxSeedingTime { get; set; } // Get the global share time limit in minutes
 
+        [JsonProperty(PropertyName = "max_inactive_seeding_time_enabled")]
+        public bool MaxInactiveSeedingTimeEnabled { get; set; } // True if share inactive time limit is enabled
+
+        [JsonProperty(PropertyName = "max_inactive_seeding_time")]
+        public long MaxInactiveSeedingTime { get; set; } // Get the global share inactive time limit in minutes
+
         [JsonProperty(PropertyName = "max_ratio_act")]
         public QBittorrentMaxRatioAction MaxRatioAction { get; set; } // Action performed when a torrent reaches the maximum share ratio.
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentTorrent.cs
@@ -37,6 +37,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         [JsonProperty(PropertyName = "seeding_time_limit")] // Per torrent seeding time limit (-2 = use global, -1 = unlimited)
         public long SeedingTimeLimit { get; set; } = -2;
+
+        [JsonProperty(PropertyName = "inactive_seeding_time_limit")] // Per torrent inactive seeding time limit (-2 = use global, -1 = unlimited)
+        public long InactiveSeedingTimeLimit { get; set; } = -2;
+
+        [JsonProperty(PropertyName = "last_activity")] // Timestamp in unix seconds when a chunk was last downloaded/uploaded
+        public long LastActivity { get; set; }
     }
 
     public class QBittorrentTorrentProperties


### PR DESCRIPTION
#### Description
Related to #6266 

qBitorrent supports a new share limit based on how long the torrent has been inactive. This causes Sonarr to not remove completed torrents since it's checking to see if the share limits are met before removing.

This PR adds logic to check if torrents are using inactive time as the share limit and remove them appropriately.
