### PR TITLE
Fixed: Importing files without media info available

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
@@ -60,6 +60,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         {
             var episodeFiles = Builder<EpisodeFile>.CreateListOfSize(3)
                 .All()
+                .With(v => v.Path = null)
                 .With(v => v.RelativePath = "media.mkv")
                 .TheFirst(1)
                 .With(v => v.MediaInfo = new MediaInfoModel { SchemaRevision = VideoFileInfoReader.CURRENT_MEDIA_INFO_SCHEMA_REVISION })
@@ -86,6 +87,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         {
             var episodeFiles = Builder<EpisodeFile>.CreateListOfSize(3)
                 .All()
+                .With(v => v.Path = null)
                 .With(v => v.RelativePath = "media.mkv")
                 .TheFirst(1)
                 .With(v => v.MediaInfo = new MediaInfoModel { SchemaRevision = VideoFileInfoReader.MINIMUM_MEDIA_INFO_SCHEMA_REVISION })
@@ -112,6 +114,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         {
             var episodeFiles = Builder<EpisodeFile>.CreateListOfSize(3)
                 .All()
+                .With(v => v.Path = null)
                 .With(v => v.RelativePath = "media.mkv")
                 .TheFirst(1)
                 .With(v => v.MediaInfo = new MediaInfoModel())
@@ -161,6 +164,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         {
             var episodeFiles = Builder<EpisodeFile>.CreateListOfSize(2)
                    .All()
+                   .With(v => v.Path = null)
                    .With(v => v.RelativePath = "media.mkv")
                    .TheFirst(1)
                    .With(v => v.RelativePath = "media2.mkv")
@@ -240,6 +244,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
         public void should_update_media_info()
         {
             var episodeFile = Builder<EpisodeFile>.CreateNew()
+                .With(v => v.Path = null)
                 .With(v => v.RelativePath = "media.mkv")
                 .With(e => e.MediaInfo = new MediaInfoModel { SchemaRevision = 3 })
                 .Build();
@@ -284,6 +289,27 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
             GivenFailedScan(Path.Combine(_series.Path, "media.mkv"));
 
             Subject.Update(episodeFile, _series);
+
+            Mocker.GetMock<IMediaFileService>()
+                .Verify(v => v.Update(episodeFile), Times.Never());
+        }
+
+        [Test]
+        public void should_not_update_media_info_if_file_does_not_support_media_info()
+        {
+            var path = Path.Combine(_series.Path, "media.iso");
+
+            var episodeFile = Builder<EpisodeFile>.CreateNew()
+                .With(v => v.Path = path)
+                .Build();
+
+            GivenFileExists();
+            GivenFailedScan(path);
+
+            Subject.Update(episodeFile, _series);
+
+            Mocker.GetMock<IVideoFileInfoReader>()
+                .Verify(v => v.GetMediaInfo(path), Times.Once());
 
             Mocker.GetMock<IMediaFileService>()
                 .Verify(v => v.Update(episodeFile), Times.Never());

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -68,7 +69,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         public bool UpdateMediaInfo(EpisodeFile episodeFile, Series series)
         {
-            var path = Path.Combine(series.Path, episodeFile.RelativePath);
+            var path = episodeFile.Path.IsNotNullOrWhiteSpace() ? episodeFile.Path : Path.Combine(series.Path, episodeFile.RelativePath);
 
             if (!_diskProvider.FileExists(path))
             {


### PR DESCRIPTION
#### Description
Sonarr seems to allow manual importing of ISO files just fine with renaming disabled, but with renaming enabled it fails to because `shouldUpdateMediaInfo` is true due to missing media info. Leading to this place where at this moment the `Path` is the source path of a not yet import file.

Reference https://github.com/Radarr/Radarr/issues/7828

