### PR TITLE
Fixed: Loading queue with pending releases for deleted series

### DIFF
--- a/src/NzbDrone.Core/Datastore/Extensions/BuilderExtensions.cs
+++ b/src/NzbDrone.Core/Datastore/Extensions/BuilderExtensions.cs
@@ -64,19 +64,25 @@ namespace NzbDrone.Core.Datastore
         public static SqlBuilder Join<TLeft, TRight>(this SqlBuilder builder, Expression<Func<TLeft, TRight, bool>> filter)
         {
             var wb = GetWhereBuilder(builder.DatabaseType, filter, false, builder.Sequence);
-
             var rightTable = TableMapping.Mapper.TableNameMapping(typeof(TRight));
 
-            return builder.Join($"\"{rightTable}\" ON {wb.ToString()}");
+            return builder.Join($"\"{rightTable}\" ON {wb}");
         }
 
         public static SqlBuilder LeftJoin<TLeft, TRight>(this SqlBuilder builder, Expression<Func<TLeft, TRight, bool>> filter)
         {
             var wb = GetWhereBuilder(builder.DatabaseType, filter, false, builder.Sequence);
-
             var rightTable = TableMapping.Mapper.TableNameMapping(typeof(TRight));
 
-            return builder.LeftJoin($"\"{rightTable}\" ON {wb.ToString()}");
+            return builder.LeftJoin($"\"{rightTable}\" ON {wb}");
+        }
+
+        public static SqlBuilder InnerJoin<TLeft, TRight>(this SqlBuilder builder, Expression<Func<TLeft, TRight, bool>> filter)
+        {
+            var wb = GetWhereBuilder(builder.DatabaseType, filter, false, builder.Sequence);
+            var rightTable = TableMapping.Mapper.TableNameMapping(typeof(TRight));
+
+            return builder.InnerJoin($"\"{rightTable}\" ON {wb}");
         }
 
         public static SqlBuilder GroupBy<TModel>(this SqlBuilder builder, Expression<Func<TModel, object>> property)

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Download.Pending
 {
@@ -30,7 +31,11 @@ namespace NzbDrone.Core.Download.Pending
 
         public List<PendingRelease> WithoutFallback()
         {
-            return Query(p => p.Reason != PendingReleaseReason.Fallback);
+            var builder = new SqlBuilder(_database.DatabaseType)
+                .InnerJoin<PendingRelease, Series>((p, s) => p.SeriesId == s.Id)
+                .Where<PendingRelease>(p => p.Reason != PendingReleaseReason.Fallback);
+
+            return Query(builder);
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -274,10 +274,7 @@ namespace NzbDrone.Core.Download.Pending
             {
                 foreach (var series in knownRemoteEpisodes.Values.Select(v => v.Series))
                 {
-                    if (!seriesMap.ContainsKey(series.Id))
-                    {
-                        seriesMap[series.Id] = series;
-                    }
+                    seriesMap.TryAdd(series.Id, series);
                 }
             }
 
@@ -293,7 +290,7 @@ namespace NzbDrone.Core.Download.Pending
                 // Just in case the series was removed, but wasn't cleaned up yet (housekeeper will clean it up)
                 if (series == null)
                 {
-                    return null;
+                    continue;
                 }
 
                 // Languages will be empty if added before upgrading to v4, reparsing the languages if they're empty will set it to Unknown or better.


### PR DESCRIPTION
#### Description
While we have `CleanupOrphanedPendingReleases` and a clean up on SeriesDeletedEvent, we still get cases where we get pending releases with non-existing series ids.

We should load only the pending releases with existing series by using an INNER JOIN to prevent queue loading errors.

#### Issues Fixed or Closed by this PR
* Closes https://github.com/Radarr/Radarr/issues/10616

