### PR TITLE
Fixed: Use of indexer flags for torrent release pushes

### DIFF
--- a/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
@@ -174,7 +174,8 @@ namespace Sonarr.Api.V3.Indexers
                     MagnetUrl = resource.MagnetUrl,
                     InfoHash = resource.InfoHash,
                     Seeders = resource.Seeders,
-                    Peers = (resource.Seeders.HasValue && resource.Leechers.HasValue) ? (resource.Seeders + resource.Leechers) : null
+                    Peers = (resource.Seeders.HasValue && resource.Leechers.HasValue) ? (resource.Seeders + resource.Leechers) : null,
+                    IndexerFlags = (IndexerFlags)resource.IndexerFlags
                 };
             }
             else


### PR DESCRIPTION
#### Description
Allows the use of indexer flags for torrent release pushes by apps like autobrr, etc.