### PR TITLE
Add rating as option in sort dropdown

### DIFF
--- a/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.tsx
+++ b/frontend/src/Series/Index/Menus/SeriesIndexSortMenu.tsx
@@ -153,6 +153,15 @@ function SeriesIndexSortMenu(props: SeriesIndexSortMenuProps) {
         >
           {translate('Tags')}
         </SortMenuItem>
+
+        <SortMenuItem
+          name="ratings"
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onPress={onSortSelect}
+        >
+          {translate('Rating')}
+        </SortMenuItem>
       </MenuContent>
     </SortMenu>
   );


### PR DESCRIPTION
Description

Now that ratings are populated again, adding this option to the sorting dropdown in Series Overview. Sorting of ratings was already possible via table header in table view, can now also be done in the other views.