### PR TITLE
Fixed: Don't set last write time on episode files if difference is within the same second

### DIFF
--- a/src/NzbDrone.Common/Extensions/DateTimeExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/DateTimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace NzbDrone.Common.Extensions
 {
@@ -37,6 +37,11 @@ namespace NzbDrone.Common.Extensions
         public static bool Between(this DateTime dateTime, DateTime afterDateTime, DateTime beforeDateTime)
         {
             return dateTime >= afterDateTime && dateTime <= beforeDateTime;
+        }
+
+        public static DateTime WithoutTicks(this DateTime dateTime)
+        {
+            return dateTime.AddTicks(-(dateTime.Ticks % TimeSpan.TicksPerSecond));
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.MediaFiles
             if (DateTime.TryParse(fileDate + ' ' + fileTime, out var airDate))
             {
                 // avoiding false +ve checks and set date skewing by not using UTC (Windows)
-                var oldDateTime = _diskProvider.FileGetLastWrite(filePath);
+                var oldLastWrite = _diskProvider.FileGetLastWrite(filePath);
 
                 if (OsInfo.IsNotWindows && airDate < EpochTime)
                 {
@@ -92,12 +92,12 @@ namespace NzbDrone.Core.MediaFiles
                     airDate = EpochTime;
                 }
 
-                if (!DateTime.Equals(airDate, oldDateTime))
+                if (!DateTime.Equals(airDate.WithoutTicks(), oldLastWrite.WithoutTicks()))
                 {
                     try
                     {
                         _diskProvider.FileSetLastWriteTime(filePath, airDate);
-                        _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldDateTime, airDate);
+                        _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, airDate);
 
                         return true;
                     }
@@ -125,11 +125,11 @@ namespace NzbDrone.Core.MediaFiles
                 airDateUtc = EpochTime;
             }
 
-            if (!DateTime.Equals(airDateUtc, oldLastWrite))
+            if (!DateTime.Equals(airDateUtc.WithoutTicks(), oldLastWrite.WithoutTicks()))
             {
                 try
                 {
-                    _diskProvider.FileSetLastWriteTime(filePath, airDateUtc);
+                    _diskProvider.FileSetLastWriteTime(filePath, airDateUtc.AddMilliseconds(oldLastWrite.Millisecond));
                     _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, airDateUtc);
 
                     return true;


### PR DESCRIPTION
#### Description
Allows SnapRAID's sub-millisecond comparison to not be overwritten when series is refreshed and Sonarr sees the timestamp has changed.


#### Issues Fixed or Closed by this PR
* Closes #7228

