### PR TITLE
Fixed: Stopped/Started as initial state for qBittorrent v5.0

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
@@ -26,8 +26,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, QBittorrentSettings settings);
-        void PauseTorrent(string hash, QBittorrentSettings settings);
-        void ResumeTorrent(string hash, QBittorrentSettings settings);
         void SetForceStart(string hash, bool enabled, QBittorrentSettings settings);
     }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -177,7 +177,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // if setCategory fails due to method not being found, then try older setLabel command for qBittorrent < v.3.3.5
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.NotFound)
                 {
                     var setLabelRequest = BuildRequest(settings).Resource("/command/setLabel")
                                                                 .Post()
@@ -255,29 +255,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // qBittorrent rejects all Prio commands with 403: Forbidden if Options -> BitTorrent -> Torrent Queueing is not enabled
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.Forbidden)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.Forbidden)
                 {
                     return;
                 }
 
                 throw;
             }
-        }
-
-        public void PauseTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/pause")
-                                                 .Post()
-                                                 .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
-        }
-
-        public void ResumeTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/resume")
-                                                .Post()
-                                                .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
         }
 
         public void SetForceStart(string hash, bool enabled, QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
@@ -1,9 +1,16 @@
+using NzbDrone.Core.Annotations;
+
 namespace NzbDrone.Core.Download.Clients.QBittorrent
 {
     public enum QBittorrentState
     {
+        [FieldOption(Label = "Started")]
         Start = 0,
+
+        [FieldOption(Label = "Force Started")]
         ForceStart = 1,
-        Pause = 2
+
+        [FieldOption(Label = "Stopped")]
+        Stop = 2
     }
 }


### PR DESCRIPTION
#### Description
In qBittorrent v5.0 `paused` was renamed to `stopped` in https://github.com/qbittorrent/qBittorrent/commit/5d1c2496063b41874e85af0145b153e006fc92d3.

Unused methods `PauseTorrent` and `ResumeTorrent` were removed.

#### Issues Fixed or Closed by this PR
* Closes https://github.com/Radarr/Radarr/issues/10551

