### PR TITLE
Prefer newer Usenet releases

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.DecisionEngine
                     return 10;
                 }
 
-                return 1;
+                return Math.Round(Math.Log10(age)) * -1;
             });
         }
 


### PR DESCRIPTION
#### Description
A minor change to give newer usenet releases that are older than 7 days a minor bump while still allowing sorting by preferred sizes a chance by rounding log10(ageDays).

#### Issues Fixed or Closed by this PR
* Closes #6057

