### PR TITLE
New: Use 307 redirect for requests missing URL Base

### DIFF
--- a/src/Sonarr.Http/Middleware/UrlBaseMiddleware.cs
+++ b/src/Sonarr.Http/Middleware/UrlBaseMiddleware.cs
@@ -20,6 +20,8 @@ namespace Sonarr.Http.Middleware
             if (_urlBase.IsNotNullOrWhiteSpace() && context.Request.PathBase.Value.IsNullOrWhiteSpace())
             {
                 context.Response.Redirect($"{_urlBase}{context.Request.Path}{context.Request.QueryString}");
+                context.Response.StatusCode = 307;
+
                 return;
             }
 


### PR DESCRIPTION
#### Description

Using 307 redirects prevents the method from being dropped.

#### Issues Fixed or Closed by this PR
* Closes #7262

