### PR TITLE
[DiskTransferService] WaitForIO after Copy/Move file

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -507,7 +507,7 @@ namespace NzbDrone.Common.Disk
             var targetSize = _diskProvider.GetFileSize(targetPath);
             if (targetSize != originalSize)
             {
-                _logger.Info("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
+                _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
                 WaitForIO();
             }
             targetSize = _diskProvider.GetFileSize(targetPath);

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -511,7 +511,7 @@ namespace NzbDrone.Common.Disk
                 return;
             }
 
-            _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
+            _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize);
             WaitForIO();
             targetSize = _diskProvider.GetFileSize(targetPath);
 

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -475,6 +475,8 @@ namespace NzbDrone.Common.Disk
             {
                 _diskProvider.CopyFile(sourcePath, targetPath);
 
+                WaitForIO();
+
                 var targetSize = _diskProvider.GetFileSize(targetPath);
                 if (targetSize != originalSize)
                 {
@@ -493,6 +495,8 @@ namespace NzbDrone.Common.Disk
             try
             {
                 _diskProvider.MoveFile(sourcePath, targetPath);
+
+                WaitForIO();
 
                 var targetSize = _diskProvider.GetFileSize(targetPath);
                 if (targetSize != originalSize)

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -489,7 +489,6 @@ namespace NzbDrone.Common.Disk
             {
                 _diskProvider.MoveFile(sourcePath, targetPath);
                 VerifyFile(sourcePath, targetPath, originalSize, "move");
-
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -505,16 +505,22 @@ namespace NzbDrone.Common.Disk
         private void VerifyFile(string sourcePath, string targetPath, long originalSize, string action)
         {
             var targetSize = _diskProvider.GetFileSize(targetPath);
-            if (targetSize != originalSize)
+
+            if (targetSize == originalSize)
             {
-                _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
-                WaitForIO();
+                return;
             }
+
+            _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
+            WaitForIO();
             targetSize = _diskProvider.GetFileSize(targetPath);
-            if (targetSize != originalSize)
+
+            if (targetSize == originalSize)
             {
-                throw new IOException(string.Format("File {0} incomplete, data loss may have occurred. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
+                return;
             }
+
+            throw new IOException(string.Format("File {0} incomplete, data loss may have occurred. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize));
         }
 
         private bool ShouldIgnore(DirectoryInfo folder)


### PR DESCRIPTION
#### Description

I'm encountering an issue where the file size right after a copy is reported as smaller than the original file size. I believe this is because the remote copy destination is over NFS which takes a moment to sync the most recent writes. This change adds `WaitForIO();` after the copy and move actions before the file size check to give time for the writes to sync. `WaitForIO()` will simply sleep for 3 seconds as is done in `RollbackMove` and `RollbackPartialMove` already:  https://github.com/Sonarr/Sonarr/blob/e196c1be69593b26c49e9844efd56d4322e3b334/src/NzbDrone.Common/Disk/DiskTransferService.cs#L466-L470 
