### PR TITLE
Fix: Fail downloads for dangerous or exe

### DIFF
--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -22,7 +22,7 @@ public class RejectedImportService : IRejectedImportService
 
     public bool Process(TrackedDownload trackedDownload, ImportResult importResult)
     {
-        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode != null)
+        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode == null)
         {
             return false;
         }

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -260,6 +260,26 @@ namespace NzbDrone.Core.MediaFiles
 
             var extension = Path.GetExtension(fileInfo.Name);
 
+            if (FileExtensions.DangerousExtensions.Contains(extension))
+            {
+                return new List<ImportResult>
+                {
+                    new ImportResult(new ImportDecision(new LocalEpisode { Path = fileInfo.FullName },
+                            new ImportRejection(ImportRejectionReason.DangerousFile, "Caution: Found potentially dangerous file")),
+                        $"Caution: Found potentially dangerous file")
+                };
+            }
+
+            if (FileExtensions.ExecutableExtensions.Contains(extension))
+            {
+                return new List<ImportResult>
+                {
+                    new ImportResult(new ImportDecision(new LocalEpisode { Path = fileInfo.FullName },
+                            new ImportRejection(ImportRejectionReason.ExecutableFile, "Caution: Found executable file")),
+                        $"Caution: Found executable file")
+                };
+            }
+
             if (extension.IsNullOrWhiteSpace() || !MediaFileExtensions.Extensions.Contains(extension))
             {
                 _logger.Debug("[{0}] has an unsupported extension: '{1}'", fileInfo.FullName, extension);

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -265,8 +265,8 @@ namespace NzbDrone.Core.MediaFiles
                 return new List<ImportResult>
                 {
                     new ImportResult(new ImportDecision(new LocalEpisode { Path = fileInfo.FullName },
-                            new ImportRejection(ImportRejectionReason.DangerousFile, "Caution: Found potentially dangerous file")),
-                        $"Caution: Found potentially dangerous file")
+                            new ImportRejection(ImportRejectionReason.DangerousFile, $"Caution: Found potentially dangerous file with extension: {extension}")),
+                        $"Caution: Found potentially dangerous file with extension: {extension}")
                 };
             }
 
@@ -275,8 +275,8 @@ namespace NzbDrone.Core.MediaFiles
                 return new List<ImportResult>
                 {
                     new ImportResult(new ImportDecision(new LocalEpisode { Path = fileInfo.FullName },
-                            new ImportRejection(ImportRejectionReason.ExecutableFile, "Caution: Found executable file")),
-                        $"Caution: Found executable file")
+                            new ImportRejection(ImportRejectionReason.ExecutableFile, $"Caution: Found executable file with extension: '{extension}'")),
+                        $"Caution: Found executable file with extension: '{extension}'")
                 };
             }
 


### PR DESCRIPTION
#### Description
It seems that the failed download handling per indexer doesn't actually fail the download and retry, for two reasons as far as I can see:

* the filetype is checked against a list of acceptable filetypes before the checks for dangerous or executable types is done. The download is already rejected on basis of filetype then and never reaches the empty results check.
* the RejectedImport service seems to return false when localEpisode != null - I assume we should be returning out this method only when localEpisode is null (i.e. can't be matched and therefore can't be re-searched)
