### PR TITLE
Fixed: Normalize unicode characters when comparing paths for equality

### DIFF
--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -433,6 +434,15 @@ namespace NzbDrone.Common.Test
         public void unix_path_should_return_relative_path(string parentPath, string childPath, string relativePath)
         {
             parentPath.GetRelativePath(childPath).Should().Be(relativePath);
+        }
+
+        [Test]
+        public void should_be_equal_with_different_unicode_representations()
+        {
+            var path1 = @"C:\Test\file.mkv".AsOsAgnostic().Normalize(NormalizationForm.FormC);
+            var path2 = @"C:\Test\file.mkv".AsOsAgnostic().Normalize(NormalizationForm.FormD);
+
+            path1.PathEquals(path2);
         }
     }
 }

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -54,6 +54,10 @@ namespace NzbDrone.Common.Extensions
 
         public static bool PathEquals(this string firstPath, string secondPath, StringComparison? comparison = null)
         {
+            // Normalize paths to ensure unicode characters are represented the same way
+            firstPath = firstPath.Normalize();
+            secondPath = secondPath?.Normalize();
+
             if (!comparison.HasValue)
             {
                 comparison = DiskProviderBase.PathStringComparison;

--- a/src/NzbDrone.Common/PathEqualityComparer.cs
+++ b/src/NzbDrone.Common/PathEqualityComparer.cs
@@ -21,10 +21,10 @@ namespace NzbDrone.Common
         {
             if (OsInfo.IsWindows)
             {
-                return obj.CleanFilePath().ToLower().GetHashCode();
+                return obj.CleanFilePath().Normalize().ToLower().GetHashCode();
             }
 
-            return obj.CleanFilePath().GetHashCode();
+            return obj.CleanFilePath().Normalize().GetHashCode();
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -567,7 +567,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 _logger.ProgressTrace("Manually imported {0} files", imported.Count);
             }
 
-            var untrackedImports = imported.Where(i => importedTrackedDownload.FirstOrDefault(t => t.ImportResult != i) == null).ToList();
+            var untrackedImports = imported.Where(i => i.Result == ImportResultType.Imported && importedTrackedDownload.FirstOrDefault(t => t.ImportResult != i) == null).ToList();
 
             if (untrackedImports.Any())
             {


### PR DESCRIPTION
#### Description

Untested with the exact scenario on macOS, but ensures we're comparing paths with the same unicode normalization.

#### Issues Fixed or Closed by this PR
* Closes #6657

