### PR TITLE
New: Include seasons and episodes in Trakt import lists

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
         {
             var link = Settings.BaseUrl.Trim();
 
-            link += $"/users/{Settings.Username.Trim()}/lists/{Settings.Listname.ToUrlSlug()}/items/shows?limit={Settings.Limit}";
+            link += $"/users/{Settings.Username.Trim()}/lists/{Settings.Listname.ToUrlSlug()}/items/show,season,episode?limit={Settings.Limit}";
 
             var request = new ImportListRequest(link, HttpAccept.Json);
 


### PR DESCRIPTION
#### Description

Includes season and episode entities in Trakt lists. The whole series will still be added regardless of which entity is included.


#### Issues Fixed or Closed by this PR
* Closes #7137

