### PR TITLE
Fixed: Use download client name for history column

### DIFF
--- a/frontend/src/Activity/History/HistoryRow.tsx
+++ b/frontend/src/Activity/History/HistoryRow.tsx
@@ -195,9 +195,14 @@ function HistoryRow(props: HistoryRowProps) {
         }
 
         if (name === 'downloadClient') {
+          const downloadClientName =
+            'downloadClientName' in data ? data.downloadClientName : null;
+          const downloadClient =
+            'downloadClient' in data ? data.downloadClient : null;
+
           return (
             <TableRowCell key={name} className={styles.downloadClient}>
-              {'downloadClient' in data ? data.downloadClient : ''}
+              {downloadClientName ?? downloadClient ?? ''}
             </TableRowCell>
           );
         }

--- a/frontend/src/typings/History.ts
+++ b/frontend/src/typings/History.ts
@@ -40,6 +40,8 @@ export interface DownloadFailedHistory {
 
 export interface DownloadFolderImportedHistory {
   customFormatScore?: string;
+  downloadClient: string;
+  downloadClientName: string;
   droppedPath: string;
   importedPath: string;
 }


### PR DESCRIPTION
#### Description

Changes from the implementation name (`SABnzbd`), to the assigned name (`SAB`),