### PR TITLE
remove `0.0.0.0` validation for bind host

### DIFF
--- a/src/NzbDrone.Core/Validation/IpValidation.cs
+++ b/src/NzbDrone.Core/Validation/IpValidation.cs
@@ -1,5 +1,4 @@
 using FluentValidation;
-using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.Validation
@@ -9,11 +8,6 @@ namespace NzbDrone.Core.Validation
         public static IRuleBuilderOptions<T, string> ValidIpAddress<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             return ruleBuilder.Must(x => x.IsValidIpAddress()).WithMessage("Must contain wildcard (*) or a valid IP Address");
-        }
-
-        public static IRuleBuilderOptions<T, string> NotListenAllIp4Address<T>(this IRuleBuilder<T, string> ruleBuilder)
-        {
-            return ruleBuilder.SetValidator(new RegularExpressionValidator(@"^(?!0\.0\.0\.0)")).WithMessage("Use * instead of 0.0.0.0");
         }
     }
 }

--- a/src/Sonarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigController.cs
@@ -33,7 +33,6 @@ namespace Sonarr.Api.V3.Config
 
             SharedValidator.RuleFor(c => c.BindAddress)
                            .ValidIpAddress()
-                           .NotListenAllIp4Address()
                            .When(c => c.BindAddress != "*" && c.BindAddress != "localhost");
 
             SharedValidator.RuleFor(c => c.Port).ValidPort();


### PR DESCRIPTION
#### Description
removes the validation failure of ip `0.0.0.0` in the bind on host, allowing user to bind to only ipv4 addresses

#### Issues Fixed or Closed by this PR
* Closes #7526

