### PR TITLE
An *advanced* option to change a metadata provider / skyhook endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img width="24px" src="./Logo/256.png" alt="Sonarr"></img> Sonarr
+# <img width="24px" src="./Logo/256.png" alt="Sonarr"></img> Sonarr - fork
 
 [![Translated](https://translate.servarr.com/widgets/servarr/-/sonarr/svg-badge.svg)](https://translate.servarr.com/engage/servarr/)
 [![Backers on Open Collective](https://opencollective.com/Sonarr/backers/badge.svg)](#backers)


### PR DESCRIPTION
Hi Sonarr team.

I would like to open a discussion for creating a way in Sonarr to change the default metadata provider / skyhook provider to a custom one. Would such change be welcomed and approved? 

For the initial implementation, I could see it as an option hidden behind advanced settings flag. There are multiple scenarios I have thought of:

1) Users would be able to change the endpoint used for the skyhook provider. The user would have to guarantee that the implementation of this endpoint has the same external API as the official skyhook. In such case, it would be nice to at least maintain an updated open API spec for the skyhook, which is available for anyone to implement themselves.

2) Users would be able to change to a different provider entirely, chosen from a predefined set of providers the new implementation would be compatible with. The communication between Sonarr and the custom provider would continue to be over HTTP.

3) The same as _2)_, but the providers would be more like a C# plugin implementing an interface that the Sonarr could natively call. The provider would provide the plugin manually by placing a .dll somewhere Sonarr can find.

The options I have described are sorted in the necessary implementation / refactoring complexity.

To reiterate: changing a metadata provider would be considered an advanced feature and even "officially unsupported" to not burden support channels, but I believe this would be helpful for advanced users.

I am opening this discussion by submitting this blank PR mainly to avoid some of the communication issues https://github.com/Sonarr/Sonarr/pull/7186 had.