### PR TITLE
Fixed: Interactive searches when using Escape to close previous searches

### DIFF
--- a/frontend/src/InteractiveSearch/InteractiveSearch.tsx
+++ b/frontend/src/InteractiveSearch/InteractiveSearch.tsx
@@ -160,13 +160,17 @@ function InteractiveSearch({ type, searchPayload }: InteractiveSearchProps) {
     [dispatch]
   );
 
-  useEffect(() => {
-    // Only fetch releases if they are not already being fetched and not yet populated.
+  useEffect(
+    () => {
+      // Only fetch releases if they are not already being fetched and not yet populated.
 
-    if (!isFetching && !isPopulated) {
-      dispatch(fetchReleases(searchPayload));
-    }
-  }, [isFetching, isPopulated, searchPayload, dispatch]);
+      if (!isFetching && !isPopulated) {
+        dispatch(fetchReleases(searchPayload));
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   const errorMessage = getErrorMessage(error);
 

--- a/frontend/src/Series/Search/SeasonInteractiveSearchModal.tsx
+++ b/frontend/src/Series/Search/SeasonInteractiveSearchModal.tsx
@@ -23,10 +23,10 @@ function SeasonInteractiveSearchModal(
   const dispatch = useDispatch();
 
   const handleModalClose = useCallback(() => {
+    onModalClose();
+
     dispatch(cancelFetchReleases());
     dispatch(clearReleases());
-
-    onModalClose();
   }, [dispatch, onModalClose]);
 
   useEffect(() => {


### PR DESCRIPTION
#### Description
As I already detailed [here](https://github.com/Sonarr/Sonarr/pull/7217#issuecomment-2450525371), when using Escape key to close the interactive search modal the `clearReleases` resets `isFetching` and `isPopulated` to false which is propagated to `InteractiveSearch` which triggers a `fetchReleases` right before closing the modal.

Couldn't find anything related to `useEffect` and propagation issues like this. And weird that `onBackdropEndPress` worked fine with `closeOnBackgroundClick={true}`, so maybe it's something weird going on with eventListeners and `useEffect`.

Moving `onModalClose` call in `handleModalClose` was enough to fix this, but I resorted to use both.