### PR TITLE
Fix download links for FileList when passkey contains spaces

### DIFF
--- a/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Indexers.FileList
             var url = new HttpUri(_settings.BaseUrl)
                 .CombinePath("download.php")
                 .AddQueryParam("id", torrentId)
-                .AddQueryParam("passkey", _settings.Passkey);
+                .AddQueryParam("passkey", _settings.Passkey.Trim());
 
             return url.FullUri;
         }


### PR DESCRIPTION
#### Description
We're trimming the spaces in the request generator, but not in the parser where it generates the download links.

