### PR TITLE
Tweak text-wrapping for title and overview in series view

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -59,10 +59,10 @@
 }
 
 .title {
+  text-wrap: balance;
   font-weight: 300;
   font-size: 50px;
   line-height: 50px;
-  text-wrap: balance;
 }
 
 .toggleMonitoredContainer {
@@ -144,8 +144,8 @@
   flex: 1 0 0;
   margin-top: 8px;
   min-height: 0;
-  font-size: $intermediateFontSize;
   text-wrap: balance;
+  font-size: $intermediateFontSize;
 }
 
 .contentContainer {

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -62,6 +62,7 @@
   font-weight: 300;
   font-size: 50px;
   line-height: 50px;
+  text-wrap: balance;
 }
 
 .toggleMonitoredContainer {
@@ -144,6 +145,7 @@
   margin-top: 8px;
   min-height: 0;
   font-size: $intermediateFontSize;
+  text-wrap: balance;
 }
 
 .contentContainer {


### PR DESCRIPTION
Tweak text-wrapping for title and overview

#### Description
Tweak CSS to improve text wrapping by adding text-wrap: balance to series view

#### Screenshots

Before:
![Screenshot_20241116_204700](https://github.com/user-attachments/assets/fa581aa6-539c-4529-9131-5c310bd57101)

After:
![Screenshot_20241116_204232](https://github.com/user-attachments/assets/091e4df8-3c32-4236-87af-13e88f037100)
