### PR TITLE
Use the first allowed quality for cutoff met rejection message with disabled upgrades

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -36,8 +36,6 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     continue;
                 }
 
-                var customFormats = _formatService.ParseCustomFormat(file);
-
                 _logger.Debug("Comparing file quality with report. Existing file is {0}.", file.Quality);
 
                 if (!_upgradableSpecification.CutoffNotMet(qualityProfile,
@@ -47,11 +45,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 {
                     _logger.Debug("Cutoff already met, rejecting.");
 
-                    var qualityCutoffIndex = qualityProfile.GetIndex(qualityProfile.Cutoff);
-                    var qualityCutoff = qualityProfile.Items[qualityCutoffIndex.Index];
+                    var cutoff = qualityProfile.UpgradeAllowed ? qualityProfile.Cutoff : qualityProfile.FirststAllowedQuality().Id;
+                    var qualityCutoff = qualityProfile.Items[qualityProfile.GetIndex(cutoff).Index];
 
                     return Decision.Reject("Existing file meets cutoff: {0}", qualityCutoff);
                 }
+
+                var customFormats = _formatService.ParseCustomFormat(file);
 
                 var upgradeableRejectReason = _upgradableSpecification.IsUpgradable(qualityProfile,
                     file.Quality,


### PR DESCRIPTION
#### Description
It's a little confusing when you have a WEB-DL but the message uses Bluray Remux in your cutoff met rejection.

#### Screenshots for UI Changes
before
![1](https://github.com/user-attachments/assets/7af776e8-fb28-4aa1-beb4-da61ed35769b)

after
![2](https://github.com/user-attachments/assets/094714a8-ffd3-48e9-af14-e2c17d24874d)


