### PR TITLE
Fix wrongly named field in TransmissionProxy

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 "seedRatioMode",
                 "seedIdleLimit",
                 "seedIdleMode",
-                "fileCount"
+                "fileCount",
                 "file-count"
             };
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -179,6 +179,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 "seedIdleLimit",
                 "seedIdleMode",
                 "fileCount"
+                "file-count"
             };
 
             var arguments = new Dictionary<string, object>();

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
@@ -1,4 +1,6 @@
-﻿namespace NzbDrone.Core.Download.Clients.Transmission
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.Download.Clients.Transmission
 {
     public class TransmissionTorrent
     {
@@ -20,6 +22,12 @@
         public int SeedRatioMode { get; set; }
         public long SeedIdleLimit { get; set; }
         public int SeedIdleMode { get; set; }
-        public int FileCount { get; set; }
+        public int FileCount => TransmissionFileCount ?? VuzeFileCount ?? 0;
+
+        [JsonProperty(PropertyName = "file-count")]
+        public int? TransmissionFileCount { get; set; }
+
+        [JsonProperty(PropertyName = "fileCount")]
+        public int? VuzeFileCount { get; set; }
     }
 }


### PR DESCRIPTION
There is no such field `fileCount` in [Transmission RPC](https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#33-torrent-accessor-torrent-get), however, there is one called `file-count`. The naming is inconsistent, so the mistake is understandable. Also, it doesn't help that Transmission will ignore any fields it doesn't recognize.

I stumbled upon this while testing Sonarr with a client I'm developing which aims to be Transmission RPC compatible. Only, my code throws an error when asked for invalid fields (oops).

You may verify by running these commands:

_(this returns the field)_

```
curl -H "X-Transmission-Session-Id: <session-id>" <host>/transmission/rpc --data-raw '{ "method": "torrent-get", "arguments": { "fields": ["file-count"] } }'
```

_(this does not return field)_

```
curl -H "X-Transmission-Session-Id: <session-id>" <host>/transmission/rpc --data-raw '{ "method": "torrent-get", "arguments": { "fields": ["fileCount"] } }'
```
