### PR TITLE
Fixed: Improve paths longer than 256 on Windows failing to hardlink

### DIFF
--- a/src/NzbDrone.Windows/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Windows/Disk/DiskProvider.cs
@@ -170,6 +170,11 @@ namespace NzbDrone.Windows.Disk
         {
             try
             {
+                if (source.Length > 256 && !source.StartsWith(@"\\?\"))
+                {
+                    source = @"\\?\" + source;
+                }
+
                 return CreateHardLink(destination, source, IntPtr.Zero);
             }
             catch (Exception ex)


### PR DESCRIPTION
#### Description

On Discord we had a user with a source path of more than 256 characters silently failing to hardlink, this is due to kernel32.dll silently failing (no exception thrown in Sonarr). We can't control the source path, but prepending the path with `\\?\` allows the file to be hardlinked properly as verified by `fsutils` via the command line.