### PR TITLE
Fixed: Updating series path from different OS paths

### DIFF
--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -135,9 +135,14 @@ namespace NzbDrone.Common.Test
         [TestCase(@"C:\test", @"C:\Test\mydir\")]
         public void windows_path_should_be_parent(string parentPath, string childPath)
         {
-            var expectedResult = OsInfo.IsWindows;
+            parentPath.IsParentPath(childPath).Should().Be(true);
+        }
 
-            parentPath.IsParentPath(childPath).Should().Be(expectedResult);
+        [TestCase("/test", "/test/mydir/")]
+        [TestCase("/test/", "/test/mydir")]
+        public void posix_path_should_be_parent(string parentPath, string childPath)
+        {
+            parentPath.IsParentPath(childPath).Should().Be(true);
         }
 
         [TestCase(@"C:\Test\mydir", @"C:\Test")]

--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -133,7 +133,7 @@ namespace NzbDrone.Common.Test
 
         [TestCase(@"C:\test\", @"C:\Test\mydir")]
         [TestCase(@"C:\test", @"C:\Test\mydir\")]
-        public void path_should_be_parent_on_windows_only(string parentPath, string childPath)
+        public void windows_path_should_be_parent(string parentPath, string childPath)
         {
             var expectedResult = OsInfo.IsWindows;
 
@@ -145,22 +145,22 @@ namespace NzbDrone.Common.Test
         [TestCase(@"C:\", null)]
         [TestCase(@"\\server\share", null)]
         [TestCase(@"\\server\share\test", @"\\server\share")]
-        public void path_should_return_parent_windows(string path, string parentPath)
+        public void windows_path_should_return_parent(string path, string parentPath)
         {
-            WindowsOnly();
             path.GetParentPath().Should().Be(parentPath);
         }
 
         [TestCase(@"/", null)]
         [TestCase(@"/test", "/")]
-        public void path_should_return_parent_mono(string path, string parentPath)
+        [TestCase(@"/test/tv", "/test")]
+        public void unix_path_should_return_parent(string path, string parentPath)
         {
-            PosixOnly();
             path.GetParentPath().Should().Be(parentPath);
         }
 
         [TestCase(@"C:\Test\mydir", "Test")]
         [TestCase(@"C:\Test\", @"C:\")]
+        [TestCase(@"C:\Test", @"C:\")]
         [TestCase(@"C:\", null)]
         [TestCase(@"\\server\share", null)]
         [TestCase(@"\\server\share\test", @"\\server\share")]
@@ -172,10 +172,29 @@ namespace NzbDrone.Common.Test
 
         [TestCase(@"/", null)]
         [TestCase(@"/test", "/")]
+        [TestCase(@"/test/tv", "test")]
         public void path_should_return_parent_name_mono(string path, string parentPath)
         {
             PosixOnly();
             path.GetParentName().Should().Be(parentPath);
+        }
+
+        [TestCase(@"C:\Test\mydir", "mydir")]
+        [TestCase(@"C:\Test\", "Test")]
+        [TestCase(@"C:\Test", "Test")]
+        [TestCase(@"C:\", "C:\\")]
+        [TestCase(@"\\server\share", @"\\server\share")]
+        [TestCase(@"\\server\share\test", "test")]
+        public void path_should_return_directory_name_windows(string path, string parentPath)
+        {
+            path.GetDirectoryName().Should().Be(parentPath);
+        }
+
+        [TestCase(@"/test", "test")]
+        [TestCase(@"/test/tv", "tv")]
+        public void path_should_return_directory_name_mono(string path, string parentPath)
+        {
+            path.GetDirectoryName().Should().Be(parentPath);
         }
 
         [Test]

--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -166,7 +166,6 @@ namespace NzbDrone.Common.Test
         [TestCase(@"\\server\share\test", @"\\server\share")]
         public void path_should_return_parent_name_windows(string path, string parentPath)
         {
-            WindowsOnly();
             path.GetParentName().Should().Be(parentPath);
         }
 
@@ -175,7 +174,6 @@ namespace NzbDrone.Common.Test
         [TestCase(@"/test/tv", "test")]
         public void path_should_return_parent_name_mono(string path, string parentPath)
         {
-            PosixOnly();
             path.GetParentName().Should().Be(parentPath);
         }
 
@@ -190,6 +188,7 @@ namespace NzbDrone.Common.Test
             path.GetDirectoryName().Should().Be(parentPath);
         }
 
+        [TestCase(@"/", "/")]
         [TestCase(@"/test", "test")]
         [TestCase(@"/test/tv", "tv")]
         public void path_should_return_directory_name_mono(string path, string parentPath)

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -361,6 +361,11 @@ namespace NzbDrone.Common.Disk
 
         public bool Equals(OsPath other)
         {
+            return Equals(other, false);
+        }
+
+        public bool Equals(OsPath other, bool ignoreTrailingSlash)
+        {
             if (ReferenceEquals(other, null))
             {
                 return false;
@@ -371,8 +376,8 @@ namespace NzbDrone.Common.Disk
                 return true;
             }
 
-            var left = PathWithoutTrailingSlash;
-            var right = other.PathWithoutTrailingSlash;
+            var left = ignoreTrailingSlash ? PathWithoutTrailingSlash : _path;
+            var right = ignoreTrailingSlash ? other.PathWithoutTrailingSlash : other._path;
 
             if (Kind == OsPathKind.Windows || other.Kind == OsPathKind.Windows)
             {

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -99,35 +99,23 @@ namespace NzbDrone.Common.Extensions
                 return null;
             }
 
-            var path = new OsPath(cleanPath).Directory.AsDirectory();
+            var path = new OsPath(cleanPath).Directory;
 
-            return path == OsPath.Null ? null : path.FullPath;
+            return path == OsPath.Null ? null : path.PathWithoutTrailingSlash;
         }
 
         public static string GetParentName(this string childPath)
         {
-            var cleanPath = childPath.GetCleanPath();
+            var path = new OsPath(childPath).Directory;
 
-            if (cleanPath.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            return Directory.GetParent(cleanPath)?.Name;
+            return path == OsPath.Null ? null : path.Name;
         }
 
         public static string GetDirectoryName(this string childPath)
         {
-            var cleanPath = childPath.GetCleanPath();
+            var path = new OsPath(childPath);
 
-            if (cleanPath.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            var directoryInfo = new DirectoryInfo(cleanPath);
-
-            return directoryInfo.Name;
+            return path == OsPath.Null ? null : path.Name;
         }
 
         public static string GetCleanPath(this string path)

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -99,7 +99,9 @@ namespace NzbDrone.Common.Extensions
                 return null;
             }
 
-            return Directory.GetParent(cleanPath)?.FullName;
+            var path = new OsPath(cleanPath).Directory.AsDirectory();
+
+            return path == OsPath.Null ? null : path.FullPath;
         }
 
         public static string GetParentName(this string childPath)
@@ -114,6 +116,20 @@ namespace NzbDrone.Common.Extensions
             return Directory.GetParent(cleanPath)?.Name;
         }
 
+        public static string GetDirectoryName(this string childPath)
+        {
+            var cleanPath = childPath.GetCleanPath();
+
+            if (cleanPath.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            var directoryInfo = new DirectoryInfo(cleanPath);
+
+            return directoryInfo.Name;
+        }
+
         public static string GetCleanPath(this string path)
         {
             var cleanPath = OsInfo.IsWindows
@@ -125,27 +141,17 @@ namespace NzbDrone.Common.Extensions
 
         public static bool IsParentPath(this string parentPath, string childPath)
         {
-            if (parentPath != "/" && !parentPath.EndsWith(":\\"))
-            {
-                parentPath = parentPath.TrimEnd(Path.DirectorySeparatorChar);
-            }
+            var parent = new OsPath(parentPath);
+            var child = new OsPath(childPath);
 
-            if (childPath != "/" && !parentPath.EndsWith(":\\"))
+            while (child.Directory != OsPath.Null)
             {
-                childPath = childPath.TrimEnd(Path.DirectorySeparatorChar);
-            }
-
-            var parent = new DirectoryInfo(parentPath);
-            var child = new DirectoryInfo(childPath);
-
-            while (child.Parent != null)
-            {
-                if (child.Parent.FullName.Equals(parent.FullName, DiskProviderBase.PathStringComparison))
+                if (child.Directory.Equals(parent))
                 {
                     return true;
                 }
 
-                child = child.Parent;
+                child = child.Directory;
             }
 
             return false;

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -92,14 +92,7 @@ namespace NzbDrone.Common.Extensions
 
         public static string GetParentPath(this string childPath)
         {
-            var cleanPath = childPath.GetCleanPath();
-
-            if (cleanPath.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            var path = new OsPath(cleanPath).Directory;
+            var path = new OsPath(childPath).Directory;
 
             return path == OsPath.Null ? null : path.PathWithoutTrailingSlash;
         }
@@ -134,7 +127,7 @@ namespace NzbDrone.Common.Extensions
 
             while (child.Directory != OsPath.Null)
             {
-                if (child.Directory.Equals(parent))
+                if (child.Directory.Equals(parent, true))
                 {
                     return true;
                 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -940,15 +940,15 @@ namespace NzbDrone.Core.Parser
         public static string RemoveFileExtension(string title)
         {
             title = FileExtensionRegex.Replace(title, m =>
+            {
+                var extension = m.Value.ToLower();
+                if (MediaFiles.MediaFileExtensions.Extensions.Contains(extension) || new[] { ".par2", ".nzb" }.Contains(extension))
                 {
-                    var extension = m.Value.ToLower();
-                    if (MediaFiles.MediaFileExtensions.Extensions.Contains(extension) || new[] { ".par2", ".nzb" }.Contains(extension))
-                    {
-                        return string.Empty;
-                    }
+                    return string.Empty;
+                }
 
-                    return m.Value;
-                });
+                return m.Value;
+            });
 
             return title;
         }


### PR DESCRIPTION
#### Description

.net on non-Windows machines mangles Windows paths preventing Sonarr from finding relative paths, this improves support for that as well as falling back if things fail instead of failing the request completely.

#### Issues Fixed or Closed by this PR
* Closes #6953

