### PR TITLE
Fixed: Error getting processes in some cases

### DIFF
--- a/src/NzbDrone.Common/Processes/ProcessProvider.cs
+++ b/src/NzbDrone.Common/Processes/ProcessProvider.cs
@@ -313,7 +313,7 @@ namespace NzbDrone.Common.Processes
                 processInfo = new ProcessInfo();
                 processInfo.Id = process.Id;
                 processInfo.Name = process.ProcessName;
-                processInfo.StartPath = process.MainModule.FileName;
+                processInfo.StartPath = process.MainModule?.FileName;
 
                 if (process.Id != GetCurrentProcessId() && process.HasExited)
                 {


### PR DESCRIPTION
#### Description

Prevents a process with a null `MainModule` from throwing when getting process info.


#### Issues Fixed or Closed by this PR
* Closes #7470

