### PR TITLE
Fixed: Unable to login when instance name contained brackets

### DIFF
--- a/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Sonarr.Http.Authentication
 {
     public static class AuthenticationBuilderExtensions
     {
-        private static readonly Regex CookieNameRegex = new Regex(@"[^a-z0-9]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex CookieNameRegex = new Regex(@"[^a-z0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static AuthenticationBuilder AddApiKey(this AuthenticationBuilder authenticationBuilder, string name, Action<ApiKeyAuthenticationOptions> options)
         {


### PR DESCRIPTION
#### Description

Just strip out anything that may cause issues with setting the cookie name.

#### Issues Fixed or Closed by this PR
* Closes #7229

