### PR TITLE
Don't send session information to Sentry

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -110,7 +110,7 @@ namespace NzbDrone.Common.Instrumentation.Sentry
                                       o.Environment = BuildInfo.Branch;
 
                                       // Crash free run statistics (sends a ping for healthy and for crashes sessions)
-                                      o.AutoSessionTracking = true;
+                                      o.AutoSessionTracking = false;
 
                                       // Caches files in the event device is offline
                                       // Sentry creates a 'sentry' sub directory, no need to concat here


### PR DESCRIPTION
#### Description

Although not being captured, Sentry was sending session information outside of attempted error reporting.

#### Issues Fixed or Closed by this PR
* Closes #7518

