### PR TITLE
New: Wrap specification blocks in modals

### DIFF
--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css
@@ -26,7 +26,7 @@
   background-color: var(--cardCenterBackgroundColor);
 }
 
-.customFormats{
+.customFormats {
   display: flex;
   flex-wrap: wrap;
 }

--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css
@@ -25,3 +25,8 @@
   border-radius: 4px;
   background-color: var(--cardCenterBackgroundColor);
 }
+
+.customFormats{
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css.d.ts
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.css.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'addSpecification': string;
   'center': string;
+  'customFormats': string;
   'deleteButton': string;
   'rightButtons': string;
 }

--- a/frontend/src/Settings/Tags/AutoTagging/EditAutoTaggingModalContent.css
+++ b/frontend/src/Settings/Tags/AutoTagging/EditAutoTaggingModalContent.css
@@ -25,3 +25,8 @@
   border-radius: 4px;
   background-color: var(--cardCenterBackgroundColor);
 }
+
+.autoTaggings {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/frontend/src/Settings/Tags/AutoTagging/EditAutoTaggingModalContent.css.d.ts
+++ b/frontend/src/Settings/Tags/AutoTagging/EditAutoTaggingModalContent.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'addSpecification': string;
+  'autoTaggings': string;
   'center': string;
   'deleteButton': string;
   'rightButtons': string;


### PR DESCRIPTION
#### Description
wraps specifications in the modals for custom formats and autotagging. helpful in large custom formats

#### Screenshots for UI Changes

from this:

![image](https://github.com/user-attachments/assets/52f1d47d-f57b-4523-ada1-9995fc141a7e)

to:

![image](https://github.com/user-attachments/assets/0a2f50c0-86ae-4b4f-aa4f-32f3e0f9bd77)
