### PR TITLE
Treat CorruptDatabaseException as a startup failure

### DIFF
--- a/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
+++ b/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
@@ -3,7 +3,7 @@ using NzbDrone.Common.Exceptions;
 
 namespace NzbDrone.Core.Datastore
 {
-    public class CorruptDatabaseException : NzbDroneException
+    public class CorruptDatabaseException : SonarrStartupException
     {
         public CorruptDatabaseException(string message, params object[] args)
             : base(message, args)
@@ -16,12 +16,12 @@ namespace NzbDrone.Core.Datastore
         }
 
         public CorruptDatabaseException(string message, Exception innerException, params object[] args)
-            : base(message, innerException, args)
+            : base(innerException, message, args)
         {
         }
 
         public CorruptDatabaseException(string message, Exception innerException)
-            : base(message, innerException)
+            : base(innerException, message)
         {
         }
     }


### PR DESCRIPTION
#### Description
Doesn't change much expect for prepending `Sonarr failed to start` to the message, but fits better as a startup exception due to it's nature.