### PR TITLE
Fixed: Map covers to local for Series Editor

### DIFF
--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -329,7 +329,7 @@ namespace Sonarr.Api.V3.Series
         {
             foreach (var series in message.Series)
             {
-                BroadcastResourceChange(ModelAction.Deleted, series.ToResource());
+                BroadcastResourceChange(ModelAction.Deleted, GetSeriesResource(series, false));
             }
         }
 
@@ -344,7 +344,7 @@ namespace Sonarr.Api.V3.Series
         {
             foreach (var series in message.Series)
             {
-                BroadcastResourceChange(ModelAction.Updated, series.ToResource());
+                BroadcastResourceChange(ModelAction.Updated, GetSeriesResource(series, false));
             }
         }
 


### PR DESCRIPTION
#### Description
Fixing a regression after 1c30ecd66dd0fd1dafaf9ab0e41a11a54eaac132 due to no longer using just the response body to update the state but it's also updated via SignalR without skipping the images update like it was before in https://github.com/Sonarr/Sonarr/blob/acebe87dbabe0def975bd43b9e4a40287f50fb33/frontend/src/Store/Actions/seriesActions.js#L758-L764

