### PR TITLE
Fix SDR Files Being Parsed As HLG

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/VideoFileInfoReaderFixture.cs
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         [TestCase(10, "", "", "", null, HdrFormat.None)]
         [TestCase(10, "bt709", "bt709", "", null, HdrFormat.None)]
         [TestCase(8, "bt2020", "smpte2084", "", null, HdrFormat.None)]
-        [TestCase(10, "bt2020", "bt2020-10", "", null, HdrFormat.Hlg10)]
+        [TestCase(10, "bt2020", "bt2020-10", "", null, HdrFormat.None)]
         [TestCase(10, "bt2020", "arib-std-b67", "", null, HdrFormat.Hlg10)]
         [TestCase(10, "bt2020", "smpte2084", "", null, HdrFormat.Pq10)]
         [TestCase(10, "bt2020", "smpte2084", "FFMpegCore.SideData", null, HdrFormat.Pq10)]

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly List<FFProbePixelFormat> _pixelFormats;
 
         public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 8;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 10;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 11;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
         private static readonly string[] HlgTransferFunctions = { "arib-std-b67" };

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 10;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
-        private static readonly string[] HlgTransferFunctions = { "bt2020-10", "arib-std-b67" };
+        private static readonly string[] HlgTransferFunctions = { "arib-std-b67" };
         private static readonly string[] PqTransferFunctions = { "smpte2084" };
         private static readonly string[] ValidHdrTransferFunctions = HlgTransferFunctions.Concat(PqTransferFunctions).ToArray();
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -642,7 +642,7 @@ namespace NzbDrone.Core.Organizer
             new Dictionary<string, int>(FileNameBuilderTokenEqualityComparer.Instance)
         {
             { MediaInfoVideoDynamicRangeToken, 5 },
-            { MediaInfoVideoDynamicRangeTypeToken, 10 }
+            { MediaInfoVideoDynamicRangeTypeToken, 11 }
         };
 
         private void AddMediaInfoTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, EpisodeFile episodeFile)


### PR DESCRIPTION
#### Description
This relates to an issue I opened for Radarr, but I thought it might be better to apply the fix to Sonarr first seeing as it seems to be present there too. Radarr issue: https://github.com/Radarr/Radarr/issues/9890

SDR files are being parsed as HLG owing to `bt2020-10` being a match in `HlgTransferFunctions`. It is only the `arib-std-b67` transfer function that indicates a file is using HLG: https://en.wikipedia.org/wiki/Hybrid_log–gamma

I am not hugely familiar with the whole application code, so it may be that there are other areas that would need to be addressed too.