### PR TITLE
fix width on interactive import modal dropdowns for mobile

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.css
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.css
@@ -37,7 +37,7 @@
   composes: select from '~Components/Form/SelectInput.css';
 
   margin-right: 10px;
-  width: auto;
+  max-width: fit-content;
 }
 
 .errorMessage {
@@ -53,6 +53,7 @@
 
     .leftButtons {
       align-items: flex-start;
+      max-width: fit-content;
     }
 
     .rightButtons {


### PR DESCRIPTION
#### Description
change the width properties of interactive import dropdowns on small screens to not overflow when translation is long

#### Screenshots for UI Changes

![image](https://github.com/user-attachments/assets/65acf9ed-cbde-4f4b-9435-774c2364ad58)

![image](https://github.com/user-attachments/assets/7cd3cf8f-61ab-4740-8b1b-5c0316255d2c)

#### Issues Fixed or Closed by this PR
* Closes #7015

