### PR TITLE
Fix: respect MonitoredOnly for search for specials by title

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -369,6 +369,7 @@ namespace NzbDrone.Core.IndexerSearch
             searchSpec.EpisodeQueryTitles = episodes.Where(e => !string.IsNullOrWhiteSpace(e.Title))
                                                     .Where(e => !monitoredOnly || e.Monitored)
                                                     .SelectMany(e => searchSpec.CleanSceneTitles.Select(title => title + " " + SearchCriteriaBase.GetCleanSceneTitle(e.Title)))
+                                                    .Distinct(StringComparer.InvariantCultureIgnoreCase)
                                                     .ToArray();
 
             downloadDecisions.AddRange(await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec));

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -367,7 +367,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             // build list of queries for each episode in the form: "<series> <episode-title>"
             searchSpec.EpisodeQueryTitles = episodes.Where(e => !string.IsNullOrWhiteSpace(e.Title))
-                                                    .Where(e => !monitoredOnly || e.Monitored)
+                                                    .Where(e => interactiveSearch || !monitoredOnly || e.Monitored)
                                                     .SelectMany(e => searchSpec.CleanSceneTitles.Select(title => title + " " + SearchCriteriaBase.GetCleanSceneTitle(e.Title)))
                                                     .Distinct(StringComparer.InvariantCultureIgnoreCase)
                                                     .ToArray();

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -367,6 +367,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             // build list of queries for each episode in the form: "<series> <episode-title>"
             searchSpec.EpisodeQueryTitles = episodes.Where(e => !string.IsNullOrWhiteSpace(e.Title))
+                                                    .Where(e => !monitoredOnly || e.Monitored)
                                                     .SelectMany(e => searchSpec.CleanSceneTitles.Select(title => title + " " + SearchCriteriaBase.GetCleanSceneTitle(e.Title)))
                                                     .ToArray();
 


### PR DESCRIPTION
#### Description
when the user triggers a search (non-interactive) for a season of specials, the monitored status is not respected in the episode title search

#### Issues Fixed or Closed by this PR
* Closes #7589

