### PR TITLE
Fixed: Skip invalid series paths during validation

### DIFF
--- a/src/NzbDrone.Core/Tv/MoveSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/MoveSeriesService.cs
@@ -37,6 +37,12 @@ namespace NzbDrone.Core.Tv
 
         private void MoveSingleSeries(Series series, string sourcePath, string destinationPath, int? index = null, int? total = null)
         {
+            if (!sourcePath.IsPathValid(PathValidationType.CurrentOs))
+            {
+                _logger.Warn("Folder '{0}' for '{1}' is invalid, unable to move series. Try moving files manually", sourcePath, series.Title);
+                return;
+            }
+
             if (!_diskProvider.FolderExists(sourcePath))
             {
                 _logger.Debug("Folder '{0}' for '{1}' does not exist, not moving.", sourcePath, series.Title);

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation.Validators;
+using FluentValidation.Validators;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RootFolders;
 
@@ -24,7 +25,7 @@ namespace NzbDrone.Core.Validation.Paths
 
             context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
-            return !_rootFolderService.All().Exists(r => r.Path.PathEquals(context.PropertyValue.ToString()));
+            return !_rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(context.PropertyValue.ToString()));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using FluentValidation.Validators;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
 
@@ -28,7 +29,10 @@ namespace NzbDrone.Core.Validation.Paths
             dynamic instance = context.ParentContext.InstanceToValidate;
             var instanceId = (int)instance.Id;
 
-            return !_seriesService.GetAllSeriesPaths().Any(s => s.Value.PathEquals(context.PropertyValue.ToString()) && s.Key != instanceId);
+            // Skip the path for this series and any invalid paths
+            return !_seriesService.GetAllSeriesPaths().Any(s => s.Key != instanceId &&
+                                                                s.Value.IsPathValid(PathValidationType.CurrentOs) &&
+                                                                s.Value.PathEquals(context.PropertyValue.ToString()));
         }
     }
 }


### PR DESCRIPTION
#### Description
This currently prevents people from fixing invalid paths for a series, but we don't need to validate the existing stored series paths as they are validated elsewhere.
