### PR TITLE
Fix: adding a new root folder from series edit modal

### DIFF
--- a/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
@@ -134,7 +134,7 @@ function RootFolderSelectInput({
   const handleNewRootFolderSelect = useCallback(
     ({ value: newValue }: InputChanged<string>) => {
       setNewRootFolderPath(newValue);
-      dispatch(addRootFolder(newValue));
+      dispatch(addRootFolder({ path: newValue }));
     },
     [setNewRootFolderPath, dispatch]
   );


### PR DESCRIPTION
#### Description
Adding a new root folder from series edit modal doesn't function - no path is passed to the API endpoint

![firefox_2024-12-17_18-10-14](https://github.com/user-attachments/assets/edb55bab-58da-49f1-bf06-bd50b8c82d29)

Fixes #7497
