### PR TITLE
Fixed: Don't use cleaned up release title for release title

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -745,7 +745,7 @@ namespace NzbDrone.Core.Parser
                         Logger.Trace(regex);
                         try
                         {
-                            var result = ParseMatchCollection(match, simpleTitle);
+                            var result = ParseMatchCollection(match, releaseTitle);
 
                             if (result != null)
                             {
@@ -1209,8 +1209,7 @@ namespace NzbDrone.Core.Parser
                 }
             }
 
-            // TODO: This needs to check the modified title
-            if (lastSeasonEpisodeStringIndex != releaseTitle.Length)
+            if (lastSeasonEpisodeStringIndex < releaseTitle.Length)
             {
                 result.ReleaseTokens = releaseTitle.Substring(lastSeasonEpisodeStringIndex);
             }


### PR DESCRIPTION
#### Description

Using the simplified title is too aggressive and loses too much. There is a good chance that `ReleaseTokens` is wrong in a lot of cases, but not an easily solved problem, nor a new one.