### PR TITLE
Fixed: Persist indexer flags for automatic imports

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -215,7 +215,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         {
             DownloadClientItem downloadClientItem = null;
             Series series = null;
-            TrackedDownload trackedDownload = null;
 
             var directoryInfo = new DirectoryInfo(baseFolder);
 
@@ -237,7 +236,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
             if (downloadId.IsNotNullOrWhiteSpace())
             {
-                trackedDownload = _trackedDownloadService.Find(downloadId);
+                var trackedDownload = _trackedDownloadService.Find(downloadId);
                 downloadClientItem = trackedDownload.DownloadItem;
 
                 if (series == null)
@@ -272,11 +271,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             var folderInfo = Parser.Parser.ParseTitle(directoryInfo.Name);
             var seriesFiles = _diskScanService.FilterPaths(rootFolder, _diskScanService.GetVideoFiles(baseFolder).ToList());
             var decisions = _importDecisionMaker.GetImportDecisions(seriesFiles, series, downloadClientItem, folderInfo, SceneSource(series, baseFolder), filterExistingFiles);
-
-            foreach (var decision in decisions)
-            {
-                decision.LocalEpisode.IndexerFlags = trackedDownload?.RemoteEpisode?.Release?.IndexerFlags ?? 0;
-            }
 
             return decisions.Select(decision => MapItem(decision, rootFolder, downloadId, directoryInfo.Name)).ToList();
         }
@@ -337,10 +331,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (importDecisions.Any())
                 {
-                    var importDecision = importDecisions.First();
-                    importDecision.LocalEpisode.IndexerFlags = trackedDownload?.RemoteEpisode?.Release?.IndexerFlags ?? 0;
-
-                    return MapItem(importDecision, rootFolder, downloadId, null);
+                    return MapItem(importDecisions.First(), rootFolder, downloadId, null);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
#### Description
Ref https://github.com/Radarr/Radarr/issues/10237#issuecomment-2259635395

Mostly reverting 217611d7165e2f24068697e4996f0dcfc54f786c since automatic imports are affected as well, and moving the indexer flags assignment to `ImportDecisionMaker` which I tried to avoid in my previous commit, but `DownloadedEpisodesImportService` and `ManualImportService` both are using this method call. 