### PR TITLE
Fixed: Prevent exception for seed configuration provider with invalid indexer ID

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/SeedConfigProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/SeedConfigProviderFixture.cs
@@ -22,10 +22,33 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             var result = Subject.GetSeedConfiguration(new RemoteEpisode
             {
-                Release = new ReleaseInfo()
+                Release = new ReleaseInfo
                 {
                     DownloadProtocol = DownloadProtocol.Torrent,
                     IndexerId = 0
+                }
+            });
+
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void should_not_return_config_for_invalid_indexer()
+        {
+            Mocker.GetMock<ICachedIndexerSettingsProvider>()
+                  .Setup(v => v.GetSettings(It.IsAny<int>()))
+                  .Returns<CachedIndexerSettings>(null);
+
+            var result = Subject.GetSeedConfiguration(new RemoteEpisode
+            {
+                Release = new ReleaseInfo
+                {
+                    DownloadProtocol = DownloadProtocol.Torrent,
+                    IndexerId = 1
+                },
+                ParsedEpisodeInfo = new ParsedEpisodeInfo
+                {
+                    FullSeason = true
                 }
             });
 
@@ -48,7 +71,7 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             var result = Subject.GetSeedConfiguration(new RemoteEpisode
             {
-                Release = new ReleaseInfo()
+                Release = new ReleaseInfo
                 {
                     DownloadProtocol = DownloadProtocol.Torrent,
                     IndexerId = 1


### PR DESCRIPTION
#### Description
Prevent NullRef when fetching seed configuration with an invalid indexer ID, which may happen after an indexer gets removed as the ID would be used from grab history.

Also clearing the cache on indexer removal to avoid any stale settings.

#### Issues Fixed or Closed by this PR
* Closes #7508

