### PR TITLE
Show a series path as example in Mount Health Check

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MountCheck.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Localization;
@@ -21,16 +22,16 @@ namespace NzbDrone.Core.HealthCheck.Checks
         {
             // Not best for optimization but due to possible symlinks and junctions, we get mounts based on series path so internals can handle mount resolution.
             var mounts = _seriesService.GetAllSeriesPaths()
-                .Select(s => _diskProvider.GetMount(s.Value))
-                .Where(m => m is { MountOptions.IsReadOnly: true })
-                .DistinctBy(m => m.RootDirectory)
+                .Select(p => new Tuple<IMount, string>(_diskProvider.GetMount(p.Value), p.Value))
+                .Where(m => m.Item1 is { MountOptions.IsReadOnly: true })
+                .DistinctBy(m => m.Item1.RootDirectory)
                 .ToList();
 
             if (mounts.Any())
             {
                 return new HealthCheck(GetType(),
                     HealthCheckResult.Error,
-                    $"{_localizationService.GetLocalizedString("MountSeriesHealthCheckMessage")}{string.Join(", ", mounts.Select(m => m.Name))}",
+                    $"{_localizationService.GetLocalizedString("MountSeriesHealthCheckMessage")}{string.Join(", ", mounts.Select(m => $"{m.Item1.Name} ({m.Item2})"))}",
                     "#series-mount-ro");
             }
 


### PR DESCRIPTION
#### Description
Adding a series path as example for MountCheck to make it easier to debug if the path it's in /home. 

Should help support with recent Archlinux hardening with `ProtectHome=true`.

#### Screenshots for UI Changes

![image](https://github.com/user-attachments/assets/d591d18a-55af-46cb-8e22-1e13cb941d72)
