### PR TITLE
Fixed: Augmenting languages from indexer for release with stale indexer ID

### DIFF
--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -82,9 +82,10 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
 
                 if (releaseInfo is { IndexerId: > 0 })
                 {
-                    indexer = _indexerFactory.Get(releaseInfo.IndexerId);
+                    indexer = _indexerFactory.Find(releaseInfo.IndexerId);
                 }
-                else if (releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true)
+
+                if (indexer == null && releaseInfo.Indexer?.IsNotNullOrWhiteSpace() == true)
                 {
                     indexer = _indexerFactory.FindByName(releaseInfo.Indexer);
                 }


### PR DESCRIPTION
#### Description

Deleted indexers break look ups by the indexer's original ID, will now try to fall back to the name in case it was re-created.

#### Issues Fixed or Closed by this PR
* Closes #7476

