### PR TITLE
Fixed: Encoded unicode characters in Transmission torrent names

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ReplaceEncodedUnicodeCharactersFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/ReplaceEncodedUnicodeCharactersFixture.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Common.Test.ExtensionTests.StringExtensionTests
+{
+    [TestFixture]
+    public class ReplaceEncodedUnicodeCharactersFixture
+    {
+        [TestCase("+\\u2b50", "\u2b50")]
+        [TestCase("\\u2b50", "\u2b50")]
+        [TestCase("+\\u00e9", "é")]
+        [TestCase("\\u00e9", "é")]
+        [TestCase("é", "é")]
+        public void should_replace_encoded_unicode_character(string input, string expected)
+        {
+            input.ReplaceEncodedUnicodeCharacters().Should().Be(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Common.Test/OsPathFixture.cs
+++ b/src/NzbDrone.Common.Test/OsPathFixture.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Test.Common;

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Common.Extensions
     public static class StringExtensions
     {
         private static readonly Regex CamelCaseRegex = new Regex("(?<!^)[A-Z]", RegexOptions.Compiled);
+        private static readonly Regex UnicodeEscapeRegex = new Regex(@"\+?\\u(?<Value>[a-z0-9]{4})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static string NullSafe(this string target)
         {
@@ -250,6 +251,11 @@ namespace NzbDrone.Common.Extensions
             Array.Reverse(array);
 
             return new string(array);
+        }
+
+        public static string ReplaceEncodedUnicodeCharacters(this string text)
+        {
+            return UnicodeEscapeRegex.Replace(text, m => ((char)int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber)).ToString());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -440,5 +440,26 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             item.CanBeRemoved.Should().BeTrue();
             item.CanMoveFiles.Should().BeTrue();
         }
+
+        [TestCase(@"Pok\u00e9 Bowl Complete", "Poké Bowl Complete")]
+        [TestCase("Pok\u00e9 Bowl Complete", "Poké Bowl Complete")]
+        [TestCase(@"Series with a +\u2b50", "Series with a \u2b50")]
+        [TestCase("Series with a \u2b50", "Series with a \u2b50")]
+
+        public void should_replace_unicode_characters(string input, string expected)
+        {
+            _completed.DownloadDir = @"/Downloads/Finished/transmission";
+            _completed.Name = input;
+
+            GivenTorrents(new List<TransmissionTorrent>
+            {
+                _completed
+            });
+
+            var items = Subject.GetItems().ToList();
+
+            items.Should().HaveCount(1);
+            items.First().OutputPath.Should().Be(@"/Downloads/Finished/transmission/" + expected);
+        }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 var item = new DownloadClientItem();
                 item.DownloadId = torrent.HashString.ToUpper();
                 item.Category = Settings.TvCategory;
-                item.Title = torrent.Name;
+                item.Title = torrent.Name.ReplaceEncodedUnicodeCharacters();
 
                 item.DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false);
 
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         protected virtual OsPath GetOutputPath(OsPath outputPath, TransmissionTorrent torrent)
         {
-            return outputPath + torrent.Name.Replace(":", "_");
+            return outputPath + torrent.Name.ReplaceEncodedUnicodeCharacters().Replace(":", "_");
         }
 
         protected string GetDownloadDirectory()


### PR DESCRIPTION
#### Description

Transmission encodes the backslashes in unicode escape strings in torrent names in the JSON which don't get converted back to their unicode characters. I've added a helper message and convert them in the title and when building the path which resolves it.

If this ends up being necessary for other clients we'll need to add it there, but left it Transmission only as it's the only one with a known issues.

#### Issues Fixed or Closed by this PR

* Closes #7270

