### PR TITLE
Cache root folders and improve getting disk space for series path roots

### DIFF
--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NLog;
 using NzbDrone.Common;
+using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Organizer;
@@ -30,6 +31,8 @@ namespace NzbDrone.Core.RootFolders
         private readonly INamingConfigService _namingConfigService;
         private readonly Logger _logger;
 
+        private readonly ICached<string> _cache;
+
         private static readonly HashSet<string> SpecialFolders = new HashSet<string>
                                                                  {
                                                                      "$recycle.bin",
@@ -47,6 +50,7 @@ namespace NzbDrone.Core.RootFolders
                                  IDiskProvider diskProvider,
                                  ISeriesRepository seriesRepository,
                                  INamingConfigService namingConfigService,
+                                 ICacheManager cacheManager,
                                  Logger logger)
         {
             _rootFolderRepository = rootFolderRepository;
@@ -54,6 +58,8 @@ namespace NzbDrone.Core.RootFolders
             _seriesRepository = seriesRepository;
             _namingConfigService = namingConfigService;
             _logger = logger;
+
+            _cache = cacheManager.GetCache<string>(GetType());
         }
 
         public List<RootFolder> All()
@@ -110,19 +116,21 @@ namespace NzbDrone.Core.RootFolders
 
             if (!_diskProvider.FolderWritable(rootFolder.Path))
             {
-                throw new UnauthorizedAccessException(string.Format("Root folder path '{0}' is not writable by user '{1}'", rootFolder.Path, Environment.UserName));
+                throw new UnauthorizedAccessException($"Root folder path '{rootFolder.Path}' is not writable by user '{Environment.UserName}'");
             }
 
             _rootFolderRepository.Insert(rootFolder);
             var seriesPaths = _seriesRepository.AllSeriesPaths();
 
             GetDetails(rootFolder, seriesPaths, true);
+            _cache.Clear();
 
             return rootFolder;
         }
 
         public void Remove(int id)
         {
+            _cache.Clear();
             _rootFolderRepository.Delete(id);
         }
 
@@ -186,16 +194,7 @@ namespace NzbDrone.Core.RootFolders
 
         public string GetBestRootFolderPath(string path)
         {
-            var possibleRootFolder = All().Where(r => r.Path.IsParentPath(path)).MaxBy(r => r.Path.Length);
-
-            if (possibleRootFolder == null)
-            {
-                var osPath = new OsPath(path);
-
-                return osPath.Directory.ToString().TrimEnd(osPath.IsUnixPath ? '/' : '\\');
-            }
-
-            return possibleRootFolder?.Path;
+            return _cache.Get(path, () => GetBestRootFolderPathInternal(path), TimeSpan.FromDays(1));
         }
 
         private void GetDetails(RootFolder rootFolder, Dictionary<int, string> seriesPaths, bool timeout)
@@ -210,6 +209,20 @@ namespace NzbDrone.Core.RootFolders
                     rootFolder.UnmappedFolders = GetUnmappedFolders(rootFolder.Path, seriesPaths);
                 }
             }).Wait(timeout ? 5000 : -1);
+        }
+
+        private string GetBestRootFolderPathInternal(string path)
+        {
+            var possibleRootFolder = All().Where(r => r.Path.IsParentPath(path)).MaxBy(r => r.Path.Length);
+
+            if (possibleRootFolder == null)
+            {
+                var osPath = new OsPath(path);
+
+                return osPath.Directory.ToString().TrimEnd(osPath.IsUnixPath ? '/' : '\\');
+            }
+
+            return possibleRootFolder.Path;
         }
     }
 }

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -130,8 +130,8 @@ namespace NzbDrone.Core.RootFolders
 
         public void Remove(int id)
         {
-            _cache.Clear();
             _rootFolderRepository.Delete(id);
+            _cache.Clear();
         }
 
         private List<UnmappedFolder> GetUnmappedFolders(string path, Dictionary<int, string> seriesPaths)


### PR DESCRIPTION
#### Description
Caching root folders for each series path will speed up the places where they're necessary and we can also use them for determining the path root instead of doing it once per series.

#### Issues Fixed or Closed by this PR
* Closes #6076

