### PR TITLE
Upgrade nlog to 5.3.2

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/NumberExtensionFixture.cs
@@ -1,11 +1,11 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Common.Test.ExtensionTests
 {
     [TestFixture]
-    public class Int64ExtensionFixture
+    public class NumberExtensionFixture
     {
         [TestCase(0, "0 B")]
         [TestCase(1000, "1,000.0 B")]

--- a/src/NzbDrone.Common/Extensions/NumberExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/NumberExtensions.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Globalization;
 
 namespace NzbDrone.Common.Extensions
 {
-    public static class Int64Extensions
+    public static class NumberExtensions
     {
         private static readonly string[] SizeSuffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
 
@@ -25,6 +25,26 @@ namespace NzbDrone.Common.Extensions
             var adjustedSize = bytes / (decimal)Math.Pow(bytesInKb, mag);
 
             return string.Format(CultureInfo.InvariantCulture, "{0:n1} {1}", adjustedSize, SizeSuffixes[mag]);
+        }
+
+        public static long Megabytes(this int megabytes)
+        {
+            return Convert.ToInt64(megabytes * 1024L * 1024L);
+        }
+
+        public static long Gigabytes(this int gigabytes)
+        {
+            return Convert.ToInt64(gigabytes * 1024L * 1024L * 1024L);
+        }
+
+        public static long Megabytes(this double megabytes)
+        {
+            return Convert.ToInt64(megabytes * 1024L * 1024L);
+        }
+
+        public static long Gigabytes(this double gigabytes)
+        {
+            return Convert.ToInt64(gigabytes * 1024L * 1024L * 1024L);
         }
     }
 }

--- a/src/NzbDrone.Common/Instrumentation/Extensions/SentryLoggerExtensions.cs
+++ b/src/NzbDrone.Common/Instrumentation/Extensions/SentryLoggerExtensions.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
 using NLog;
-using NLog.Fluent;
 
 namespace NzbDrone.Common.Instrumentation.Extensions
 {
@@ -8,47 +8,46 @@ namespace NzbDrone.Common.Instrumentation.Extensions
     {
         public static readonly Logger SentryLogger = LogManager.GetLogger("Sentry");
 
-        public static LogBuilder SentryFingerprint(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder SentryFingerprint(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return logBuilder.Property("Sentry", fingerprint);
         }
 
-        public static LogBuilder WriteSentryDebug(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryDebug(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Debug, fingerprint);
         }
 
-        public static LogBuilder WriteSentryInfo(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryInfo(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Info, fingerprint);
         }
 
-        public static LogBuilder WriteSentryWarn(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryWarn(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Warn, fingerprint);
         }
 
-        public static LogBuilder WriteSentryError(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryError(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Error, fingerprint);
         }
 
-        private static LogBuilder LogSentryMessage(LogBuilder logBuilder, LogLevel level, string[] fingerprint)
+        private static LogEventBuilder LogSentryMessage(LogEventBuilder logBuilder, LogLevel level, string[] fingerprint)
         {
-            SentryLogger.Log(level)
-                        .CopyLogEvent(logBuilder.LogEventInfo)
+            SentryLogger.ForLogEvent(level)
+                        .CopyLogEvent(logBuilder.LogEvent)
                         .SentryFingerprint(fingerprint)
-                        .Write();
+                        .Log();
 
-            return logBuilder.Property("Sentry", null);
+            return logBuilder.Property<string>("Sentry", null);
         }
 
-        private static LogBuilder CopyLogEvent(this LogBuilder logBuilder, LogEventInfo logEvent)
+        private static LogEventBuilder CopyLogEvent(this LogEventBuilder logBuilder, LogEventInfo logEvent)
         {
-            return logBuilder.LoggerName(logEvent.LoggerName)
-                             .TimeStamp(logEvent.TimeStamp)
+            return logBuilder.TimeStamp(logEvent.TimeStamp)
                              .Message(logEvent.Message, logEvent.Parameters)
-                             .Properties(logEvent.Properties.ToDictionary(v => v.Key, v => v.Value))
+                             .Properties(logEvent.Properties.Select(p => new KeyValuePair<string, object>(p.Key.ToString(), p.Value)))
                              .Exception(logEvent.Exception);
         }
     }

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneFileTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneFileTarget.cs
@@ -1,13 +1,15 @@
-﻿using NLog;
+using System.Text;
+using NLog;
 using NLog.Targets;
 
 namespace NzbDrone.Common.Instrumentation
 {
     public class NzbDroneFileTarget : FileTarget
     {
-        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
-            return CleanseLogMessage.Cleanse(Layout.Render(logEvent));
+            var result = CleanseLogMessage.Cleanse(Layout.Render(logEvent));
+            target.Append(result);
         }
     }
 }

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -34,6 +34,8 @@ namespace NzbDrone.Common.Instrumentation
 
             var appFolderInfo = new AppFolderInfo(startupContext);
 
+            RegisterGlobalFilters();
+
             if (Debugger.IsAttached)
             {
                 RegisterDebugger();
@@ -194,6 +196,17 @@ namespace NzbDrone.Common.Instrumentation
             }
 
             LogManager.Configuration.LoggingRules.Insert(0, rule);
+        }
+
+        private static void RegisterGlobalFilters()
+        {
+            LogManager.Setup().LoadConfiguration(c =>
+            {
+                c.ForLogger("System.*").WriteToNil(LogLevel.Warn);
+                c.ForLogger("Microsoft.*").WriteToNil(LogLevel.Warn);
+                c.ForLogger("Microsoft.Hosting.Lifetime*").WriteToNil(LogLevel.Info);
+                c.ForLogger("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware").WriteToNil(LogLevel.Fatal);
+            });
         }
 
         public static Logger GetLogger(Type obj)

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -162,7 +162,7 @@ namespace NzbDrone.Common.Instrumentation
             fileTarget.ConcurrentWrites = false;
             fileTarget.ConcurrentWriteAttemptDelay = 50;
             fileTarget.ConcurrentWriteAttempts = 10;
-            fileTarget.ArchiveAboveSize = 1024000;
+            fileTarget.ArchiveAboveSize = 1.Megabytes();
             fileTarget.MaxArchiveFiles = maxArchiveFiles;
             fileTarget.EnableFileDelete = true;
             fileTarget.ArchiveNumbering = ArchiveNumberingMode.Rolling;

--- a/src/NzbDrone.Common/Options/LogOptions.cs
+++ b/src/NzbDrone.Common/Options/LogOptions.cs
@@ -7,6 +7,7 @@ public class LogOptions
     public int? Rotate { get; set; }
     public bool? Sql { get; set; }
     public string ConsoleLevel { get; set; }
+    public string ConsoleFormat { get; set; }
     public bool? AnalyticsEnabled { get; set; }
     public string SyslogServer { get; set; }
     public int? SyslogPort { get; set; }

--- a/src/NzbDrone.Common/Options/LogOptions.cs
+++ b/src/NzbDrone.Common/Options/LogOptions.cs
@@ -5,6 +5,7 @@ public class LogOptions
     public string Level { get; set; }
     public bool? FilterSentryEvents { get; set; }
     public int? Rotate { get; set; }
+    public int? SizeLimit { get; set; }
     public bool? Sql { get; set; }
     public string ConsoleLevel { get; set; }
     public string ConsoleFormat { get; set; }

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.2" />
+    <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.0" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageReference Include="Sentry" Version="4.0.2" />

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -8,9 +8,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="4.7.14" />
-    <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
+    <PackageReference Include="NLog" Version="5.3.2" />
+    <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageReference Include="Sentry" Version="4.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/OriginalLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/OriginalLanguageFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core.Test/Datastore/Migration/203_release_typeFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/203_release_typeFixture.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Datastore.Migration;
 using NzbDrone.Core.MediaFiles.MediaInfo;

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.MediaFiles;

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportApprovedEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/ImportApprovedEpisodesFixture.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.History;

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecificationFixture.cs
@@ -1,10 +1,11 @@
-﻿using System.IO;
+using System.IO;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Specifications;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.Configuration
         ConsoleLogFormat ConsoleLogFormat { get; }
         bool LogSql { get; }
         int LogRotate { get; }
+        int LogSizeLimit { get; }
         bool FilterSentryEvents { get; }
         string Branch { get; }
         string ApiKey { get; }
@@ -241,6 +242,7 @@ namespace NzbDrone.Core.Configuration
         public bool LogDbEnabled => _logOptions.DbEnabled ?? GetValueBoolean("LogDbEnabled", true, persist: false);
         public bool LogSql => _logOptions.Sql ?? GetValueBoolean("LogSql", false, persist: false);
         public int LogRotate => _logOptions.Rotate ?? GetValueInt("LogRotate", 50, persist: false);
+        public int LogSizeLimit => Math.Min(Math.Max(_logOptions.SizeLimit ?? GetValueInt("LogSizeLimit", 1, persist: false), 0), 10);
         public bool FilterSentryEvents => _logOptions.FilterSentryEvents ?? GetValueBoolean("FilterSentryEvents", true, persist: false);
         public string SslCertPath => _serverOptions.SslCertPath ?? GetValue("SslCertPath", "");
         public string SslCertPassword => _serverOptions.SslCertPassword ?? GetValue("SslCertPassword", "");

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -10,6 +10,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Options;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration.Events;
@@ -38,6 +39,7 @@ namespace NzbDrone.Core.Configuration
         bool AnalyticsEnabled { get; }
         string LogLevel { get; }
         string ConsoleLogLevel { get; }
+        ConsoleLogFormat ConsoleLogFormat { get; }
         bool LogSql { get; }
         int LogRotate { get; }
         bool FilterSentryEvents { get; }
@@ -222,6 +224,11 @@ namespace NzbDrone.Core.Configuration
 
         public string LogLevel => _logOptions.Level ?? GetValue("LogLevel", "info").ToLowerInvariant();
         public string ConsoleLogLevel => _logOptions.ConsoleLevel ?? GetValue("ConsoleLogLevel", string.Empty, persist: false);
+
+        public ConsoleLogFormat ConsoleLogFormat =>
+            Enum.TryParse<ConsoleLogFormat>(_logOptions.ConsoleFormat, out var enumValue)
+                ? enumValue
+                : GetValueEnum("ConsoleLogFormat", ConsoleLogFormat.Standard, false);
 
         public string Theme => _appOptions.Theme ?? GetValue("Theme", "auto", persist: false);
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/SizeSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/SizeSpecification.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
 

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Parser.Model;

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
@@ -1,4 +1,5 @@
-﻿using NLog;
+using NLog;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -247,14 +246,14 @@ namespace NzbDrone.Core.Download
                 }
                 else
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("No Episodes were just imported, but all episodes were previously imported, possible issue with download history.")
                            .Property("SeriesId", trackedDownload.RemoteEpisode.Series.Id)
                            .Property("DownloadId", trackedDownload.DownloadItem.DownloadId)
                            .Property("Title", trackedDownload.DownloadItem.Title)
                            .Property("Path", trackedDownload.ImportItem.OutputPath.ToString())
                            .WriteSentryWarn("DownloadHistoryIncomplete")
