### PR TITLE
Don't search individual episodes when searching for anime seasons

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -332,23 +332,6 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public async Task season_search_for_anime_should_search_for_each_monitored_episode()
-        {
-            WithEpisodes();
-            _xemSeries.SeriesType = SeriesTypes.Anime;
-            _xemEpisodes.ForEach(e => e.EpisodeFileId = 0);
-
-            var seasonNumber = 1;
-            var allCriteria = WatchForSearchCriteria();
-
-            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
-
-            var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
-
-            criteria.Count.Should().Be(_xemEpisodes.Count(e => e.SeasonNumber == seasonNumber));
-        }
-
-        [Test]
         public async Task season_search_for_anime_should_not_search_for_unmonitored_episodes()
         {
             WithEpisodes();
@@ -399,24 +382,6 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
 
             criteria.Count.Should().Be(0);
-        }
-
-        [Test]
-        public async Task season_search_for_anime_should_set_isSeasonSearch_flag()
-        {
-            WithEpisodes();
-            _xemSeries.SeriesType = SeriesTypes.Anime;
-            _xemEpisodes.ForEach(e => e.EpisodeFileId = 0);
-
-            var seasonNumber = 1;
-            var allCriteria = WatchForSearchCriteria();
-
-            await Subject.SeasonSearch(_xemSeries.Id, seasonNumber, true, false, true, false);
-
-            var criteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
-
-            criteria.Count.Should().Be(_xemEpisodes.Count(e => e.SeasonNumber == seasonNumber));
-            criteria.ForEach(c => c.IsSeasonSearch.Should().BeTrue());
         }
 
         [Test]

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -413,11 +413,6 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadDecisions.AddRange(decisions);
             }
 
-            foreach (var episode in episodesToSearch)
-            {
-                downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
-            }
-
             return DeDupeDecisions(downloadDecisions);
         }
 


### PR DESCRIPTION
#### Description
Changes the anime season search implementation to no longer search for all episodes in a season individually. Searching for each episode makes searching for anime seasons prohibitively slow and doesn't result in any better search results (see issue #6495)

This PR is a relatively naive fix for the issue, which simply removes the episode searching without fixing any of the other things mentioned in #6495