### PR TITLE
Fixed: Ignore case for name validation in providers

### DIFF
--- a/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
@@ -86,7 +86,8 @@ namespace Sonarr.Api.V3.Indexers
         {
             if (release.IndexerId == 0 && release.Indexer.IsNotNullOrWhiteSpace())
             {
-                var indexer = _indexerFactory.All().FirstOrDefault(v => v.Name == release.Indexer);
+                var indexer = _indexerFactory.All().FirstOrDefault(v => v.Name.EqualsIgnoreCase(release.Indexer));
+
                 if (indexer != null)
                 {
                     release.IndexerId = indexer.Id;

--- a/src/Sonarr.Api.V3/ProviderControllerBase.cs
+++ b/src/Sonarr.Api.V3/ProviderControllerBase.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
@@ -32,7 +33,7 @@ namespace Sonarr.Api.V3
             _bulkResourceMapper = bulkResourceMapper;
 
             SharedValidator.RuleFor(c => c.Name).NotEmpty();
-            SharedValidator.RuleFor(c => c.Name).Must((v, c) => !_providerFactory.All().Any(p => p.Name == c && p.Id != v.Id)).WithMessage("Should be unique");
+            SharedValidator.RuleFor(c => c.Name).Must((v, c) => !_providerFactory.All().Any(p => p.Name.EqualsIgnoreCase(c) && p.Id != v.Id)).WithMessage("Should be unique");
             SharedValidator.RuleFor(c => c.Implementation).NotEmpty();
             SharedValidator.RuleFor(c => c.ConfigContract).NotEmpty();
 


### PR DESCRIPTION
#### Description
Personally I think it would be better if provider existence by name is case insensitive to prevent any providers by the same name, and also to do the same regarding the case when resolving the indexer in release/push.