### PR TITLE
Fixed: Trimming slashes from UrlBase when using environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
 
         echo "SDK_PATH=${{ env.DOTNET_ROOT }}/sdk/${DOTNET_VERSION}" >> "$GITHUB_ENV"
         echo "SONARR_VERSION=$SONARR_VERSION" >> "$GITHUB_ENV"
-        echo "BRANCH=${RAW_BRANCH_NAME/\//-}" >> "$GITHUB_ENV"
+        echo "BRANCH=${RAW_BRANCH_NAME//\//-}" >> "$GITHUB_ENV"
 
         echo "framework=${{ env.FRAMEWORK }}" >> "$GITHUB_OUTPUT"
         echo "major_version=${{ env.SONARR_MAJOR_VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,5 +8,6 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.repository == 'Sonarr/Sonarr'
     steps:
       - uses: actions/labeler@v5

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lock:
     runs-on: ubuntu-latest
+    if: github.repository == 'Sonarr/Sonarr'
     steps:
       - uses: dessant/lock-threads@v5
         with:

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.Configuration
         {
             get
             {
-                var urlBase = _serverOptions.UrlBase ?? GetValue("UrlBase", "").Trim('/');
+                var urlBase = (_serverOptions.UrlBase ?? GetValue("UrlBase", "")).Trim('/');
 
                 if (urlBase.IsNullOrWhiteSpace())
                 {


### PR DESCRIPTION
#### Description
The slashes aren't trimmed from UrlBase when set by an env variable. 

Plus fix for branch name which only replaces the first occurrence of `/` and disable some workflows on forks. 