### PR TITLE
Fixed: Saving indexer flags when manual importing from queue

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -97,6 +97,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     episodeFile.ReleaseGroup = localEpisode.ReleaseGroup;
                     episodeFile.ReleaseHash = localEpisode.ReleaseHash;
                     episodeFile.Languages = localEpisode.Languages;
+                    episodeFile.IndexerFlags = localEpisode.IndexerFlags;
 
                     // Prefer the release type from the download client, folder and finally the file so we have the most accurate information.
                     episodeFile.ReleaseType = localEpisode.DownloadClientEpisodeInfo?.ReleaseType ??
@@ -109,11 +110,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                             .OrderByDescending(h => h.Date)
                             .FirstOrDefault(h => h.EventType == EpisodeHistoryEventType.Grabbed);
 
-                        if (Enum.TryParse(grabHistory?.Data.GetValueOrDefault("indexerFlags"), true, out IndexerFlags flags))
-                        {
-                            episodeFile.IndexerFlags = flags;
-                        }
-
                         // Prefer the release type from the grabbed history
                         if (Enum.TryParse(grabHistory?.Data.GetValueOrDefault("releaseType"), true, out ReleaseType releaseType))
                         {
@@ -122,7 +118,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     }
                     else
                     {
-                        episodeFile.IndexerFlags = localEpisode.IndexerFlags;
                         episodeFile.ReleaseType = localEpisode.ReleaseType;
                     }
 


### PR DESCRIPTION
#### Description
After merging #7039, I think we can remove the assignment from download history of the indexer flags to allow use of the values you set in the manual import from a failed import from queue.
