### PR TITLE
Fixed: Custom Format score bypassing upgrades not being allowed

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeSpecificationFixture.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                        new List<CustomFormat>(),
                        new QualityModel(Quality.DVD, new Revision(version: 2)),
                        new List<CustomFormat>())
-                   .Should().Be(UpgradeableRejectReason.CustomFormatScore);
+                   .Should().Be(UpgradeableRejectReason.UpgradesNotAllowed);
         }
 
         [Test]
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                        new List<CustomFormat>(),
                        new QualityModel(Quality.HDTV720p, new Revision(version: 1)),
                        new List<CustomFormat>())
-                   .Should().Be(UpgradeableRejectReason.CustomFormatScore);
+                   .Should().Be(UpgradeableRejectReason.UpgradesNotAllowed);
         }
 
         [Test]

--- a/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
@@ -20,6 +20,7 @@ public enum DownloadRejectionReason
     HistoryCustomFormatCutoffMet,
     HistoryCustomFormatScore,
     HistoryCustomFormatScoreIncrement,
+    HistoryUpgradesNotAllowed,
     NoMatchingTag,
     PropersDisabled,
     ProperForOldFile,
@@ -53,7 +54,7 @@ public enum DownloadRejectionReason
     QueueCustomFormatCutoffMet,
     QueueCustomFormatScore,
     QueueCustomFormatScoreIncrement,
-    QueueNoUpgrades,
+    QueueUpgradesNotAllowed,
     QueuePropersDisabled,
     Raw,
     MustContainMissing,
@@ -72,4 +73,5 @@ public enum DownloadRejectionReason
     DiskCustomFormatCutoffMet,
     DiskCustomFormatScore,
     DiskCustomFormatScoreIncrement,
+    DiskUpgradesNotAllowed
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -95,17 +95,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                     case UpgradeableRejectReason.MinCustomFormatScore:
                         return DownloadSpecDecision.Reject(DownloadRejectionReason.QueueCustomFormatScoreIncrement, "Release in queue has Custom Format score within Custom Format score increment: {0}", qualityProfile.MinUpgradeFormatScore);
-                }
 
-                _logger.Debug("Checking if profiles allow upgrading. Queued: {0}", remoteEpisode.ParsedEpisodeInfo.Quality);
-
-                if (!_upgradableSpecification.IsUpgradeAllowed(subject.Series.QualityProfile,
-                                                               remoteEpisode.ParsedEpisodeInfo.Quality,
-                                                               queuedItemCustomFormats,
-                                                               subject.ParsedEpisodeInfo.Quality,
-                                                               subject.CustomFormats))
-                {
-                    return DownloadSpecDecision.Reject(DownloadRejectionReason.QueueNoUpgrades, "Another release is queued and the Quality profile does not allow upgrades");
+                    case UpgradeableRejectReason.UpgradesNotAllowed:
+                        return DownloadSpecDecision.Reject(DownloadRejectionReason.QueueUpgradesNotAllowed, "Release in queue and Quality Profile '{0}' does not allow upgrades", qualityProfile.Name);
                 }
 
                 if (_upgradableSpecification.IsRevisionUpgrade(remoteEpisode.ParsedEpisodeInfo.Quality, subject.ParsedEpisodeInfo.Quality))

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -111,6 +111,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
                         case UpgradeableRejectReason.MinCustomFormatScore:
                             return DownloadSpecDecision.Reject(DownloadRejectionReason.HistoryCustomFormatScoreIncrement, "{0} grab event in history has Custom Format score within Custom Format score increment: {1}", rejectionSubject, qualityProfile.MinUpgradeFormatScore);
+
+                        case UpgradeableRejectReason.UpgradesNotAllowed:
+                            return DownloadSpecDecision.Reject(DownloadRejectionReason.HistoryUpgradesNotAllowed, "{0} grab event in history and Quality Profile '{1}' does not allow upgrades", rejectionSubject, qualityProfile.Name);
                     }
                 }
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -57,6 +57,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return UpgradeableRejectReason.None;
             }
 
+            if (!qualityProfile.UpgradeAllowed)
+            {
+                _logger.Debug("Quality profile '{0}' does not allow upgrading. Skipping.", qualityProfile.Name);
+
+                return UpgradeableRejectReason.UpgradesNotAllowed;
+            }
+
             // Reject unless the user does not prefer propers/repacks and it's a revision downgrade.
             if (downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                 qualityRevisionCompare < 0)
@@ -86,7 +93,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return UpgradeableRejectReason.CustomFormatScore;
             }
 
-            if (qualityProfile.UpgradeAllowed && currentFormatScore >= qualityProfile.CutoffFormatScore)
+            if (currentFormatScore >= qualityProfile.CutoffFormatScore)
             {
                 _logger.Debug("Existing item meets cut-off for custom formats, skipping. Existing: [{0}] ({1}). Cutoff score: {2}",
                     currentCustomFormats.ConcatToString(),

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -81,6 +81,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                     case UpgradeableRejectReason.MinCustomFormatScore:
                         return DownloadSpecDecision.Reject(DownloadRejectionReason.DiskCustomFormatScoreIncrement, "Existing file on disk has Custom Format score within Custom Format score increment: {0}", qualityProfile.MinUpgradeFormatScore);
+
+                    case UpgradeableRejectReason.UpgradesNotAllowed:
+                        return DownloadSpecDecision.Reject(DownloadRejectionReason.DiskUpgradesNotAllowed, "Existing file on disk and Quality Profile '{0}' does not allow upgrades", qualityProfile.Name);
                 }
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/UpgradeableRejectReason.cs
+++ b/src/NzbDrone.Core/DecisionEngine/UpgradeableRejectReason.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.DecisionEngine
         QualityCutoff,
         CustomFormatScore,
         CustomFormatCutoff,
-        MinCustomFormatScore
+        MinCustomFormatScore,
+        UpgradesNotAllowed
     }
 }


### PR DESCRIPTION
#### Description

A CF score upgrade could bypass `Upgrades Allowed` being disabled if it was a revision upgrade for the existing quality.
