### PR TITLE
Fixed: Parse version after quality in renamed files

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -502,6 +502,13 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Revision.IsRepack.Should().Be(isRepack);
         }
 
+        [TestCase("[MTBB] Series Title - S02E02 - 027 - Episode Title [WEBDL-1080p v2][x264][AAC]", 2)]
+        public void should_be_able_to_parse_anime_version(string title, int version)
+        {
+            var result = QualityParser.ParseQuality(title);
+            result.Revision.Version.Should().Be(version);
+        }
+
         private void ParseAndVerifyQuality(string title, Quality quality, bool proper)
         {
             var result = QualityParser.ParseQuality(title);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RepackRegex = new (@"\b(?<repack>repack\d?|rerip\d?)\b",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex VersionRegex = new (@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)",
+        private static readonly Regex VersionRegex = new (@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)|(?:480|576|720|1080|2160)p[._ ]v(?<version>\d)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex RealRegex = new (@"\b(?<real>REAL)\b",


### PR DESCRIPTION
#### Description

Parse `v2` as anime version 2 when following resolution (720p, 1080p, etc).

#### Issues Fixed or Closed by this PR
* Closes #7302

