### PR TITLE
Plex Watchlist Can Be Empty

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.ImportLists.Plex
                 return new ValidationFailure(string.Empty, $"Unable to connect to Plex Watchlist: {ex.Message}. Check the log for details.");
             }
 
-            return null; // Indicate no fatal errors even if the list is empty.
+            return null;
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -7,6 +7,8 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.ImportLists.Exceptions;
+using NzbDrone.Core.Indexers.Exceptions;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.Notifications.Plex.PlexTv;
 using NzbDrone.Core.Parser;
@@ -122,10 +124,27 @@ namespace NzbDrone.Core.ImportLists.Plex
                     _logger.Info("No results were returned from Plex Watchlist.");
                 }
             }
+            catch (RequestLimitReachedException)
+            {
+                _logger.Warn("Request limit reached");
+            }
+            catch (UnsupportedFeedException ex)
+            {
+                _logger.Warn(ex, "Plex Watchlist feed is not supported");
+
+                return new ValidationFailure(string.Empty, "Plex Watchlist feed is not supported: " + ex.Message);
+            }
+            catch (ImportListException ex)
+            {
+                _logger.Warn(ex, "Unable to connect to Plex Watchlist");
+
+                return new ValidationFailure(string.Empty, $"Unable to connect to Plex Watchlist: {ex.Message}. Check the log surrounding this error for details.");
+            }
             catch (Exception ex)
             {
                 _logger.Warn(ex, "Unable to connect to Plex Watchlist");
-                return new ValidationFailure(string.Empty, $"Unable to connect to Plex Watchlist: {ex.Message}. Check the log for details.");
+
+                return new ValidationFailure(string.Empty, $"Unable to connect to Plex Watchlist: {ex.Message}. Check the log surrounding this error for details.");
             }
 
             return null;


### PR DESCRIPTION
#### Description
Allows for Plex Watchlists to be empty at any time. With this code change, when they are empty an info logger message is displayed, rather than an error being thrown. It shouldn't be a requirement for the list to be populated at all times as they will likely always be in flux with entries being removed and added. 

This overcomes a few issues with the current implementation:
1. The UI throws an error and will not allow you to add a Plex Watchlist when it is empty. 
2. If you managed to add the list and it becomes empty later on, you will get errors in the logs and UI noting that the list is empty. 

A small improvement I would like to make is to have the logger message contain the list name so it's more obvious to the user which list is empty if multiples are used. I need some help with figuring out how to call the list name as it's shown in the UI Watchlist "name" field like:

```
_logger.Info($"No results were returned from Plex Watchlist '{listName}'.");
```
