### PR TITLE
Fixed: Timezone issue with next/previous/last air dates

### DIFF
--- a/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
@@ -28,7 +29,7 @@ namespace NzbDrone.Core.SeriesStats
 
                 try
                 {
-                    if (!DateTime.TryParse(NextAiringString, out nextAiring))
+                    if (!DateTime.TryParse(NextAiringString, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out nextAiring))
                     {
                         return null;
                     }
@@ -51,7 +52,7 @@ namespace NzbDrone.Core.SeriesStats
 
                 try
                 {
-                    if (!DateTime.TryParse(PreviousAiringString, out previousAiring))
+                    if (!DateTime.TryParse(PreviousAiringString, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out previousAiring))
                     {
                         return null;
                     }
@@ -74,7 +75,7 @@ namespace NzbDrone.Core.SeriesStats
 
                 try
                 {
-                    if (!DateTime.TryParse(LastAiredString, out lastAired))
+                    if (!DateTime.TryParse(LastAiredString, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out lastAired))
                     {
                         return null;
                     }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
@@ -7,83 +7,14 @@ namespace NzbDrone.Core.SeriesStats
     public class SeriesStatistics : ResultSet
     {
         public int SeriesId { get; set; }
-        public string NextAiringString { get; set; }
-        public string PreviousAiringString { get; set; }
-        public string LastAiredString { get; set; }
+        public DateTime? NextAiring { get; set; }
+        public DateTime? PreviousAiring { get; set; }
+        public DateTime? LastAired { get; set; }
         public int EpisodeFileCount { get; set; }
         public int EpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
         public long SizeOnDisk { get; set; }
         public List<string> ReleaseGroups { get; set; }
         public List<SeasonStatistics> SeasonStatistics { get; set; }
-
-        public DateTime? NextAiring
-        {
-            get
-            {
-                DateTime nextAiring;
-
-                try
-                {
-                    if (!DateTime.TryParse(NextAiringString, out nextAiring))
-                    {
-                        return null;
-                    }
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // GHI 3518: Can throw on mono (6.x?) despite being a Try*
-                    return null;
-                }
-
-                return nextAiring;
-            }
-        }
-
-        public DateTime? PreviousAiring
-        {
-            get
-            {
-                DateTime previousAiring;
-
-                try
-                {
-                    if (!DateTime.TryParse(PreviousAiringString, out previousAiring))
-                    {
-                        return null;
-                    }
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // GHI 3518: Can throw on mono (6.x?) despite being a Try*
-                    return null;
-                }
-
-                return previousAiring;
-            }
-        }
-
-        public DateTime? LastAired
-        {
-            get
-            {
-                DateTime lastAired;
-
-                try
-                {
-                    if (!DateTime.TryParse(LastAiredString, out lastAired))
-                    {
-                        return null;
-                    }
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // GHI 3518: Can throw on mono (6.x?) despite being a Try*
-                    return null;
-                }
-
-                return lastAired;
-            }
-        }
     }
 }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
@@ -40,23 +40,23 @@ namespace NzbDrone.Core.SeriesStats
         private SeriesStatistics MapSeriesStatistics(List<SeasonStatistics> seasonStatistics)
         {
             var seriesStatistics = new SeriesStatistics
-                                   {
-                                       SeasonStatistics = seasonStatistics,
-                                       SeriesId = seasonStatistics.First().SeriesId,
-                                       EpisodeFileCount = seasonStatistics.Sum(s => s.EpisodeFileCount),
-                                       EpisodeCount = seasonStatistics.Sum(s => s.EpisodeCount),
-                                       TotalEpisodeCount = seasonStatistics.Sum(s => s.TotalEpisodeCount),
-                                       SizeOnDisk = seasonStatistics.Sum(s => s.SizeOnDisk),
-                                       ReleaseGroups = seasonStatistics.SelectMany(s => s.ReleaseGroups).Distinct().ToList()
-                                   };
+            {
+                SeasonStatistics = seasonStatistics,
+                SeriesId = seasonStatistics.First().SeriesId,
+                EpisodeFileCount = seasonStatistics.Sum(s => s.EpisodeFileCount),
+                EpisodeCount = seasonStatistics.Sum(s => s.EpisodeCount),
+                TotalEpisodeCount = seasonStatistics.Sum(s => s.TotalEpisodeCount),
+                SizeOnDisk = seasonStatistics.Sum(s => s.SizeOnDisk),
+                ReleaseGroups = seasonStatistics.SelectMany(s => s.ReleaseGroups).Distinct().ToList()
+            };
 
             var nextAiring = seasonStatistics.Where(s => s.NextAiring != null).MinBy(s => s.NextAiring);
             var previousAiring = seasonStatistics.Where(s => s.PreviousAiring != null).MaxBy(s => s.PreviousAiring);
             var lastAired = seasonStatistics.Where(s => s.SeasonNumber > 0 && s.LastAired != null).MaxBy(s => s.LastAired);
 
-            seriesStatistics.NextAiringString = nextAiring?.NextAiringString;
-            seriesStatistics.PreviousAiringString = previousAiring?.PreviousAiringString;
-            seriesStatistics.LastAiredString = lastAired?.LastAiredString;
+            seriesStatistics.NextAiring = nextAiring?.NextAiring;
+            seriesStatistics.PreviousAiring = previousAiring?.PreviousAiring;
+            seriesStatistics.LastAired = lastAired?.LastAired;
 
             return seriesStatistics;
         }


### PR DESCRIPTION
#### Description
~~When a model has type string apparently Npgsql is doing a DateTime.ToString() that loses the timezone information.~~

The previous fix worked fine under PG but with SQLite would still return a string even when mapped to `DateTime`. Reverted to to using AssumeUniversal.

#### Issues Fixed or Closed by this PR
* Closes #6790

