### PR TITLE
Fixed: Paths for renamed episode files in Custom Script and Webhook

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -253,7 +253,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
             environmentVariables.Add("Sonarr_Series_Tags", string.Join("|", GetTagLabels(series)));
             environmentVariables.Add("Sonarr_EpisodeFile_Ids", string.Join(",", renamedFiles.Select(e => e.EpisodeFile.Id)));
             environmentVariables.Add("Sonarr_EpisodeFile_RelativePaths", string.Join("|", renamedFiles.Select(e => e.EpisodeFile.RelativePath)));
-            environmentVariables.Add("Sonarr_EpisodeFile_Paths", string.Join("|", renamedFiles.Select(e => e.EpisodeFile.Path)));
+            environmentVariables.Add("Sonarr_EpisodeFile_Paths", string.Join("|", renamedFiles.Select(e => Path.Combine(series.Path, e.EpisodeFile.RelativePath))));
             environmentVariables.Add("Sonarr_EpisodeFile_PreviousRelativePaths", string.Join("|", renamedFiles.Select(e => e.PreviousRelativePath)));
             environmentVariables.Add("Sonarr_EpisodeFile_PreviousPaths", string.Join("|", renamedFiles.Select(e => e.PreviousPath)));
 

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookEpisodeFile.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookEpisodeFile.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Notifications.Webhook
         {
             Id = episodeFile.Id;
             RelativePath = episodeFile.RelativePath;
-            Path = episodeFile.Path;
+            Path = System.IO.Path.Combine(episodeFile.Series.Value.Path, episodeFile.RelativePath);
             Quality = episodeFile.Quality.Quality.Name;
             QualityVersion = episodeFile.Quality.Revision.Version;
             ReleaseGroup = episodeFile.ReleaseGroup;


### PR DESCRIPTION
#### Description
Path seems to be empty and ignored in TableMapping.

- Fixes #7135