### PR TITLE
New: Ignore Deluge torrents without a title

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             foreach (var torrent in torrents)
             {
-                if (torrent.Hash == null)
+                if (torrent.Hash.IsNullOrWhiteSpace() || torrent.Name.IsNullOrWhiteSpace())
                 {
                     continue;
                 }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -128,12 +128,13 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             foreach (var torrent in torrents)
             {
+                // Silently ignore torrents with no hash
                 if (torrent.Hash.IsNullOrWhiteSpace())
                 {
                     continue;
                 }
 
-                // Ignore invalid torrents. No point logging Deluge's mess every ~60-90 seconds.
+                // Ignore torrents without a name, but track to log a single warning for all invalid torrents.
                 if (torrent.Name.IsNullOrWhiteSpace())
                 {
                     ignoredCount++;


### PR DESCRIPTION
#### Description

Apparently when Deluge crashes it can lead to torrents without names being returned to Sonarr, we'll now just ignore those items, same as we do for torrents without hashes.

I opted not to add logging because it could get very noisy and we're just guarding against Deluge sending us junk.

#### Issues Fixed or Closed by this PR
* Closes #6885

