### PR TITLE
New: Add opt-in CGNAT support for authentication bypass

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
@@ -8,26 +8,11 @@ namespace NzbDrone.Common.Test.ExtensionTests
     [TestFixture]
     public class IPAddressExtensionsFixture
     {
-        [OneTimeSetUp]
-        public void Setup()
-        {
-            Environment.SetEnvironmentVariable("SONARR_TRUST_CGNAT", "true");
-        }
-
-        [OneTimeTearDown]
-        public void Cleanup()
-        {
-            Environment.SetEnvironmentVariable("SONARR_TRUST_CGNAT", null);
-        }
-
         [TestCase("::1")]
         [TestCase("10.64.5.1")]
         [TestCase("127.0.0.1")]
         [TestCase("172.16.0.1")]
         [TestCase("192.168.5.1")]
-        [TestCase("100.64.0.1")]
-        [TestCase("100.127.255.254")]
-        [TestCase("100.100.100.100")]
         public void should_return_true_for_local_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeTrue();
@@ -36,9 +21,9 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase("1.2.3.4")]
         [TestCase("172.55.0.1")]
         [TestCase("192.55.0.1")]
-        [TestCase("100.63.255.255")]
-        [TestCase("100.128.0.0")]
-        [TestCase("100.0.0.1")]
+        [TestCase("100.64.0.1")]
+        [TestCase("100.127.255.254")]
+        [TestCase("100.100.100.100")]
         public void should_return_false_for_public_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeFalse();

--- a/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
@@ -23,10 +23,26 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase("192.55.0.1")]
         [TestCase("100.64.0.1")]
         [TestCase("100.127.255.254")]
-        [TestCase("100.100.100.100")]
         public void should_return_false_for_public_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeFalse();
+        }
+
+        [TestCase("100.64.0.1")]
+        [TestCase("100.127.255.254")]
+        [TestCase("100.100.100.100")]
+        public void should_return_true_for_cgnat_ip_address(string ipAddress)
+        {
+            IPAddress.Parse(ipAddress).IsCgnatIpAddress().Should().BeTrue();
+        }
+
+        [TestCase("1.2.3.4")]
+        [TestCase("192.168.5.1")]
+        [TestCase("100.63.255.255")]
+        [TestCase("100.128.0.0")]
+        public void should_return_false_for_non_cgnat_ip_address(string ipAddress)
+        {
+            IPAddress.Parse(ipAddress).IsCgnatIpAddress().Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
@@ -8,6 +8,18 @@ namespace NzbDrone.Common.Test.ExtensionTests
     [TestFixture]
     public class IPAddressExtensionsFixture
     {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            Environment.SetEnvironmentVariable("SONARR_TRUST_CGNAT", "true");
+        }
+
+        [OneTimeTearDown]
+        public void Cleanup()
+        {
+            Environment.SetEnvironmentVariable("SONARR_TRUST_CGNAT", null);
+        }
+
         [TestCase("::1")]
         [TestCase("10.64.5.1")]
         [TestCase("127.0.0.1")]

--- a/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/IPAddressExtensionsFixture.cs
@@ -13,6 +13,9 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase("127.0.0.1")]
         [TestCase("172.16.0.1")]
         [TestCase("192.168.5.1")]
+        [TestCase("100.64.0.1")]
+        [TestCase("100.127.255.254")]
+        [TestCase("100.100.100.100")]
         public void should_return_true_for_local_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeTrue();
@@ -21,6 +24,9 @@ namespace NzbDrone.Common.Test.ExtensionTests
         [TestCase("1.2.3.4")]
         [TestCase("172.55.0.1")]
         [TestCase("192.55.0.1")]
+        [TestCase("100.63.255.255")]
+        [TestCase("100.128.0.0")]
+        [TestCase("100.0.0.1")]
         public void should_return_false_for_public_ip_address(string ipAddress)
         {
             IPAddress.Parse(ipAddress).IsLocalAddress().Should().BeFalse();

--- a/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
@@ -52,5 +52,11 @@ namespace NzbDrone.Common.Extensions
 
             return IsLinkLocal() || IsClassA() || IsClassC() || IsClassB();
         }
+
+        public static bool IsCgnatIpAddress(this IPAddress ipAddress)
+        {
+            var bytes = ipAddress.GetAddressBytes();
+            return bytes.Length == 4 && bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127;
+        }
     }
 }

