### PR TITLE
New: Except language option for Language Custom Formats

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
@@ -43,6 +43,26 @@ namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
         }
 
         [Test]
+        public void should_match_language_if_other_languages_are_present()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.ExceptLanguage = true;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_match_language_if_not_original_language_is_present()
+        {
+            Subject.Value = Language.Original.Id;
+            Subject.ExceptLanguage = true;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
         public void should_not_match_different_language()
         {
             Subject.Value = Language.Spanish.Id;
@@ -67,6 +87,16 @@ namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
             Subject.Negate = true;
 
             Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_negate_language_if_other_languages_are_present()
+        {
+            Subject.Value = Language.Spanish.Id;
+            Subject.ExceptLanguage = true;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
         }
 
         [Test]
-        public void should_match_negated_except_language_if_language_is_missing()
+        public void should_match_negated_except_language_if_language_is_only_present_language()
         {
             Subject.Value = Language.French.Id;
             Subject.ExceptLanguage = true;

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
@@ -67,5 +67,15 @@ namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
 
             Subject.IsSatisfiedBy(_input).Should().BeTrue();
         }
+
+        [Test]
+        public void should_match_negated_except_language_if_language_is_missing()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.ExceptLanguage = true;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -30,6 +30,9 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "CustomFormatsSpecificationLanguage", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
         public int Value { get; set; }
 
+        [FieldDefinition(1, Label = "CustomFormatsSpecificationExceptLanguage", HelpText = "CustomFormatsSpecificationExceptLanguageHelpText", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
+        public bool ExceptLanguage { get; set; }
+
         public override bool IsSatisfiedBy(CustomFormatInput input)
         {
             if (Negate)
@@ -46,6 +49,11 @@ namespace NzbDrone.Core.CustomFormats
                 ? input.Series.OriginalLanguage
                 : (Language)Value;
 
+            if (ExceptLanguage)
+            {
+                return input.Languages?.Any(l => l != comparedLanguage) ?? false;
+            }
+
             return input.Languages?.Contains(comparedLanguage) ?? false;
         }
 
@@ -54,6 +62,11 @@ namespace NzbDrone.Core.CustomFormats
             var comparedLanguage = input.EpisodeInfo != null && input.Series != null && Value == Language.Original.Id && input.Series.OriginalLanguage != Language.Unknown
                 ? input.Series.OriginalLanguage
                 : (Language)Value;
+
+            if (ExceptLanguage)
+            {
+                return !input.Languages?.Any(l => l != comparedLanguage) ?? false;
+            }
 
             return !input.Languages?.Contains(comparedLanguage) ?? false;
         }

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "CustomFormatsSpecificationLanguage", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
         public int Value { get; set; }
 
-        [FieldDefinition(1, Label = "CustomFormatsSpecificationExceptLanguage", HelpText = "CustomFormatsSpecificationExceptLanguageHelpText", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
+        [FieldDefinition(1, Label = "CustomFormatsSpecificationExceptLanguage", HelpText = "CustomFormatsSpecificationExceptLanguageHelpText", Type = FieldType.Checkbox)]
         public bool ExceptLanguage { get; set; }
 
         public override bool IsSatisfiedBy(CustomFormatInput input)

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -290,6 +290,8 @@
   "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied to a release or file when it matches at least one of each of the different condition types chosen.",
   "CustomFormatsSpecificationFlag": "Flag",
   "CustomFormatsSpecificationLanguage": "Language",
+  "CustomFormatsSpecificationExceptLanguage": "Except Language",
+  "CustomFormatsSpecificationExceptLanguageHelpText": "Matches if any language other than the selected language is present",
   "CustomFormatsSpecificationMaximumSize": "Maximum Size",
   "CustomFormatsSpecificationMaximumSizeHelpText": "Release must be less than or equal to this size",
   "CustomFormatsSpecificationMinimumSize": "Minimum Size",


### PR DESCRIPTION
#### Description

Adds an Except Language option for Language CF that allows matching on languages other than the selected language. This will allow Except Original Language to match if a language other than the original language is present and negating that will allow matching if none of the other languages are present.

#### Issues Fixed or Closed by this PR
* Closes #7120

