### PR TITLE
Fixed: Opening episode info modal on calendar event click

### DIFF
--- a/frontend/src/Calendar/Events/CalendarEvent.tsx
+++ b/frontend/src/Calendar/Events/CalendarEvent.tsx
@@ -74,12 +74,12 @@ function CalendarEvent(props: CalendarEventProps) {
 
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
-  const handleDetailsModalClose = useCallback(() => {
+  const handlePress = useCallback(() => {
     setIsDetailsModalOpen(true);
     onEventModalOpenToggle(true);
   }, [onEventModalOpenToggle]);
 
-  const handlePress = useCallback(() => {
+  const handleDetailsModalClose = useCallback(() => {
     setIsDetailsModalOpen(false);
     onEventModalOpenToggle(false);
   }, [onEventModalOpenToggle]);

--- a/src/NzbDrone.Core/Download/DownloadClientProvider.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientProvider.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Download
 
         public IDownloadClient GetDownloadClient(DownloadProtocol downloadProtocol, int indexerId = 0, bool filterBlockedClients = false, HashSet<int> tags = null)
         {
-            // Tags aren't required, but indexers with tags should not be picked unless there is at least one matching tag.
+            // Tags aren't required, but download clients with tags should not be picked unless there is at least one matching tag.
             // Defaulting to an empty HashSet ensures this is always checked.
             tags ??= new HashSet<int>();
 


### PR DESCRIPTION
#### Description
Swapping callbacks for calendar event clicks to open the episode info modal.

#### Issues Fixed or Closed by this PR
* Closes #7486

