### PR TITLE
Fixed: Exclude invalid releases from Newznab and Torznab parsers

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -68,16 +68,17 @@ namespace NzbDrone.Core.Indexers.Newznab
         protected override bool PostProcess(IndexerResponse indexerResponse, List<XElement> items, List<ReleaseInfo> releases)
         {
             var enclosureTypes = items.SelectMany(GetEnclosures).Select(v => v.Type).Distinct().ToArray();
+
             if (enclosureTypes.Any() && enclosureTypes.Intersect(PreferredEnclosureMimeTypes).Empty())
             {
                 if (enclosureTypes.Intersect(TorrentEnclosureMimeTypes).Any())
                 {
                     _logger.Warn("{0} does not contain {1}, found {2}, did you intend to add a Torznab indexer?", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
+
+                    return false;
                 }
-                else
-                {
-                    _logger.Warn("{1} does not contain {1}, found {2}.", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
-                }
+
+                _logger.Warn("{0} does not contain {1}, found {2}.", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
             }
 
             return true;

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -262,26 +262,26 @@ namespace NzbDrone.Core.Indexers
         protected virtual RssEnclosure[] GetEnclosures(XElement item)
         {
             var enclosures = item.Elements("enclosure")
-                                 .Select(v =>
-                                 {
-                                     try
-                                     {
-                                         return new RssEnclosure
-                                         {
-                                             Url = v.Attribute("url")?.Value,
-                                             Type = v.Attribute("type")?.Value,
-                                             Length = v.Attribute("length")?.Value?.ParseInt64() ?? 0
-                                         };
-                                     }
-                                     catch (Exception e)
-                                     {
-                                         _logger.Warn(e, "Failed to get enclosure for: {0}", item.Title());
-                                     }
+                .Select(v =>
+                {
+                    try
+                    {
+                        return new RssEnclosure
+                        {
+                            Url = v.Attribute("url")?.Value,
+                            Type = v.Attribute("type")?.Value,
+                            Length = v.Attribute("length")?.Value?.ParseInt64() ?? 0
+                        };
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Warn(ex, "Failed to get enclosure for: {0}", item.Title());
+                    }
 
-                                     return null;
-                                 })
-                                 .Where(v => v != null)
-                                 .ToArray();
+                    return null;
+                })
+                .Where(v => v != null)
+                .ToArray();
 
             return enclosures;
         }

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -59,16 +59,17 @@ namespace NzbDrone.Core.Indexers.Torznab
         protected override bool PostProcess(IndexerResponse indexerResponse, List<XElement> items, List<ReleaseInfo> releases)
         {
             var enclosureTypes = items.SelectMany(GetEnclosures).Select(v => v.Type).Distinct().ToArray();
+
             if (enclosureTypes.Any() && enclosureTypes.Intersect(PreferredEnclosureMimeTypes).Empty())
             {
                 if (enclosureTypes.Intersect(UsenetEnclosureMimeTypes).Any())
                 {
                     _logger.Warn("{0} does not contain {1}, found {2}, did you intend to add a Newznab indexer?", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
+
+                    return false;
                 }
-                else
-                {
-                    _logger.Warn("{1} does not contain {1}, found {2}.", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
-                }
+
+                _logger.Warn("{0} does not contain {1}, found {2}.", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
             }
 
             return true;


### PR DESCRIPTION
#### Description
I didn't find an easy way of adding a ValidationFailure without overriding and duplicating some code from `TestConnection`, so I think we should just ignore the releases so it triggers a validation error in
 https://github.com/Sonarr/Sonarr/blob/d15c116f13c79153c1b1f0ee2e2a2c48eed904a2/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs#L385-L388