### PR TITLE
Fix: set sorting mode for new sabnzbd sorting on update status

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -262,7 +262,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
             if (category != null)
             {
-                if (config.Misc.enable_tv_sorting && ContainsCategory(config.Misc.tv_categories, Settings.TvCategory))
+                if ((config.Misc.enable_tv_sorting && ContainsCategory(config.Misc.tv_categories, Settings.TvCategory)) || config.Sorters.Any(s => s.is_active && ContainsCategory(s.sort_cats, Settings.TvCategory)))
                 {
                     status.SortingMode = "TV";
                 }


### PR DESCRIPTION
#### Description
sorting mode based on new sabnzbd sorting response only gets check when adding, but is not refreshed on a status update, thus never throwing a health check.

This fix ensures that SortingMode is set when enabled ensuring the health check is raised.

