### PR TITLE
Shift quality definition limits management to the backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ src/.idea/
 
 # API doc generation
 .config/
+
+# Ignore Jetbrains IntelliJ Workspace Directories
+.idea/

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -8,19 +8,12 @@ namespace NzbDrone.Api.Test.v3.Qualities;
 [Parallelizable(ParallelScope.All)]
 public class QualityDefinitionResourceValidatorTests
 {
-    private readonly QualityDefinitionResourceValidator _validator;
-    private readonly QualityDefinitionLimits _limits;
-
-    public QualityDefinitionResourceValidatorTests()
-    {
-        _limits = new QualityDefinitionLimits();
-        _validator = new QualityDefinitionResourceValidator(_limits);
-    }
+    private readonly QualityDefinitionResourceValidator _validator = new ();
 
     [Test]
     public void Validate_fails_when_min_size_is_below_min_limit()
     {
-        var resource = new QualityDefinitionResource { MinSize = _limits.MinLimit - 1 };
+        var resource = new QualityDefinitionResource { MinSize = QualityDefinitionLimits.MinLimit - 1 };
 
         var result = _validator.TestValidate(resource);
 
@@ -48,8 +41,8 @@ public class QualityDefinitionResourceValidatorTests
     {
         var resource = new QualityDefinitionResource
         {
-            MinSize = _limits.MinLimit,
-            PreferredSize = _limits.MaxLimit
+            MinSize = QualityDefinitionLimits.MinLimit,
+            PreferredSize = QualityDefinitionLimits.MaxLimit
         };
 
         var result = _validator.TestValidate(resource);
@@ -75,7 +68,7 @@ public class QualityDefinitionResourceValidatorTests
     [Test]
     public void Validate_fails_when_max_size_exceeds_max_limit()
     {
-        var resource = new QualityDefinitionResource { MaxSize = _limits.MaxLimit + 1 };
+        var resource = new QualityDefinitionResource { MaxSize = QualityDefinitionLimits.MaxLimit + 1 };
 
         var result = _validator.TestValidate(resource);
 
@@ -88,8 +81,8 @@ public class QualityDefinitionResourceValidatorTests
     {
         var resource = new QualityDefinitionResource
         {
-            MaxSize = _limits.MaxLimit,
-            PreferredSize = _limits.MinLimit
+            MaxSize = QualityDefinitionLimits.MaxLimit,
+            PreferredSize = QualityDefinitionLimits.MinLimit
         };
 
         var result = _validator.TestValidate(resource);

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -1,0 +1,99 @@
+﻿using FluentValidation.TestHelper;
+using NUnit.Framework;
+using NzbDrone.Core.Qualities;
+using Sonarr.Api.V3.Qualities;
+
+namespace NzbDrone.Api.Test.v3.Qualities;
+
+[Parallelizable(ParallelScope.All)]
+public class QualityDefinitionResourceValidatorTests
+{
+    private readonly QualityDefinitionResourceValidator _validator;
+    private readonly QualityDefinitionLimits _limits;
+
+    public QualityDefinitionResourceValidatorTests()
+    {
+        _limits = new QualityDefinitionLimits();
+        _validator = new QualityDefinitionResourceValidator(_limits);
+    }
+
+    [Test]
+    public void Validate_fails_when_min_size_is_below_min_limit()
+    {
+        var resource = new QualityDefinitionResource { MinSize = _limits.MinLimit - 1 };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.MinSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_fails_when_min_size_is_above_preferred_size()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 10,
+            PreferredSize = 5
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.MinSize)
+            .WithErrorCode("LessThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_passes_when_min_size_is_within_limits()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = _limits.MinLimit,
+            PreferredSize = _limits.MaxLimit
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Test]
+    public void Validate_fails_when_max_size_is_below_preferred_size()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MaxSize = 5,
+            PreferredSize = 10
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.MaxSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_fails_when_max_size_exceeds_max_limit()
+    {
+        var resource = new QualityDefinitionResource { MaxSize = _limits.MaxLimit + 1 };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.MaxSize)
+            .WithErrorCode("LessThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_passes_when_max_size_is_within_limits()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MaxSize = _limits.MaxLimit,
+            PreferredSize = _limits.MinLimit
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -15,7 +15,7 @@ public class QualityDefinitionResourceValidatorTests
     {
         var resource = new QualityDefinitionResource
         {
-            MinSize = QualityDefinitionLimits.MinLimit - 1,
+            MinSize = QualityDefinitionLimits.Min - 1,
             PreferredSize = null,
             MaxSize = null
         };
@@ -50,7 +50,7 @@ public class QualityDefinitionResourceValidatorTests
     {
         var resource = new QualityDefinitionResource
         {
-            MinSize = QualityDefinitionLimits.MinLimit,
+            MinSize = QualityDefinitionLimits.Min,
             PreferredSize = null,
             MaxSize = null
         };
@@ -86,7 +86,7 @@ public class QualityDefinitionResourceValidatorTests
         {
             MinSize = null,
             PreferredSize = null,
-            MaxSize = QualityDefinitionLimits.MaxLimit + 1
+            MaxSize = QualityDefinitionLimits.Max + 1
         };
 
         var result = _validator.TestValidate(resource);
@@ -102,7 +102,7 @@ public class QualityDefinitionResourceValidatorTests
         {
             MinSize = null,
             PreferredSize = null,
-            MaxSize = QualityDefinitionLimits.MaxLimit
+            MaxSize = QualityDefinitionLimits.Max
         };
 
         var result = _validator.TestValidate(resource);

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -13,7 +13,12 @@ public class QualityDefinitionResourceValidatorTests
     [Test]
     public void Validate_fails_when_min_size_is_below_min_limit()
     {
-        var resource = new QualityDefinitionResource { MinSize = QualityDefinitionLimits.MinLimit - 1 };
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = QualityDefinitionLimits.MinLimit - 1,
+            PreferredSize = null,
+            MaxSize = null
+        };
 
         var result = _validator.TestValidate(resource);
 
@@ -22,18 +27,22 @@ public class QualityDefinitionResourceValidatorTests
     }
 
     [Test]
-    public void Validate_fails_when_min_size_is_above_preferred_size()
+    public void Validate_fails_when_min_size_is_above_preferred_size_and_below_limit()
     {
         var resource = new QualityDefinitionResource
         {
             MinSize = 10,
-            PreferredSize = 5
+            PreferredSize = 5,
+            MaxSize = null
         };
 
         var result = _validator.TestValidate(resource);
 
         result.ShouldHaveValidationErrorFor(r => r.MinSize)
             .WithErrorCode("LessThanOrEqualTo");
+
+        result.ShouldHaveValidationErrorFor(r => r.PreferredSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
     }
 
     [Test]
@@ -42,7 +51,8 @@ public class QualityDefinitionResourceValidatorTests
         var resource = new QualityDefinitionResource
         {
             MinSize = QualityDefinitionLimits.MinLimit,
-            PreferredSize = QualityDefinitionLimits.MaxLimit
+            PreferredSize = null,
+            MaxSize = null
         };
 
         var result = _validator.TestValidate(resource);
@@ -51,24 +61,33 @@ public class QualityDefinitionResourceValidatorTests
     }
 
     [Test]
-    public void Validate_fails_when_max_size_is_below_preferred_size()
+    public void Validate_fails_when_max_size_is_below_preferred_size_and_above_limit()
     {
         var resource = new QualityDefinitionResource
         {
-            MaxSize = 5,
-            PreferredSize = 10
+            MinSize = null,
+            PreferredSize = 10,
+            MaxSize = 5
         };
 
         var result = _validator.TestValidate(resource);
 
         result.ShouldHaveValidationErrorFor(r => r.MaxSize)
             .WithErrorCode("GreaterThanOrEqualTo");
+
+        result.ShouldHaveValidationErrorFor(r => r.PreferredSize)
+            .WithErrorCode("LessThanOrEqualTo");
     }
 
     [Test]
     public void Validate_fails_when_max_size_exceeds_max_limit()
     {
-        var resource = new QualityDefinitionResource { MaxSize = QualityDefinitionLimits.MaxLimit + 1 };
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = null,
+            PreferredSize = null,
+            MaxSize = QualityDefinitionLimits.MaxLimit + 1
+        };
 
         var result = _validator.TestValidate(resource);
 
@@ -81,8 +100,95 @@ public class QualityDefinitionResourceValidatorTests
     {
         var resource = new QualityDefinitionResource
         {
-            MaxSize = QualityDefinitionLimits.MaxLimit,
-            PreferredSize = QualityDefinitionLimits.MinLimit
+            MinSize = null,
+            PreferredSize = null,
+            MaxSize = QualityDefinitionLimits.MaxLimit
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Test]
+    public void Validate_fails_when_preferred_size_is_below_min_size_and_above_max_size()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 10,
+            PreferredSize = 7,
+            MaxSize = 5
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.PreferredSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+
+        result.ShouldHaveValidationErrorFor(r => r.MaxSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_passes_when_preferred_size_is_null_and_other_sizes_are_valid()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 5,
+            PreferredSize = null,
+            MaxSize = 10
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Test]
+    public void Validate_passes_when_preferred_size_equals_limits()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 5,
+            PreferredSize = 5,
+            MaxSize = 10
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Test]
+    public void Validate_fails_when_all_sizes_are_provided_and_invalid()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 15,
+            PreferredSize = 10,
+            MaxSize = 5
+        };
+
+        var result = _validator.TestValidate(resource);
+
+        result.ShouldHaveValidationErrorFor(r => r.MinSize)
+            .WithErrorCode("LessThanOrEqualTo");
+
+        result.ShouldHaveValidationErrorFor(r => r.MaxSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+
+        result.ShouldHaveValidationErrorFor(r => r.PreferredSize)
+            .WithErrorCode("GreaterThanOrEqualTo");
+    }
+
+    [Test]
+    public void Validate_passes_when_preferred_size_is_valid_within_limits()
+    {
+        var resource = new QualityDefinitionResource
+        {
+            MinSize = 5,
+            PreferredSize = 7,
+            MaxSize = 10
         };
 
         var result = _validator.TestValidate(resource);

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace NzbDrone.Core.Qualities;
+
+[SuppressMessage("Performance", "CA1822:Mark members as static", Justification =
+    "Serializable properties of a DTO")]
+public record QualityDefinitionLimits
+{
+    public int MinLimit => 0;
+    public int MaxLimit => 1000;
+}

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
@@ -1,7 +1,7 @@
-﻿namespace NzbDrone.Core.Qualities;
+namespace NzbDrone.Core.Qualities;
 
 public static class QualityDefinitionLimits
 {
-    public const int MinLimit = 0;
-    public const int MaxLimit = 1000;
+    public const int Min = 0;
+    public const int Max = 1000;
 }

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionLimits.cs
@@ -1,11 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿namespace NzbDrone.Core.Qualities;
 
-namespace NzbDrone.Core.Qualities;
-
-[SuppressMessage("Performance", "CA1822:Mark members as static", Justification =
-    "Serializable properties of a DTO")]
-public record QualityDefinitionLimits
+public static class QualityDefinitionLimits
 {
-    public int MinLimit => 0;
-    public int MaxLimit => 1000;
+    public const int MinLimit = 0;
+    public const int MaxLimit = 1000;
 }

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Qualities
         List<QualityDefinition> All();
         QualityDefinition GetById(int id);
         QualityDefinition Get(Quality quality);
+        QualityDefinitionLimits GetLimits();
     }
 
     public class QualityDefinitionService : IQualityDefinitionService, IExecute<ResetQualityDefinitionsCommand>, IHandle<ApplicationStartedEvent>
@@ -62,6 +63,11 @@ namespace NzbDrone.Core.Qualities
         public QualityDefinition Get(Quality quality)
         {
             return GetAll()[quality];
+        }
+
+        public QualityDefinitionLimits GetLimits()
+        {
+            return new QualityDefinitionLimits();
         }
 
         private void InsertMissingDefinitions()

--- a/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
+++ b/src/NzbDrone.Core/Qualities/QualityDefinitionService.cs
@@ -17,7 +17,6 @@ namespace NzbDrone.Core.Qualities
         List<QualityDefinition> All();
         QualityDefinition GetById(int id);
         QualityDefinition Get(Quality quality);
-        QualityDefinitionLimits GetLimits();
     }
 
     public class QualityDefinitionService : IQualityDefinitionService, IExecute<ResetQualityDefinitionsCommand>, IHandle<ApplicationStartedEvent>
@@ -63,11 +62,6 @@ namespace NzbDrone.Core.Qualities
         public QualityDefinition Get(Quality quality)
         {
             return GetAll()[quality];
-        }
-
-        public QualityDefinitionLimits GetLimits()
-        {
-            return new QualityDefinitionLimits();
         }
 
         private void InsertMissingDefinitions()

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -55,6 +55,12 @@ namespace Sonarr.Api.V3.Qualities
                 .ToResource());
         }
 
+        [HttpGet("limits")]
+        public ActionResult<QualityDefinitionLimits> GetLimits()
+        {
+            return Ok(_qualityDefinitionService.GetLimits());
+        }
+
         [NonAction]
         public void Handle(CommandExecutedEvent message)
         {

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -25,18 +25,12 @@ namespace Sonarr.Api.V3.Qualities
         {
             _qualityDefinitionService = qualityDefinitionService;
 
-            SetupValidation();
-        }
-
-        private void SetupValidation()
-        {
             SharedValidator.RuleFor(c => c)
                 .SetValidator(new QualityDefinitionResourceValidator());
         }
 
         [RestPutById]
-        public ActionResult<QualityDefinitionResource> Update(
-            [FromBody] QualityDefinitionResource resource)
+        public ActionResult<QualityDefinitionResource> Update([FromBody] QualityDefinitionResource resource)
         {
             var model = resource.ToModel();
             _qualityDefinitionService.Update(model);
@@ -70,8 +64,8 @@ namespace Sonarr.Api.V3.Qualities
         public ActionResult<QualityDefinitionLimitsResource> GetLimits()
         {
             return Ok(new QualityDefinitionLimitsResource(
-                QualityDefinitionLimits.MinLimit,
-                QualityDefinitionLimits.MaxLimit));
+                QualityDefinitionLimits.Min,
+                QualityDefinitionLimits.Max));
         }
 
         [NonAction]

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -20,6 +20,15 @@ namespace Sonarr.Api.V3.Qualities
             : base(signalRBroadcaster)
         {
             _qualityDefinitionService = qualityDefinitionService;
+
+            SetupValidation(qualityDefinitionService);
+        }
+
+        private void SetupValidation(IQualityDefinitionService qualityDefinitionService)
+        {
+            var limits = qualityDefinitionService.GetLimits();
+            SharedValidator.RuleFor(c => c)
+                .SetValidator(new QualityDefinitionResourceValidator(limits));
         }
 
         [RestPutById]

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionController.cs
@@ -12,27 +12,31 @@ using Sonarr.Http.REST.Attributes;
 namespace Sonarr.Api.V3.Qualities
 {
     [V3ApiController]
-    public class QualityDefinitionController : RestControllerWithSignalR<QualityDefinitionResource, QualityDefinition>, IHandle<CommandExecutedEvent>
+    public class QualityDefinitionController :
+        RestControllerWithSignalR<QualityDefinitionResource, QualityDefinition>,
+        IHandle<CommandExecutedEvent>
     {
         private readonly IQualityDefinitionService _qualityDefinitionService;
 
-        public QualityDefinitionController(IQualityDefinitionService qualityDefinitionService, IBroadcastSignalRMessage signalRBroadcaster)
+        public QualityDefinitionController(
+            IQualityDefinitionService qualityDefinitionService,
+            IBroadcastSignalRMessage signalRBroadcaster)
             : base(signalRBroadcaster)
         {
             _qualityDefinitionService = qualityDefinitionService;
 
-            SetupValidation(qualityDefinitionService);
+            SetupValidation();
         }
 
-        private void SetupValidation(IQualityDefinitionService qualityDefinitionService)
+        private void SetupValidation()
         {
-            var limits = qualityDefinitionService.GetLimits();
             SharedValidator.RuleFor(c => c)
-                .SetValidator(new QualityDefinitionResourceValidator(limits));
+                .SetValidator(new QualityDefinitionResourceValidator());
         }
 
         [RestPutById]
-        public ActionResult<QualityDefinitionResource> Update([FromBody] QualityDefinitionResource resource)
+        public ActionResult<QualityDefinitionResource> Update(
+            [FromBody] QualityDefinitionResource resource)
         {
             var model = resource.ToModel();
             _qualityDefinitionService.Update(model);
@@ -54,9 +58,7 @@ namespace Sonarr.Api.V3.Qualities
         public object UpdateMany([FromBody] List<QualityDefinitionResource> resource)
         {
             // Read from request
-            var qualityDefinitions = resource
-                                                 .ToModel()
-                                                 .ToList();
+            var qualityDefinitions = resource.ToModel().ToList();
 
             _qualityDefinitionService.UpdateMany(qualityDefinitions);
 
@@ -65,9 +67,11 @@ namespace Sonarr.Api.V3.Qualities
         }
 
         [HttpGet("limits")]
-        public ActionResult<QualityDefinitionLimits> GetLimits()
+        public ActionResult<QualityDefinitionLimitsResource> GetLimits()
         {
-            return Ok(_qualityDefinitionService.GetLimits());
+            return Ok(new QualityDefinitionLimitsResource(
+                QualityDefinitionLimits.MinLimit,
+                QualityDefinitionLimits.MaxLimit));
         }
 
         [NonAction]

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionLimitsResource.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionLimitsResource.cs
@@ -1,9 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
 namespace Sonarr.Api.V3.Qualities;
 
-[SuppressMessage("StyleCop.CSharp.NamingRules",
-    "SA1313:Parameter names should begin with lower-case letter",
-    Justification =
-        "False positive for record types since params should follow property naming rules")]
-public record QualityDefinitionLimitsResource(int MinLimit, int MaxLimit);
+// SA1313 still applies to records until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3181 is available in a release build.
+#pragma warning disable SA1313
+public record QualityDefinitionLimitsResource(int Min, int Max);
+#pragma warning restore SA1313

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionLimitsResource.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionLimitsResource.cs
@@ -1,0 +1,9 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Sonarr.Api.V3.Qualities;
+
+[SuppressMessage("StyleCop.CSharp.NamingRules",
+    "SA1313:Parameter names should begin with lower-case letter",
+    Justification =
+        "False positive for record types since params should follow property naming rules")]
+public record QualityDefinitionLimitsResource(int MinLimit, int MaxLimit);

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
@@ -7,22 +7,25 @@ public class QualityDefinitionResourceValidator : AbstractValidator<QualityDefin
 {
     public QualityDefinitionResourceValidator()
     {
-        When(c => c.MinSize is not null, () =>
-        {
-            RuleFor(c => c.MinSize)
-                .GreaterThanOrEqualTo(QualityDefinitionLimits.MinLimit)
-                .WithErrorCode("GreaterThanOrEqualTo")
-                .LessThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MaxLimit)
-                .WithErrorCode("LessThanOrEqualTo");
-        });
+        RuleFor(c => c.MinSize)
+            .GreaterThanOrEqualTo(QualityDefinitionLimits.MinLimit)
+            .WithErrorCode("GreaterThanOrEqualTo")
+            .LessThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MaxLimit)
+            .WithErrorCode("LessThanOrEqualTo")
+            .When(c => c.MinSize is not null);
 
-        When(c => c.MaxSize is not null, () =>
-        {
-            RuleFor(c => c.MaxSize)
-                .GreaterThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MinLimit)
-                .WithErrorCode("GreaterThanOrEqualTo")
-                .LessThanOrEqualTo(QualityDefinitionLimits.MaxLimit)
-                .WithErrorCode("LessThanOrEqualTo");
-        });
+        RuleFor(c => c.PreferredSize)
+            .GreaterThanOrEqualTo(c => c.MinSize ?? QualityDefinitionLimits.MinLimit)
+            .WithErrorCode("GreaterThanOrEqualTo")
+            .LessThanOrEqualTo(c => c.MaxSize ?? QualityDefinitionLimits.MaxLimit)
+            .WithErrorCode("LessThanOrEqualTo")
+            .When(c => c.PreferredSize is not null);
+
+        RuleFor(c => c.MaxSize)
+            .GreaterThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MinLimit)
+            .WithErrorCode("GreaterThanOrEqualTo")
+            .LessThanOrEqualTo(QualityDefinitionLimits.MaxLimit)
+            .WithErrorCode("LessThanOrEqualTo")
+            .When(c => c.MaxSize is not null);
     }
 }

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
@@ -1,0 +1,28 @@
+﻿using FluentValidation;
+using NzbDrone.Core.Qualities;
+
+namespace Sonarr.Api.V3.Qualities;
+
+public class QualityDefinitionResourceValidator : AbstractValidator<QualityDefinitionResource>
+{
+    public QualityDefinitionResourceValidator(QualityDefinitionLimits limits)
+    {
+        When(c => c.MinSize is not null, () =>
+        {
+            RuleFor(c => c.MinSize)
+                .GreaterThanOrEqualTo(limits.MinLimit)
+                .WithErrorCode("GreaterThanOrEqualTo")
+                .LessThanOrEqualTo(c => c.PreferredSize ?? limits.MaxLimit)
+                .WithErrorCode("LessThanOrEqualTo");
+        });
+
+        When(c => c.MaxSize is not null, () =>
+        {
+            RuleFor(c => c.MaxSize)
+                .GreaterThanOrEqualTo(c => c.PreferredSize ?? limits.MinLimit)
+                .WithErrorCode("GreaterThanOrEqualTo")
+                .LessThanOrEqualTo(limits.MaxLimit)
+                .WithErrorCode("LessThanOrEqualTo");
+        });
+    }
+}

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
@@ -8,23 +8,23 @@ public class QualityDefinitionResourceValidator : AbstractValidator<QualityDefin
     public QualityDefinitionResourceValidator()
     {
         RuleFor(c => c.MinSize)
-            .GreaterThanOrEqualTo(QualityDefinitionLimits.MinLimit)
+            .GreaterThanOrEqualTo(QualityDefinitionLimits.Min)
             .WithErrorCode("GreaterThanOrEqualTo")
-            .LessThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MaxLimit)
+            .LessThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.Max)
             .WithErrorCode("LessThanOrEqualTo")
             .When(c => c.MinSize is not null);
 
         RuleFor(c => c.PreferredSize)
-            .GreaterThanOrEqualTo(c => c.MinSize ?? QualityDefinitionLimits.MinLimit)
+            .GreaterThanOrEqualTo(c => c.MinSize ?? QualityDefinitionLimits.Min)
             .WithErrorCode("GreaterThanOrEqualTo")
-            .LessThanOrEqualTo(c => c.MaxSize ?? QualityDefinitionLimits.MaxLimit)
+            .LessThanOrEqualTo(c => c.MaxSize ?? QualityDefinitionLimits.Max)
             .WithErrorCode("LessThanOrEqualTo")
             .When(c => c.PreferredSize is not null);
 
         RuleFor(c => c.MaxSize)
-            .GreaterThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MinLimit)
+            .GreaterThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.Min)
             .WithErrorCode("GreaterThanOrEqualTo")
