### PR TITLE
Fixed: Sending Manual Interaction Required notifications for unknown series

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -406,18 +406,18 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_EventType", "ManualInteractionRequired");
             environmentVariables.Add("Sonarr_InstanceName", _configFileProvider.InstanceName);
             environmentVariables.Add("Sonarr_ApplicationUrl", _configService.ApplicationUrl);
-            environmentVariables.Add("Sonarr_Series_Id", series.Id.ToString());
-            environmentVariables.Add("Sonarr_Series_Title", series.Title);
-            environmentVariables.Add("Sonarr_Series_TitleSlug", series.TitleSlug);
-            environmentVariables.Add("Sonarr_Series_Path", series.Path);
-            environmentVariables.Add("Sonarr_Series_TvdbId", series.TvdbId.ToString());
-            environmentVariables.Add("Sonarr_Series_TvMazeId", series.TvMazeId.ToString());
-            environmentVariables.Add("Sonarr_Series_TmdbId", series.TmdbId.ToString());
-            environmentVariables.Add("Sonarr_Series_ImdbId", series.ImdbId ?? string.Empty);
-            environmentVariables.Add("Sonarr_Series_Type", series.SeriesType.ToString());
-            environmentVariables.Add("Sonarr_Series_Year", series.Year.ToString());
-            environmentVariables.Add("Sonarr_Series_OriginalLanguage", IsoLanguages.Get(series.OriginalLanguage).ThreeLetterCode);
-            environmentVariables.Add("Sonarr_Series_Genres", string.Join("|", series.Genres));
+            environmentVariables.Add("Sonarr_Series_Id", series?.Id.ToString());
+            environmentVariables.Add("Sonarr_Series_Title", series?.Title);
+            environmentVariables.Add("Sonarr_Series_TitleSlug", series?.TitleSlug);
+            environmentVariables.Add("Sonarr_Series_Path", series?.Path);
+            environmentVariables.Add("Sonarr_Series_TvdbId", series?.TvdbId.ToString());
+            environmentVariables.Add("Sonarr_Series_TvMazeId", series?.TvMazeId.ToString());
+            environmentVariables.Add("Sonarr_Series_TmdbId", series?.TmdbId.ToString());
+            environmentVariables.Add("Sonarr_Series_ImdbId", series?.ImdbId ?? string.Empty);
+            environmentVariables.Add("Sonarr_Series_Type", series?.SeriesType.ToString());
+            environmentVariables.Add("Sonarr_Series_Year", series?.Year.ToString());
+            environmentVariables.Add("Sonarr_Series_OriginalLanguage", IsoLanguages.Get(series?.OriginalLanguage)?.ThreeLetterCode);
+            environmentVariables.Add("Sonarr_Series_Genres", string.Join("|", series?.Genres ?? new List<string>()));
             environmentVariables.Add("Sonarr_Series_Tags", string.Join("|", GetTagLabels(series)));
             environmentVariables.Add("Sonarr_Download_Client", message.DownloadClientInfo?.Name ?? string.Empty);
             environmentVariables.Add("Sonarr_Download_Client_Type", message.DownloadClientInfo?.Type ?? string.Empty);
@@ -482,6 +482,11 @@ namespace NzbDrone.Core.Notifications.CustomScript
 
         private List<string> GetTagLabels(Series series)
         {
+            if (series == null)
+            {
+                return null;
+            }
+
             return _tagRepository.GetTags(series.Tags)
                 .Select(s => s.Label)
                 .Where(l => l.IsNotNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -28,15 +28,15 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnGrab(GrabMessage message)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Fallback = message.Message,
-                                      Title = message.Series.Title,
-                                      Text = message.Message,
-                                      Color = "warning"
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Fallback = message.Message,
+                    Title = message.Series.Title,
+                    Text = message.Message,
+                    Color = "warning"
+                }
+            };
             var payload = CreatePayload($"Grabbed: {message.Message}", attachments);
 
             _proxy.SendPayload(payload, Settings);
@@ -45,15 +45,15 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnDownload(DownloadMessage message)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Fallback = message.Message,
-                                      Title = message.Series.Title,
-                                      Text = message.Message,
-                                      Color = "good"
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Fallback = message.Message,
+                    Title = message.Series.Title,
+                    Text = message.Message,
+                    Color = "good"
+                }
+            };
             var payload = CreatePayload($"Imported: {message.Message}", attachments);
 
             _proxy.SendPayload(payload, Settings);
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new Attachment
+                new ()
                 {
                     Fallback = message.Message,
                     Title = message.Series.Title,
@@ -79,12 +79,12 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnRename(Series series, List<RenamedEpisodeFile> renamedFiles)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = series.Title,
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = series.Title,
+                }
+            };
 
             var payload = CreatePayload("Renamed", attachments);
 
