### PR TITLE
Set minor version for core-js in babel/preset-env

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = (env) => {
                       loose: true,
                       debug: false,
                       useBuiltIns: 'entry',
-                      corejs: 3
+                      corejs: '3.39'
                     }
                   ]
                 ]


### PR DESCRIPTION
#### Description
According to https://github.com/zloirock/core-js?tab=readme-ov-file#babelpolyfill it's recommended to specify the minor version if you want to use polyfills introduced in minor versions.

