### PR TITLE
Fixed: New values for custom filters

### DIFF
--- a/frontend/src/Components/Form/Tag/TagInput.tsx
+++ b/frontend/src/Components/Form/Tag/TagInput.tsx
@@ -26,7 +26,7 @@ import TagInputTag, { EditedTag, TagInputTagProps } from './TagInputTag';
 import styles from './TagInput.css';
 
 export interface TagBase {
-  id: boolean | number | string;
+  id: boolean | number | string | null;
   name: string | number;
 }
 
@@ -44,7 +44,7 @@ function getTag<T extends { id: T['id']; name: T['name'] }>(
     if (existingTag) {
       return existingTag;
     } else if (allowNew) {
-      return { id: 0, name: value } as T;
+      return { name: value } as T;
     }
   } else if (selectedIndex != null) {
     return suggestions[selectedIndex];


### PR DESCRIPTION
#### Description
Since it can be multiple types, making `id` nullable would revert the previous supported behavior.


#### Issues Fixed or Closed by this PR
* Closes #7347

