### PR TITLE
New: Return downloading magnets from Transmission

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -49,10 +49,13 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         }
 
         [Test]
-        public void magnet_download_should_not_return_the_item()
+        public void magnet_download_should_be_returned_as_queued()
         {
             PrepareClientToReturnMagnetItem();
-            Subject.GetItems().Count().Should().Be(0);
+
+            var item = Subject.GetItems().Single();
+
+            item.Status.Should().Be(DownloadItemStatus.Queued);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/VuzeTests/VuzeFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -60,7 +60,10 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.VuzeTests
         public void magnet_download_should_not_return_the_item()
         {
             PrepareClientToReturnMagnetItem();
-            Subject.GetItems().Count().Should().Be(0);
+
+            var item = Subject.GetItems().Single();
+
+            item.Status.Should().Be(DownloadItemStatus.Queued);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -43,12 +43,6 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
             foreach (var torrent in torrents)
             {
-                // If totalsize == 0 the torrent is a magnet downloading metadata
-                if (torrent.TotalSize == 0)
-                {
-                    continue;
-                }
-
                 var outputPath = new OsPath(torrent.DownloadDir);
 
                 if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
@@ -98,6 +92,10 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 {
                     item.Status = DownloadItemStatus.Warning;
                     item.Message = torrent.ErrorString;
+                }
+                else if (torrent.TotalSize == 0)
+                {
+                    item.Status = DownloadItemStatus.Queued;
                 }
                 else if (torrent.LeftUntilDone == 0 && (torrent.Status == TransmissionTorrentStatus.Stopped ||
                                                         torrent.Status == TransmissionTorrentStatus.Seeding ||


### PR DESCRIPTION
#### Description

Return magnet downloads from Transmission so they can be removed and blocklisted.

#### Issues Fixed or Closed by this PR
* Closes #7029

