### PR TITLE
New: Labels support for Transmission

### DIFF
--- a/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
@@ -148,10 +148,5 @@ namespace NzbDrone.Common.Extensions
         {
             return string.Join(separator, source.Select(predicate));
         }
-
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer = null)
-        {
-            return new HashSet<T>(source, comparer);
-        }
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -13,6 +13,14 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
     [TestFixture]
     public class TransmissionFixture : TransmissionFixtureBase<Transmission>
     {
+        [SetUp]
+        public void Setup_Transmission()
+        {
+            Mocker.GetMock<ITransmissionProxy>()
+                .Setup(v => v.GetClientVersion(It.IsAny<TransmissionSettings>(), It.IsAny<bool>()))
+                .Returns("4.0.6");
+        }
+
         [Test]
         public void queued_item_should_have_required_properties()
         {
@@ -272,7 +280,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
         public void should_only_check_version_number(string version)
         {
             Mocker.GetMock<ITransmissionProxy>()
-                  .Setup(s => s.GetClientVersion(It.IsAny<TransmissionSettings>()))
+                  .Setup(s => s.GetClientVersion(It.IsAny<TransmissionSettings>(), true))
                   .Returns(version);
 
             Subject.Test().IsValid.Should().BeTrue();

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixtureBase.cs
@@ -29,7 +29,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
                 Host = "127.0.0.1",
                 Port = 2222,
                 Username = "admin",
-                Password = "pass"
+                Password = "pass",
+                TvCategory = ""
             };
 
             Subject.Definition = new DownloadClientDefinition();
@@ -152,7 +153,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             }
 
             Mocker.GetMock<ITransmissionProxy>()
-                  .Setup(s => s.GetTorrents(It.IsAny<TransmissionSettings>()))
+                  .Setup(s => s.GetTorrents(null, It.IsAny<TransmissionSettings>()))
                   .Returns(torrents);
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 if (Settings.TvCategory.IsNotNullOrWhiteSpace() && SupportsLabels && torrent.Labels is { Count: > 0 })
                 {
-                    if (!torrent.Labels.Contains(Settings.TvCategory))
+                    if (!torrent.Labels.Contains(Settings.TvCategory, StringComparer.InvariantCultureIgnoreCase))
                     {
                         continue;
                     }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -18,6 +19,8 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 {
     public abstract class TransmissionBase : TorrentClientBase<TransmissionSettings>
     {
+        public abstract bool SupportsLabels { get; }
+
         protected readonly ITransmissionProxy _proxy;
 
         public TransmissionBase(ITransmissionProxy proxy,
@@ -37,7 +40,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public override IEnumerable<DownloadClientItem> GetItems()
         {
             var configFunc = new Lazy<TransmissionConfig>(() => _proxy.GetConfig(Settings));
-            var torrents = _proxy.GetTorrents(Settings);
+            var torrents = _proxy.GetTorrents(null, Settings);
 
             var items = new List<DownloadClientItem>();
 
@@ -45,36 +48,45 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             {
                 var outputPath = new OsPath(torrent.DownloadDir);
 
-                if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
+                if (Settings.TvCategory.IsNotNullOrWhiteSpace() && SupportsLabels && torrent.Labels is { Count: > 0 })
                 {
-                    if (!new OsPath(Settings.TvDirectory).Contains(outputPath))
+                    if (!torrent.Labels.Contains(Settings.TvCategory))
                     {
                         continue;
                     }
                 }
-                else if (Settings.TvCategory.IsNotNullOrWhiteSpace())
+                else
                 {
-                    var directories = outputPath.FullPath.Split('\\', '/');
-                    if (!directories.Contains(Settings.TvCategory))
+                    if (Settings.TvDirectory.IsNotNullOrWhiteSpace())
                     {
-                        continue;
+                        if (!new OsPath(Settings.TvDirectory).Contains(outputPath))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (Settings.TvCategory.IsNotNullOrWhiteSpace())
+                    {
+                        var directories = outputPath.FullPath.Split('\\', '/');
+                        if (!directories.Contains(Settings.TvCategory))
+                        {
+                            continue;
+                        }
                     }
                 }
 
                 outputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, outputPath);
 
-                var item = new DownloadClientItem();
-                item.DownloadId = torrent.HashString.ToUpper();
-                item.Category = Settings.TvCategory;
-                item.Title = torrent.Name;
-
-                item.DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false);
-
-                item.OutputPath = GetOutputPath(outputPath, torrent);
-                item.TotalSize = torrent.TotalSize;
-                item.RemainingSize = torrent.LeftUntilDone;
-                item.SeedRatio = torrent.DownloadedEver <= 0 ? 0 :
-                    (double)torrent.UploadedEver / torrent.DownloadedEver;
+                var item = new DownloadClientItem
+                {
+                    DownloadId = torrent.HashString.ToUpper(),
+                    Category = Settings.TvCategory,
+                    Title = torrent.Name,
+                    DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, Settings.TvImportedCategory.IsNotNullOrWhiteSpace() && SupportsLabels),
+                    OutputPath = GetOutputPath(outputPath, torrent),
+                    TotalSize = torrent.TotalSize,
+                    RemainingSize = torrent.LeftUntilDone,
+                    SeedRatio = torrent.DownloadedEver <= 0 ? 0 : (double)torrent.UploadedEver / torrent.DownloadedEver
+                };
 
                 if (torrent.Eta >= 0)
                 {
@@ -300,7 +312,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             try
             {
-                _proxy.GetTorrents(Settings);
+                _proxy.GetTorrents(null, Settings);
             }
             catch (Exception ex)
             {
@@ -309,6 +321,16 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             }
 
             return null;
+        }
+
+        protected bool HasClientVersion(int major, int minor)
+        {
+            var rawVersion = _proxy.GetClientVersion(Settings);
+
+            var versionResult = Regex.Match(rawVersion, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)").Value;
+            var clientVersion = Version.Parse(versionResult);
+
+            return clientVersion >= new Version(major, minor);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionProxy.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Net;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -12,15 +15,16 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 {
     public interface ITransmissionProxy
     {
-        List<TransmissionTorrent> GetTorrents(TransmissionSettings settings);
+        IReadOnlyCollection<TransmissionTorrent> GetTorrents(IReadOnlyCollection<string> hashStrings, TransmissionSettings settings);
         void AddTorrentFromUrl(string torrentUrl, string downloadDirectory, TransmissionSettings settings);
         void AddTorrentFromData(byte[] torrentData, string downloadDirectory, TransmissionSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, TransmissionSettings settings);
         TransmissionConfig GetConfig(TransmissionSettings settings);
         string GetProtocolVersion(TransmissionSettings settings);
-        string GetClientVersion(TransmissionSettings settings);
+        string GetClientVersion(TransmissionSettings settings, bool force = false);
         void RemoveTorrent(string hash, bool removeData, TransmissionSettings settings);
         void MoveTorrentToTopInQueue(string hashString, TransmissionSettings settings);
+        void SetTorrentLabels(string hash, IEnumerable<string> labels, TransmissionSettings settings);
     }
 
     public class TransmissionProxy : ITransmissionProxy
@@ -28,34 +32,43 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         private readonly IHttpClient _httpClient;
         private readonly Logger _logger;
 
-        private ICached<string> _authSessionIDCache;
+        private readonly ICached<string> _authSessionIdCache;
+        private readonly ICached<string> _versionCache;
 
         public TransmissionProxy(ICacheManager cacheManager, IHttpClient httpClient, Logger logger)
         {
             _httpClient = httpClient;
             _logger = logger;
 
-            _authSessionIDCache = cacheManager.GetCache<string>(GetType(), "authSessionID");
+            _authSessionIdCache = cacheManager.GetCache<string>(GetType(), "authSessionID");
+            _versionCache = cacheManager.GetCache<string>(GetType(), "versions");
         }
 
-        public List<TransmissionTorrent> GetTorrents(TransmissionSettings settings)
+        public IReadOnlyCollection<TransmissionTorrent> GetTorrents(IReadOnlyCollection<string> hashStrings, TransmissionSettings settings)
         {
-            var result = GetTorrentStatus(settings);
+            var result = GetTorrentStatus(hashStrings, settings);
 
-            var torrents = ((JArray)result.Arguments["torrents"]).ToObject<List<TransmissionTorrent>>();
+            var torrents = ((JArray)result.Arguments["torrents"]).ToObject<ReadOnlyCollection<TransmissionTorrent>>();
 
             return torrents;
         }
 
         public void AddTorrentFromUrl(string torrentUrl, string downloadDirectory, TransmissionSettings settings)
         {
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("filename", torrentUrl);
-            arguments.Add("paused", settings.AddPaused);
+            var arguments = new Dictionary<string, object>
+            {
+                { "filename", torrentUrl },
+                { "paused", settings.AddPaused }
+            };
 
             if (!downloadDirectory.IsNullOrWhiteSpace())
             {
                 arguments.Add("download-dir", downloadDirectory);
+            }
+
+            if (settings.TvCategory.IsNotNullOrWhiteSpace())
+            {
+                arguments.Add("labels", new List<string> { settings.TvCategory });
             }
 
             ProcessRequest("torrent-add", arguments, settings);
@@ -63,13 +76,20 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         public void AddTorrentFromData(byte[] torrentData, string downloadDirectory, TransmissionSettings settings)
         {
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("metainfo", Convert.ToBase64String(torrentData));
-            arguments.Add("paused", settings.AddPaused);
+            var arguments = new Dictionary<string, object>
+            {
+                { "metainfo", Convert.ToBase64String(torrentData) },
+                { "paused", settings.AddPaused }
+            };
 
             if (!downloadDirectory.IsNullOrWhiteSpace())
             {
                 arguments.Add("download-dir", downloadDirectory);
+            }
+
+            if (settings.TvCategory.IsNotNullOrWhiteSpace())
+            {
+                arguments.Add("labels", new List<string> { settings.TvCategory });
             }
 
             ProcessRequest("torrent-add", arguments, settings);
@@ -82,8 +102,10 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 return;
             }
 
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("ids", new[] { hash });
+            var arguments = new Dictionary<string, object>
+            {
+                { "ids", new List<string> { hash } }
+            };
 
             if (seedConfiguration.Ratio != null)
             {
@@ -97,6 +119,12 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 arguments.Add("seedIdleMode", 1);
             }
 
+            // Avoid extraneous request if no limits are to be set
+            if (arguments.All(arg => arg.Key == "ids"))
+            {
+                return;
+            }
+
             ProcessRequest("torrent-set", arguments, settings);
         }
 
@@ -107,11 +135,16 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             return config.RpcVersion;
         }
 
-        public string GetClientVersion(TransmissionSettings settings)
+        public string GetClientVersion(TransmissionSettings settings, bool force = false)
         {
-            var config = GetConfig(settings);
+            var cacheKey = $"version:{$"{GetBaseUrl(settings)}:{settings.Password}".SHA256Hash()}";
 
-            return config.Version;
+            if (force)
+            {
+                _versionCache.Remove(cacheKey);
+            }
+
+            return _versionCache.Get(cacheKey, () => GetConfig(settings).Version, TimeSpan.FromHours(6));
         }
 
         public TransmissionConfig GetConfig(TransmissionSettings settings)
@@ -124,19 +157,34 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         public void RemoveTorrent(string hashString, bool removeData, TransmissionSettings settings)
         {
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("ids", new string[] { hashString });
-            arguments.Add("delete-local-data", removeData);
+            var arguments = new Dictionary<string, object>
+            {
+                { "ids", new List<string> { hashString } },
+                { "delete-local-data", removeData }
+            };
 
             ProcessRequest("torrent-remove", arguments, settings);
         }
 
         public void MoveTorrentToTopInQueue(string hashString, TransmissionSettings settings)
         {
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("ids", new string[] { hashString });
+            var arguments = new Dictionary<string, object>
+            {
+                { "ids", new List<string> { hashString } }
+            };
 
             ProcessRequest("queue-move-top", arguments, settings);
+        }
+
+        public void SetTorrentLabels(string hash, IEnumerable<string> labels, TransmissionSettings settings)
+        {
+            var arguments = new Dictionary<string, object>
+            {
+                { "ids", new List<string> { hash } },
+                { "labels", labels.ToImmutableHashSet() }
+            };
+
+            ProcessRequest("torrent-set", arguments, settings);
         }
 
         private TransmissionResponse GetSessionVariables(TransmissionSettings settings)
@@ -151,14 +199,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             return ProcessRequest("session-stats", null, settings);
         }
 
-        private TransmissionResponse GetTorrentStatus(TransmissionSettings settings)
-        {
-            return GetTorrentStatus(null, settings);
-        }
-
         private TransmissionResponse GetTorrentStatus(IEnumerable<string> hashStrings, TransmissionSettings settings)
         {
-            var fields = new string[]
+            var fields = new List<string>
             {
                 "id",
                 "hashString", // Unique torrent ID. Use this instead of the client id?
@@ -179,11 +222,14 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 "seedIdleLimit",
                 "seedIdleMode",
                 "fileCount",
-                "file-count"
+                "file-count",
+                "labels"
             };
 
-            var arguments = new Dictionary<string, object>();
-            arguments.Add("fields", fields);
+            var arguments = new Dictionary<string, object>
+            {
+                { "fields", fields }
+            };
 
             if (hashStrings != null)
             {
@@ -195,9 +241,14 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             return result;
         }
 
+        private string GetBaseUrl(TransmissionSettings settings)
+        {
+            return HttpRequestBuilder.BuildBaseUrl(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase);
+        }
+
         private HttpRequestBuilder BuildRequest(TransmissionSettings settings)
         {
-            var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
+            var requestBuilder = new HttpRequestBuilder(GetBaseUrl(settings))
                 .Resource("rpc")
                 .Accept(HttpAccept.Json);
 
@@ -212,11 +263,11 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var authKey = string.Format("{0}:{1}", requestBuilder.BaseUrl, settings.Password);
 
-            var sessionId = _authSessionIDCache.Find(authKey);
+            var sessionId = _authSessionIdCache.Find(authKey);
 
             if (sessionId == null || reauthenticate)
             {
-                _authSessionIDCache.Remove(authKey);
+                _authSessionIdCache.Remove(authKey);
 
                 var authLoginRequest = BuildRequest(settings).Build();
                 authLoginRequest.SuppressHttpError = true;
@@ -244,7 +295,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 _logger.Debug("Transmission authentication succeeded.");
 
-                _authSessionIDCache.Set(authKey, sessionId);
+                _authSessionIdCache.Set(authKey, sessionId);
             }
 
             requestBuilder.SetHeader("X-Transmission-Session-Id", sessionId);

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -32,6 +32,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             Host = "localhost";
             Port = 9091;
             UrlBase = "/transmission/";
+            TvCategory = "tv-sonarr";
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
@@ -59,16 +60,19 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         [FieldDefinition(6, Label = "Category", Type = FieldType.Textbox, HelpText = "DownloadClientSettingsCategorySubFolderHelpText")]
         public string TvCategory { get; set; }
 
-        [FieldDefinition(7, Label = "Directory", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientTransmissionSettingsDirectoryHelpText")]
+        [FieldDefinition(7, Label = "PostImportCategory", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientSettingsPostImportCategoryHelpText")]
+        public string TvImportedCategory { get; set; }
+
+        [FieldDefinition(8, Label = "Directory", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientTransmissionSettingsDirectoryHelpText")]
         public string TvDirectory { get; set; }
 
-        [FieldDefinition(8, Label = "DownloadClientSettingsRecentPriority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "DownloadClientSettingsRecentPriorityEpisodeHelpText")]
+        [FieldDefinition(9, Label = "DownloadClientSettingsRecentPriority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "DownloadClientSettingsRecentPriorityEpisodeHelpText")]
         public int RecentTvPriority { get; set; }
 
-        [FieldDefinition(9, Label = "DownloadClientSettingsOlderPriority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "DownloadClientSettingsOlderPriorityEpisodeHelpText")]
+        [FieldDefinition(10, Label = "DownloadClientSettingsOlderPriority", Type = FieldType.Select, SelectOptions = typeof(TransmissionPriority), HelpText = "DownloadClientSettingsOlderPriorityEpisodeHelpText")]
         public int OlderTvPriority { get; set; }
 
-        [FieldDefinition(10, Label = "DownloadClientSettingsAddPaused", Type = FieldType.Checkbox)]
+        [FieldDefinition(11, Label = "DownloadClientSettingsAddPaused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }
 
         public override NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionTorrent.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace NzbDrone.Core.Download.Clients.Transmission
@@ -11,6 +13,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         public long TotalSize { get; set; }
         public long LeftUntilDone { get; set; }
         public bool IsFinished { get; set; }
+        public IReadOnlyCollection<string> Labels { get; set; } = Array.Empty<string>();
         public long Eta { get; set; }
         public TransmissionTorrentStatus Status { get; set; }
         public long SecondsDownloading { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -15,6 +15,9 @@ namespace NzbDrone.Core.Download.Clients.Vuze
     {
         private const int MINIMUM_SUPPORTED_PROTOCOL_VERSION = 14;
 
+        public override string Name => "Vuze";
+        public override bool SupportsLabels => false;
+
         public Vuze(ITransmissionProxy proxy,
                     ITorrentFileInfoReader torrentFileInfoReader,
                     IHttpClient httpClient,
@@ -67,7 +70,5 @@ namespace NzbDrone.Core.Download.Clients.Vuze
 
             return null;
         }
-
-        public override string Name => "Vuze";
     }
 }


### PR DESCRIPTION
#### Description
Adding support for labels starting with Transmission v3.0.0 with some caveats:
- ~~v3.0.0 has torrent labels support only on `torrent-set`, labels support was added on `torrent-add` since v4.0.0 so for < v4.0.0 an extra request is mandatory.~~
- Adding support for `Post-Import Category`
- Changing the default value for `Category` to `tv-sonarr`.
- To maintain BC I didn't touched the destination directory logic so it would still create a sub-folder with the `Category`. I think it's best anyway to have a sub-folder anyway since the labels aren't like in Qbit with a save path.

#### Issues Fixed or Closed by this PR
* Closes #7300

