### PR TITLE
Fixed: Failing to import any file for series if one has bad encoding

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -119,17 +119,17 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
         {
             ImportDecision decision = null;
 
-            var fileEpisodeInfo = Parser.Parser.ParsePath(localEpisode.Path);
-
-            localEpisode.FileEpisodeInfo = fileEpisodeInfo;
-            localEpisode.Size = _diskProvider.GetFileSize(localEpisode.Path);
-            localEpisode.ReleaseType = localEpisode.DownloadClientEpisodeInfo?.ReleaseType ??
-                                       localEpisode.FolderEpisodeInfo?.ReleaseType ??
-                                       localEpisode.FileEpisodeInfo?.ReleaseType ??
-                                       ReleaseType.Unknown;
-
             try
             {
+                var fileEpisodeInfo = Parser.Parser.ParsePath(localEpisode.Path);
+
+                localEpisode.FileEpisodeInfo = fileEpisodeInfo;
+                localEpisode.Size = _diskProvider.GetFileSize(localEpisode.Path);
+                localEpisode.ReleaseType = localEpisode.DownloadClientEpisodeInfo?.ReleaseType ??
+                                           localEpisode.FolderEpisodeInfo?.ReleaseType ??
+                                           localEpisode.FileEpisodeInfo?.ReleaseType ??
+                                           ReleaseType.Unknown;
+
                 _aggregationService.Augment(localEpisode, downloadClientItem);
 
                 if (localEpisode.Episodes.Empty())


### PR DESCRIPTION
#### Description

Moves the try up to catch getting the file size if that fails for some reason, like bad unicode encoding.


#### Issues Fixed or Closed by this PR
* Closes #7157

