### PR TITLE
Fixed: Cleaning the French preposition 'à' from titles

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeSeriesTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeSeriesTitleFixture.cs
@@ -24,6 +24,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("test/test", "testtest")]
         [TestCase("90210", "90210")]
         [TestCase("24", "24")]
+        [TestCase("Test: Something à Deux", "testsomethingdeux")]
+        [TestCase("Parler à", "parlera")]
         public void should_remove_special_characters_and_casing(string dirty, string clean)
         {
             var result = dirty.CleanSeriesTitle();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -517,7 +517,7 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)(a(?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
+        private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -845,7 +845,7 @@ namespace NzbDrone.Core.Parser
             // Replace `%` with `percent` to deal with the 3% case
             title = PercentRegex.Replace(title, "percent");
 
-            return NormalizeRegex.Replace(title).ToLower().RemoveAccent();
+            return NormalizeRegex.Replace(title).ToLowerInvariant().RemoveAccent();
         }
 
         public static string NormalizeEpisodeTitle(string title)


### PR DESCRIPTION
#### Description
Properly normalize the French preposition `à` in order for `Something a Deux` and `Something à Deux` to generate the same clean title.
