### PR TITLE
Bug: If a revision upgrade exists and CF scoring is higher than on disk, "upgrade allowed" is completely bypassed

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Languages;
@@ -393,6 +394,78 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.WEBDL1080p));
             GivenNewQuality(new QualityModel(Quality.WEBDL1080p));
+
+            GivenOldCustomFormats(new List<CustomFormat>());
+            GivenNewCustomFormats(new List<CustomFormat> { customFormat });
+
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_quality_profile_does_not_allow_upgrades_but_format_cutoff_is_above_current_score_and_is_revision_upgrade()
+        {
+            var customFormat = new CustomFormat("My Format", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 1 };
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(s => s.DownloadPropersAndRepacks)
+                  .Returns(ProperDownloadTypes.DoNotPrefer);
+
+            GivenProfile(new QualityProfile
+            {
+                Cutoff = Quality.SDTV.Id,
+                MinFormatScore = 0,
+                CutoffFormatScore = 10000,
+                Items = Qualities.QualityFixture.GetDefaultQualities(),
+                FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems("My Format"),
+                UpgradeAllowed = false
+            });
+
+            _parseResultSingle.Series.QualityProfile.Value.FormatItems = new List<ProfileFormatItem>
+            {
+                new ProfileFormatItem
+                {
+                    Format = customFormat,
+                    Score = 50
+                }
+            };
+
+            GivenFileQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 1)));
+            GivenNewQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 2)));
+
+            GivenOldCustomFormats(new List<CustomFormat>());
+            GivenNewCustomFormats(new List<CustomFormat> { customFormat });
+
+            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void this_is_a_dummy_test_only_meant_to_show_that_no_upgrade_will_occur_with_no_revision_upgrade()
+        {
+            var customFormat = new CustomFormat("My Format", new ResolutionSpecification { Value = (int)Resolution.R1080p }) { Id = 1 };
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(s => s.DownloadPropersAndRepacks)
+                  .Returns(ProperDownloadTypes.DoNotPrefer);
+
+            GivenProfile(new QualityProfile
+            {
+                Cutoff = Quality.SDTV.Id,
+                MinFormatScore = 0,
+                CutoffFormatScore = 10000,
+                Items = Qualities.QualityFixture.GetDefaultQualities(),
+                FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems("My Format"),
+                UpgradeAllowed = false
+            });
+
+            _parseResultSingle.Series.QualityProfile.Value.FormatItems = new List<ProfileFormatItem>
+            {
+                new ProfileFormatItem
+                {
+                    Format = customFormat,
+                    Score = 50
+                }
+            };
+
+            GivenFileQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 1)));
+            GivenNewQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 1)));
 
             GivenOldCustomFormats(new List<CustomFormat>());
             GivenNewCustomFormats(new List<CustomFormat> { customFormat });


### PR DESCRIPTION
#### Description
If a revision upgrade exists and CF scoring is higher than on disk, "upgrade allowed" is completely bypassed, even if repack setting is "Do not prefer".

Continuing from #7427 with added tests to showcase the bug. The 2 tests I added are exact copies of each other. The only difference in the dummy second one, is that I made it not be a revision upgrade. If there is a revision upgrade, then the test always fails, if there isn't, it always passes.

#### Issues Fixed or Closed by this PR
* Revision upgrades no longer bypass "Upgrade allowed" even if set to "Do no prefer"

