### PR TITLE
Add special character to search criteria

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SearchDefinitionFixture.cs
@@ -15,6 +15,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         [TestCase("Franklin & Bash", "Franklin+and+Bash")]
         [TestCase("Chicago P.D.", "Chicago+PD")]
         [TestCase("Kourtney And Khlo\u00E9 Take The Hamptons", "Kourtney+And+Khloe+Take+The+Hamptons")]
+        [TestCase("Betty White`s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
+        [TestCase("Betty White\u00b4s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
+        [TestCase("Betty White‘s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
+        [TestCase("Betty White’s Off Their Rockers", "Betty+Whites+Off+Their+Rockers")]
         public void should_replace_some_special_characters(string input, string expected)
         {
             Subject.SceneTitles = new List<string> { input };

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"['.\u0060\u00B4\u2018\u2019]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 


### PR DESCRIPTION
Removes special character ’ from series & episode titles when searching.

