### PR TITLE
fix: annotate passing apikey as query parameter consistently in description

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -135,7 +135,7 @@ namespace NzbDrone.Host
                     Name = "apikey",
                     Type = SecuritySchemeType.ApiKey,
                     Scheme = "apiKey",
-                    Description = "Apikey passed as header",
+                    Description = "Apikey passed as query parameter",
                     In = ParameterLocation.Query,
                     Reference = new OpenApiReference
                     {


### PR DESCRIPTION
I've stumbled upon [this line](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Host/Startup.cs#L138) the description of api key query parameter while looking at Available authorizations in [https://sonarr.tv/docs/api](https://sonarr.tv/docs/api).


**X-Api-Key (apiKey)**
_Apikey passed as header_

Name: `X-Api-Key`
In: `header`


**apikey (apiKey)**
_Apikey passed as header_

Name: `apikey`
In: `query`


I think it should be `Apikey passed as query parameter`, right?

hope this helps, please let me know if I am missing something obvious here.
