### PR TITLE
New: Expose log size limit to API and WebUI

### DIFF
--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -157,6 +157,7 @@ class GeneralSettings extends Component {
                 />
 
                 <LoggingSettings
+                  advancedSettings={advancedSettings}
                   settings={settings}
                   onInputChange={onInputChange}
                 />

--- a/frontend/src/Settings/General/LoggingSettings.js
+++ b/frontend/src/Settings/General/LoggingSettings.js
@@ -30,12 +30,14 @@ const logLevelOptions = [
 
 function LoggingSettings(props) {
   const {
+    advancedSettings,
     settings,
     onInputChange
   } = props;
 
   const {
-    logLevel
+    logLevel,
+    logSizeLimit
   } = settings;
 
   return (
@@ -52,11 +54,30 @@ function LoggingSettings(props) {
           {...logLevel}
         />
       </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>{translate('LogSizeLimit')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.NUMBER}
+          name="logSizeLimit"
+          min={1}
+          max={10}
+          unit="MB"
+          helpText={translate('LogSizeLimitHelpText')}
+          onChange={onInputChange}
+          {...logSizeLimit}
+        />
+      </FormGroup>
     </FieldSet>
   );
 }
 
 LoggingSettings.propTypes = {
+  advancedSettings: PropTypes.bool.isRequired,
   settings: PropTypes.object.isRequired,
   onInputChange: PropTypes.func.isRequired
 };

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1097,6 +1097,8 @@
   "LogLevel": "Log Level",
   "LogLevelTraceHelpTextWarning": "Trace logging should only be enabled temporarily",
   "LogOnly": "Log Only",
+  "LogSizeLimit": "Log Size Limit",
+  "LogSizeLimitHelpText": "Maximum log file size in MB before archiving. Default is 1MB.",
   "Logging": "Logging",
   "Logout": "Logout",
   "Logs": "Logs",

--- a/src/Sonarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigController.cs
@@ -61,6 +61,8 @@ namespace Sonarr.Api.V3.Config
                 .Must((resource, path) => IsValidSslCertificate(resource)).WithMessage("Invalid SSL certificate file or password")
                 .When(c => c.EnableSsl);
 
+            SharedValidator.RuleFor(c => c.LogSizeLimit).InclusiveBetween(1, 10);
+
             SharedValidator.RuleFor(c => c.Branch).NotEmpty().WithMessage("Branch name is required, 'main' is the default");
             SharedValidator.RuleFor(c => c.UpdateScriptPath).IsValidPath().When(c => c.UpdateMechanism == UpdateMechanism.Script);
 

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -21,6 +21,7 @@ namespace Sonarr.Api.V3.Config
         public string Password { get; set; }
         public string PasswordConfirmation { get; set; }
         public string LogLevel { get; set; }
+        public int LogSizeLimit { get; set; }
         public string ConsoleLogLevel { get; set; }
         public string Branch { get; set; }
         public string ApiKey { get; set; }
@@ -65,6 +66,7 @@ namespace Sonarr.Api.V3.Config
                 // Username
                 // Password
                 LogLevel = model.LogLevel,
+                LogSizeLimit = model.LogSizeLimit,
                 ConsoleLogLevel = model.ConsoleLogLevel,
                 Branch = model.Branch,
                 ApiKey = model.ApiKey,

--- a/src/Sonarr.Api.V3/openapi.json
+++ b/src/Sonarr.Api.V3/openapi.json
@@ -8858,6 +8858,10 @@
             "type": "string",
             "nullable": true
           },
+          "logSizeLimit": {
+            "type": "integer",
+            "nullable": true
+          },
           "consoleLogLevel": {
             "type": "string",
             "nullable": true


### PR DESCRIPTION
#### Description
This PR exposes the newly added LogSizeLimit from this commit https://github.com/Sonarr/Sonarr/commit/813965e6a20edef2772d68eaa7646af33028425a to the API and the WebUI.

#### Screenshots for UI Changes

![image](https://github.com/user-attachments/assets/09880c49-65d0-4909-93ad-d0c9ac33a1d9)

#### Proposals

While fiddling this together i noticed that the log size limit has a hardcoded upper limit of 10 MB.
https://github.com/Sonarr/Sonarr/blob/cd3a1c18ab4f8b644ddea3e6358ec23eb3069526/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs#L245
Is there a specific reason for that limit or could this be subject to change?
