### PR TITLE
New: Has Unmonitored Season filter for Series

### DIFF
--- a/frontend/src/Store/Actions/seriesActions.js
+++ b/frontend/src/Store/Actions/seriesActions.js
@@ -192,6 +192,22 @@ export const filterPredicates = {
     });
 
     return predicate(hasMissingSeason, filterValue);
+  },
+
+  hasUnmonitoredSeason: function(item, filterValue, type) {
+    const predicate = filterTypePredicates[type];
+    const { seasons = [] } = item;
+
+    const hasUnmonitoredSeason = seasons.some((season) => {
+      const {
+        seasonNumber,
+        monitored
+      } = season;
+
+      return seasonNumber > 0 && !monitored;
+    });
+
+    return predicate(hasUnmonitoredSeason, filterValue);
   }
 };
 
@@ -350,6 +366,12 @@ export const filterBuilderProps = [
   {
     name: 'hasMissingSeason',
     label: () => translate('HasMissingSeason'),
+    type: filterBuilderTypes.EXACT,
+    valueType: filterBuilderValueTypes.BOOL
+  },
+  {
+    name: 'hasUnmonitoredSeason',
+    label: () => translate('HasUnmonitoredSeason'),
     type: filterBuilderTypes.EXACT,
     valueType: filterBuilderValueTypes.BOOL
   },

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -751,6 +751,7 @@
   "Group": "Group",
   "HardlinkCopyFiles": "Hardlink/Copy Files",
   "HasMissingSeason": "Has Missing Season",
+  "HasUnmonitoredSeason": "Has Unmonitored Season",
   "Health": "Health",
   "HealthMessagesInfoBox": "You can find more information about the cause of these health check messages by clicking the wiki link (book icon) at the end of the row, or by checking your [logs]({link}). If you have difficulty interpreting these messages then you can reach out to our support, at the links below.",
   "Here": "here",


### PR DESCRIPTION
#### Description

I forget whether this was brought up on the forums or reddit, but this adds a filter for series to find series with an unmonitored season so you can quickly find series and not need to blindly set episode monitoring to all episodes.