### PR TITLE
Fixed: Health warning for downloading inside root folders

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
@@ -77,6 +77,19 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         }
 
         [Test]
+        public void should_return_warning_if_downloading_inside_root_folder()
+        {
+            var rootFolderPath = "c:\\Test".AsOsAgnostic();
+            var downloadRootPath = "c:\\Test\\Downloads".AsOsAgnostic();
+
+            GivenRootFolder(rootFolderPath);
+
+            _clientStatus.OutputRootFolders = new List<OsPath> { new (downloadRootPath) };
+
+            Subject.Check().ShouldBeWarning();
+        }
+
+        [Test]
         public void should_return_ok_if_not_downloading_to_root_folder()
         {
             var rootFolderPath = "c:\\Test2".AsOsAgnostic();
@@ -87,7 +100,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
         }
 
         [Test]
-        [TestCaseSource("DownloadClientExceptions")]
+        [TestCaseSource(nameof(DownloadClientExceptions))]
         public void should_return_ok_if_client_throws_downloadclientexception(Exception ex)
         {
             _downloadClient.Setup(s => s.GetStatus())

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 try
                 {
                     var status = client.GetStatus();
-                    var folders = status.OutputRootFolders.Where(folder => rootFolders.Any(r => r.Path.PathEquals(folder.FullPath)));
+                    var folders = rootFolders.Where(r => status.OutputRootFolders.Any(folder => r.Path.PathEquals(folder.FullPath) || r.Path.IsParentPath(folder.FullPath)));
 
                     foreach (var folder in folders)
                     {
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                             _localizationService.GetLocalizedString("DownloadClientRootFolderHealthCheckMessage", new Dictionary<string, object>
                             {
                                 { "downloadClientName", client.Definition.Name },
-                                { "rootFolderPath", folder.FullPath }
+                                { "rootFolderPath", folder.Path }
                             }),
                             "#downloads-in-root-folder");
                     }


### PR DESCRIPTION
#### Description
Check if the root folder is parent to the downloads folder to display the downloading to root warning.

Example of such setup:
* root folder: `/datasets/music`
* download folder: `/datasets/music/download`

#### Issues Fixed or Closed by this PR
* Closes https://github.com/Lidarr/Lidarr/issues/5384

