### PR TITLE
Fix height of tags in tag inputs

### DIFF
--- a/frontend/src/Components/Form/TagInputTag.css
+++ b/frontend/src/Components/Form/TagInputTag.css
@@ -30,5 +30,6 @@
 .label {
   composes: label from '~Components/Label.css';
 
+  display: flex;
   max-width: 100%;
 }


### PR DESCRIPTION
#### Description
Fixes the height so it doesn't fill all vertical space.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
![image](https://github.com/user-attachments/assets/70dc1ff8-d0cd-47d3-9cb9-3cb660d5ef95)
![image](https://github.com/user-attachments/assets/a4bac3e3-f24f-4525-86e2-e80a588b3e1f)


