### PR TITLE
New: Include time for episode/season/series history

### DIFF
--- a/frontend/src/Components/Table/Cells/RelativeDateCell.js
+++ b/frontend/src/Components/Table/Cells/RelativeDateCell.js
@@ -15,6 +15,7 @@ class RelativeDateCell extends PureComponent {
       className,
       date,
       includeSeconds,
+      includeTime,
       showRelativeDates,
       shortDateFormat,
       longDateFormat,
@@ -39,7 +40,7 @@ class RelativeDateCell extends PureComponent {
         title={formatDateTime(date, longDateFormat, timeFormat, { includeSeconds, includeRelativeDay: !showRelativeDates })}
         {...otherProps}
       >
-        {getRelativeDate(date, shortDateFormat, showRelativeDates, { timeFormat, includeSeconds, timeForToday: true })}
+        {getRelativeDate(date, shortDateFormat, showRelativeDates, { timeFormat, includeSeconds, includeTime, timeForToday: true })}
       </Component>
     );
   }
@@ -49,6 +50,7 @@ RelativeDateCell.propTypes = {
   className: PropTypes.string.isRequired,
   date: PropTypes.string,
   includeSeconds: PropTypes.bool.isRequired,
+  includeTime: PropTypes.bool.isRequired,
   showRelativeDates: PropTypes.bool.isRequired,
   shortDateFormat: PropTypes.string.isRequired,
   longDateFormat: PropTypes.string.isRequired,
@@ -60,6 +62,7 @@ RelativeDateCell.propTypes = {
 RelativeDateCell.defaultProps = {
   className: styles.cell,
   includeSeconds: false,
+  includeTime: false,
   component: TableRowCell
 };
 

--- a/frontend/src/Episode/History/EpisodeHistoryRow.js
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.js
@@ -111,6 +111,8 @@ class EpisodeHistoryRow extends Component {
 
         <RelativeDateCellConnector
           date={date}
+          includeSeconds={true}
+          includeTime={true}
         />
 
         <TableRowCell className={styles.actions}>

--- a/frontend/src/Series/History/SeriesHistoryModal.js
+++ b/frontend/src/Series/History/SeriesHistoryModal.js
@@ -14,7 +14,7 @@ function SeriesHistoryModal(props) {
   return (
     <Modal
       isOpen={isOpen}
-      size={sizes.EXTRA_LARGE}
+      size={sizes.EXTRA_EXTRA_LARGE}
       onModalClose={onModalClose}
     >
       <SeriesHistoryModalContentConnector

--- a/frontend/src/Series/History/SeriesHistoryRow.js
+++ b/frontend/src/Series/History/SeriesHistoryRow.js
@@ -135,6 +135,8 @@ class SeriesHistoryRow extends Component {
 
         <RelativeDateCellConnector
           date={date}
+          includeSeconds={true}
+          includeTime={true}
         />
 
         <TableRowCell className={styles.actions}>

--- a/frontend/src/Utilities/Date/getRelativeDate.js
+++ b/frontend/src/Utilities/Date/getRelativeDate.js
@@ -5,16 +5,18 @@ import isToday from 'Utilities/Date/isToday';
 import isTomorrow from 'Utilities/Date/isTomorrow';
 import isYesterday from 'Utilities/Date/isYesterday';
 import translate from 'Utilities/String/translate';
+import formatDateTime from './formatDateTime';
 
-function getRelativeDate(date, shortDateFormat, showRelativeDates, { timeFormat, includeSeconds = false, timeForToday = false } = {}) {
+function getRelativeDate(date, shortDateFormat, showRelativeDates, { timeFormat, includeSeconds = false, timeForToday = false, includeTime = false } = {}) {
   if (!date) {
     return null;
   }
 
   const isTodayDate = isToday(date);
+  const time = formatTime(date, timeFormat, { includeMinuteZero: true, includeSeconds });
 
   if (isTodayDate && timeForToday && timeFormat) {
-    return formatTime(date, timeFormat, { includeMinuteZero: true, includeSeconds });
+    return time;
   }
 
   if (!showRelativeDates) {
@@ -22,22 +24,26 @@ function getRelativeDate(date, shortDateFormat, showRelativeDates, { timeFormat,
   }
 
   if (isYesterday(date)) {
-    return translate('Yesterday');
+    return includeTime ? translate('YesterdayAt', { time } ): translate('Yesterday');
   }
 
   if (isTodayDate) {
-    return translate('Today');
+    return includeTime ? translate('TodayAt', { time } ): translate('Today');
   }
 
   if (isTomorrow(date)) {
-    return translate('Tomorrow');
+    return includeTime ? translate('TomorrowAt', { time } ): translate('Tomorrow');
   }
 
   if (isInNextWeek(date)) {
-    return moment(date).format('dddd');
+    const day = moment(date).format('dddd');
+
+    return includeTime ? translate('DayOfWeekAt', { day, time }) : day;
   }
 
-  return moment(date).format(shortDateFormat);
+  return includeTime ?
+    formatDateTime(date, shortDateFormat, timeFormat, { includeSeconds }) :
+    moment(date).format(shortDateFormat);
 }
 
 export default getRelativeDate;

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -308,6 +308,7 @@
   "Date": "Date",
   "Dates": "Dates",
   "Day": "Day",
+  "DayOfWeekAt": "{day} at {time}",
   "Debug": "Debug",
   "Default": "Default",
   "DefaultCase": "Default Case",
@@ -1949,10 +1950,12 @@
   "Title": "Title",
   "Titles": "Titles",
   "Today": "Today",
+  "TodayAt": "Today at {time}",
   "ToggleMonitoredSeriesUnmonitored ": "Cannot toggle monitored state when series is unmonitored",
   "ToggleMonitoredToUnmonitored": "Monitored, click to unmonitor",
   "ToggleUnmonitoredToMonitored": "Unmonitored, click to monitor",
   "Tomorrow": "Tomorrow",
+  "TomorrowAt": "Tomorrow at {time}",
   "TorrentBlackhole": "Torrent Blackhole",
   "TorrentBlackholeSaveMagnetFiles": "Save Magnet Files",
   "TorrentBlackholeSaveMagnetFilesExtension": "Save Magnet Files Extension",
@@ -2074,5 +2077,6 @@
   "Year": "Year",
   "Yes": "Yes",
   "YesCancel": "Yes, Cancel",
-  "Yesterday": "Yesterday"
+  "Yesterday": "Yesterday",
+  "YesterdayAt": "Yesterday at {time}"
 }


### PR DESCRIPTION
#### Description
A follow up to https://github.com/Sonarr/Sonarr/pull/6767 that adds time stamps to relative dates including seconds for episode/season/series history.

#### Screenshots for UI Changes
![image](https://github.com/Sonarr/Sonarr/assets/413544/82a3ab77-df80-48ee-9dd8-254178f2820c) vs ![image](https://github.com/Sonarr/Sonarr/assets/413544/472e2130-f016-4e2f-b4fd-28b3e31ea9bc)

