### PR TITLE
Fixed: Custom Format upgrading not respecting 'Upgrades Allowed'

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -135,8 +135,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         private bool CustomFormatCutoffNotMet(QualityProfile profile, List<CustomFormat> currentFormats)
         {
             var score = profile.CalculateCustomFormatScore(currentFormats);
+            var cutoff = profile.UpgradeAllowed ? profile.CutoffFormatScore : profile.MinFormatScore;
 
-            return score < profile.CutoffFormatScore;
+            return score < cutoff;
         }
 
         public bool CutoffNotMet(QualityProfile profile, QualityModel currentQuality, List<CustomFormat> currentFormats, QualityModel newQuality = null)


### PR DESCRIPTION
#### Description

Came up on Discord, https://discord.com/channels/383686866005917708/383688189941907459/1310364478965288990

CF score upgrading will use the minimum score when Upgrades Allowed is disabled, which matches quality upgrading using the lowest allowed quality.
