### PR TITLE
Fixed: Matched alternative titles and tags in header search results

### DIFF
--- a/frontend/src/Components/Page/Header/SeriesSearchResult.js
+++ b/frontend/src/Components/Page/Header/SeriesSearchResult.js
@@ -22,9 +22,9 @@ function SeriesSearchResult(props) {
   let tag = null;
 
   if (match.key === 'alternateTitles.title') {
-    alternateTitle = alternateTitles[match.arrayIndex];
+    alternateTitle = alternateTitles[match.refIndex];
   } else if (match.key === 'tags.label') {
-    tag = tags[match.arrayIndex];
+    tag = tags[match.refIndex];
   }
 
   return (

--- a/frontend/src/Components/Page/Header/fuse.worker.js
+++ b/frontend/src/Components/Page/Header/fuse.worker.js
@@ -37,7 +37,7 @@ function getSuggestions(series, value) {
               key: 'title'
             }
           ],
-          arrayIndex: 0
+          refIndex: 0
         });
         if (suggestions.length > limit) {
           break;


### PR DESCRIPTION
#### Description
fuse.js seems to actually return `refIndex` now, not `arrayIndexer`.

#### Screenshots for UI Changes
Before
[before 1](https://github.com/user-attachments/assets/74f56d0a-8aa6-4a88-a3ea-7ab9e87bf665)
[before 2](https://github.com/user-attachments/assets/90d1c93f-1296-40d1-b8a4-ee1a589fd578)

After
[after 3](https://github.com/user-attachments/assets/4f99cc89-bff1-4ec3-9cd0-b4255a2f5475) 
[after 4](https://github.com/user-attachments/assets/89f57c5c-a5ee-4451-8b90-65a07d0ba2f7)


