### PR TITLE
Support Postgres with non-standard version string

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/DatabaseVersionParserFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/DatabaseVersionParserFixture.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Test.Datastore;
+
+[TestFixture]
+public class DatabaseVersionParserFixture
+{
+    [TestCase("3.44.2", 3, 44, 2)]
+    public void should_parse_sqlite_database_version(string serverVersion, int majorVersion, int minorVersion, int buildVersion)
+    {
+        var version = DatabaseVersionParser.ParseServerVersion(serverVersion);
+
+        version.Should().NotBeNull();
+        version.Major.Should().Be(majorVersion);
+        version.Minor.Should().Be(minorVersion);
+        version.Build.Should().Be(buildVersion);
+    }
+
+    [TestCase("14.8 (Debian 14.8-1.pgdg110+1)", 14, 8, null)]
+    [TestCase("16.3 (Debian 16.3-1.pgdg110+1)", 16, 3, null)]
+    [TestCase("16.3 - Percona Distribution", 16, 3, null)]
+    [TestCase("17.0 - Percona Server", 17, 0, null)]
+    public void should_parse_postgres_database_version(string serverVersion, int majorVersion, int minorVersion, int? buildVersion)
+    {
+        var version = DatabaseVersionParser.ParseServerVersion(serverVersion);
+
+        version.Should().NotBeNull();
+        version.Major.Should().Be(majorVersion);
+        version.Minor.Should().Be(minorVersion);
+
+        if (buildVersion.HasValue)
+        {
+            version.Build.Should().Be(buildVersion.Value);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Database.cs
+++ b/src/NzbDrone.Core/Datastore/Database.cs
@@ -2,7 +2,6 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Data.SQLite;
-using System.Text.RegularExpressions;
 using Dapper;
 using NLog;
 using NzbDrone.Common.Instrumentation;
@@ -52,9 +51,8 @@ namespace NzbDrone.Core.Datastore
             {
                 using var db = _datamapperFactory();
                 var dbConnection = db as DbConnection;
-                var version = Regex.Replace(dbConnection.ServerVersion, @"\(.*?\)", "");
 
-                return new Version(version);
+                return DatabaseVersionParser.ParseServerVersion(dbConnection.ServerVersion);
             }
         }
 

--- a/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
+++ b/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace NzbDrone.Core.Datastore;
+
+public static class DatabaseVersionParser
+{
+    private static readonly Regex VersionRegex = new (@"^[^ ]+", RegexOptions.Compiled);
+
+    public static Version ParseServerVersion(string serverVersion)
+    {
+        var match = VersionRegex.Match(serverVersion);
+
+        return match.Success ? new Version(match.Value) : null;
+    }
+}


### PR DESCRIPTION
#### Description

Supports non-standard Postgres version information such as `16.3 - Percona Distribution` as well as official releases.