### PR TITLE
Use `OperatingSystem` class to get OS information

### DIFF
--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -32,7 +32,8 @@ namespace NzbDrone.Common.EnvironmentInfo
             {
                 Os = Os.Osx;
             }
-            else if (OperatingSystem.IsFreeBSD())
+            // the OperatingSystem class does not have an IsNetBSD method
+            else if (OperatingSystem.IsFreeBSD() || OperatingSystem.IsOSPlatform("NETBSD"))
             {
                 Os = Os.Bsd;
             }

--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Common.EnvironmentInfo
             {
                 Os = Os.Osx;
             }
-            // the OperatingSystem class does not have an IsNetBSD method
+            // The OperatingSystem class does not have an IsNetBSD method
             else if (OperatingSystem.IsFreeBSD() || OperatingSystem.IsOSPlatform("NETBSD"))
             {
                 Os = Os.Bsd;

--- a/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/OsInfo.cs
@@ -32,8 +32,7 @@ namespace NzbDrone.Common.EnvironmentInfo
             {
                 Os = Os.Osx;
             }
-            // The OperatingSystem class does not have an IsNetBSD method
-            else if (OperatingSystem.IsFreeBSD() || OperatingSystem.IsOSPlatform("NETBSD"))
+            else if (OperatingSystem.IsFreeBSD())
             {
                 Os = Os.Bsd;
             }


### PR DESCRIPTION
#### Description

The goal of  this PR is to simplify the logic in `OsInfo` by relying on the [OperatingSystem](https://learn.microsoft.com/en-us/dotnet/api/system.operatingsystem?view=net-8.0) class to detect the running OS instead of running `uname` and parsing its output.