### PR TITLE
Fixed: Reprocessing items that were previously blocked during importing

### DIFF
--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -73,8 +73,8 @@ namespace NzbDrone.Core.Download
 
         public void Check(TrackedDownload trackedDownload)
         {
-            // Only process tracked downloads that are still downloading
-            if (trackedDownload.State != TrackedDownloadState.Downloading)
+            // Only process tracked downloads that are still downloading or import is blocked (if they fail after attempting to be processed)
+            if (trackedDownload.State != TrackedDownloadState.Downloading && trackedDownload.State != TrackedDownloadState.ImportBlocked)
             {
                 return;
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                     _trackedDownloadService.TrackDownload((DownloadClientDefinition)downloadClient.Definition,
                         downloadItem);
 
-                if (trackedDownload != null && trackedDownload.State == TrackedDownloadState.Downloading)
+                if (trackedDownload is { State: TrackedDownloadState.Downloading or TrackedDownloadState.ImportBlocked })
                 {
                     _failedDownloadService.Check(trackedDownload);
                     _completedDownloadService.Check(trackedDownload);


### PR DESCRIPTION
#### Description

A follow up to https://github.com/Sonarr/Sonarr/pull/6889 because blocked items weren't being reprocessed after the underlying reason they were blocked was resolved.