### PR TITLE
Fixed: Initialize databases after app folder migrations

### DIFF
--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -23,7 +23,6 @@ using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Common.Options;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore.Extensions;
-using Sonarr.Http.ClientSchema;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 using PostgresOptions = NzbDrone.Core.Datastore.PostgresOptions;
@@ -171,8 +170,6 @@ namespace NzbDrone.Host
                     {
                         c.AddDummyLogDatabase();
                     }
-
-                    SchemaBuilder.Initialize(c);
                 })
                 .ConfigureServices(services =>
                 {

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -26,6 +27,7 @@ using NzbDrone.SignalR;
 using Sonarr.Api.V3.System;
 using Sonarr.Http;
 using Sonarr.Http.Authentication;
+using Sonarr.Http.ClientSchema;
 using Sonarr.Http.ErrorManagement;
 using Sonarr.Http.Frontend;
 using Sonarr.Http.Middleware;
@@ -193,6 +195,7 @@ namespace NzbDrone.Host
         }
 
         public void Configure(IApplicationBuilder app,
+                              IContainer container,
                               IStartupContext startupContext,
                               Lazy<IMainDatabase> mainDatabaseFactory,
                               Lazy<ILogDatabase> logDatabaseFactory,
@@ -226,6 +229,8 @@ namespace NzbDrone.Host
                 _ = logDatabaseFactory.Value;
                 dbTarget.Register();
             }
+
+            SchemaBuilder.Initialize(container);
 
             if (OsInfo.IsNotWindows)
             {


### PR DESCRIPTION
#### Description
Fix to call `AppFolderFactory.MigrateAppDataFolder` before the database migrations.