### PR TITLE
Fixed: Stale custom formats after changing quality profile for series 

### DIFF
--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -212,6 +212,8 @@ class SignalRConnector extends Component {
 
     if (action === 'updated') {
       this.props.dispatchUpdateItem({ section, ...body.resource });
+
+      repopulatePage('seriesUpdated');
     } else if (action === 'deleted') {
       this.props.dispatchRemoveItem({ section, id: body.resource.id });
     }

--- a/frontend/src/Series/Details/SeriesDetailsConnector.js
+++ b/frontend/src/Series/Details/SeriesDetailsConnector.js
@@ -152,7 +152,7 @@ class SeriesDetailsConnector extends Component {
   // Lifecycle
 
   componentDidMount() {
-    registerPagePopulator(this.populate);
+    registerPagePopulator(this.populate, ['seriesUpdated']);
     this.populate();
   }
 

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetConnector.js
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetConnector.js
@@ -49,7 +49,7 @@ class CutoffUnmetConnector extends Component {
       gotoCutoffUnmetFirstPage
     } = this.props;
 
-    registerPagePopulator(this.repopulate, ['episodeFileUpdated', 'episodeFileDeleted']);
+    registerPagePopulator(this.repopulate, ['seriesUpdated', 'episodeFileUpdated', 'episodeFileDeleted']);
 
     if (useCurrentPage) {
       fetchCutoffUnmet();


### PR DESCRIPTION
#### Description
If you change the quality profile for a series it's necessary to either reload the page or go back and forward for the custom formats to reflect the new scores.

