### PR TITLE
Fixed: Loading series images after placeholder in Safari

### DIFF
--- a/frontend/src/Series/SeriesImage.tsx
+++ b/frontend/src/Series/SeriesImage.tsx
@@ -43,7 +43,7 @@ function SeriesImage({
 }: SeriesImageProps) {
   const [url, setUrl] = useState<string | null>(null);
   const [hasError, setHasError] = useState(false);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(true);
   const image = useRef<Image | null>(null);
 
   const handleLoad = useCallback(() => {


### PR DESCRIPTION
#### Description

Safari doesn't execute `onLoad` callbacks if the same image has already been loaded, which also affected scrolling down the series list, which is the case for the placeholder base64 image and results in the series image never loading. This changes the default for `isLoaded` to true so the image will attempt to be loaded.

#### Issues Fixed or Closed by this PR
* Closes Radarr/Radarr#10474

