### PR TITLE
Fixed: Don't reject revision upgrades if profile doesn't allow upgrades

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeAllowedSpecificationFixture .cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeAllowedSpecificationFixture .cs
@@ -206,5 +206,19 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 new List<CustomFormat>())
             .Should().BeTrue();
         }
+
+        [Test]
+        public void should_returntrue_when_quality_is_revision_upgrade_for_same_quality()
+        {
+            _qualityProfile.UpgradeAllowed = false;
+
+            Subject.IsUpgradeAllowed(
+                    _qualityProfile,
+                    new QualityModel(Quality.DVD, new Revision(1)),
+                    new List<CustomFormat> { _customFormatOne },
+                    new QualityModel(Quality.DVD, new Revision(2)),
+                    new List<CustomFormat> { _customFormatOne })
+                .Should().BeTrue();
+        }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -178,6 +178,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             var isQualityUpgrade = new QualityModelComparer(qualityProfile).Compare(newQuality, currentQuality) > 0;
             var isCustomFormatUpgrade = qualityProfile.CalculateCustomFormatScore(newCustomFormats) > qualityProfile.CalculateCustomFormatScore(currentCustomFormats);
 
+            if (IsRevisionUpgrade(currentQuality, newQuality))
+            {
+                _logger.Debug("New quality '{0}' is a revision upgrade for '{1}'", newQuality, currentQuality);
+                return true;
+            }
+
             if ((isQualityUpgrade || isCustomFormatUpgrade) && qualityProfile.UpgradeAllowed)
             {
                 _logger.Debug("Quality profile allows upgrading");


### PR DESCRIPTION
#### Description

Don't block revision upgrades when the profile doesn't allow upgrades.

