### PR TITLE
Inherit trigger from pushed command models

### DIFF
--- a/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
@@ -106,6 +106,8 @@ namespace NzbDrone.Core.Messaging.Commands
             _logger.Trace("Publishing {0}", command.Name);
             _logger.Trace("Checking if command is queued or started: {0}", command.Name);
 
+            command.Trigger = trigger;
+
             lock (_commandQueue)
             {
                 var existingCommands = QueuedOrStarted(command.Name);
@@ -142,7 +144,6 @@ namespace NzbDrone.Core.Messaging.Commands
             var command = GetCommand(commandName);
             command.LastExecutionTime = lastExecutionTime;
             command.LastStartTime = lastStartTime;
-            command.Trigger = trigger;
 
             return Push(command, priority, trigger);
         }
@@ -244,13 +245,13 @@ namespace NzbDrone.Core.Messaging.Commands
             _repo.Trim();
         }
 
-        private dynamic GetCommand(string commandName)
+        private Command GetCommand(string commandName)
         {
             commandName = commandName.Split('.').Last();
             var commands = _knownTypes.GetImplementations(typeof(Command));
             var commandType = commands.Single(c => c.Name.Equals(commandName, StringComparison.InvariantCultureIgnoreCase));
 
-            return Json.Deserialize("{}", commandType);
+            return Json.Deserialize("{}", commandType) as Command;
         }
 
         private void Update(CommandModel command, CommandStatus status, string message)

--- a/src/Sonarr.Api.V3/Commands/CommandController.cs
+++ b/src/Sonarr.Api.V3/Commands/CommandController.cs
@@ -66,9 +66,8 @@ namespace Sonarr.Api.V3.Commands
                     ? CommandPriority.High
                     : CommandPriority.Normal;
 
-                dynamic command = STJson.Deserialize(body, commandType);
+                var command = STJson.Deserialize(body, commandType) as Command;
 
-                command.Trigger = CommandTrigger.Manual;
                 command.SuppressMessages = !command.SendUpdatesToClient;
                 command.SendUpdatesToClient = true;
                 command.ClientUserAgent = Request.Headers["UserAgent"];

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -190,9 +190,8 @@ namespace Sonarr.Api.V3.Series
                 {
                     SeriesId = series.Id,
                     SourcePath = sourcePath,
-                    DestinationPath = destinationPath,
-                    Trigger = CommandTrigger.Manual
-                });
+                    DestinationPath = destinationPath
+                }, trigger: CommandTrigger.Manual);
             }
 
             var model = seriesResource.ToModel(series);


### PR DESCRIPTION
#### Description
I had to debug why all `CommandQueueManager.Push` where having a `unspecified` command trigger while scheduled tasks had the right trigger, and it was because for scheduled tasks it was set [here](https://github.com/Sonarr/Sonarr/blob/86446a768627b98909389eac230720fcd00cb127/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs#L145). 

Same for the pushes via API due to this [part](https://github.com/Sonarr/Sonarr/blob/2f87d52a962df65d59fd5cafbfc144e78fd2e52f/src/Sonarr.Api.V3/Commands/CommandController.cs#L71).

We can set Trigger on pushed commands and would be fine, but like [this](https://github.com/Sonarr/Sonarr/blob/0e95ba2021b23cc65bce0a0620dd48e355250dab/src/NzbDrone.Core/Update/InstallUpdateService.cs#L283) the CommandTrigger is lost as we have access only to the Command body and not the CommandModel wrapper.

This would also ensure the command trigger is the same across both objects.