### PR TITLE
Making status messages for meta downloading consistent 

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -281,6 +281,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         break;
 
                     case "metaDL": // torrent magnet is being downloaded
+                    case "forcedMetaDL": // torrent metadata is being forcibly downloaded
                         if (config.DhtEnabled)
                         {
                             item.Status = DownloadItemStatus.Queued;
@@ -295,7 +296,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         break;
 
                     case "forcedDL": // torrent is being downloaded, and was forced started
-                    case "forcedMetaDL": // torrent metadata is being forcibly downloaded
                     case "moving": // torrent is being moved from a folder
                     case "downloading": // torrent is being downloaded and data is being transferred
                         item.Status = DownloadItemStatus.Downloading;


### PR DESCRIPTION
#### Description
Currently, when downloading metadata the status is "queued" and the message is `DownloadClientQbittorrentTorrentStateMetadata`

When the download is forced, though, the status is "downloading" and the isn't a message. 
I think that is inconsitent, and in both cases the status and he message should be `queued` / `DownloadClientQbittorrentTorrentStateMetadata`



