### PR TITLE
New: Improve UI status when downloads cannot be imported automatically

### DIFF
--- a/frontend/src/Activity/Queue/QueueStatus.js
+++ b/frontend/src/Activity/Queue/QueueStatus.js
@@ -70,6 +70,11 @@ function QueueStatus(props) {
     iconName = icons.DOWNLOADED;
     title = translate('Downloaded');
 
+    if (trackedDownloadState === 'importBlocked') {
+      title += ` - ${translate('UnableToImportAutomatically')}`;
+      iconKind = kinds.WARNING;
+    }
+
     if (trackedDownloadState === 'importPending') {
       title += ` - ${translate('WaitingToImport')}`;
       iconKind = kinds.PURPLE;

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -366,7 +366,7 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
             Mocker.GetMock<IEventAggregator>()
                   .Verify(v => v.PublishEvent(It.IsAny<DownloadCompletedEvent>()), Times.Never());
 
-            _trackedDownload.State.Should().Be(TrackedDownloadState.ImportPending);
+            _trackedDownload.State.Should().Be(TrackedDownloadState.ImportBlocked);
         }
 
         private void AssertImported()

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -40,6 +40,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
     public enum TrackedDownloadState
     {
         Downloading,
+        ImportBlocked,
         ImportPending,
         Importing,
         Imported,

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1992,6 +1992,7 @@
   "Umask770Description": "{octal} - Owner & Group write",
   "Umask775Description": "{octal} - Owner & Group write, Other read",
   "Umask777Description": "{octal} - Everyone write",
+  "UnableToImportAutomatically": "Unable to Import Automatically",
   "UnableToLoadAutoTagging": "Unable to load auto tagging",
   "UnableToLoadBackups": "Unable to load backups",
   "UnableToUpdateSonarrDirectly": "Unable to update {appName} directly,",


### PR DESCRIPTION
#### Description
Adds a new `ImportBlocked` state when manual interaction is required along with improved messaging in the UI. If a title is added then Sonarr will still try to automatically process the release.

#### Screenshots for UI Changes
![image](https://github.com/Sonarr/Sonarr/assets/413544/45df7ab8-9f76-40c3-a11c-acc7624e23e4)

#### Issues Fixed or Closed by this PR
* Closes #6873

