### PR TITLE
fix: Allow `GetFileSize` to follow symlinks

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -189,6 +189,17 @@ namespace NzbDrone.Common.Disk
             }
 
             var fi = new FileInfo(path);
+
+            // If the file is a symlink, resolve the target path and get the size of the target file.
+            if ((fi.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+            {
+                var targetPath = fi.ResolveLinkTarget(true)?.FullName;
+                if (targetPath != null)
+                {
+                    fi = new FileInfo(targetPath);
+                }
+            }
+
             return fi.Length;
         }
 

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -191,9 +191,10 @@ namespace NzbDrone.Common.Disk
             var fi = new FileInfo(path);
 
             // If the file is a symlink, resolve the target path and get the size of the target file.
-            if ((fi.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+            if (fi.Attributes.HasFlag(FileAttributes.ReparsePoint))
             {
                 var targetPath = fi.ResolveLinkTarget(true)?.FullName;
+
                 if (targetPath != null)
                 {
                     fi = new FileInfo(targetPath);


### PR DESCRIPTION
#### Description

Some of the videos in my library are symlinks because they are too large to store on the disk space I have, so I download it to the cloud and mount it using [rclone](https://rclone.org) instead.

The problem with using symlinks is that Sonarr does not follow symlinks when reading file sizes. So, the videos will report as being only a few hundred KBs.