### PR TITLE
New: Litestream compatibility for SQLite

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
@@ -219,7 +219,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
         protected virtual IList<TableDefinition> ReadTables()
         {
-            const string sqlCommand = @"SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name;";
+            const string sqlCommand = @"SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_litestream_%' ORDER BY name;";
             var dtTable = Read(sqlCommand).Tables[0];
 
             var tableDefinitionList = new List<TableDefinition>();


### PR DESCRIPTION
#### Description
Ignoring tables created by Litestream to be excluded from being managed by FluentMigrator seems to enough to prevent errors on start-up.

Ref https://github.com/Prowlarr/Prowlarr/issues/2178 https://github.com/Radarr/Radarr/issues/7930