### PR TITLE
Fixed: Ignore extra spaces in path when not running on Windows

### DIFF
--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -147,14 +147,14 @@ namespace NzbDrone.Common.Extensions
                 return false;
             }
 
-            if (path.Trim() != path)
-            {
-                return false;
-            }
-
             // Only check for leading or trailing spaces for path when running on Windows.
             if (OsInfo.IsWindows)
             {
+                if (path.Trim() != path)
+                {
+                    return false;
+                }
+
                 var directoryInfo = new DirectoryInfo(path);
 
                 while (directoryInfo != null)


### PR DESCRIPTION
#### Description

Trailing spaces should be ignored on non-Windows systems.

#### Issues Fixed or Closed by this PR
* Closes #7251

