### PR TITLE
Fixed: Telegram notification link text

### DIFF
--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -128,12 +128,12 @@ namespace NzbDrone.Core.Notifications.Telegram
 
                 if (linkType == MetadataLinkType.Trakt && series.TvdbId > 0)
                 {
-                    links.Add(new TelegramLink("TVMaze", $"http://trakt.tv/search/tvdb/{series.TvdbId}?id_type=show"));
+                    links.Add(new TelegramLink("Trakt", $"http://trakt.tv/search/tvdb/{series.TvdbId}?id_type=show"));
                 }
 
                 if (linkType == MetadataLinkType.Tvmaze && series.TvMazeId > 0)
                 {
-                    links.Add(new TelegramLink("Trakt", $"http://www.tvmaze.com/shows/{series.TvMazeId}/_"));
+                    links.Add(new TelegramLink("TVMaze", $"http://www.tvmaze.com/shows/{series.TvMazeId}/_"));
                 }
             }
 


### PR DESCRIPTION
#### Description
Small fix to the links label on telegram notification so the label would match the link itself

<!-- Remove any of the following sections if they are not used -->

