### PR TITLE
Fixed: Format bitrate for primary streams in media info

### DIFF
--- a/frontend/src/Episode/Summary/MediaInfo.tsx
+++ b/frontend/src/Episode/Summary/MediaInfo.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
 import MediaInfoProps from 'typings/MediaInfo';
+import formatBitrate from 'Utilities/Number/formatBitrate';
 import getEntries from 'Utilities/Object/getEntries';
 
 function MediaInfo(props: MediaInfoProps) {
@@ -16,9 +17,19 @@ function MediaInfo(props: MediaInfoProps) {
           return null;
         }
 
-        return (
-          <DescriptionListItem key={key} title={title} data={props[key]} />
-        );
+        if (key === 'audioBitrate' || key === 'videoBitrate') {
+          return (
+            <DescriptionListItem
+              key={key}
+              title={title}
+              data={
+                <span title={value.toString()}>{formatBitrate(value)}</span>
+              }
+            />
+          );
+        }
+
+        return <DescriptionListItem key={key} title={title} data={value} />;
       })}
     </DescriptionList>
   );

--- a/frontend/src/Utilities/Number/formatBitrate.ts
+++ b/frontend/src/Utilities/Number/formatBitrate.ts
@@ -1,0 +1,19 @@
+import { filesize } from 'filesize';
+
+function formatBitrate(input: string | number) {
+  const size = Number(input);
+
+  if (isNaN(size)) {
+    return '';
+  }
+
+  const { value, symbol } = filesize(size, {
+    base: 10,
+    round: 1,
+    output: 'object',
+  });
+
+  return `${value} ${symbol}/s`;
+}
+
+export default formatBitrate;


### PR DESCRIPTION
#### Description
Fixing the value for video bitrate by using the tag `BPS`, and using filesize in base 10 to properly format both bitrates in a human readable output.

#### Issues Fixed or Closed by this PR
* Closes #7585