-                           .Write();
+                           .Log();
                 }
 
                 var episodes = _episodeService.GetEpisodes(trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id));

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcNfoDetector.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 {

--- a/src/NzbDrone.Core/Fluent.cs
+++ b/src/NzbDrone.Core/Fluent.cs
@@ -20,26 +20,6 @@ namespace NzbDrone.Core
             return actual;
         }
 
-        public static long Megabytes(this int megabytes)
-        {
-            return Convert.ToInt64(megabytes * 1024L * 1024L);
-        }
-
-        public static long Gigabytes(this int gigabytes)
-        {
-            return Convert.ToInt64(gigabytes * 1024L * 1024L * 1024L);
-        }
-
-        public static long Megabytes(this double megabytes)
-        {
-            return Convert.ToInt64(megabytes * 1024L * 1024L);
-        }
-
-        public static long Gigabytes(this double gigabytes)
-        {
-            return Convert.ToInt64(gigabytes * 1024L * 1024L * 1024L);
-        }
-
         public static long Round(this long number, long level)
         {
             return Convert.ToInt64(Math.Floor((decimal)number / level) * level);

--- a/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
+++ b/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
@@ -33,22 +33,25 @@ namespace NzbDrone.Core.Instrumentation
 
             LogManager.Configuration.AddTarget("DbLogger", target);
             LogManager.Configuration.LoggingRules.Add(Rule);
-            LogManager.ConfigurationReloaded += OnLogManagerOnConfigurationReloaded;
+            LogManager.ConfigurationChanged += OnLogManagerOnConfigurationReloaded;
             LogManager.ReconfigExistingLoggers();
         }
 
         public void UnRegister()
         {
-            LogManager.ConfigurationReloaded -= OnLogManagerOnConfigurationReloaded;
+            LogManager.ConfigurationChanged -= OnLogManagerOnConfigurationReloaded;
             LogManager.Configuration.RemoveTarget("DbLogger");
             LogManager.Configuration.LoggingRules.Remove(Rule);
             LogManager.ReconfigExistingLoggers();
             Dispose();
         }
 