--- a/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
@@ -5,15 +5,6 @@ namespace NzbDrone.Common.Extensions
 {
     public static class IPAddressExtensions
     {
-        private static readonly IConfigService _configService;
-        private static readonly bool TrustCGNAT;
-
-        static IPAddressExtensions()
-        {
-            _configService = ServiceFactory.Instance.GetInstance<IConfigService>();
-            TrustCGNAT = _configService?.TrustCGNAT ?? Environment.GetEnvironmentVariable("SONARR_TRUST_CGNAT")?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false;
-        }
-
         public static bool IsLocalAddress(this IPAddress ipAddress)
         {
             // Map back to IPv4 if mapped to IPv6, for example "::ffff:1.2.3.4" to "1.2.3.4".
@@ -59,10 +50,7 @@ namespace NzbDrone.Common.Extensions
             // Class C private range: 192.168.0.0 – 192.168.255.255 (192.168.0.0/16)
             bool IsClassC() => ipv4Bytes[0] == 192 && ipv4Bytes[1] == 168;
 
-            // CGNAT range: 100.64.0.0 - 100.127.255.255 (100.64.0.0/10)
-            bool IsCGNAT() => ipv4Bytes[0] == 100 && ipv4Bytes[1] >= 64 && ipv4Bytes[1] <= 127;
-
-            return IsLinkLocal() || IsClassA() || IsClassC() || IsClassB() || (TrustCGNAT && IsCGNAT());
+            return IsLinkLocal() || IsClassA() || IsClassC() || IsClassB();
         }
     }
 }

--- a/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IpAddressExtensions.cs
@@ -50,7 +50,10 @@ namespace NzbDrone.Common.Extensions
             // Class C private range: 192.168.0.0 – 192.168.255.255 (192.168.0.0/16)
             bool IsClassC() => ipv4Bytes[0] == 192 && ipv4Bytes[1] == 168;
 
-            return IsLinkLocal() || IsClassA() || IsClassC() || IsClassB();
+            // Tailscale CGNAT range: 100.64.0.0 - 100.127.255.255 (100.64.0.0/10)
+            bool IsTailscaleCGNAT() => ipv4Bytes[0] == 100 && ipv4Bytes[1] >= 64 && ipv4Bytes[1] <= 127;
+
+            return IsLinkLocal() || IsClassA() || IsClassC() || IsClassB() || IsTailscaleCGNAT();
         }
     }
 }

--- a/src/NzbDrone.Common/Options/AuthOptions.cs
+++ b/src/NzbDrone.Common/Options/AuthOptions.cs
@@ -6,4 +6,5 @@ public class AuthOptions
     public bool? Enabled { get; set; }
     public string Method { get; set; }
     public string Required { get; set; }
+    public bool? TrustCgnat { get; set; }
 }

--- a/src/NzbDrone.Common/Options/AuthOptions.cs
+++ b/src/NzbDrone.Common/Options/AuthOptions.cs
@@ -6,5 +6,5 @@ public class AuthOptions
     public bool? Enabled { get; set; }
     public string Method { get; set; }
     public string Required { get; set; }
-    public bool? TrustCgnat { get; set; }
+    public bool? TrustCgnatIpAddresses { get; set; }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -65,6 +65,7 @@ namespace NzbDrone.Core.Configuration
         string PostgresPassword { get; }
         string PostgresMainDb { get; }
         string PostgresLogDb { get; }
+        bool TrustCgnat { get; }
     }
 
     public class ConfigFileProvider : IConfigFileProvider
@@ -475,5 +476,7 @@ namespace NzbDrone.Core.Configuration
         {
             SetValue("ApiKey", GenerateApiKey());
         }
+
+        public bool TrustCgnat => _authOptions.TrustCgnat ?? GetValueBoolean("TrustCgnat", false, persist: false);
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Configuration
         string PostgresPassword { get; }
         string PostgresMainDb { get; }
         string PostgresLogDb { get; }
-        bool TrustCgnat { get; }
+        bool TrustCgnatIpAddresses { get; }
     }
 
     public class ConfigFileProvider : IConfigFileProvider
@@ -477,6 +477,6 @@ namespace NzbDrone.Core.Configuration
             SetValue("ApiKey", GenerateApiKey());
         }
 
-        public bool TrustCgnat => _authOptions.TrustCgnat ?? GetValueBoolean("TrustCgnat", false, persist: false);
+        public bool TrustCgnatIpAddresses => _authOptions.TrustCgnatIpAddresses ?? GetValueBoolean("TrustCgnatIpAddresses", false, persist: false);
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -390,10 +390,10 @@ namespace NzbDrone.Core.Configuration
 
         public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
 
-        public bool TrustCgnat
+        public bool TrustCgnatIpAddresses
         {
-            get { return GetValueBoolean("TrustCgnat", false); }
-            set { SetValue("TrustCgnat", value); }
+            get { return GetValueBoolean("TrustCgnatIpAddresses", false); }
+            set { SetValue("TrustCgnatIpAddresses", value); }
         }
 
         private string GetValue(string key)

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -390,6 +390,12 @@ namespace NzbDrone.Core.Configuration
 
         public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
 
