### PR TITLE
Fixed: Avoid default category on existing Transmission configurations 

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
@@ -27,12 +28,25 @@ namespace NzbDrone.Core.Download.Clients.Transmission
     {
         private static readonly TransmissionSettingsValidator Validator = new ();
 
+        // This constructor is used when creating a new instance, such as the user adding a new Transmission client.
         public TransmissionSettings()
         {
             Host = "localhost";
             Port = 9091;
             UrlBase = "/transmission/";
             TvCategory = "tv-sonarr";
+        }
+
+        // TODO: Remove this in v5
+        // This constructor is used when deserializing from JSON, it will set the
+        // category to the deserialized value, defaulting to null.
+        [JsonConstructor]
+        public TransmissionSettings(string tvCategory = null)
+        {
+            Host = "localhost";
+            Port = 9091;
+            UrlBase = "/transmission/";
+            TvCategory = tvCategory;
         }
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]


### PR DESCRIPTION
#### Description
Reverting the default category that was introduced in 675e3cd38a14ea33c27f2d66a4be2bf802e17d88. Sadly while this was a regression due to the fact `TvCategory` was null for some configurations and using the new default value, at this point I can't imagine a solution to revert this without manual intervention on the user side.

#### Issues Fixed or Closed by this PR
* Closes #7424

