### PR TITLE
New: Ignore inaccessible folders with getting folders

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -153,7 +153,11 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(path, () => path).IsValidPath(PathValidationType.CurrentOs);
 
-            return Directory.EnumerateDirectories(path);
+            return Directory.EnumerateDirectories(path, "*", new EnumerationOptions
+            {
+                AttributesToSkip = FileAttributes.System,
+                IgnoreInaccessible = true
+            });
         }
 
         public IEnumerable<string> GetFiles(string path, bool recursive)

--- a/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
@@ -48,11 +48,11 @@ namespace NzbDrone.Core.Test.UpdateTests
         {
             const string branch = "main";
             UseRealHttp();
-            var recent = Subject.GetRecentUpdates(branch, new Version(3, 0), null);
+            var recent = Subject.GetRecentUpdates(branch, new Version(4, 0), null);
 
             recent.Should().NotBeEmpty();
             recent.Should().OnlyContain(c => c.Hash.IsNotNullOrWhiteSpace());
-            recent.Should().OnlyContain(c => c.FileName.Contains($"Sonarr.{c.Branch}.3."));
+            recent.Should().OnlyContain(c => c.FileName.Contains($"Sonarr.{c.Branch}.4."));
             recent.Should().OnlyContain(c => c.ReleaseDate.Year >= 2014);
             recent.Where(c => c.Changes != null).Should().OnlyContain(c => c.Changes.New != null);
             recent.Where(c => c.Changes != null).Should().OnlyContain(c => c.Changes.Fixed != null);


### PR DESCRIPTION
#### Description
Pretty much based on e5aa8584100d96a2077c57f74ae5b2ceab63de19 and d493f8762fcb1684b44e182753c21d7a493db787 to skip inaccessible folders that breaks manual import if the selected folder contains such folders.

https://github.com/Radarr/Radarr/issues/10085