### PR TITLE
New: Use instance name in PWA manifest

### DIFF
--- a/frontend/src/Content/manifest.json
+++ b/frontend/src/Content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sonarr",
+  "name": "__INSTANCE_NAME__",
   "icons": [
     {
       "src": "__URL_BASE__/Content/Images/Icons/android-chrome-192x192.png",

--- a/src/Sonarr.Http/Frontend/Mappers/ManifestMapper.cs
+++ b/src/Sonarr.Http/Frontend/Mappers/ManifestMapper.cs
@@ -8,9 +8,14 @@ namespace Sonarr.Http.Frontend.Mappers
 {
     public class ManifestMapper : UrlBaseReplacementResourceMapperBase
     {
+        private readonly IConfigFileProvider _configFileProvider;
+
+        private string _generatedContent;
+
         public ManifestMapper(IAppFolderInfo appFolderInfo, IDiskProvider diskProvider, IConfigFileProvider configFileProvider, Logger logger)
             : base(diskProvider, configFileProvider, logger)
         {
+            _configFileProvider = configFileProvider;
             FilePath = Path.Combine(appFolderInfo.StartUpFolder, configFileProvider.UiFolder, "Content", "manifest.json");
         }
 
@@ -22,6 +27,22 @@ namespace Sonarr.Http.Frontend.Mappers
         public override bool CanHandle(string resourceUrl)
         {
             return resourceUrl.StartsWith("/Content/manifest");
+        }
+
+        protected override string GetFileText()
+        {
+            if (RuntimeInfo.IsProduction && _generatedContent != null)
+            {
+                return _generatedContent;
+            }
+
+            var text = base.GetFileText();
+
+            text = text.Replace("__INSTANCE_NAME__", _configFileProvider.InstanceName);
+
+            _generatedContent = text;
+
+            return _generatedContent;
         }
     }
 }


### PR DESCRIPTION
#### Description

Uses the `Instance Name` setting for the name in the PWA manifest.

#### Issues Fixed or Closed by this PR
* Closes #7315

