### PR TITLE
Fixed: Status output root folders for completed directories in Deluge

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
@@ -312,11 +312,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
         [Test]
         public void should_return_status_with_outputdirs()
         {
-            var configItems = new Dictionary<string, object>();
-
-            configItems.Add("download_location", @"C:\Downloads\Downloading\deluge".AsOsAgnostic());
-            configItems.Add("move_completed_path", @"C:\Downloads\Finished\deluge".AsOsAgnostic());
-            configItems.Add("move_completed", true);
+            var configItems = new Dictionary<string, object>
+            {
+                { "download_location", @"C:\Downloads\Downloading\deluge".AsOsAgnostic() },
+                { "move_completed_path", @"C:\Downloads\Finished\deluge".AsOsAgnostic() },
+                { "move_completed", true }
+            };
 
             Mocker.GetMock<IDelugeProxy>()
                 .Setup(v => v.GetConfig(It.IsAny<DelugeSettings>()))
@@ -327,6 +328,19 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
             result.IsLocalhost.Should().BeTrue();
             result.OutputRootFolders.Should().NotBeNull();
             result.OutputRootFolders.First().Should().Be(@"C:\Downloads\Finished\deluge".AsOsAgnostic());
+        }
+
+        [Test]
+        public void should_return_status_with_outputdirs_for_directories_in_settings()
+        {
+            Subject.Definition.Settings.As<DelugeSettings>().DownloadDirectory =  @"D:\Downloads\Downloading\deluge".AsOsAgnostic();
+            Subject.Definition.Settings.As<DelugeSettings>().CompletedDirectory =  @"D:\Downloads\Finished\deluge".AsOsAgnostic();
+
+            var result = Subject.GetStatus();
+
+            result.IsLocalhost.Should().BeTrue();
+            result.OutputRootFolders.Should().NotBeNull();
+            result.OutputRootFolders.First().Should().Be(@"D:\Downloads\Finished\deluge".AsOsAgnostic());
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -216,9 +216,18 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         {
             var config = _proxy.GetConfig(Settings);
             var label = _proxy.GetLabelOptions(Settings);
+
             OsPath destDir;
 
-            if (label != null && label.ApplyMoveCompleted && label.MoveCompleted)
+            if (Settings.CompletedDirectory.IsNotNullOrWhiteSpace())
+            {
+                destDir = new OsPath(Settings.CompletedDirectory);
+            }
+            else if (Settings.DownloadDirectory.IsNotNullOrWhiteSpace())
+            {
+                destDir = new OsPath(Settings.DownloadDirectory);
+            }
+            else if (label is { ApplyMoveCompleted: true, MoveCompleted: true })
             {
                 // if label exists and a label completed path exists and is enabled use it instead of global
                 destDir = new OsPath(label.MoveCompletedPath);
@@ -234,7 +243,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host is "127.0.0.1" or "localhost"
             };
 
             if (!destDir.IsEmpty)


### PR DESCRIPTION
#### Description
If you use `DownloadDirectory` and `CompletedDirectory`, the DownloadClientRootFolderCheck fails to trigger a warning with the right paths for Deluge.
