### PR TITLE
New: Increase max size limit for quality definitions

### DIFF
--- a/frontend/src/Settings/Quality/Definition/QualityDefinition.js
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinition.js
@@ -13,7 +13,7 @@ import QualityDefinitionLimits from './QualityDefinitionLimits';
 import styles from './QualityDefinition.css';
 
 const MIN = 0;
-const MAX = 400;
+const MAX = 1000;
 const MIN_DISTANCE = 1;
 
 const slider = {

--- a/frontend/src/Store/Actions/Settings/qualityDefinitions.js
+++ b/frontend/src/Store/Actions/Settings/qualityDefinitions.js
@@ -77,7 +77,7 @@ export default {
 
       const promise = createAjaxRequest({
         method: 'PUT',
-        url: '/qualityDefinition/update',
+        url: '/qualitydefinition/update',
         data: JSON.stringify(upatedDefinitions),
         contentType: 'application/json',
         dataType: 'json'


### PR DESCRIPTION
#### Description
> GoT would be somewhere between 500 and 580 looking at only S2 and S3. So I think 1000 would be a good unlimited for Sonarr, but 2000 for Radarr.

#### Issues Fixed or Closed by this PR
* Closes #7084

