### PR TITLE
Correcting download status when fetching metadata

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -229,7 +229,6 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
         [TestCase("queuedDL")]
         [TestCase("checkingDL")]
         [TestCase("checkingUP")]
-        [TestCase("metaDL")]
         [TestCase("checkingResumeData")]
         public void queued_item_should_have_required_properties(string state)
         {
@@ -248,6 +247,28 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
             var item = Subject.GetItems().Single();
             VerifyQueued(item);
+            item.RemainingTime.Should().NotHaveValue();
+        }
+
+        [TestCase("metaDL")]
+        [TestCase("forcedMetaDL")]
+        public void metaDL_item_should_have_required_properties(string state)
+        {
+            var torrent = new QBittorrentTorrent
+            {
+                Hash = "HASH",
+                Name = _title,
+                Size = 1000,
+                Progress = 0.0,
+                Eta = 8640000,
+                State = state,
+                Label = "",
+                SavePath = ""
+            };
+            GivenTorrents(new List<QBittorrentTorrent> { torrent });
+
+            var item = Subject.GetItems().Single();
+            VerifyDownloading(item);
             item.RemainingTime.Should().NotHaveValue();
         }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -287,7 +287,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     case "forcedMetaDL": // torrent metadata is being forcibly downloaded
                         if (config.DhtEnabled)
                         {
-                            item.Status = DownloadItemStatus.Queued;
+                            item.Status = DownloadItemStatus.Downloading;
                             item.Message = _localizationService.GetLocalizedString("DownloadClientQbittorrentTorrentStateMetadata");
                         }
                         else


### PR DESCRIPTION
When qBit is **downloading** metadata, the corresponding queue item download status should be '**`Downloading`**', and not `Queued` as it is currently implemented.

qBit queued-status would - to my understanding - refer to a situation where qBit is waiting for a download slot to become available, which is currently occupied by other downloads. This is not the case here and quite the opposite is happening:the downloading (of metadata) is in progress, and thus I'd suggest `Queued` is incorrect and I propose to change it to `Downloading` with this PR.