### PR TITLE
Reordered Series Details, and split onto two rows (except for small s…

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -199,6 +199,7 @@ class SeriesDetails extends Component {
       isSearching,
       isFetching,
       isPopulated,
+      isSmallScreen,
       episodesError,
       episodeFilesError,
       hasEpisodes,
@@ -428,99 +429,6 @@ class SeriesDetails extends Component {
                 </div>
 
                 <div className={styles.detailsLabels}>
-                  <Label
-                    className={styles.detailsLabel}
-                    size={sizes.LARGE}
-                  >
-                    <div>
-                      <Icon
-                        name={icons.FOLDER}
-                        size={17}
-                      />
-                      <span className={styles.path}>
-                        {path}
-                      </span>
-                    </div>
-                  </Label>
-
-                  <Tooltip
-                    anchor={
-                      <Label
-                        className={styles.detailsLabel}
-                        size={sizes.LARGE}
-                      >
-                        <div>
-                          <Icon
-                            name={icons.DRIVE}
-                            size={17}
-                          />
-
-                          <span className={styles.sizeOnDisk}>
-                            {formatBytes(sizeOnDisk)}
-                          </span>
-                        </div>
-                      </Label>
-                    }
-                    tooltip={
-                      <span>
-                        {episodeFilesCountMessage}
-                      </span>
-                    }
-                    kind={kinds.INVERSE}
-                    position={tooltipPositions.BOTTOM}
-                  />
-
-                  <Label
-                    className={styles.detailsLabel}
-                    title={translate('QualityProfile')}
-                    size={sizes.LARGE}
-                  >
-                    <div>
-                      <Icon
-                        name={icons.PROFILE}
-                        size={17}
-                      />
-                      <span className={styles.qualityProfileName}>
-                        {
-                          <QualityProfileNameConnector
-                            qualityProfileId={qualityProfileId}
-                          />
-                        }
-                      </span>
-                    </div>
-                  </Label>
-
-                  <Label
-                    className={styles.detailsLabel}
-                    size={sizes.LARGE}
-                  >
-                    <div>
-                      <Icon
-                        name={monitored ? icons.MONITORED : icons.UNMONITORED}
-                        size={17}
-                      />
-                      <span className={styles.qualityProfileName}>
-                        {monitored ? translate('Monitored') : translate('Unmonitored')}
-                      </span>
-                    </div>
-                  </Label>
-
-                  <Label
-                    className={styles.detailsLabel}
-                    title={statusDetails.message}
-                    size={sizes.LARGE}
-                    kind={status === 'deleted' ? kinds.INVERSE : undefined}
-                  >
-                    <div>
-                      <Icon
-                        name={statusDetails.icon}
-                        size={17}
-                      />
-                      <span className={styles.statusName}>
-                        {statusDetails.title}
-                      </span>
-                    </div>
-                  </Label>
 
                   {
                     originalLanguage?.name ?
@@ -562,6 +470,23 @@ class SeriesDetails extends Component {
                       null
                   }
 
+                  <Label
+                    className={styles.detailsLabel}
+                    title={statusDetails.message}
+                    size={sizes.LARGE}
+                    kind={status === 'deleted' ? kinds.INVERSE : undefined}
+                  >
+                    <div>
+                      <Icon
+                        name={statusDetails.icon}
+                        size={17}
+                      />
+                      <span className={styles.statusName}>
+                        {statusDetails.title}
+                      </span>
+                    </div>
+                  </Label>
+
                   <Tooltip
                     anchor={
                       <Label
@@ -591,6 +516,43 @@ class SeriesDetails extends Component {
                     position={tooltipPositions.BOTTOM}
                   />
 
+                  { !isSmallScreen && <br /> }
+
+                  <Label
+                    className={styles.detailsLabel}
+                    size={sizes.LARGE}
+                  >
+                    <div>
+                      <Icon
+                        name={monitored ? icons.MONITORED : icons.UNMONITORED}
+                        size={17}
+                      />
+                      <span className={styles.qualityProfileName}>
+                        {monitored ? translate('Monitored') : translate('Unmonitored')}
+                      </span>
+                    </div>
+                  </Label>
+
+                  <Label
+                    className={styles.detailsLabel}
+                    title={translate('QualityProfile')}
+                    size={sizes.LARGE}
+                  >
+                    <div>
+                      <Icon
+                        name={icons.PROFILE}
+                        size={17}
+                      />
+                      <span className={styles.qualityProfileName}>
+                        {
+                          <QualityProfileNameConnector
+                            qualityProfileId={qualityProfileId}
+                          />
+                        }
+                      </span>
+                    </div>
+                  </Label>
+
                   {
                     !!tags.length &&
                       <Tooltip
@@ -613,8 +575,50 @@ class SeriesDetails extends Component {
                         kind={kinds.INVERSE}
                         position={tooltipPositions.BOTTOM}
                       />
-
                   }
+
+                  <Tooltip
+                    anchor={
+                      <Label
+                        className={styles.detailsLabel}
+                        size={sizes.LARGE}
+                      >
+                        <div>
+                          <Icon
+                            name={icons.DRIVE}
+                            size={17}
+                          />
+
+                          <span className={styles.sizeOnDisk}>
+                            {formatBytes(sizeOnDisk)}
+                          </span>
+                        </div>
+                      </Label>
+                    }
+                    tooltip={
+                      <span>
+                        {episodeFilesCountMessage}
+                      </span>
+                    }
+                    kind={kinds.INVERSE}
+                    position={tooltipPositions.BOTTOM}
+                  />
+
+                  <Label
+                    className={styles.detailsLabel}
+                    size={sizes.LARGE}
+                  >
+                    <div>
+                      <Icon
+                        name={icons.FOLDER}
+                        size={17}
+                      />
+                      <span className={styles.path}>
+                        {path}
+                      </span>
+                    </div>
+                  </Label>
+
                 </div>
 
                 <Measure onMeasure={this.onMeasure}>
@@ -765,6 +769,7 @@ SeriesDetails.propTypes = {
   isSearching: PropTypes.bool.isRequired,
   isFetching: PropTypes.bool.isRequired,
   isPopulated: PropTypes.bool.isRequired,
+  isSmallScreen: PropTypes.bool.isRequired,
   episodesError: PropTypes.object,
   episodeFilesError: PropTypes.object,
   hasEpisodes: PropTypes.bool.isRequired,


### PR DESCRIPTION
Reordered the series details.
Advantage:
- Information about the series are together (Language, Network, etc)
- Information that are user defined are together (such as save path, whether monitored, etc)
- Above break into two rows (except for small screens)
- Path is at the very end (since it is dynamic and kept pushing the other labels around, which I found distracting for the eye)

**New order:**
![image](https://github.com/user-attachments/assets/564a049d-3de1-43f1-af4d-9dc88a3311aa)

**Old order:**
![image](https://github.com/user-attachments/assets/a21569e9-23f5-43e6-8a0e-23c3111d982a)


**Compatibility:**
If ever, we wanted to move to a different way of showing the details, for instance, like in radarr, this should still work:
![image](https://github.com/user-attachments/assets/a77e9d79-2bbf-4ebc-8ed6-432f2eca0081)
