### PR TITLE
Rename SizeLeft and TimeLeft queue item properties

### DIFF
--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -359,11 +359,11 @@ namespace NzbDrone.Core.Download.Pending
                 ect = ect.AddMinutes(_configService.RssSyncInterval);
             }
 
-            var timeleft = ect.Subtract(DateTime.UtcNow);
+            var timeLeft = ect.Subtract(DateTime.UtcNow);
 
-            if (timeleft.TotalSeconds < 0)
+            if (timeLeft.TotalSeconds < 0)
             {
-                timeleft = TimeSpan.Zero;
+                timeLeft = TimeSpan.Zero;
             }
 
             string downloadClientName = null;
@@ -385,9 +385,9 @@ namespace NzbDrone.Core.Download.Pending
                 Quality = pendingRelease.RemoteEpisode.ParsedEpisodeInfo.Quality,
                 Title = pendingRelease.Title,
                 Size = pendingRelease.RemoteEpisode.Release.Size,
-                Sizeleft = pendingRelease.RemoteEpisode.Release.Size,
+                SizeLeft = pendingRelease.RemoteEpisode.Release.Size,
                 RemoteEpisode = pendingRelease.RemoteEpisode,
-                Timeleft = timeleft,
+                TimeLeft = timeLeft,
                 EstimatedCompletionTime = ect,
                 Added = pendingRelease.Added,
                 Status = Enum.TryParse(pendingRelease.Reason.ToString(), out QueueStatus outValue) ? outValue : QueueStatus.Unknown,

--- a/src/NzbDrone.Core/Queue/Queue.cs
+++ b/src/NzbDrone.Core/Queue/Queue.cs
@@ -18,8 +18,8 @@ namespace NzbDrone.Core.Queue
         public QualityModel Quality { get; set; }
         public decimal Size { get; set; }
         public string Title { get; set; }
-        public decimal Sizeleft { get; set; }
-        public TimeSpan? Timeleft { get; set; }
+        public decimal SizeLeft { get; set; }
+        public TimeSpan? TimeLeft { get; set; }
         public DateTime? EstimatedCompletionTime { get; set; }
         public DateTime? Added { get; set; }
         public QueueStatus Status { get; set; }

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -67,8 +67,8 @@ namespace NzbDrone.Core.Queue
                 Quality = trackedDownload.RemoteEpisode?.ParsedEpisodeInfo.Quality ?? new QualityModel(Quality.Unknown),
                 Title = Parser.Parser.RemoveFileExtension(trackedDownload.DownloadItem.Title),
                 Size = trackedDownload.DownloadItem.TotalSize,
-                Sizeleft = trackedDownload.DownloadItem.RemainingSize,
-                Timeleft = trackedDownload.DownloadItem.RemainingTime,
+                SizeLeft = trackedDownload.DownloadItem.RemainingSize,
+                TimeLeft = trackedDownload.DownloadItem.RemainingTime,
                 Status = Enum.TryParse(trackedDownload.DownloadItem.Status.ToString(), out QueueStatus outValue) ? outValue : QueueStatus.Unknown,
                 TrackedDownloadStatus = trackedDownload.Status,
                 TrackedDownloadState = trackedDownload.State,
@@ -86,9 +86,9 @@ namespace NzbDrone.Core.Queue
 
             queue.Id = HashConverter.GetHashInt31($"trackedDownload-{trackedDownload.DownloadClient}-{trackedDownload.DownloadItem.DownloadId}-ep{episode?.Id ?? 0}");
 
-            if (queue.Timeleft.HasValue)
+            if (queue.TimeLeft.HasValue)
             {
-                queue.EstimatedCompletionTime = DateTime.UtcNow.Add(queue.Timeleft.Value);
+                queue.EstimatedCompletionTime = DateTime.UtcNow.Add(queue.TimeLeft.Value);
             }
 
             return queue;

