### PR TITLE
Additional logging for custom format score

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -117,6 +117,8 @@ namespace NzbDrone.Core.DecisionEngine
                             remoteEpisode.CustomFormats = _formatCalculator.ParseCustomFormat(remoteEpisode, remoteEpisode.Release.Size);
                             remoteEpisode.CustomFormatScore = remoteEpisode?.Series?.QualityProfile?.Value.CalculateCustomFormatScore(remoteEpisode.CustomFormats) ?? 0;
 
+                            _logger.Trace("Custom Format Score of '{0}' [{1}] calculated for '{2}'", remoteEpisode.CustomFormatScore, remoteEpisode.CustomFormats?.ConcatToString(), report.Title);
+
                             remoteEpisode.DownloadAllowed = remoteEpisode.Episodes.Any();
                             decision = GetDecisionForReport(remoteEpisode, searchCriteria);
                         }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
@@ -1,3 +1,4 @@
+using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -6,6 +7,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 {
     public class CustomFormatAllowedbyProfileSpecification : IDownloadDecisionEngineSpecification
     {
+        private readonly Logger _logger;
+
+        public CustomFormatAllowedbyProfileSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
@@ -18,6 +26,8 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             {
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.CustomFormatMinimumScore, "Custom Formats {0} have score {1} below Series profile minimum {2}", subject.CustomFormats.ConcatToString(), score, minScore);
             }
+
+            _logger.Trace("Custom Format Score of {0} [{1}] above Series profile minumum {2}", score, subject.CustomFormats.ConcatToString(), minScore);
 
             return DownloadSpecDecision.Accept();
         }


### PR DESCRIPTION
#### Description
Currently CF score is only logged during download decisions when its below the minimum quality profile score.
This adds a couple of extra trace log entries that could help when providing support.