-        private void OnLogManagerOnConfigurationReloaded(object sender, LoggingConfigurationReloadedEventArgs args)
+        private void OnLogManagerOnConfigurationReloaded(object sender, LoggingConfigurationChangedEventArgs args)
         {
-            Register();
+            if (args.ActivatedConfiguration != null)
+            {
+                Register();
+            }
         }
 
         public LoggingRule Rule { get; set; }

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NLog.Config;
+using NLog.Targets;
 using NLog.Targets.Syslog;
 using NLog.Targets.Syslog.Settings;
 using NzbDrone.Common.EnvironmentInfo;
@@ -51,6 +52,7 @@ namespace NzbDrone.Core.Instrumentation
             var rules = LogManager.Configuration.LoggingRules;
 
             // Console
+            ReconfigureConsole();
             SetMinimumLogLevel(rules, "consoleLogger", minimumConsoleLogLevel);
 
             // Log Files
@@ -106,6 +108,22 @@ namespace NzbDrone.Core.Instrumentation
             {
                 sentryTarget.SentryEnabled = (RuntimeInfo.IsProduction && _configFileProvider.AnalyticsEnabled) || RuntimeInfo.IsDevelopment;
                 sentryTarget.FilterEvents = _configFileProvider.FilterSentryEvents;
+            }
+        }
+
+        private void ReconfigureConsole()
+        {
+            var consoleTarget = LogManager.Configuration.AllTargets.OfType<ColoredConsoleTarget>().FirstOrDefault();
+
+            if (consoleTarget != null)
+            {
+                var format = _configFileProvider.ConsoleLogFormat;
+
+                consoleTarget.Layout = format switch
+                {
+                    ConsoleLogFormat.Clef => NzbDroneLogger.ClefLogLayout,
+                    _ => NzbDroneLogger.ConsoleLogLayout
+                };
             }
         }
 

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Instrumentation
             SetMinimumLogLevel(rules, "appFileInfo", minimumLogLevel <= LogLevel.Info ? LogLevel.Info : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileDebug", minimumLogLevel <= LogLevel.Debug ? LogLevel.Debug : LogLevel.Off);
             SetMinimumLogLevel(rules, "appFileTrace", minimumLogLevel <= LogLevel.Trace ? LogLevel.Trace : LogLevel.Off);
-            SetLogRotation();
+            ReconfigureFile();
 
             // Log Sql
             SqlBuilderExtensions.LogSql = _configFileProvider.LogSql;
@@ -93,11 +93,12 @@ namespace NzbDrone.Core.Instrumentation
             }
         }
 
