### PR TITLE
Fixed: Retrying download on not suppressed HTTP errors

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -34,6 +34,7 @@ namespace NzbDrone.Core.Download
                 {
                     { Result.HasHttpServerError: true } => PredicateResult.True(),
                     { Result.StatusCode: HttpStatusCode.RequestTimeout } => PredicateResult.True(),
+                    { Exception: HttpException { Response.HasHttpServerError: true } } => PredicateResult.True(),
                     _ => PredicateResult.False()
                 },
                 Delay = TimeSpan.FromSeconds(3),


### PR DESCRIPTION
#### Description
Adding another use case for when the HTTP errors are not suppressed and we should treat the exception instead. First case remains valid for `request.SuppressHttpError = true;`

#### Issues Fixed or Closed by this PR
* Closes #6752

