### PR TITLE
Fix indexer multi-languages for release/push

### DIFF
--- a/src/NzbDrone.Core/Indexers/IndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentValidation.Results;
 using NLog;
@@ -20,8 +19,6 @@ namespace NzbDrone.Core.Indexers
     public abstract class IndexerBase<TSettings> : IIndexer
         where TSettings : IIndexerSettings, new()
     {
-        private static readonly Regex MultiRegex = new (@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         protected readonly IIndexerStatusService _indexerStatusService;
         protected readonly IConfigService _configService;
         protected readonly IParsingService _parsingService;
@@ -94,7 +91,7 @@ namespace NzbDrone.Core.Indexers
             result.ForEach(c =>
             {
                 // Use multi languages from setting if ReleaseInfo languages is empty
-                if (c.Languages.Empty() && MultiRegex.IsMatch(c.Title) && settings.MultiLanguages.Any())
+                if (c.Languages.Empty() && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(c.Title))
                 {
                     c.Languages = settings.MultiLanguages.Select(i => (Language)i).ToList();
                 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -575,6 +575,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
 
+        private static readonly Regex MultiRegex = new (@"[_. ](?<multi>multi)[_. ]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         public static ParsedEpisodeInfo ParsePath(string path)
         {
             var fileInfo = new FileInfo(path);
@@ -957,6 +959,11 @@ namespace NzbDrone.Core.Parser
             });
 
             return title;
+        }
+
+        public static bool HasMultipleLanguages(string title)
+        {
+            return MultiRegex.IsMatch(title);
         }
 
         private static SeriesTitleInfo GetSeriesTitleInfo(string title, MatchCollection matchCollection)


### PR DESCRIPTION
#### Description
Use the indexer default languages configuration for multi-languages when a release with `MULTI` is pushed using the API `/release/push`.
The Interactive search and RSS sync seems to be already correct.

I had to change `IndexerBase.cs` to put the regex expression for MULTI in `FileNameBuilder.cs`, not quite sure if it's the right place.

Note : this is my first PR for Sonarr, I tried to look around at the function, tests naming convention to use it. If something is not good enough for a merge, feel free to say it I and will change it.

#### Issues Fixed or Closed by this PR
* Closes #7059

