### PR TITLE
New: Fetch up to 1000 series from Plex Watchlist

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -14,10 +14,14 @@ namespace NzbDrone.Core.ImportLists.Plex
 {
     public class PlexImport : HttpImportListBase<PlexListSettings>
     {
-        public readonly IPlexTvService _plexTvService;
-
+        public override string Name => _localizationService.GetLocalizedString("ImportListsPlexSettingsWatchlistName");
         public override ImportListType ListType => ImportListType.Plex;
         public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(6);
+
+        public override int PageSize => 100;
+        public override TimeSpan RateLimit => TimeSpan.FromSeconds(5);
+
+        private readonly IPlexTvService _plexTvService;
 
         public PlexImport(IPlexTvService plexTvService,
                                   IHttpClient httpClient,
@@ -31,14 +35,9 @@ namespace NzbDrone.Core.ImportLists.Plex
             _plexTvService = plexTvService;
         }
 
-        public override string Name => _localizationService.GetLocalizedString("ImportListsPlexSettingsWatchlistName");
-        public override int PageSize => 50;
-
         public override ImportListFetchResult Fetch()
         {
             Settings.Validate().Filter("AccessToken").ThrowOnError();
-
-            // var generator = GetRequestGenerator();
 
             return FetchItems(g => g.GetListItems());
         }
@@ -50,10 +49,7 @@ namespace NzbDrone.Core.ImportLists.Plex
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new PlexListRequestGenerator(_plexTvService, PageSize)
-            {
-                Settings = Settings
-            };
+            return new PlexListRequestGenerator(_plexTvService, Settings, PageSize);
         }
 
         public override object RequestAction(string action, IDictionary<string, string> query)

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexListRequestGenerator.cs
@@ -5,13 +5,16 @@ namespace NzbDrone.Core.ImportLists.Plex
 {
     public class PlexListRequestGenerator : IImportListRequestGenerator
     {
-        private readonly IPlexTvService _plexTvService;
-        private readonly int _pageSize;
-        public PlexListSettings Settings { get; set; }
+        private const int MaxPages = 10;
 
-        public PlexListRequestGenerator(IPlexTvService plexTvService, int pageSize)
+        private readonly IPlexTvService _plexTvService;
+        private readonly PlexListSettings _settings;
+        private readonly int _pageSize;
+
+        public PlexListRequestGenerator(IPlexTvService plexTvService, PlexListSettings settings, int pageSize)
         {
             _plexTvService = plexTvService;
+            _settings = settings;
             _pageSize = pageSize;
         }
 
@@ -26,11 +29,9 @@ namespace NzbDrone.Core.ImportLists.Plex
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var maxPages = 10;
-
-            for (var page = 0; page < maxPages; page++)
+            for (var page = 0; page < MaxPages; page++)
             {
-                yield return new ImportListRequest(_plexTvService.GetWatchlist(Settings.AccessToken, _pageSize, page * _pageSize));
+                yield return new ImportListRequest(_plexTvService.GetWatchlist(_settings.AccessToken, _pageSize, page * _pageSize));
             }
         }
     }


### PR DESCRIPTION
#### Description
Increasing PageSize to 100 to allow 1000 items to be fetched, and raising the RateLimit from to 5s.

Minor CS cleanup while at it.

Ref https://github.com/Radarr/Radarr/issues/10447