### PR TITLE
Fixed: Allow leading/trailing spaces on non-Windows

### DIFF
--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -380,8 +380,17 @@ namespace NzbDrone.Common.Test
         [TestCase(@" C:\Test\TV\")]
         [TestCase(@" C:\Test\TV")]
 
-        public void IsPathValid_should_be_false(string path)
+        public void IsPathValid_should_be_false_on_windows(string path)
         {
+            WindowsOnly();
+            path.IsPathValid(PathValidationType.CurrentOs).Should().BeFalse();
+        }
+
+        [TestCase(@"")]
+        [TestCase(@"relative/path")]
+        public void IsPathValid_should_be_false_on_unix(string path)
+        {
+            PosixOnly();
             path.AsOsAgnostic().IsPathValid(PathValidationType.CurrentOs).Should().BeFalse();
         }
     }

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -152,16 +152,20 @@ namespace NzbDrone.Common.Extensions
                 return false;
             }
 
-            var directoryInfo = new DirectoryInfo(path);
-
-            while (directoryInfo != null)
+            // Only check for leading or trailing spaces for path when running on Windows.
+            if (OsInfo.IsWindows)
             {
-                if (directoryInfo.Name.Trim() != directoryInfo.Name)
-                {
-                    return false;
-                }
+                var directoryInfo = new DirectoryInfo(path);
 
-                directoryInfo = directoryInfo.Parent;
+                while (directoryInfo != null)
+                {
+                    if (directoryInfo.Name.Trim() != directoryInfo.Name)
+                    {
+                        return false;
+                    }
+
+                    directoryInfo = directoryInfo.Parent;
+                }
             }
 
             if (validationType == PathValidationType.AnyOs)


### PR DESCRIPTION
#### Description
Allows leading/trailing spaces in folder/file names on Linux/Mac/everything else.

#### Issues Fixed or Closed by this PR
* Closes #6971

