### PR TITLE
Fixed: Don't fail import if symlink target can't be resolved

### DIFF
--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -190,15 +190,22 @@ namespace NzbDrone.Common.Disk
 
             var fi = new FileInfo(path);
 
-            // If the file is a symlink, resolve the target path and get the size of the target file.
-            if (fi.Attributes.HasFlag(FileAttributes.ReparsePoint))
+            try
             {
-                var targetPath = fi.ResolveLinkTarget(true)?.FullName;
-
-                if (targetPath != null)
+                // If the file is a symlink, resolve the target path and get the size of the target file.
+                if (fi.Attributes.HasFlag(FileAttributes.ReparsePoint))
                 {
-                    fi = new FileInfo(targetPath);
+                    var targetPath = fi.ResolveLinkTarget(true)?.FullName;
+
+                    if (targetPath != null)
+                    {
+                        fi = new FileInfo(targetPath);
+                    }
                 }
+            }
+            catch (IOException ex)
+            {
+                Logger.Trace(ex, "Unable to resolve symlink target for {0}", path);
             }
 
             return fi.Length;

--- a/src/Sonarr.Api.V3/Series/SeriesLookupController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesLookupController.cs
@@ -24,7 +24,7 @@ namespace Sonarr.Api.V3.Series
         }
 
         [HttpGet]
-        public object Search([FromQuery] string term)
+        public IEnumerable<SeriesResource> Search([FromQuery] string term)
         {
             var tvDbResults = _searchProxy.SearchForNewSeries(term);
             return MapToResource(tvDbResults);


### PR DESCRIPTION
#### Description

Catch IOExceptions trying to resolve symlinks so they can be logged, but not fail.

Adds the correct return type for the `series/lookup` endpoint.

#### Issues Fixed or Closed by this PR
* Closes #7431
* Closes #7438

