### PR TITLE
Fixed: Allow files to be moved from Torrent Blackhole even when remove is disabled

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/Blackhole/TorrentBlackholeFixture.cs
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.Blackhole
 
             VerifyCompleted(result);
 
-            result.CanBeRemoved.Should().BeFalse();
+            result.CanBeRemoved.Should().BeTrue();
             result.CanMoveFiles.Should().BeFalse();
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -104,9 +104,8 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                     Status = item.Status
                 };
 
-                queueItem.CanMoveFiles = queueItem.CanBeRemoved =
-                    queueItem.DownloadClientInfo.RemoveCompletedDownloads &&
-                    !Settings.ReadOnly;
+                queueItem.CanMoveFiles = !Settings.ReadOnly;
+                queueItem.CanBeRemoved = queueItem.DownloadClientInfo.RemoveCompletedDownloads;
 
                 yield return queueItem;
             }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         {
             foreach (var item in _scanWatchFolder.GetItems(Settings.WatchFolder, ScanGracePeriod))
             {
-                yield return new DownloadClientItem
+                var queueItem = new DownloadClientItem
                 {
                     DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false),
                     DownloadId = Definition.Name + "_" + item.DownloadId,
@@ -72,10 +72,12 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                     OutputPath = item.OutputPath,
 
                     Status = item.Status,
-
-                    CanBeRemoved = true,
-                    CanMoveFiles = true
                 };
+
+                queueItem.CanMoveFiles = true;
+                queueItem.CanBeRemoved = queueItem.DownloadClientInfo.RemoveCompletedDownloads;
+
+                yield return queueItem;
             }
         }
 


### PR DESCRIPTION
#### Description

Torrent Blackhole will move files when read-only is disabled regardless of `Remove Completed Downloads` being enabled or not