@@ -94,12 +94,12 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnEpisodeFileDelete(EpisodeDeleteMessage deleteMessage)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = GetTitle(deleteMessage.Series, deleteMessage.EpisodeFile.Episodes),
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = GetTitle(deleteMessage.Series, deleteMessage.EpisodeFile.Episodes),
+                }
+            };
 
             var payload = CreatePayload("Episode Deleted", attachments);
 
@@ -109,12 +109,12 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnSeriesAdd(SeriesAddMessage message)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = message.Series.Title,
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = message.Series.Title,
+                }
+            };
 
             var payload = CreatePayload("Series Added", attachments);
 
@@ -124,13 +124,13 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnSeriesDelete(SeriesDeleteMessage deleteMessage)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = deleteMessage.Series.Title,
-                                      Text = deleteMessage.DeletedFilesMessage
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = deleteMessage.Series.Title,
+                    Text = deleteMessage.DeletedFilesMessage
+                }
+            };
 
             var payload = CreatePayload("Series Deleted", attachments);
 
@@ -140,14 +140,14 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnHealthIssue(HealthCheck.HealthCheck healthCheck)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = healthCheck.Source.Name,
-                                      Text = healthCheck.Message,
-                                      Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? "warning" : "danger"
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = healthCheck.Source.Name,
+                    Text = healthCheck.Message,
+                    Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? "warning" : "danger"
+                }
+            };
 
             var payload = CreatePayload("Health Issue", attachments);
 
@@ -157,14 +157,14 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnHealthRestored(HealthCheck.HealthCheck previousCheck)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = previousCheck.Source.Name,
-                                      Text = $"The following issue is now resolved: {previousCheck.Message}",
-                                      Color = "good"
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = previousCheck.Source.Name,
+                    Text = $"The following issue is now resolved: {previousCheck.Message}",
+                    Color = "good"
+                }
+            };
 
             var payload = CreatePayload("Health Issue Resolved", attachments);
 
@@ -174,14 +174,14 @@ namespace NzbDrone.Core.Notifications.Slack
         public override void OnApplicationUpdate(ApplicationUpdateMessage updateMessage)
         {
             var attachments = new List<Attachment>
-                              {
-                                  new Attachment
-                                  {
-                                      Title = Environment.MachineName,
-                                      Text = updateMessage.Message,
-                                      Color = "good"
-                                  }
-                              };
+            {
+                new ()
+                {
+                    Title = Environment.MachineName,
+                    Text = updateMessage.Message,
+                    Color = "good"
+                }
+            };
 
             var payload = CreatePayload("Application Updated", attachments);
 
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new Attachment
+                new ()
                 {
                     Title = Environment.MachineName,
                     Text = message.Message,

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -229,9 +229,9 @@ namespace NzbDrone.Core.Notifications.Webhook
                     TvdbId = 1234,
                     Tags = new List<string> { "test-tag" }
                 },
-                Episodes = new List<WebhookEpisode>()
+                Episodes = new List<WebhookEpisode>
                 {
-                    new WebhookEpisode()
+                    new ()
                     {
                         Id = 123,
                         EpisodeNumber = 1,
@@ -244,6 +244,11 @@ namespace NzbDrone.Core.Notifications.Webhook
 
         private WebhookSeries GetSeries(Series series)
         {
+            if (series == null)
+            {
+                return null;
+            }
+
             _mediaCoverService.ConvertToLocalUrls(series.Id, series.Images);
 
             return new WebhookSeries(series, GetTagLabels(series));
@@ -251,6 +256,11 @@ namespace NzbDrone.Core.Notifications.Webhook
 
         private List<string> GetTagLabels(Series series)
         {
+            if (series == null)
+            {
+                return null;
+            }
+
             return _tagRepository.GetTags(series.Tags)
                 .Select(s => s.Label)
                 .Where(l => l.IsNotNullOrWhiteSpace())


### PR DESCRIPTION
#### Description
Affecting Discord/Slack/Webhooks/CustomScript

Logs from Radarr, but same applies to Sonarr.
```
2024-07-18 20:48:45.6|Error|NotificationService|Unable to send OnManualInteractionRequired notification to probleme detecte

[v5.7.0.8882] System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.Notifications.Discord.Discord.OnManualInteractionRequired(ManualInteractionRequiredMessage message) in ./Radarr.Core/Notifications/Discord/Discord.cs:line 444
   at NzbDrone.Core.Notifications.NotificationService.Handle(ManualInteractionRequiredEvent message) in ./Radarr.Core/Notifications/NotificationService.cs:line 296
```

