### PR TITLE
Add Last Search Time to /episode API and to the Frontend (Cut-off Unmet & Missing)

### DIFF
--- a/frontend/src/Episode/Episode.ts
+++ b/frontend/src/Episode/Episode.ts
@@ -9,6 +9,7 @@ interface Episode extends ModelBase {
   episodeNumber: number;
   airDate: string;
   airDateUtc?: string;
+  lastSearchTime?: string;
   runtime: number;
   absoluteEpisodeNumber?: number;
   sceneSeasonNumber?: number;

--- a/frontend/src/Store/Actions/wantedActions.js
+++ b/frontend/src/Store/Actions/wantedActions.js
@@ -51,6 +51,12 @@ export const defaultState = {
         isVisible: true
       },
       {
+        name: 'episodes.lastSearchTime',
+        label: () => translate('LastSearched'),
+        isSortable: true,
+        isVisible: false
+      },
+      {
         name: 'status',
         label: () => translate('Status'),
         isVisible: true
@@ -121,6 +127,12 @@ export const defaultState = {
         label: () => translate('AirDate'),
         isSortable: true,
         isVisible: true
+      },
+      {
+        name: 'episodes.lastSearchTime',
+        label: () => translate('LastSearched'),
+        isSortable: true,
+        isVisible: false
       },
       {
         name: 'languages',

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetConnector.js
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetConnector.js
@@ -126,14 +126,16 @@ class CutoffUnmetConnector extends Component {
   onSearchSelectedPress = (selected) => {
     this.props.executeCommand({
       name: commandNames.EPISODE_SEARCH,
-      episodeIds: selected
+      episodeIds: selected,
+      commandFinished: this.repopulate
     });
   };
 
   onSearchAllCutoffUnmetPress = (monitored) => {
     this.props.executeCommand({
       name: commandNames.CUTOFF_UNMET_EPISODE_SEARCH,
-      monitored
+      monitored,
+      commandFinished: this.repopulate
     });
   };
 

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.js
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.js
@@ -26,6 +26,7 @@ function CutoffUnmetRow(props) {
     sceneAbsoluteEpisodeNumber,
     unverifiedSceneNumbering,
     airDateUtc,
+    lastSearchTime,
     title,
     isSelected,
     columns,
@@ -106,6 +107,16 @@ function CutoffUnmetRow(props) {
             );
           }
 
+          if (name === 'episodes.lastSearchTime') {
+            return (
+              <RelativeDateCell
+                key={name}
+                date={lastSearchTime}
+                includeSeconds={true}
+              />
+            );
+          }
+
           if (name === 'languages') {
             return (
               <TableRowCell
@@ -166,6 +177,7 @@ CutoffUnmetRow.propTypes = {
   sceneAbsoluteEpisodeNumber: PropTypes.number,
   unverifiedSceneNumbering: PropTypes.bool.isRequired,
   airDateUtc: PropTypes.string.isRequired,
+  lastSearchTime: PropTypes.string,
   title: PropTypes.string.isRequired,
   isSelected: PropTypes.bool,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Wanted/Missing/MissingConnector.js
+++ b/frontend/src/Wanted/Missing/MissingConnector.js
@@ -117,14 +117,16 @@ class MissingConnector extends Component {
   onSearchSelectedPress = (selected) => {
     this.props.executeCommand({
       name: commandNames.EPISODE_SEARCH,
-      episodeIds: selected
+      episodeIds: selected,
+      commandFinished: this.repopulate
     });
   };
 
   onSearchAllMissingPress = (monitored) => {
     this.props.executeCommand({
       name: commandNames.MISSING_EPISODE_SEARCH,
-      monitored
+      monitored,
+      commandFinished: this.repopulate
     });
   };
 

--- a/frontend/src/Wanted/Missing/MissingRow.js
+++ b/frontend/src/Wanted/Missing/MissingRow.js
@@ -25,6 +25,7 @@ function MissingRow(props) {
     sceneAbsoluteEpisodeNumber,
     unverifiedSceneNumbering,
     airDateUtc,
+    lastSearchTime,
     title,
     isSelected,
     columns,
@@ -109,6 +110,16 @@ function MissingRow(props) {
             );
           }
 
+          if (name === 'episodes.lastSearchTime') {
+            return (
+              <RelativeDateCell
+                key={name}
+                date={lastSearchTime}
+                includeSeconds={true}
+              />
+            );
+          }
+
           if (name === 'status') {
             return (
               <TableRowCell
@@ -156,6 +167,7 @@ MissingRow.propTypes = {
   sceneAbsoluteEpisodeNumber: PropTypes.number,
   unverifiedSceneNumbering: PropTypes.bool.isRequired,
   airDateUtc: PropTypes.string.isRequired,
+  lastSearchTime: PropTypes.string,
   title: PropTypes.string.isRequired,
   isSelected: PropTypes.bool,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1063,6 +1063,7 @@
   "Large": "Large",
   "LastDuration": "Last Duration",
   "LastExecution": "Last Execution",
+  "LastSearched": "Last Searched",
   "LastUsed": "Last Used",
   "LastWriteTime": "Last Write Time",
   "LatestSeason": "Latest Season",

--- a/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
@@ -21,6 +21,7 @@ namespace Sonarr.Api.V3.Episodes
         public string Title { get; set; }
         public string AirDate { get; set; }
         public DateTime? AirDateUtc { get; set; }
+        public DateTime? LastSearchTime { get; set; }
         public int Runtime { get; set; }
         public string FinaleType { get; set; }
         public string Overview { get; set; }
@@ -35,7 +36,6 @@ namespace Sonarr.Api.V3.Episodes
         public DateTime? EndTime { get; set; }
         public DateTime? GrabDate { get; set; }
         public SeriesResource Series { get; set; }
-
         public List<MediaCover> Images { get; set; }
 
         // Hiding this so people don't think its usable (only used to set the initial state)
@@ -68,6 +68,7 @@ namespace Sonarr.Api.V3.Episodes
                 Runtime = model.Runtime,
                 FinaleType = model.FinaleType,
                 Overview = model.Overview,
+                LastSearchTime = model.LastSearchTime,
 
                 // EpisodeFile
 


### PR DESCRIPTION
#### Description
Adds ability to check when user has added/last searched for a given episode.
Reason to chose /episode over /episodeFile is because /episodeFile is not returned until the first file is available.
Since here we deal with items that are in process of being searched, chance is high that no file is there yet, hence /episode rather than /episodeFile


