### PR TITLE
Fixed: Prefer episode runtime when determining whether a file is a sample

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotSampleSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/NotSampleSpecificationFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotSampleSpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
             try
             {
-                var sample = _detectSample.IsSample(localEpisode.Series, localEpisode.Path, localEpisode.IsSpecial);
+                var sample = _detectSample.IsSample(localEpisode);
 
                 if (sample == DetectSampleResult.Sample)
                 {


### PR DESCRIPTION
#### Description

Prefers the combined runtime of all episodes over the series runtime. Previously the number of episodes was not considered, but will be now. Also uses the `MediaInfo` from the importing episode instead of getting the runtime from the again.

#### Issues Fixed or Closed by this PR
* Closes #7086