-            .LessThanOrEqualTo(QualityDefinitionLimits.MaxLimit)
+            .LessThanOrEqualTo(QualityDefinitionLimits.Max)
             .WithErrorCode("LessThanOrEqualTo")
             .When(c => c.MaxSize is not null);
     }

--- a/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
+++ b/src/Sonarr.Api.V3/Qualities/QualityDefinitionResourceValidator.cs
@@ -5,23 +5,23 @@ namespace Sonarr.Api.V3.Qualities;
 
 public class QualityDefinitionResourceValidator : AbstractValidator<QualityDefinitionResource>
 {
-    public QualityDefinitionResourceValidator(QualityDefinitionLimits limits)
+    public QualityDefinitionResourceValidator()
     {
         When(c => c.MinSize is not null, () =>
         {
             RuleFor(c => c.MinSize)
-                .GreaterThanOrEqualTo(limits.MinLimit)
+                .GreaterThanOrEqualTo(QualityDefinitionLimits.MinLimit)
                 .WithErrorCode("GreaterThanOrEqualTo")
-                .LessThanOrEqualTo(c => c.PreferredSize ?? limits.MaxLimit)
+                .LessThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MaxLimit)
                 .WithErrorCode("LessThanOrEqualTo");
         });
 
         When(c => c.MaxSize is not null, () =>
         {
             RuleFor(c => c.MaxSize)
-                .GreaterThanOrEqualTo(c => c.PreferredSize ?? limits.MinLimit)
+                .GreaterThanOrEqualTo(c => c.PreferredSize ?? QualityDefinitionLimits.MinLimit)
                 .WithErrorCode("GreaterThanOrEqualTo")
-                .LessThanOrEqualTo(limits.MaxLimit)
+                .LessThanOrEqualTo(QualityDefinitionLimits.MaxLimit)
                 .WithErrorCode("LessThanOrEqualTo");
         });
     }

