### PR TITLE
Fixed: {Episode CleanTitle} Does Not Remove Apostrophe, Backtick and Most Contractions

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
@@ -72,6 +72,14 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("I'm the Boss", "Im the Boss")]
         [TestCase("The Title's", "The Title's")]
         [TestCase("I'm after I'm", "Im after I'm")]
+        [TestCase("I've Been Caught", "Ive Been Caught")]
+        [TestCase("I'm Lost", "Im Lost")]
+        [TestCase("That'll Be The Day", "Thatll Be The Day")]
+        [TestCase("I'd Rather Be Alone", "I'd Rather Be Alone")]
+        [TestCase("I Can't Die", "I Cant Die")]
+        [TestCase("Won`t Get Fooled Again", "Wont Get Fooled Again")]
+        [TestCase("Don’t Blink", "Dont Blink")]
+        [TestCase("The ` Legend of Kings", "The Legend of Kings")]
 
         // [TestCase("", "")]
         public void should_get_expected_title_back(string title, string expected)

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/CleanTitleFixture.cs
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         [TestCase("I've Been Caught", "Ive Been Caught")]
         [TestCase("I'm Lost", "Im Lost")]
         [TestCase("That'll Be The Day", "Thatll Be The Day")]
-        [TestCase("I'd Rather Be Alone", "I'd Rather Be Alone")]
+        [TestCase("I'd Rather Be Alone", "Id Rather Be Alone")]
         [TestCase("I Can't Die", "I Cant Die")]
         [TestCase("Won`t Get Fooled Again", "Wont Get Fooled Again")]
         [TestCase("Don’t Blink", "Dont Blink")]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Organizer
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
         private static readonly Regex TrimSeparatorsRegex = new Regex(@"[- ._]+$", RegexOptions.Compiled);
 
-        private static readonly Regex ScenifyRemoveChars = new Regex(@"(?<=\s)(,|<|>|\/|\\|;|:|'|""|\||`|~|!|\?|@|$|%|^|\*|-|_|=){1}(?=\s)|('|:|\?|,)(?=(?:(?:s|m)\s)|\s|$)|(\(|\)|\[|\]|\{|\})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ScenifyRemoveChars = new Regex(@"(?<=\s)(,|<|>|\/|\\|;|:|'|""|\||`|’|~|!|\?|@|$|%|^|\*|-|_|=){1}(?=\s)|('|`|’|:|\?|,)(?=(?:(?:s|m|t|ve|ll|d|re)\s)|\s|$)|(\(|\)|\[|\]|\{|\})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ScenifyReplaceChars = new Regex(@"[\/]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // TODO: Support Written numbers (One, Two, etc) and Roman Numerals (I, II, III etc)


### PR DESCRIPTION
#### Description
Updating the regex for removing characters to the proposed allows episode titles to be more thoroughly cleaned.

When using {Episode CleanTitle}, add the backtick and apostrophe to the regex for contraction cleaning when they are used instead of a single quote. As they are now, both the backtick and the apostrophe are being used in the filename, even though {Episode CleanTitle} option is set.

When using {Episode CleanTitle} only quotes from contractions that end in s or m (i.e. world's > worlds, i'm > im, etc.) are being cleaned. This adds contractions that end in t, ve, re, ll or d (i.e. don't > dont, i've > ive, they're > theyre, i'll > ill, i'd > id, etc.). 

