### PR TITLE
Fixed: Removing invalid statuses on provider deletion

### DIFF
--- a/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusRepository.cs
+++ b/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusRepository.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.ThingiProvider.Status
         where TModel : ProviderStatusBase, new()
     {
         TModel FindByProviderId(int providerId);
+        void DeleteByProviderId(int providerId);
     }
 
     public class ProviderStatusRepository<TModel> : BasicRepository<TModel>, IProviderStatusRepository<TModel>
@@ -21,6 +22,11 @@ namespace NzbDrone.Core.ThingiProvider.Status
         public TModel FindByProviderId(int providerId)
         {
             return Query(c => c.ProviderId == providerId).SingleOrDefault();
+        }
+
+        public void DeleteByProviderId(int providerId)
+        {
+            Delete(c => c.ProviderId == providerId);
         }
     }
 }

--- a/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusServiceBase.cs
+++ b/src/NzbDrone.Core/ThingiProvider/Status/ProviderStatusServiceBase.cs
@@ -151,12 +151,7 @@ namespace NzbDrone.Core.ThingiProvider.Status
 
         public virtual void HandleAsync(ProviderDeletedEvent<TProvider> message)
         {
-            var providerStatus = _providerStatusRepository.FindByProviderId(message.ProviderId);
-
-            if (providerStatus != null)
-            {
-                _providerStatusRepository.Delete(providerStatus);
-            }
+            _providerStatusRepository.DeleteByProviderId(message.ProviderId);
         }
     }
 }


### PR DESCRIPTION
#### Description
As noticed on support channels, some users report issues like `System.Data.DataException: Error parsing column 6 (LastRssSyncReleaseInfo={ ... } ---> System.FormatException: The DateTime represented by the string '10169-05-19T05:09:00Z' is not supported in calendar 'System.Globalization.ThaiBuddhistCalendar'.` where the only solution is to tell them to install another 3rd-party app and execute the query `UPDATE IndexerStatus SET LastRssSyncReleaseInfo = NULL;` to make it work again. 

Switching to deletion directly without loading the provider entity with Dapper would allow us to recommend the removal the indexer and to add once again to clear the issue.