### PR TITLE
Fixed: Formatting empty size on disk values

### DIFF
--- a/frontend/src/RootFolder/RootFolderRow.tsx
+++ b/frontend/src/RootFolder/RootFolderRow.tsx
@@ -21,7 +21,7 @@ interface RootFolderRowProps {
 }
 
 function RootFolderRow(props: RootFolderRowProps) {
-  const { id, path, accessible, freeSpace, unmappedFolders = [] } = props;
+  const { id, path, accessible, freeSpace = 0, unmappedFolders = [] } = props;
 
   const isUnavailable = !accessible;
 

--- a/frontend/src/Series/Details/SeasonInfo.tsx
+++ b/frontend/src/Series/Details/SeasonInfo.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
@@ -6,14 +5,19 @@ import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
 import styles from './SeasonInfo.css';
 
-function SeasonInfo(props) {
-  const {
-    totalEpisodeCount,
-    monitoredEpisodeCount,
-    episodeFileCount,
-    sizeOnDisk
-  } = props;
+interface SeasonInfoProps {
+  totalEpisodeCount: number;
+  monitoredEpisodeCount: number;
+  episodeFileCount: number;
+  sizeOnDisk: number;
+}
 
+function SeasonInfo({
+  totalEpisodeCount,
+  monitoredEpisodeCount,
+  episodeFileCount,
+  sizeOnDisk,
+}: SeasonInfoProps) {
   return (
     <DescriptionList>
       <DescriptionListItem
@@ -46,12 +50,5 @@ function SeasonInfo(props) {
     </DescriptionList>
   );
 }
-
-SeasonInfo.propTypes = {
-  totalEpisodeCount: PropTypes.number.isRequired,
-  monitoredEpisodeCount: PropTypes.number.isRequired,
-  episodeFileCount: PropTypes.number.isRequired,
-  sizeOnDisk: PropTypes.number.isRequired
-};
 
 export default SeasonInfo;

--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -212,8 +212,8 @@ class SeriesDetails extends Component {
     } = this.props;
 
     const {
-      episodeFileCount,
-      sizeOnDisk
+      episodeFileCount = 0,
+      sizeOnDisk = 0
     } = statistics;
 
     const {
@@ -454,10 +454,9 @@ class SeriesDetails extends Component {
                             name={icons.DRIVE}
                             size={17}
                           />
+
                           <span className={styles.sizeOnDisk}>
-                            {
-                              formatBytes(sizeOnDisk || 0)
-                            }
+                            {formatBytes(sizeOnDisk)}
                           </span>
                         </div>
                       </Label>

--- a/frontend/src/Series/Index/Overview/SeriesIndexOverviewInfo.tsx
+++ b/frontend/src/Series/Index/Overview/SeriesIndexOverviewInfo.tsx
@@ -194,10 +194,12 @@ function getInfoRowProps(
   }
 
   if (name === 'sizeOnDisk') {
+    const { sizeOnDisk = 0 } = props;
+
     return {
       title: translate('SizeOnDisk'),
       iconName: icons.DRIVE,
-      label: formatBytes(props.sizeOnDisk),
+      label: formatBytes(sizeOnDisk),
     };
   }
 

--- a/frontend/src/Series/Index/Posters/SeriesIndexPosterInfo.tsx
+++ b/frontend/src/Series/Index/Posters/SeriesIndexPosterInfo.tsx
@@ -37,7 +37,7 @@ function SeriesIndexPosterInfo(props: SeriesIndexPosterInfoProps) {
     added,
     seasonCount,
     path,
-    sizeOnDisk,
+    sizeOnDisk = 0,
     tags,
     sortKey,
     showRelativeDates,

--- a/frontend/src/Utilities/Number/formatBytes.ts
+++ b/frontend/src/Utilities/Number/formatBytes.ts
@@ -1,10 +1,6 @@
 import { filesize } from 'filesize';
 
-function formatBytes(input?: string | number) {
-  if (!input) {
-    return '';
-  }
-
+function formatBytes(input: string | number) {
   const size = Number(input);
 
   if (isNaN(size)) {


### PR DESCRIPTION
#### Description
Reverting a regression introduced in d46f4b215483e3a902454aa706336f3869328b3e where 0 is not displayed anymore making the UI inconsistent.

#### Screenshots for UI Changes
![1](https://github.com/user-attachments/assets/895d5e79-4713-407d-9734-b3d393be130e)
![2](https://github.com/user-attachments/assets/101ad6d5-7ccf-4834-bab0-780427471aee)