-        private void SetLogRotation()
+        private void ReconfigureFile()
         {
             foreach (var target in LogManager.Configuration.AllTargets.OfType<NzbDroneFileTarget>())
             {
                 target.MaxArchiveFiles = _configFileProvider.LogRotate;
+                target.ArchiveAboveSize = _configFileProvider.LogSizeLimit.Megabytes();
             }
         }
 

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Instrumentation
             syslogTarget.MessageSend.Protocol = ProtocolType.Udp;
             syslogTarget.MessageSend.Udp.Port = syslogPort;
             syslogTarget.MessageSend.Udp.Server = syslogServer;
-            syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
+            syslogTarget.MessageSend.Retry.ConstantBackoff.BaseDelay = 500;
             syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
             syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -153,10 +152,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "WMA";
             }
 
-            Logger.Debug()
+            Logger.ForDebugEvent()
                   .Message("Unknown audio format: '{0}' in '{1}'. Streams: {2}", audioFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownAudioFormatFFProbe", mediaInfo.ContainerFormat, mediaInfo.AudioFormat, audioCodecID)
-                  .Write();
+                  .Log();
 
             return mediaInfo.AudioFormat;
         }
@@ -268,10 +267,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "";
             }
 
-            Logger.Debug()
+            Logger.ForDebugEvent()
                   .Message("Unknown video format: '{0}' in '{1}'. Streams: {2}", videoFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownVideoFormatFFProbe", mediaInfo.ContainerFormat, videoFormat, videoCodecID)
-                  .Write();
+                  .Log();
 
             return result;
         }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.DataAugmentation.Scene;
