### PR TITLE
Fix: adjust qBittorrent ratio limit check accounting for float

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/QBittorrentTests/QBittorrentFixture.cs
@@ -714,10 +714,58 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.QBittorrentTests
 
         [TestCase("pausedUP")]
         [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_max_ratio_reached_after_rounding_and_paused(string state)
+        {
+            GivenGlobalSeedLimits(1.0f);
+            GivenCompletedTorrent(state, ratio: 1.1006066990976857f);
+
+            var item = Subject.GetItems().Single();
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
+        }
+
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_just_under_max_ratio_reached_after_rounding_and_paused(string state)
+        {
+            GivenGlobalSeedLimits(1.0f);
+            GivenCompletedTorrent(state, ratio: 0.9999f);
+
+            var item = Subject.GetItems().Single();
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
+        }
+
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
         public void should_be_removable_and_should_allow_move_files_if_overridden_max_ratio_reached_and_paused(string state)
         {
             GivenGlobalSeedLimits(2.0f);
             GivenCompletedTorrent(state, ratio: 1.0f, ratioLimit: 0.8f);
+
+            var item = Subject.GetItems().Single();
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
+        }
+
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_overridden_max_ratio_reached_after_rounding_and_paused(string state)
+        {
+            GivenGlobalSeedLimits(2.0f);
+            GivenCompletedTorrent(state, ratio: 1.1006066990976857f, ratioLimit: 1.1f);
+
+            var item = Subject.GetItems().Single();
+            item.CanBeRemoved.Should().BeTrue();
+            item.CanMoveFiles.Should().BeTrue();
+        }
+
+        [TestCase("pausedUP")]
+        [TestCase("stoppedUP")]
+        public void should_be_removable_and_should_allow_move_files_if_just_under_overridden_max_ratio_reached_after_rounding_and_paused(string state)
+        {
+            GivenGlobalSeedLimits(2.0f);
+            GivenCompletedTorrent(state, ratio: 0.9999f, ratioLimit: 1.0f);
 
             var item = Subject.GetItems().Single();
             item.CanBeRemoved.Should().BeTrue();

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -630,14 +630,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         {
             if (torrent.RatioLimit >= 0)
             {
-                if (torrent.Ratio >= torrent.RatioLimit)
+                if (torrent.RatioLimit - torrent.Ratio <= 0.001f)
                 {
                     return true;
                 }
             }
             else if (torrent.RatioLimit == -2 && config.MaxRatioEnabled)
             {
-                if (Math.Round(torrent.Ratio, 2) >= config.MaxRatio)
+                if (config.MaxRatio - torrent.Ratio <= 0.001f)
                 {
                     return true;
                 }


### PR DESCRIPTION
#### Description
Math.Round returns a double, which then causes some discrepancies in the comparison between a double and a float.
Instead allow a check with a low tolerance of 0.001f

applies the same check also to torrents that have their own ratio limit set, not only global torrents.

#### Issues Fixed or Closed by this PR
* Closes #7527

