### PR TITLE
Fixed: Overwriting query params for remove item handler

### DIFF
--- a/frontend/src/Store/Actions/Creators/createRemoveItemHandler.js
+++ b/frontend/src/Store/Actions/Creators/createRemoveItemHandler.js
@@ -7,7 +7,7 @@ function createRemoveItemHandler(section, url) {
   return function(getState, payload, dispatch) {
     const {
       id,
-      ...queryParams
+      queryParams
     } = payload;
 
     dispatch(set({ section, isDeleting: true }));


### PR DESCRIPTION
#### Description
Seems not to be possible to overwrite queryParams, like for example in https://github.com/Sonarr/Sonarr/blob/c9b5a1258ade0dbf45132aae5c1df8730c4c0fe3/frontend/src/Store/Actions/seriesActions.js#L501-L504

