### PR TITLE
Don't persist value for SslCertHash when checking for existence

### DIFF
--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -381,7 +381,7 @@ namespace NzbDrone.Core.Configuration
             }
 
             // If SSL is enabled and a cert hash is still in the config file or cert path is empty disable SSL
-            if (EnableSsl && (GetValue("SslCertHash", null).IsNotNullOrWhiteSpace() || SslCertPath.IsNullOrWhiteSpace()))
+            if (EnableSsl && (GetValue("SslCertHash", string.Empty, false).IsNotNullOrWhiteSpace() || SslCertPath.IsNullOrWhiteSpace()))
             {
                 SetValue("EnableSsl", false);
             }


### PR DESCRIPTION
#### Description
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.Configuration.ConfigFileProvider.SetValue(String key, Object value) in ./Prowlarr.Core/Configuration/ConfigFileProvider.cs:line 335
   at NzbDrone.Core.Configuration.ConfigFileProvider.<>c__DisplayClass89_0.<GetValue>b__0() in ./Prowlarr.Core/Configuration/ConfigFileProvider.cs:line 325
   at NzbDrone.Common.Cache.Cached`1.Get(String key, Func`1 function, Nullable`1 lifeTime) in ./Prowlarr.Common/Cache/Cached.cs:line 98
   at NzbDrone.Core.Configuration.ConfigFileProvider.GetValue(String key, Object defaultValue, Boolean persist) in ./Prowlarr.Core/Configuration/ConfigFileProvider.cs:line 308
   at NzbDrone.Core.Configuration.ConfigFileProvider.MigrateConfigFile() in ./Prowlarr.Core/Configuration/ConfigFileProvider.cs:line 378
```

