### PR TITLE
Cleanse console log messages

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/CleansingClefLogLayout.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleansingClefLogLayout.cs
@@ -1,0 +1,21 @@
+using System.Text;
+using NLog;
+using NLog.Layouts.ClefJsonLayout;
+using NzbDrone.Common.EnvironmentInfo;
+
+namespace NzbDrone.Common.Instrumentation;
+
+public class CleansingClefLogLayout : CompactJsonLayout
+{
+    protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+    {
+        base.RenderFormattedMessage(logEvent, target);
+
+        if (RuntimeInfo.IsProduction)
+        {
+            var result = CleanseLogMessage.Cleanse(target.ToString());
+            target.Clear();
+            target.Append(result);
+        }
+    }
+}

--- a/src/NzbDrone.Common/Instrumentation/CleansingConsoleLogLayout.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleansingConsoleLogLayout.cs
@@ -1,0 +1,22 @@
+using System.Text;
+using NLog;
+using NLog.Layouts;
+using NzbDrone.Common.EnvironmentInfo;
+
+namespace NzbDrone.Common.Instrumentation;
+
+public class CleansingConsoleLogLayout(string format)
+    : SimpleLayout(format)
+{
+    protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+    {
+        base.RenderFormattedMessage(logEvent, target);
+
+        if (RuntimeInfo.IsProduction)
+        {
+            var result = CleanseLogMessage.Cleanse(target.ToString());
+            target.Clear();
+            target.Append(result);
+        }
+    }
+}

--- a/src/NzbDrone.Common/Instrumentation/CleansingFileTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleansingFileTarget.cs
@@ -4,7 +4,7 @@ using NLog.Targets;
 
 namespace NzbDrone.Common.Instrumentation
 {
-    public class NzbDroneFileTarget : FileTarget
+    public class CleansingFileTarget : FileTarget
     {
         protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Instrumentation
 
         private void ReconfigureFile()
         {
-            foreach (var target in LogManager.Configuration.AllTargets.OfType<NzbDroneFileTarget>())
+            foreach (var target in LogManager.Configuration.AllTargets.OfType<CleansingFileTarget>())
             {
                 target.MaxArchiveFiles = _configFileProvider.LogRotate;
                 target.ArchiveAboveSize = _configFileProvider.LogSizeLimit.Megabytes();
@@ -120,11 +120,7 @@ namespace NzbDrone.Core.Instrumentation
             {
                 var format = _configFileProvider.ConsoleLogFormat;
 
-                consoleTarget.Layout = format switch
-                {
-                    ConsoleLogFormat.Clef => NzbDroneLogger.ClefLogLayout,
-                    _ => NzbDroneLogger.ConsoleLogLayout
-                };
+                NzbDroneLogger.ConfigureConsoleLayout(consoleTarget, format);
             }
         }
 


### PR DESCRIPTION
#### Description

It's annoy that we need to reimplement this everywhere we want to cleanse logs, but makes sense to cleanse console logs as well, especially with CLEF and other tooling capturing logs.

I tried a few different ways to achieve this, but everything was a little clunky. I'm not a fan of clearing the value in the string builder like it's doing, but it solves the problem without too much pain.

#### Issues Fixed or Closed by this PR
* Closes #7632

