### PR TITLE
Fixed: Prevent errors parsing releases in unexpected formats

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/CrapParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/CrapParserFixture.cs
@@ -39,6 +39,13 @@ namespace NzbDrone.Core.Test.ParserTests
             ExceptionVerification.IgnoreWarns();
         }
 
+        [TestCase("علم نف) أ.دعادل الأبيض ٢٠٢٤ ٣ ٣")]
+        [TestCase("ror-240618_1007-1022-")]
+        public void should_parse_unknown_formats_without_error(string title)
+        {
+            Parser.Parser.ParseTitle(title).Should().NotBeNull();
+        }
+
         [Test]
         public void should_not_parse_md5()
         {

--- a/src/NzbDrone.Core.Test/ParserTests/UrlFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UrlFixture.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("[www.test-hyphen.ca] - Series (2011) S01", "Series (2011)")]
         [TestCase("test123.ca - Series Time S02 720p HDTV x264 CRON", "Series Time")]
         [TestCase("[www.test-hyphen123.co.za] - Series Title S01E01", "Series Title")]
+        [TestCase("(seriesawake.com) Series Super - 57 [720p] [English Subbed]", "Series Super")]
 
         public void should_not_parse_url_in_name(string postTitle, string title)
         {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -741,7 +741,7 @@ namespace NzbDrone.Core.Parser
                         Logger.Trace(regex);
                         try
                         {
-                            var result = ParseMatchCollection(match, releaseTitle);
+                            var result = ParseMatchCollection(match, simpleTitle);
 
                             if (result != null)
                             {
@@ -1205,6 +1205,7 @@ namespace NzbDrone.Core.Parser
                 }
             }
 
+            // TODO: This needs to check the modified title
             if (lastSeasonEpisodeStringIndex != releaseTitle.Length)
             {
                 result.ReleaseTokens = releaseTitle.Substring(lastSeasonEpisodeStringIndex);
@@ -1285,7 +1286,7 @@ namespace NzbDrone.Core.Parser
 
         private static int ParseNumber(string value)
         {
-            var normalized = value.Normalize(NormalizationForm.FormKC);
+            var normalized = ConvertToNumerals(value.Normalize(NormalizationForm.FormKC));
 
             if (int.TryParse(normalized, out var number))
             {
@@ -1304,7 +1305,7 @@ namespace NzbDrone.Core.Parser
 
         private static decimal ParseDecimal(string value)
         {
-            var normalized = value.Normalize(NormalizationForm.FormKC);
+            var normalized = ConvertToNumerals(value.Normalize(NormalizationForm.FormKC));
 
             if (decimal.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
             {
@@ -1312,6 +1313,25 @@ namespace NzbDrone.Core.Parser
             }
 
             throw new FormatException(string.Format("{0} isn't a number", value));
+        }
+
+        private static string ConvertToNumerals(string input)
+        {
+            var result = new StringBuilder(input.Length);
+
+            foreach (var c in input.ToCharArray())
+            {
+                if (char.IsNumber(c))
+                {
+                    result.Append(char.GetNumericValue(c));
+                }
+                else
+                {
+                    result.Append(c);
+                }
+            }
+
+            return result.ToString();
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -510,7 +510,7 @@ namespace NzbDrone.Core.Parser
 
         // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
 
-        private static readonly RegexReplace WebsitePrefixRegex = new RegexReplace(@"^(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*\]|[ -]{2,})[ -]*",
+        private static readonly RegexReplace WebsitePrefixRegex = new RegexReplace(@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
#### Description

Strips out `(website.com)` from start of release title before parsing, prevents non-numerical numbers from breaking during parsing and uses the correct release title when getting release tokens.

