### PR TITLE
Fix indexer multi-languages for tracked download

### DIFF
--- a/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Aggregation/Aggregators/AggregateLanguagesFixture.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Download.Aggregation.Aggregators;
 using NzbDrone.Core.Indexers;
@@ -82,6 +83,8 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]
@@ -115,6 +118,8 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]
@@ -129,14 +134,16 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
             };
 
             Mocker.GetMock<IIndexerFactory>()
-                .Setup(v => v.All())
-                .Returns(new List<IndexerDefinition>() { indexerDefinition });
+                .Setup(v => v.FindByName("MyIndexer (Prowlarr)"))
+                .Returns(indexerDefinition);
 
             _remoteEpisode.ParsedEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { }, releaseTitle);
             _remoteEpisode.Release.Indexer = "MyIndexer (Prowlarr)";
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.FindByName("MyIndexer (Prowlarr)"), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]
@@ -157,6 +164,8 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage, Language.French });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]
@@ -169,33 +178,28 @@ namespace NzbDrone.Core.Test.Download.Aggregation.Aggregators
                 Settings = new TorrentRssIndexerSettings { }
             };
             Mocker.GetMock<IIndexerFactory>()
-                .Setup(v => v.All())
-                .Returns(new List<IndexerDefinition>() { indexerDefinition });
+                .Setup(v => v.Get(1))
+                .Returns(indexerDefinition);
 
             _remoteEpisode.ParsedEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { }, releaseTitle);
             _remoteEpisode.Release.IndexerId = 1;
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage });
+            Mocker.GetMock<IIndexerFactory>().Verify(c => c.Get(1), Times.Once());
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]
         public void should_return_original_when_no_indexer_value()
         {
             var releaseTitle = "Series.Title.S01E01.MULTi.1080p.WEB.H265-RlsGroup";
-            var indexerDefinition = new IndexerDefinition
-            {
-                Id = 1,
-                Settings = new TorrentRssIndexerSettings { }
-            };
-            Mocker.GetMock<IIndexerFactory>()
-                .Setup(v => v.All())
-                .Returns(new List<IndexerDefinition>() { indexerDefinition });
 
             _remoteEpisode.ParsedEpisodeInfo = GetParsedEpisodeInfo(new List<Language> { }, releaseTitle);
             _remoteEpisode.Release.Title = releaseTitle;
 
             Subject.Aggregate(_remoteEpisode).Languages.Should().BeEquivalentTo(new List<Language> { _series.OriginalLanguage });
+            Mocker.GetMock<IIndexerFactory>().VerifyNoOtherCalls();
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -7,6 +7,8 @@ using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.TorrentRss;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
@@ -82,6 +84,80 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             trackedDownload.RemoteEpisode.Episodes.First().Id.Should().Be(4);
             trackedDownload.RemoteEpisode.ParsedEpisodeInfo.SeasonNumber.Should().Be(1);
             trackedDownload.RemoteEpisode.MappedSeasonNumber.Should().Be(1);
+        }
+
+        [Test]
+        public void should_set_indexer()
+        {
+            var episodeHistory = new EpisodeHistory()
+            {
+                DownloadId = "35238",
+                SourceTitle = "TV Series S01",
+                SeriesId = 5,
+                EpisodeId = 4,
+                EventType = EpisodeHistoryEventType.Grabbed,
+            };
+            episodeHistory.Data.Add("indexer", "MyIndexer (Prowlarr)");
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(It.Is<string>(sr => sr == "35238")))
+                .Returns(new List<EpisodeHistory>()
+                {
+                    episodeHistory
+                });
+
+            var indexerDefinition = new IndexerDefinition
+            {
+                Id = 1,
+                Name = "MyIndexer (Prowlarr)",
+                Settings = new TorrentRssIndexerSettings { MultiLanguages = new List<int> { Language.Original.Id, Language.French.Id } }
+            };
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.Get(indexerDefinition.Id))
+                .Returns(indexerDefinition);
+            Mocker.GetMock<IIndexerFactory>()
+                .Setup(v => v.All())
+                .Returns(new List<IndexerDefinition>() { indexerDefinition });
+
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series() { Id = 5 },
+                Episodes = new List<Episode> { new Episode { Id = 4 } },
+                ParsedEpisodeInfo = new ParsedEpisodeInfo()
+                {
+                    SeriesTitle = "TV Series",
+                    SeasonNumber = 1
+                },
+                MappedSeasonNumber = 1
+            };
+
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), null))
+                .Returns(remoteEpisode);
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            var item = new DownloadClientItem()
+            {
+                Title = "TV.Series.S01.MULTi.1080p.WEB.H265-RlsGroup",
+                DownloadId = "35238",
+                DownloadClientInfo = new DownloadClientItemClientInfo
+                {
+                    Protocol = client.Protocol,
+                    Id = client.Id,
+                    Name = client.Name
+                }
+            };
+
+            var trackedDownload = Subject.TrackDownload(client, item);
+
+            trackedDownload.Should().NotBeNull();
+            trackedDownload.RemoteEpisode.Should().NotBeNull();
+            trackedDownload.RemoteEpisode.Release.Should().NotBeNull();
+            trackedDownload.RemoteEpisode.Release.Indexer.Should().Be("MyIndexer (Prowlarr)");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Indexers/IndexerRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Indexers/IndexerRepositoryFixture.cs
@@ -1,0 +1,44 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Indexers
+{
+    [TestFixture]
+    public class IndexerRepositoryFixture : DbTest<IndexerRepository, IndexerDefinition>
+    {
+        private void GivenIndexers()
+        {
+            var indexers = Builder<IndexerDefinition>.CreateListOfSize(2)
+                .All()
+                .With(c => c.Id = 0)
+                .TheFirst(1)
+                .With(x => x.Name = "MyIndexer (Prowlarr)")
+                .TheNext(1)
+                .With(x => x.Name = "My Second Indexer (Prowlarr)")
+                .BuildList();
+
+            Subject.InsertMany(indexers);
+        }
+
+        [Test]
+        public void should_finds_with_name()
+        {
+            GivenIndexers();
+            var found = Subject.FindByName("MyIndexer (Prowlarr)");
+            found.Should().NotBeNull();
+            found.Name.Should().Be("MyIndexer (Prowlarr)");
+            found.Id.Should().Be(1);
+        }
+
+        [Test]
+        public void should_not_find_with_incorrect_case_name()
+        {
+            GivenIndexers();
+            var found = Subject.FindByName("myindexer (prowlarr)");
+            found.Should().BeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -76,18 +76,17 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                 languages = languages.Except(languagesToRemove).ToList();
             }
 
-            if ((languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown)) &&
-                releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true &&
-                (releaseInfo is { IndexerId: > 0 } || releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true))
+            if ((languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown)) && releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true)
             {
-                IndexerDefinition indexer;
+                IndexerDefinition indexer = null;
+
                 if (releaseInfo is { IndexerId: > 0 })
                 {
                     indexer = _indexerFactory.Get(releaseInfo.IndexerId);
                 }
-                else
+                else if (releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true)
                 {
-                    indexer = _indexerFactory.All().FirstOrDefault(v => v.Name.EqualsIgnoreCase(releaseInfo.Indexer));
+                    indexer = _indexerFactory.FindByName(releaseInfo.Indexer);
                 }
 
                 if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -76,9 +76,19 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                 languages = languages.Except(languagesToRemove).ToList();
             }
 
