### PR TITLE
Fixed: Series updated during Import List Sync not reflected in the UI

### DIFF
--- a/src/NzbDrone.Core/Tv/Events/SeriesBulkEditedEvent.cs
+++ b/src/NzbDrone.Core/Tv/Events/SeriesBulkEditedEvent.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using NzbDrone.Common.Messaging;
+
+namespace NzbDrone.Core.Tv.Events
+{
+    public class SeriesBulkEditedEvent : IEvent
+    {
+        public List<Series> Series { get; private set; }
+
+        public SeriesBulkEditedEvent(List<Series> series)
+        {
+            Series = series;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -251,6 +251,7 @@ namespace NzbDrone.Core.Tv
 
             _seriesRepository.UpdateMany(series);
             _logger.Debug("{0} series updated", series.Count);
+            _eventAggregator.PublishEvent(new SeriesBulkEditedEvent(series));
 
             return series;
         }
@@ -297,6 +298,8 @@ namespace NzbDrone.Core.Tv
 
                 return true;
             }
+
+            _logger.Debug("Tags not updated for '{0}'", series.Title);
 
             return false;
         }

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -34,6 +34,7 @@ namespace Sonarr.Api.V3.Series
                                 IHandle<SeriesEditedEvent>,
                                 IHandle<SeriesDeletedEvent>,
                                 IHandle<SeriesRenamedEvent>,
+                                IHandle<SeriesBulkEditedEvent>,
                                 IHandle<MediaCoversUpdatedEvent>
     {
         private readonly ISeriesService _seriesService;
@@ -336,6 +337,15 @@ namespace Sonarr.Api.V3.Series
         public void Handle(SeriesRenamedEvent message)
         {
             BroadcastResourceChange(ModelAction.Updated, message.Series.Id);
+        }
+
+        [NonAction]
+        public void Handle(SeriesBulkEditedEvent message)
+        {
+            foreach (var series in message.Series)
+            {
+                BroadcastResourceChange(ModelAction.Updated, series.ToResource());
+            }
         }
 
         [NonAction]


### PR DESCRIPTION
#### Description

Bulk editing of series doesn't result in the UI being updated, these changes will now be broadcast like other changes are so any active UI will be updated.

#### Issues Fixed or Closed by this PR
* Closes #7511