--- a/src/Sonarr.Api.V3/Queue/QueueController.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueController.cs
@@ -219,8 +219,8 @@ namespace Sonarr.Api.V3.Queue
             if (pagingSpec.SortKey == "timeleft")
             {
                 ordered = ascending
-                    ? fullQueue.OrderBy(q => q.Timeleft, new TimeleftComparer())
-                    : fullQueue.OrderByDescending(q => q.Timeleft, new TimeleftComparer());
+                    ? fullQueue.OrderBy(q => q.TimeLeft, new TimeleftComparer())
+                    : fullQueue.OrderByDescending(q => q.TimeLeft, new TimeleftComparer());
             }
             else if (pagingSpec.SortKey == "estimatedCompletionTime")
             {
@@ -271,7 +271,7 @@ namespace Sonarr.Api.V3.Queue
                 ordered = ascending ? fullQueue.OrderBy(orderByFunc) : fullQueue.OrderByDescending(orderByFunc);
             }
 
-            ordered = ordered.ThenByDescending(q => q.Size == 0 ? 0 : 100 - (q.Sizeleft / q.Size * 100));
+            ordered = ordered.ThenByDescending(q => q.Size == 0 ? 0 : 100 - (q.SizeLeft / q.Size * 100));
 
             pagingSpec.Records = ordered.Skip((pagingSpec.Page - 1) * pagingSpec.PageSize).Take(pagingSpec.PageSize).ToList();
             pagingSpec.TotalRecords = fullQueue.Count;
@@ -312,9 +312,9 @@ namespace Sonarr.Api.V3.Queue
                     return q => q.Size;
                 case "progress":
                     // Avoid exploding if a download's size is 0
-                    return q => 100 - (q.Sizeleft / Math.Max(q.Size * 100, 1));
+                    return q => 100 - (q.SizeLeft / Math.Max(q.Size * 100, 1));
                 default:
-                    return q => q.Timeleft;
+                    return q => q.TimeLeft;
             }
         }
 

--- a/src/Sonarr.Api.V3/Queue/QueueResource.cs
+++ b/src/Sonarr.Api.V3/Queue/QueueResource.cs
@@ -26,8 +26,8 @@ namespace Sonarr.Api.V3.Queue
         public int CustomFormatScore { get; set; }
         public decimal Size { get; set; }
         public string Title { get; set; }
-        public decimal Sizeleft { get; set; }
-        public TimeSpan? Timeleft { get; set; }
+        public decimal SizeLeft { get; set; }
+        public TimeSpan? TimeLeft { get; set; }
         public DateTime? EstimatedCompletionTime { get; set; }
         public DateTime? Added { get; set; }
         public QueueStatus Status { get; set; }
@@ -42,6 +42,11 @@ namespace Sonarr.Api.V3.Queue
         public string Indexer { get; set; }
         public string OutputPath { get; set; }
         public bool EpisodeHasFile { get; set; }
+
+        [Obsolete]
+        public decimal Sizeleft { get; set; }
+        [Obsolete]
+        public TimeSpan? Timeleft { get; set; }
     }
 
     public static class QueueResourceMapper
@@ -70,8 +75,8 @@ namespace Sonarr.Api.V3.Queue
                 CustomFormatScore = customFormatScore,
                 Size = model.Size,
                 Title = model.Title,
-                Sizeleft = model.Sizeleft,
-                Timeleft = model.Timeleft,
+                SizeLeft = model.SizeLeft,
+                TimeLeft = model.TimeLeft,
                 EstimatedCompletionTime = model.EstimatedCompletionTime,
                 Added = model.Added,
                 Status = model.Status,
@@ -85,7 +90,12 @@ namespace Sonarr.Api.V3.Queue
                 DownloadClientHasPostImportCategory = model.DownloadClientHasPostImportCategory,
                 Indexer = model.Indexer,
                 OutputPath = model.OutputPath,
-                EpisodeHasFile = model.Episode?.HasFile ?? false
+                EpisodeHasFile = model.Episode?.HasFile ?? false,
+
+                #pragma warning disable CS0612
+                Sizeleft = model.SizeLeft,
+                Timeleft = model.TimeLeft,
+                #pragma warning restore CS0612
             };
         }
 


### PR DESCRIPTION
#### Description

Adds `sizeLeft` and `timeLeft` properties, while marking `sizeleft` and `timeleft` obsolete for removal in a future API version.

Also fixed all health checks dying if internet is unavailable.

#### Issues Fixed or Closed by this PR
* Closes #7392

