### PR TITLE
Set default value for CustomColonReplacementFormat if not provided

### DIFF
--- a/src/Sonarr.Api.V3/Config/NamingExampleResource.cs
+++ b/src/Sonarr.Api.V3/Config/NamingExampleResource.cs
@@ -46,7 +46,7 @@ namespace Sonarr.Api.V3.Config
                 ReplaceIllegalCharacters = resource.ReplaceIllegalCharacters,
                 MultiEpisodeStyle = (MultiEpisodeStyle)resource.MultiEpisodeStyle,
                 ColonReplacementFormat = (ColonReplacementFormat)resource.ColonReplacementFormat,
-                CustomColonReplacementFormat = resource.CustomColonReplacementFormat,
+                CustomColonReplacementFormat = resource.CustomColonReplacementFormat ?? "",
                 StandardEpisodeFormat = resource.StandardEpisodeFormat,
                 DailyEpisodeFormat = resource.DailyEpisodeFormat,
                 AnimeEpisodeFormat = resource.AnimeEpisodeFormat,


### PR DESCRIPTION
#### Description

Prevents clients that aren't sending this value as null from have an issue saving to the DB to maintain backwards compatibility, eventually we'll probably want to update the API docs to correctly indicate that some fields are not nullable.

https://stackoverflow.com/a/70365325