### PR TITLE
Fixed: .plexmatch episodes on separate lines

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Plex/PlexMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Plex/PlexMetadata.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Plex
                         episodeFormat = $"SP{episodesInFile.First():00}";
                     }
 
-                    content.Append($"Episode: {episodeFormat}: {episodeFile.RelativePath}");
+                    content.AppendLine($"Episode: {episodeFormat}: {episodeFile.RelativePath}");
                 }
             }
 


### PR DESCRIPTION
#### Description

`AppendLine` instead of `Append`

#### Issues Fixed or Closed by this PR
* Closes #7362

