### PR TITLE
Fixed: Generating absolute episode file paths in webhooks

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -92,6 +92,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     episodeFile.Size = _diskProvider.GetFileSize(localEpisode.Path);
                     episodeFile.Quality = localEpisode.Quality;
                     episodeFile.MediaInfo = localEpisode.MediaInfo;
+                    episodeFile.Series = localEpisode.Series;
                     episodeFile.SeasonNumber = localEpisode.SeasonNumber;
                     episodeFile.Episodes = localEpisode.Episodes;
                     episodeFile.ReleaseGroup = localEpisode.ReleaseGroup;


### PR DESCRIPTION
#### Description
Since adding a9b93dd9c686a11ee16e717ca4e8698629a44ef7 we're using the Series on the EpisodeFile but lazyloading doesn't seem to work with models just created but not fetched yet from the db. Worked fine with renamed files since they're fetched, but not with new imports.

CustomScript was not affected because it's using the series from the DownloadMessage.


#### Issues Fixed or Closed by this PR
* Fixes #7149

