### PR TITLE
Fixed: Avoid displaying multi-languages for episodes parsed without languages

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.tsx
+++ b/frontend/src/Activity/History/HistoryRow.tsx
@@ -15,6 +15,7 @@ import SeasonEpisodeNumber from 'Episode/SeasonEpisodeNumber';
 import useEpisode from 'Episode/useEpisode';
 import usePrevious from 'Helpers/Hooks/usePrevious';
 import { icons, tooltipPositions } from 'Helpers/Props';
+import Language from 'Language/Language';
 import { QualityModel } from 'Quality/Quality';
 import SeriesTitleLink from 'Series/SeriesTitleLink';
 import useSeries from 'Series/useSeries';
@@ -31,7 +32,7 @@ interface HistoryRowProps {
   id: number;
   episodeId: number;
   seriesId: number;
-  languages: object[];
+  languages: Language[];
   quality: QualityModel;
   customFormats?: CustomFormat[];
   customFormatScore: number;

--- a/frontend/src/Episode/EpisodeLanguages.tsx
+++ b/frontend/src/Episode/EpisodeLanguages.tsx
@@ -1,18 +1,21 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import Label from 'Components/Label';
 import Popover from 'Components/Tooltip/Popover';
 import { kinds, tooltipPositions } from 'Helpers/Props';
+import Language from 'Language/Language';
 import translate from 'Utilities/String/translate';
 
-function EpisodeLanguages(props) {
-  const {
-    className,
-    languages,
-    isCutoffNotMet
-  } = props;
+interface EpisodeLanguagesProps {
+  className?: string;
+  languages: Language[];
+  isCutoffNotMet?: boolean;
+}
 
-  if (!languages) {
+function EpisodeLanguages(props: EpisodeLanguagesProps) {
+  const { className, languages, isCutoffNotMet = true } = props;
+
+  // TODO: Typescript - Remove once everything is converted
+  if (!languages || languages.length === 0) {
     return null;
   }
 
@@ -41,30 +44,14 @@ function EpisodeLanguages(props) {
       title={translate('Languages')}
       body={
         <ul>
-          {
-            languages.map((language) => {
-              return (
-                <li key={language.id}>
-                  {language.name}
-                </li>
-              );
-            })
-          }
+          {languages.map((language) => (
+            <li key={language.id}>{language.name}</li>
+          ))}
         </ul>
       }
       position={tooltipPositions.LEFT}
     />
   );
 }
-
-EpisodeLanguages.propTypes = {
-  className: PropTypes.string,
-  languages: PropTypes.arrayOf(PropTypes.object),
-  isCutoffNotMet: PropTypes.bool
-};
-
-EpisodeLanguages.defaultProps = {
-  isCutoffNotMet: true
-};
 
 export default EpisodeLanguages;


### PR DESCRIPTION
#### Description
Don't display multiple languages when actually are no languages.