### PR TITLE
Prevent page crash on console.error being used with non-string values

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -23,12 +23,13 @@ const error = console.error;
 function logError(...parameters: any[]) {
   const filter = parameters.find((parameter) => {
     return (
-      parameter.includes(
+      typeof parameter === 'string' &&
+      (parameter.includes(
         'Support for defaultProps will be removed from function components in a future major release'
       ) ||
-      parameter.includes(
-        'findDOMNode is deprecated and will be removed in the next major release'
-      )
+        parameter.includes(
+          'findDOMNode is deprecated and will be removed in the next major release'
+        ))
     );
   });
 


### PR DESCRIPTION
#### Description
Bug reported by @thezoggy on [Discord](https://discord.com/channels/264387956343570434/264388019585286144/1331133420449042504) that occurs when one of the arguments might be for example null or integer among others as `includes` is only available for String and Array.
