### PR TITLE
Fixed: Clean paths for top level root folders

### DIFF
--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -393,5 +393,26 @@ namespace NzbDrone.Common.Test
             PosixOnly();
             path.AsOsAgnostic().IsPathValid(PathValidationType.CurrentOs).Should().BeFalse();
         }
+
+        [TestCase(@"C:\", @"C:\")]
+        [TestCase(@"C:\\", @"C:\")]
+        [TestCase(@"C:\Test", @"C:\Test")]
+        [TestCase(@"C:\Test\", @"C:\Test")]
+        [TestCase(@"\\server\share", @"\\server\share")]
+        [TestCase(@"\\server\share\", @"\\server\share")]
+        public void windows_path_should_return_clean_path(string path, string cleanPath)
+        {
+            path.GetCleanPath().Should().Be(cleanPath);
+        }
+
+        [TestCase("/", "/")]
+        [TestCase("//", "/")]
+        [TestCase("/test", "/test")]
+        [TestCase("/test/", "/test")]
+        [TestCase("/test//", "/test")]
+        public void unix_path_should_return_clean_path(string path, string cleanPath)
+        {
+            path.GetCleanPath().Should().Be(cleanPath);
+        }
     }
 }

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -104,9 +104,19 @@ namespace NzbDrone.Common.Disk
             switch (kind)
             {
                 case OsPathKind.Windows when !path.EndsWith(":\\"):
-                    return path.TrimEnd('\\');
+                    while (!path.EndsWith(":\\") && path.EndsWith('\\'))
+                    {
+                        path = path[..^1];
+                    }
+
+                    return path;
                 case OsPathKind.Unix when path != "/":
-                    return path.TrimEnd('/');
+                    while (path != "/" && path.EndsWith('/'))
+                    {
+                        path = path[..^1];
+                    }
+
+                    return path;
             }
 
             return path;

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -25,8 +25,6 @@ namespace NzbDrone.Common.Extensions
         private static readonly string UPDATE_CLIENT_FOLDER_NAME = "Sonarr.Update" + Path.DirectorySeparatorChar;
         private static readonly string UPDATE_LOG_FOLDER_NAME = "UpdateLogs" + Path.DirectorySeparatorChar;
 
-        private static readonly Regex PARENT_PATH_END_SLASH_REGEX = new Regex(@"(?<!:)\\$", RegexOptions.Compiled);
-
         public static string CleanFilePath(this string path)
         {
             if (path.IsNotNullOrWhiteSpace())
@@ -113,11 +111,9 @@ namespace NzbDrone.Common.Extensions
 
         public static string GetCleanPath(this string path)
         {
-            var cleanPath = OsInfo.IsWindows
-                ? PARENT_PATH_END_SLASH_REGEX.Replace(path, "")
-                : path.TrimEnd(Path.DirectorySeparatorChar);
+            var osPath = new OsPath(path);
 
-            return cleanPath;
+            return osPath == OsPath.Null ? null : osPath.PathWithoutTrailingSlash;
         }
 
         public static bool IsParentPath(this string parentPath, string childPath)


### PR DESCRIPTION
#### Description
Prevent trailing slash trimming like:
- `/` => (empty string)
- `E:/` => `E:`