--- a/src/Sonarr.Http/REST/RestController.cs
+++ b/src/Sonarr.Http/REST/RestController.cs
@@ -70,11 +70,15 @@ namespace Sonarr.Http.REST
             var skipValidate = skipAttribute?.Skip ?? false;
             var skipShared = skipAttribute?.SkipShared ?? false;
 
-            if (Request.Method == "POST" || Request.Method == "PUT")
+            if (Request.Method is "POST" or "PUT")
             {
-                var resourceArgs = context.ActionArguments.Values.Where(x => x.GetType() == typeof(TResource))
-                    .Select(x => x as TResource)
-                    .ToList();
+                var resourceArgs = context.ActionArguments.Values
+                    .SelectMany(x => x switch
+                    {
+                        TResource single => new[] { single },
+                        IEnumerable<TResource> multiple => multiple,
+                        _ => Enumerable.Empty<TResource>()
+                    });
 
                 foreach (var resource in resourceArgs)
                 {


### PR DESCRIPTION
This update moves the minimum, maximum, and preferred quality limits to
the backend, accessible via the new `/qualitydefinition/limits`
endpoint. This change improves support for unofficial Sonarr API clients
and enables a more flexible frontend.
  
The Quality Definitions settings page has been significantly refactored
to allow for asynchronous and dynamic loading of these limits.

Additional changes:

* Add .idea directory to gitignore

  For users of the Jetbrains IDEs, the `.idea` directory isn't strictly
  necessary for version control. It's better to ignore it than tie a repo
  to specific tooling.

* Add --output-pathinfo to start & watch scripts

  The motivation for this change is to get React debugging working.
