### PR TITLE
New: Match only custom formats with score

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/QualityProfileFormatItem.js
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfileFormatItem.js
@@ -56,13 +56,13 @@ class QualityProfileFormatItem extends Component {
 QualityProfileFormatItem.propTypes = {
   formatId: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
-  score: PropTypes.number,
+  score: PropTypes.number.isRequired,
   onScoreChange: PropTypes.func
 };
 
 QualityProfileFormatItem.defaultProps = {
   // To handle the case score is deleted during edit
-  score: null
+  score: 0
 };
 
 export default QualityProfileFormatItem;

--- a/frontend/src/Settings/Profiles/Quality/QualityProfileFormatItems.js
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfileFormatItems.js
@@ -18,14 +18,6 @@ function calcOrder(profileFormatItems) {
 
   return [...profileFormatItems].sort((a, b) => {
     if (b.score !== a.score) {
-      if (a.score === null) {
-        return 1;
-      }
-
-      if (b.score === null) {
-        return -1;
-      }
-
       return b.score - a.score;
     }
 

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.CustomFormats
             var matches = new List<CustomFormat>();
 
             var profileFormatItems = input.Series?.QualityProfile?.Value?.FormatItems
-                .Where(f => f.Score.HasValue)
+                .Where(f => f.Enabled)
                 .Select(f => f.Format)
                 .ToList();
 

--- a/src/NzbDrone.Core/Profiles/ProfileFormatItem.cs
+++ b/src/NzbDrone.Core/Profiles/ProfileFormatItem.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.Profiles
     public class ProfileFormatItem : IEmbeddedDocument
     {
         public CustomFormat Format { get; set; }
-        public int? Score { get; set; }
+        public int Score { get; set; }
+        public bool Enabled { get; set; } = true;
     }
 }

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Profiles.Qualities
 
         public int CalculateCustomFormatScore(List<CustomFormat> formats)
         {
-            return FormatItems.Where(x => x.Score.HasValue && formats.Contains(x.Format)).Sum(x => x.Score.Value);
+            return FormatItems.Where(x => x.Enabled && formats.Contains(x.Format)).Sum(x => x.Score);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Profiles/Quality/QualityProfileResource.cs
+++ b/src/Sonarr.Api.V3/Profiles/Quality/QualityProfileResource.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Profiles;
 using NzbDrone.Core.Profiles.Qualities;
@@ -36,9 +35,8 @@ namespace Sonarr.Api.V3.Profiles.Quality
     {
         public int Format { get; set; }
         public string Name { get; set; }
-
-        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
-        public int? Score { get; set; }
+        public int Score { get; set; }
+        public bool Enabled { get; set; } = true;
     }
 
     public static class ProfileResourceMapper
@@ -86,7 +84,8 @@ namespace Sonarr.Api.V3.Profiles.Quality
             {
                 Format = model.Format.Id,
                 Name = model.Format.Name,
-                Score = model.Score
+                Score = model.Score,
+                Enabled = model.Enabled
             };
         }
 
@@ -132,7 +131,8 @@ namespace Sonarr.Api.V3.Profiles.Quality
             return new ProfileFormatItem
             {
                 Format = new CustomFormat { Id = resource.Format },
-                Score = resource.Score
+                Score = resource.Score,
+                Enabled = resource.Enabled
             };
         }
 


### PR DESCRIPTION
#### Description
This would be useful when you don't desire specific custom formats to be matched, for example anime related to be matched for standard shows and vice-versa.

Empty value or `null` is needed for the custom format to be skipped.