### PR TITLE
Fixed: Copy to clipboard in non-secure contexts

### DIFF
--- a/frontend/src/Components/Link/ClipboardButton.tsx
+++ b/frontend/src/Components/Link/ClipboardButton.tsx
@@ -1,3 +1,4 @@
+import copy from 'copy-to-clipboard';
 import React, { useCallback, useEffect, useState } from 'react';
 import FormInputButton from 'Components/Form/FormInputButton';
 import Icon from 'Components/Icon';
@@ -37,10 +38,16 @@ export default function ClipboardButton({
 
   const handleClick = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(value);
+      if ('clipboard' in navigator) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        copy(value);
+      }
+
       setState('success');
-    } catch (_) {
+    } catch (e) {
       setState('error');
+      console.error(`Failed to copy to clipboard`, e);
     }
   }, [value]);
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/react-dom": "18.2.25",
     "classnames": "2.3.2",
     "connected-react-router": "6.9.3",
+    "copy-to-clipboard": "3.3.3",
     "element-class": "0.2.2",
     "filesize": "10.0.7",
     "fuse.js": "6.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,6 +2609,13 @@ copy-anything@^2.0.1:
   dependencies:
     is-what "^3.14.1"
 
+copy-to-clipboard@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz#55ac43a1db8ae639a4bd99511c148cdd1b83a1b0"
+  integrity sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.36.1:
   version "3.37.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.37.0.tgz#d9570e544163779bb4dff1031c7972f44918dc73"
@@ -6782,6 +6789,11 @@ to-space-case@^1.0.0:
   integrity sha512-rLdvwXZ39VOn1IxGL3V6ZstoTbwLRckQmn/U8ZDLuWwIXNpuZDhQ3AiRUlhTbOXFVE9C+dR51wM0CBDhk31VcA==
   dependencies:
     to-no-case "^1.0.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
 
 "tough-cookie@^2.3.3 || ^3.0.1 || ^4.0.0":
   version "4.1.3"


### PR DESCRIPTION
#### Description
99fc52039f44264c83d939e5f096d8e16d2f3355 is a regression IMO, so introducing`copy-to-clipboard` to add support for older browsers and non-HTTPS installations is needed.

https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations
https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts

TLDR: `navigator.clipboard` is only available on localhost and over TLS.
