### PR TITLE
Fixed: Assume category path from qBittorent starting with '//' is a Windows path

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -561,6 +561,34 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         }
 
         [Test]
+        public void should_correct_category_output_path()
+        {
+            var config = new QBittorrentPreferences
+            {
+                SavePath = @"C:\Downloads\Finished\QBittorrent".AsOsAgnostic()
+            };
+
+            Mocker.GetMock<IQBittorrentProxy>()
+                .Setup(v => v.GetConfig(It.IsAny<QBittorrentSettings>()))
+                .Returns(config);
+
+            Mocker.GetMock<IQBittorrentProxy>()
+                .Setup(v => v.GetApiVersion(It.IsAny<QBittorrentSettings>()))
+                .Returns(new Version(2, 0));
+
+            Mocker.GetMock<IQBittorrentProxy>()
+                .Setup(s => s.GetLabels(It.IsAny<QBittorrentSettings>()))
+                .Returns(new Dictionary<string, QBittorrentLabel>
+                    { { "tv", new QBittorrentLabel { Name = "tv", SavePath = "//server/store/downloads" } } });
+
+            var result = Subject.GetStatus();
+
+            result.IsLocalhost.Should().BeTrue();
+            result.OutputRootFolders.Should().NotBeNull();
+            result.OutputRootFolders.First().Should().Be(@"\\server\store\downloads");
+        }
+
+        [Test]
         public async Task Download_should_handle_http_redirect_to_magnet()
         {
             GivenRedirectToMagnet();

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -381,6 +381,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                     if (savePath.StartsWith("//"))
                     {
+                        _logger.Trace("Replacing slashes in probable Windows UNC path '{0}'. If this is not meant to be a Windows UNC path fix your qBittorrent configuration", savePath);
                         savePath = savePath.Replace('/', '\\');
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -381,7 +381,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                     if (savePath.StartsWith("//"))
                     {
-                        _logger.Trace("Replacing slashes in probable Windows UNC path '{0}'. If this is not meant to be a Windows UNC path fix your qBittorrent configuration", savePath);
+                        _logger.Trace("Replacing double forward slashes in path '{0}'. If this is not meant to be a Windows UNC path fix the 'Save Path' in qBittorrent's {1} category", savePath, Settings.TvCategory);
                         savePath = savePath.Replace('/', '\\');
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -377,7 +377,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 if (Proxy.GetLabels(Settings).TryGetValue(Settings.TvCategory, out var label) && label.SavePath.IsNotNullOrWhiteSpace())
                 {
-                    var labelDir = new OsPath(label.SavePath);
+                    var savePath = label.SavePath;
+
+                    if (savePath.StartsWith("//"))
+                    {
+                        savePath = savePath.Replace('/', '\\');
+                    }
+
+                    var labelDir = new OsPath(savePath);
 
                     if (labelDir.IsRooted)
                     {


### PR DESCRIPTION
#### Description

For category paths qbit returns UNC paths with forward slashes instead of back slashes, this will convert those to backslashes so they can be handled properly by Sonarr. Anyone that incorrectly puts `//` at the start of their *nix path will need to fix them and should feel shame.


#### Issues Fixed or Closed by this PR
* Closes Radarr/Radarr#10162