+        public bool TrustCGNAT
+        {
+            get { return GetValueBoolean("TrustCGNAT", false); }
+            set { SetValue("TrustCGNAT", value); }
+        }
+
         private string GetValue(string key)
         {
             return GetValue(key, string.Empty);

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -390,10 +390,10 @@ namespace NzbDrone.Core.Configuration
 
         public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
 
-        public bool TrustCGNAT
+        public bool TrustCgnat
         {
-            get { return GetValueBoolean("TrustCGNAT", false); }
-            set { SetValue("TrustCGNAT", value); }
+            get { return GetValueBoolean("TrustCgnat", false); }
+            set { SetValue("TrustCgnat", value); }
         }
 
         private string GetValue(string key)

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -94,5 +94,8 @@ namespace NzbDrone.Core.Configuration
 
         CertificateValidationType CertificateValidation { get; }
         string ApplicationUrl { get; }
+
+        // Network
+        bool TrustCGNAT { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -94,8 +94,5 @@ namespace NzbDrone.Core.Configuration
 
         CertificateValidationType CertificateValidation { get; }
         string ApplicationUrl { get; }
-
-        // Network
-        bool TrustCGNAT { get; set; }
     }
 }

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -90,8 +90,7 @@ namespace Sonarr.Api.V3.Config
                 BackupFolder = configService.BackupFolder,
                 BackupInterval = configService.BackupInterval,
                 BackupRetention = configService.BackupRetention,
-                ApplicationUrl = configService.ApplicationUrl,
-                TrustCGNAT = configService.TrustCGNAT
+                ApplicationUrl = configService.ApplicationUrl
             };
         }
     }

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -45,7 +45,7 @@ namespace Sonarr.Api.V3.Config
         public string BackupFolder { get; set; }
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
-        public bool TrustCgnat { get; set; }
+        public bool TrustCgnatIpAddresses { get; set; }
     }
 
     public static class HostConfigResourceMapper

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -45,7 +45,7 @@ namespace Sonarr.Api.V3.Config
         public string BackupFolder { get; set; }
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
-        public bool TrustCGNAT { get; set; }
+        public bool TrustCgnat { get; set; }
     }
 
     public static class HostConfigResourceMapper

--- a/src/Sonarr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigResource.cs
@@ -45,6 +45,7 @@ namespace Sonarr.Api.V3.Config
         public string BackupFolder { get; set; }
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
+        public bool TrustCGNAT { get; set; }
     }
 
     public static class HostConfigResourceMapper
@@ -89,7 +90,8 @@ namespace Sonarr.Api.V3.Config
                 BackupFolder = configService.BackupFolder,
                 BackupInterval = configService.BackupInterval,
                 BackupRetention = configService.BackupRetention,
-                ApplicationUrl = configService.ApplicationUrl
+                ApplicationUrl = configService.ApplicationUrl,
+                TrustCGNAT = configService.TrustCGNAT
             };
         }
     }

--- a/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Http.Authentication
                     IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
                     if (ipAddress.IsLocalAddress() ||
-                        (_configService.TrustCgnat && IsCGNATAddress(ipAddress)))
+                        (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
                     {
                         context.Succeed(requirement);
                     }
@@ -38,22 +38,6 @@ namespace NzbDrone.Http.Authentication
             }
 
             return Task.CompletedTask;
-        }
-
-        private bool IsCGNATAddress(IPAddress ipAddress)
-        {
-            if (ipAddress.IsIPv4MappedToIPv6)
-            {
-                ipAddress = ipAddress.MapToIPv4();
-            }
-
-            if (ipAddress.AddressFamily != AddressFamily.InterNetwork)
-            {
-                return false;
-            }
-
-            var bytes = ipAddress.GetAddressBytes();
-            return bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127;
         }
 
         public void Handle(ConfigSavedEvent message)


### PR DESCRIPTION
#### Description

Added support for CGNAT IP ranges (100.64.0.0/10) to be optionally recognized as trusted addresses, allowing authentication bypass when accessing Sonarr through CGNAT networks (like Tailscale), consistent with other local network behavior.

Changes include:

- Added CGNAT validation
- Made CGNAT support configurable via config or `SONARR__AUTH__TRUSTCGNATIPADDRESSES` environment variable
- Updated test cases
- Maintains existing behavior for local IP ranges

The CGNAT support is disabled by default and must be explicitly enabled through configuration or environment variable.

#### Issues Fixed or Closed by this PR

- None