### PR TITLE
Fixed: Interactive searches causing multiple requests to indexers

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearch.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearch.tsx
@@ -161,13 +161,12 @@ function InteractiveSearch({ type, searchPayload }: InteractiveSearchProps) {
   );
 
   useEffect(() => {
-    // If search results are not yet isPopulated fetch them,
-    // otherwise re-show the existing props.
+    // Only fetch releases if they are not already being fetched and not yet populated.
 
-    if (!isPopulated) {
+    if (!isFetching && !isPopulated) {
       dispatch(fetchReleases(searchPayload));
     }
-  }, [isPopulated, searchPayload, dispatch]);
+  }, [isFetching, isPopulated, searchPayload, dispatch]);
 
   const errorMessage = getErrorMessage(error);
 


### PR DESCRIPTION
#### Description

When the modal re-rendered while fetching results it'd try to refetch them again, resulting in multiple queries being sent to the backend and multiple requests sent to indexers. This compounded in the UI and would result in queries for different searches populating results because they weren't cancelled correctly.

