### PR TITLE
Fixed: Refresh queue items for changed series

### DIFF
--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -238,6 +238,15 @@ namespace NzbDrone.Core.Tv
             _seriesRepository.UpdateMany(series);
             _logger.Debug("{0} series updated", series.Count);
 
+            var updatedSeries = GetSeries(series.Select(s => s.Id));
+
+            foreach (var s in updatedSeries)
+            {
+                var oldSeries = series.Single(c => c.Id == s.Id);
+
+                _eventAggregator.PublishEvent(new SeriesEditedEvent(s, oldSeries));
+            }
+
             return series;
         }
 


### PR DESCRIPTION
#### Description
Opted to use `SeriesEditedEvent` since it already is published when a single series is updated.
