### PR TITLE
Fixed: Dedupe titles to avoid similar search requests

### DIFF
--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
@@ -63,7 +63,9 @@ namespace NzbDrone.Core.DataAugmentation.Scene
                                             sceneSeasonNumbers.Contains(n.SceneSeasonNumber ?? -1) ||
                                             ((n.SeasonNumber ?? -1) == -1 && (n.SceneSeasonNumber ?? -1) == -1 && n.SceneOrigin != "tvdb"))
                                 .Where(n => IsEnglish(n.SearchTerm))
-                                .Select(n => n.SearchTerm).Distinct().ToList();
+                                .Select(n => n.SearchTerm)
+                                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                                .ToList();
 
             return names;
         }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -193,7 +193,7 @@ namespace NzbDrone.Core.IndexerSearch
             foreach (var item in dict)
             {
                 item.Value.Episodes = item.Value.Episodes.Distinct().ToList();
-                item.Value.SceneTitles = item.Value.SceneTitles.Distinct().ToList();
+                item.Value.SceneTitles = item.Value.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             }
 
             return dict.Values.ToList();
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             foreach (var item in dict)
             {
-                item.Value.SceneTitles = item.Value.SceneTitles.Distinct().ToList();
+                item.Value.SceneTitles = item.Value.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             }
 
             return dict.Values.ToList();
@@ -463,7 +463,7 @@ namespace NzbDrone.Core.IndexerSearch
             spec.UserInvokedSearch = userInvokedSearch;
             spec.InteractiveSearch = interactiveSearch;
 
-            if (!spec.SceneTitles.Contains(series.Title))
+            if (!spec.SceneTitles.Contains(series.Title, StringComparer.InvariantCultureIgnoreCase))
             {
                 spec.SceneTitles.Add(series.Title);
             }


### PR DESCRIPTION
#### Description
Dedupe scene titles to avoid any similar searches, like `BLEACH` and `Bleach` as seen in these [logs](https://pastebin.com/raw/2Pq0K59S).

