### PR TITLE
Fixed: Kometa and Kodi metadata failing with duplicate episode files

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Kometa/KometaMetadata.cs
@@ -131,7 +131,15 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Kometa
 
             try
             {
-                var screenshot = episodeFile.Episodes.Value.First().Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
+                var firstEpisode = episodeFile.Episodes.Value.FirstOrDefault();
+
+                if (firstEpisode == null)
+                {
+                    _logger.Debug("Episode file has no associated episodes, potentially a duplicate file");
+                    return new List<ImageFileResult>();
+                }
+
+                var screenshot = firstEpisode.Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
 
                 if (screenshot == null)
                 {

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -421,7 +421,15 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
             try
             {
-                var screenshot = episodeFile.Episodes.Value.First().Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
+                var firstEpisode = episodeFile.Episodes.Value.FirstOrDefault();
+
+                if (firstEpisode == null)
+                {
+                    _logger.Debug("Episode file has no associated episodes, potentially a duplicate file");
+                    return new List<ImageFileResult>();
+                }
+
+                var screenshot = firstEpisode.Images.SingleOrDefault(i => i.CoverType == MediaCoverTypes.Screenshot);
 
                 if (screenshot == null)
                 {


### PR DESCRIPTION
#### Description

Guard against duplicate episodes files breaking the extra file process.

#### Issues Fixed or Closed by this PR
* Closes #7381

