### PR TITLE
Fixed: Import with copy from download clients with remove completed disabled

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Download
         public string Type { get; set; }
         public int Id { get; set; }
         public string Name { get; set; }
+        public bool RemoveCompletedDownloads { get; set; }
         public bool HasPostImportCategory { get; set; }
 
         public static DownloadClientItemClientInfo FromDownloadClient<TSettings>(
@@ -49,6 +50,7 @@ namespace NzbDrone.Core.Download
                 Type = downloadClient.Name,
                 Id = downloadClient.Definition.Id,
                 Name = downloadClient.Definition.Name,
+                RemoveCompletedDownloads = downloadClient.Definition is DownloadClientDefinition { RemoveCompletedDownloads: true },
                 HasPostImportCategory = hasPostImportCategory
             };
         }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     {
                         default:
                         case ImportMode.Auto:
-                            copyOnly = downloadClientItem != null && !downloadClientItem.CanMoveFiles;
+                            copyOnly = downloadClientItem is { CanMoveFiles: false } or { DownloadClientInfo.RemoveCompletedDownloads: false };
                             break;
                         case ImportMode.Move:
                             copyOnly = false;


### PR DESCRIPTION
#### Description
After I got moved a bunch of files from qbit resulting in missing files that need to be redownloaded, this option is nothing less than destructive. If the download client has Remove Completed Downloads disabled, we should not touch the files no matter if the seeding goals are reached.