### PR TITLE
Fixed: Loading calendar on older browsers

### DIFF
--- a/frontend/src/polyfills.js
+++ b/frontend/src/polyfills.js
@@ -8,6 +8,7 @@ window.console.debug = window.console.debug || function() {};
 window.console.warn = window.console.warn || function() {};
 window.console.assert = window.console.assert || function() {};
 
+// TODO: Remove in v5, well suppoprted in browsers
 if (!String.prototype.startsWith) {
   Object.defineProperty(String.prototype, 'startsWith', {
     enumerable: false,
@@ -20,6 +21,7 @@ if (!String.prototype.startsWith) {
   });
 }
 
+// TODO: Remove in v5, well suppoprted in browsers
 if (!String.prototype.endsWith) {
   Object.defineProperty(String.prototype, 'endsWith', {
     enumerable: false,
@@ -34,8 +36,14 @@ if (!String.prototype.endsWith) {
   });
 }
 
+// TODO: Remove in v5, use `includes` instead
 if (!('contains' in String.prototype)) {
   String.prototype.contains = function(str, startIndex) {
     return String.prototype.indexOf.call(this, str, startIndex) !== -1;
   };
+}
+
+// For Firefox ESR 115 support
+if (!Object.groupBy) {
+  import('core-js/actual/object/group-by');
 }


### PR DESCRIPTION
#### Description

Allows the calendar to load again in Firefox ESR 115
