### PR TITLE
Improve context for UI language validation

### DIFF
--- a/frontend/src/typings/Settings/UiSettings.ts
+++ b/frontend/src/typings/Settings/UiSettings.ts
@@ -4,4 +4,5 @@ export default interface UiSettings {
   shortDateFormat: string;
   longDateFormat: string;
   timeFormat: string;
+  uiLanguage: number;
 }

--- a/src/Sonarr.Api.V3/Config/UiConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/UiConfigController.cs
@@ -18,17 +18,14 @@ namespace Sonarr.Api.V3.Config
             : base(configService)
         {
             _configFileProvider = configFileProvider;
-            SharedValidator.RuleFor(c => c.UILanguage).Custom((value, context) =>
-            {
-                if (!Language.All.Any(o => o.Id == value))
-                {
-                    context.AddFailure("Invalid UI Language value");
-                }
-            });
 
             SharedValidator.RuleFor(c => c.UILanguage)
-                           .GreaterThanOrEqualTo(1)
-                           .WithMessage("The UI Language value cannot be less than 1");
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("The UI Language value cannot be less than 1");
+
+            SharedValidator.RuleFor(c => c.UILanguage)
+                .Must(value => Language.All.Any(o => o.Id == value))
+                .WithMessage("Invalid UI Language ID");
         }
 
         [RestPutById]


### PR DESCRIPTION
#### Description
Switching to `Must` to simplifying the validation for UI language and for more context. 

#### Screenshots for UI Changes
before
![before](https://github.com/user-attachments/assets/0424075c-4608-479e-9b71-468d617ce2e7)

after
![after](https://github.com/user-attachments/assets/10875357-9802-41eb-9f5a-7ae7de2cc311)

