### PR TITLE
Check if backup folder is writable on backup

### DIFF
--- a/src/NzbDrone.Common/ArchiveService.cs
+++ b/src/NzbDrone.Common/ArchiveService.cs
@@ -42,17 +42,18 @@ namespace NzbDrone.Common
 
         public void CreateZip(string path, IEnumerable<string> files)
         {
-            using (var zipFile = ZipFile.Create(path))
+            _logger.Debug("Creating archive {0}", path);
+
+            using var zipFile = ZipFile.Create(path);
+
+            zipFile.BeginUpdate();
+
+            foreach (var file in files)
             {
-                zipFile.BeginUpdate();
-
-                foreach (var file in files)
-                {
-                    zipFile.Add(file, Path.GetFileName(file));
-                }
-
-                zipFile.CommitUpdate();
+                zipFile.Add(file, Path.GetFileName(file));
             }
+
+            zipFile.CommitUpdate();
         }
 
         private void ExtractZip(string compressedFile, string destination)

--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -66,12 +66,19 @@ namespace NzbDrone.Core.Backup
         {
             _logger.ProgressInfo("Starting Backup");
 
+            var backupFolder = GetBackupFolder(backupType);
+
             _diskProvider.EnsureFolder(_backupTempFolder);
-            _diskProvider.EnsureFolder(GetBackupFolder(backupType));
+            _diskProvider.EnsureFolder(backupFolder);
+
+            if (!_diskProvider.FolderWritable(backupFolder))
+            {
+                throw new UnauthorizedAccessException($"Backup folder {backupFolder} is not writable");
+            }
 
             var dateNow = DateTime.Now;
             var backupFilename = $"sonarr_backup_v{BuildInfo.Version}_{dateNow:yyyy.MM.dd_HH.mm.ss}.zip";
-            var backupPath = Path.Combine(GetBackupFolder(backupType), backupFilename);
+            var backupPath = Path.Combine(backupFolder, backupFilename);
 
             Cleanup();
 


### PR DESCRIPTION
#### Description
Adding a little more information about the backup folder and path on creating a new backup.

As reference https://github.com/Radarr/Radarr/issues/10792, the backup folder seems to be `/home/(removed)/.config/Radarr/Backups` but SharpZipLib is seeing a difference between in and out.