### PR TITLE
Fixed: Use only trackable downloads in queue

### DIFF
--- a/src/NzbDrone.Core.Test/QueueTests/QueueServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/QueueTests/QueueServiceFixture.cs
@@ -44,6 +44,7 @@ namespace NzbDrone.Core.Test.QueueTests
 
             _trackedDownloads = Builder<TrackedDownload>.CreateListOfSize(1)
                 .All()
+                .With(v => v.IsTrackable = true)
                 .With(v => v.DownloadItem = downloadItem)
                 .With(v => v.RemoteEpisode = remoteEpisode)
                 .Build()

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Queue
     public class QueueService : IQueueService, IHandle<TrackedDownloadRefreshedEvent>
     {
         private readonly IEventAggregator _eventAggregator;
-        private static List<Queue> _queue = new List<Queue>();
+        private static List<Queue> _queue = new ();
 
         public QueueService(IEventAggregator eventAggregator)
         {
@@ -96,8 +96,11 @@ namespace NzbDrone.Core.Queue
 
         public void Handle(TrackedDownloadRefreshedEvent message)
         {
-            _queue = message.TrackedDownloads.OrderBy(c => c.DownloadItem.RemainingTime).SelectMany(MapQueue)
-                            .ToList();
+            _queue = message.TrackedDownloads
+                .Where(t => t.IsTrackable)
+                .OrderBy(c => c.DownloadItem.RemainingTime)
+                .SelectMany(MapQueue)
+                .ToList();
 
             _eventAggregator.PublishEvent(new QueueUpdatedEvent());
         }


### PR DESCRIPTION
#### Description
This behavior was present before, but after ea54ade9bfcb51809797edf940b04d23b3c2eeb0 is now shown on series add which is a little annoying to see your queue displaying already imported downloads for a minute till the refresh downloads command kicks in.

This seems to be due `GetTrackedDownloads` returning everything, including non-trackable download.
https://github.com/Sonarr/Sonarr/blob/143ccb1e2a18c63cf246368a717c8a9e7732ed8f/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs#L200-L203