### PR TITLE
Fixed: Fetching ICS calendar with missing series

### DIFF
--- a/src/Sonarr.Api.V3/Calendar/CalendarFeedController.cs
+++ b/src/Sonarr.Api.V3/Calendar/CalendarFeedController.cs
@@ -54,6 +54,11 @@ namespace Sonarr.Api.V3.Calendar
             {
                 var series = allSeries.SingleOrDefault(s => s.Id == episode.SeriesId);
 
+                if (series == null)
+                {
+                    continue;
+                }
+
                 if (premieresOnly && (episode.SeasonNumber == 0 || episode.EpisodeNumber != 1))
                 {
                     continue;


### PR DESCRIPTION
#### Description
Skipping entries in the ICS calendar when episodes return a non-existing series id.

#### Issues Fixed or Closed by this PR
* Closes #7467

