### PR TITLE
New: Update AutoTags on series update

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/SeriesServiceTests/UpdateSeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesServiceTests/UpdateSeriesFixture.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.AutoTagging;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 
@@ -31,6 +33,14 @@ namespace NzbDrone.Core.Test.TvTests.SeriesServiceTests
                 new Season { SeasonNumber = 1, Monitored = true },
                 new Season { SeasonNumber = 2, Monitored = true }
             };
+
+            Mocker.GetMock<IAutoTaggingService>()
+                .Setup(s => s.GetTagChanges(It.IsAny<Series>()))
+                .Returns(new AutoTaggingChanges());
+
+            Mocker.GetMock<ISeriesRepository>()
+                .Setup(s => s.Update(It.IsAny<Series>()))
+                .Returns<Series>(r => r);
         }
 
         private void GivenExistingSeries()
@@ -67,6 +77,29 @@ namespace NzbDrone.Core.Test.TvTests.SeriesServiceTests
 
             Mocker.GetMock<IEpisodeService>()
                   .Verify(v => v.SetEpisodeMonitoredBySeason(_fakeSeries.Id, It.IsAny<int>(), It.IsAny<bool>()), Times.Once());
+        }
+
+        [Test]
+        public void should_add_and_remove_tags()
+        {
+            GivenExistingSeries();
+            var seasonNumber = 1;
+            var monitored = false;
+
+            _fakeSeries.Tags = new HashSet<int> { 1, 2 };
+            _fakeSeries.Seasons.Single(s => s.SeasonNumber == seasonNumber).Monitored = monitored;
+
+            Mocker.GetMock<IAutoTaggingService>()
+                .Setup(s => s.GetTagChanges(_fakeSeries))
+                .Returns(new AutoTaggingChanges
+                {
+                    TagsToAdd = new HashSet<int> { 3 },
+                    TagsToRemove = new HashSet<int> { 1 }
+                });
+
+            var result = Subject.UpdateSeries(_fakeSeries);
+
+            result.Tags.Should().BeEquivalentTo(new[] { 2, 3 });
         }
     }
 }

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -198,34 +198,11 @@ namespace NzbDrone.Core.Tv
 
         private void UpdateTags(Series series)
         {
-            _logger.Trace("Updating tags for {0}", series);
+            var tagsUpdated = _seriesService.UpdateTags(series);
 
-            var tagsAdded = new HashSet<int>();
-            var tagsRemoved = new HashSet<int>();
-            var changes = _autoTaggingService.GetTagChanges(series);
-
-            foreach (var tag in changes.TagsToRemove)
-            {
-                if (series.Tags.Contains(tag))
-                {
-                    series.Tags.Remove(tag);
-                    tagsRemoved.Add(tag);
-                }
-            }
-
-            foreach (var tag in changes.TagsToAdd)
-            {
-                if (!series.Tags.Contains(tag))
-                {
-                    series.Tags.Add(tag);
-                    tagsAdded.Add(tag);
-                }
-            }
-
-            if (tagsAdded.Any() || tagsRemoved.Any())
+            if (tagsUpdated)
             {
                 _seriesService.UpdateSeries(series);
-                _logger.Debug("Updated tags for '{0}'. Added: {1}, Removed: {2}", series.Title, tagsAdded.Count, tagsRemoved.Count);
             }
         }
 


### PR DESCRIPTION
#### Description

Applies updated tags during series update in addition to series metadata refresh. This will immediately remove tags that are no longer relevant instead of the next refresh.

#### Issues Fixed or Closed by this PR
* Closes #6783

