### PR TITLE
Fixed: PWA Manifest images

### DIFF
--- a/frontend/src/Content/manifest.json
+++ b/frontend/src/Content/manifest.json
@@ -2,12 +2,12 @@
   "name": "Sonarr",
   "icons": [
     {
-      "src": "android-chrome-192x192.png",
+      "src": "__URL_BASE__/Content/Images/Icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "android-chrome-512x512.png",
+      "src": "__URL_BASE__/Content/Images/Icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
#### Description

Fix the URLs for images now that `manifest.json` doesn't live along side them.

#### Issues Fixed or Closed by this PR
* Closes #7125

