### PR TITLE
Fixed: Series added via other IDs unmonitored/tagged unexpectedly

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/ImportListItemServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/ImportListItemServiceFixture.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Test.ImportListTests
     {
         private void GivenExisting(List<ImportListItemInfo> existing)
         {
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Setup(v => v.GetAllForLists(It.IsAny<List<int>>()))
                 .Returns(existing);
         }
@@ -58,13 +58,13 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             numDeleted.Should().Be(1);
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.InsertMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TvdbId == newItem.TvdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.UpdateMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TvdbId == updatedItem.TvdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.DeleteMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TvdbId != newItem.TvdbId && s[0].TvdbId != updatedItem.TvdbId)), Times.Once());
         }
 
@@ -107,13 +107,13 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             numDeleted.Should().Be(1);
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.InsertMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].ImdbId == newItem.ImdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.UpdateMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].ImdbId == updatedItem.ImdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.DeleteMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].ImdbId != newItem.ImdbId && s[0].ImdbId != updatedItem.ImdbId)), Times.Once());
         }
 
@@ -156,13 +156,13 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             numDeleted.Should().Be(1);
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.InsertMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TmdbId == newItem.TmdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.UpdateMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TmdbId == updatedItem.TmdbId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.DeleteMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].TmdbId != newItem.TmdbId && s[0].TmdbId != updatedItem.TmdbId)), Times.Once());
         }
 
@@ -205,13 +205,13 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             numDeleted.Should().Be(1);
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.InsertMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].MalId == newItem.MalId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.UpdateMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].MalId == updatedItem.MalId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.DeleteMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].MalId != newItem.MalId && s[0].MalId != updatedItem.MalId)), Times.Once());
         }
 
@@ -254,13 +254,13 @@ namespace NzbDrone.Core.Test.ImportListTests
 
             numDeleted.Should().Be(1);
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.InsertMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].AniListId == newItem.AniListId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.UpdateMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].AniListId == updatedItem.AniListId)), Times.Once());
 
-            Mocker.GetMock<IImportListItemInfoRepository>()
+            Mocker.GetMock<IImportListItemRepository>()
                 .Verify(v => v.DeleteMany(It.Is<List<ImportListItemInfo>>(s => s.Count == 1 && s[0].AniListId != newItem.AniListId && s[0].AniListId != updatedItem.AniListId)), Times.Once());
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/217_add_mal_and_anilist_ids.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/217_add_mal_and_anilist_ids.cs
@@ -1,0 +1,15 @@
+﻿using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(217)]
+    public class add_mal_and_anilist_ids : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series").AddColumn("MalIds").AsString().WithDefaultValue("[]");
+            Alter.Table("Series").AddColumn("AniListIds").AsString().WithDefaultValue("[]");
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListItems/ImportListItemRepository.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListItems/ImportListItemRepository.cs
@@ -1,18 +1,16 @@
 using System.Collections.Generic;
-using System.Linq;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.ImportLists.ImportListItems
 {
-    public interface IImportListItemInfoRepository : IBasicRepository<ImportListItemInfo>
+    public interface IImportListItemRepository : IBasicRepository<ImportListItemInfo>
     {
         List<ImportListItemInfo> GetAllForLists(List<int> listIds);
-        bool Exists(int tvdbId, string imdbId);
     }
 
-    public class ImportListItemRepository : BasicRepository<ImportListItemInfo>, IImportListItemInfoRepository
+    public class ImportListItemRepository : BasicRepository<ImportListItemInfo>, IImportListItemRepository
     {
         public ImportListItemRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
@@ -22,22 +20,6 @@ namespace NzbDrone.Core.ImportLists.ImportListItems
         public List<ImportListItemInfo> GetAllForLists(List<int> listIds)
         {
             return Query(x => listIds.Contains(x.ImportListId));
-        }
-
-        public bool Exists(int tvdbId, string imdbId)
-        {
-            List<ImportListItemInfo> items;
-
-            if (string.IsNullOrWhiteSpace(imdbId))
-            {
-                items = Query(x => x.TvdbId == tvdbId);
-            }
-            else
-            {
-                items = Query(x => x.TvdbId == tvdbId || x.ImdbId == imdbId);
-            }
-
-            return items.Any();
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -299,12 +299,18 @@ namespace NzbDrone.Core.ImportLists
 
             var seriesToUpdate = new List<Series>();
             var seriesInLibrary = _seriesService.GetAllSeries();
+            var allListItems = _importListItemService.All();
 
             foreach (var series in seriesInLibrary)
             {
-                var seriesExists = _importListItemService.Exists(series.TvdbId, series.ImdbId);
+                var seriesExists = allListItems.Where(l =>
+                    l.TvdbId == series.TvdbId ||
+                    l.ImdbId == series.ImdbId ||
+                    l.TmdbId == series.TmdbId ||
+                    series.MalIds.Contains(l.MalId) ||
+                    series.AniListIds.Contains(l.AniListId)).ToList();
 
-                if (!seriesExists)
+                if (!seriesExists.Any())
                 {
                     switch (_configService.ListSyncLevel)
                     {

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
@@ -24,7 +24,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public int? TvRageId { get; set; }
         public int? TvMazeId { get; set; }
         public int? TmdbId { get; set; }
-
+        public HashSet<int> MalIds { get; set; }
+        public HashSet<int> AniListIds { get; set; }
         public string Status { get; set; }
         public int? Runtime { get; set; }
         public TimeOfDayResource TimeOfDay { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -194,6 +194,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             }
 
             series.ImdbId = show.ImdbId;
+            series.MalIds = show.MalIds;
+            series.AniListIds = show.AniListIds;
             series.Title = show.Title;
             series.CleanTitle = Parser.Parser.CleanSeriesTitle(show.Title);
             series.SortTitle = SeriesTitleNormalizer.Normalize(show.Title, show.TvdbId);

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -94,6 +94,8 @@ namespace NzbDrone.Core.Tv
             series.TvMazeId = seriesInfo.TvMazeId;
             series.TmdbId = seriesInfo.TmdbId;
             series.ImdbId = seriesInfo.ImdbId;
+            series.MalIds = seriesInfo.MalIds;
+            series.AniListIds = seriesInfo.AniListIds;
             series.AirTime = seriesInfo.AirTime;
             series.Overview = seriesInfo.Overview;
             series.OriginalLanguage = seriesInfo.OriginalLanguage;

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -17,6 +17,8 @@ namespace NzbDrone.Core.Tv
             Seasons = new List<Season>();
             Tags = new HashSet<int>();
             OriginalLanguage = Language.English;
+            MalIds = new HashSet<int>();
+            AniListIds = new HashSet<int>();
         }
 
         public int TvdbId { get; set; }
@@ -24,6 +26,8 @@ namespace NzbDrone.Core.Tv
         public int TvMazeId { get; set; }
         public string ImdbId { get; set; }
         public int TmdbId { get; set; }
+        public HashSet<int> MalIds { get; set; }
+        public HashSet<int> AniListIds { get; set; }
         public string Title { get; set; }
         public string CleanTitle { get; set; }
         public string SortTitle { get; set; }


### PR DESCRIPTION
#### Description

Import lists that added items by alternate IDs would unmonitor/tag all items because a matching ID wasn't found.

#### Issues Fixed or Closed by this PR
* Closes #7555