@@ -386,24 +385,24 @@ namespace NzbDrone.Core.Parser
 
                 if (tvdbId > 0 && tvdbId == searchCriteria.Series.TvdbId)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVDB ID {0}, an alias may be needed for: {1}", tvdbId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvdbId", tvdbId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvdbIdMatch", tvdbId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Id);
                 }
 
                 if (tvRageId > 0 && tvRageId == searchCriteria.Series.TvRageId && tvdbId <= 0)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVRage ID {0}, an alias may be needed for: {1}", tvRageId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvRageId", tvRageId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvRageIdMatch", tvRageId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Id);
                 }
@@ -435,12 +434,12 @@ namespace NzbDrone.Core.Parser
 
                 if (series != null)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVDB ID {0}, an alias may be needed for: {1}", tvdbId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvdbId", tvdbId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvdbIdMatch", tvdbId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     matchType = SeriesMatchType.Id;
                 }
@@ -452,12 +451,12 @@ namespace NzbDrone.Core.Parser
 
                 if (series != null)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVRage ID {0}, an alias may be needed for: {1}", tvRageId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvRageId", tvRageId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvRageIdMatch", tvRageId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     matchType = SeriesMatchType.Id;
                 }

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />

--- a/src/NzbDrone.Host/Sonarr.Host.csproj
+++ b/src/NzbDrone.Host/Sonarr.Host.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="6.0.21" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.3.11" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.2" />

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -49,8 +49,8 @@ namespace NzbDrone.Host
             services.AddLogging(b =>
             {
                 b.ClearProviders();
-                b.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
-                b.AddFilter("Microsoft.AspNetCore", Microsoft.Extensions.Logging.LogLevel.Warning);
+                b.SetMinimumLevel(LogLevel.Trace);
+                b.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
                 b.AddFilter("Sonarr.Http.Authentication", LogLevel.Information);
                 b.AddFilter("Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager", LogLevel.Error);
                 b.AddNLog();

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>

--- a/src/NzbDrone.Update/Sonarr.Update.csproj
+++ b/src/NzbDrone.Update/Sonarr.Update.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Sonarr.Common.csproj" />

--- a/src/NzbDrone.Windows/Sonarr.Windows.csproj
+++ b/src/NzbDrone.Windows/Sonarr.Windows.csproj
@@ -4,7 +4,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
+++ b/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.2.0" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sonarr.Http/Sonarr.Http.csproj
+++ b/src/Sonarr.Http/Sonarr.Http.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Sonarr.Core.csproj" />


### PR DESCRIPTION
#### Description
There changes here, the first isn't really controversial, it just updated nlog to the latest (5.3.2).

The other two I'm a little less sure of.

Compact Log Event Format - only for console logging, if it's not set via environment variable then it will not be applied to the first couple logs, but other than that it seems mostly straight forward and it's a standardized format so it should be compatible with a number of tools, but we could consider adding other formats later.

File Size Limit - This came up on Discord, my first thought was no, but it's not too hard to achieve. It's possible that a file is truncated early when Sonarr starts up, could also try to read the environment variable on startup, but it's less important than the format.

#### Issues Fixed or Closed by this PR
* Closes #7045