-            if ((languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown)) && releaseInfo is { IndexerId: > 0 } && releaseInfo.Title.IsNotNullOrWhiteSpace())
+            if ((languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown)) &&
+                releaseInfo?.Title?.IsNotNullOrWhiteSpace() == true &&
+                (releaseInfo is { IndexerId: > 0 } || releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true))
             {
-                var indexer = _indexerFactory.Get(releaseInfo.IndexerId);
+                IndexerDefinition indexer;
+                if (releaseInfo is { IndexerId: > 0 })
+                {
+                    indexer = _indexerFactory.Get(releaseInfo.IndexerId);
+                }
+                else
+                {
+                    indexer = _indexerFactory.All().FirstOrDefault(v => v.Name.EqualsIgnoreCase(releaseInfo.Indexer));
+                }
 
                 if (indexer?.Settings is IIndexerSettings settings && settings.MultiLanguages.Any() && Parser.Parser.HasMultipleLanguages(releaseInfo.Title))
                 {

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -13,10 +13,12 @@ namespace NzbDrone.Core.Indexers
         List<IIndexer> RssEnabled(bool filterBlockedIndexers = true);
         List<IIndexer> AutomaticSearchEnabled(bool filterBlockedIndexers = true);
         List<IIndexer> InteractiveSearchEnabled(bool filterBlockedIndexers = true);
+        IndexerDefinition FindByName(string name);
     }
 
     public class IndexerFactory : ProviderFactory<IIndexer, IndexerDefinition>, IIndexerFactory
     {
+        private readonly IIndexerRepository _indexerRepository;
         private readonly IIndexerStatusService _indexerStatusService;
         private readonly Logger _logger;
 
@@ -28,6 +30,7 @@ namespace NzbDrone.Core.Indexers
                               Logger logger)
             : base(providerRepository, providers, container, eventAggregator, logger)
         {
+            _indexerRepository = providerRepository;
             _indexerStatusService = indexerStatusService;
             _logger = logger;
         }
@@ -80,6 +83,11 @@ namespace NzbDrone.Core.Indexers
             }
 
             return enabledIndexers.ToList();
+        }
+
+        public IndexerDefinition FindByName(string name)
+        {
+            return _indexerRepository.FindByName(name);
         }
 
         private IEnumerable<IIndexer> FilterBlockedIndexers(IEnumerable<IIndexer> indexers)

--- a/src/NzbDrone.Core/Indexers/IndexerRepository.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerRepository.cs
@@ -1,4 +1,5 @@
-﻿using NzbDrone.Core.Datastore;
+﻿using System.Linq;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.ThingiProvider;
 
@@ -6,6 +7,7 @@ namespace NzbDrone.Core.Indexers
 {
     public interface IIndexerRepository : IProviderRepository<IndexerDefinition>
     {
+        IndexerDefinition FindByName(string name);
     }
 
     public class IndexerRepository : ProviderRepository<IndexerDefinition>, IIndexerRepository
@@ -13,6 +15,11 @@ namespace NzbDrone.Core.Indexers
         public IndexerRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+        }
+
+        public IndexerDefinition FindByName(string name)
+        {
+            return Query(i => i.Name == name).SingleOrDefault();
         }
     }
 }


### PR DESCRIPTION
#### Description
Related to PR https://github.com/Sonarr/Sonarr/pull/7066, the indexer was not set before the `_aggregationService.Augment(...)` for the tracked downloads. This cause incorrect custom format score.