### PR TITLE
Fixed: Only show Additional Parameters on Trakt Popular list

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
@@ -47,6 +47,9 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
         [FieldDefinition(5, Label = "ImportListsTraktSettingsYears", HelpText = "ImportListsTraktSettingsYearsHelpText")]
         public string Years { get; set; }
 
+        [FieldDefinition(6, Label = "ImportListsTraktSettingsAdditionalParameters", HelpText = "ImportListsTraktSettingsAdditionalParametersHelpText", Advanced = true)]
+        public string TraktAdditionalParameters { get; set; }
+
         public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
@@ -59,11 +59,8 @@ namespace NzbDrone.Core.ImportLists.Trakt
         [FieldDefinition(0, Label = "ImportListsSettingsAuthUser", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
         public string AuthUser { get; set; }
 
-        [FieldDefinition(5, Label = "ImportListsTraktSettingsLimit", HelpText = "ImportListsTraktSettingsLimitHelpText")]
+        [FieldDefinition(98, Label = "ImportListsTraktSettingsLimit", HelpText = "ImportListsTraktSettingsLimitHelpText")]
         public int Limit { get; set; }
-
-        [FieldDefinition(6, Label = "ImportListsTraktSettingsAdditionalParameters", HelpText = "ImportListsTraktSettingsAdditionalParametersHelpText", Advanced = true)]
-        public string TraktAdditionalParameters { get; set; }
 
         [FieldDefinition(99, Label = "ImportListsTraktSettingsAuthenticateWithTrakt", Type = FieldType.OAuth)]
         public string SignIn { get; set; }


### PR DESCRIPTION
#### Description

`Additional Parameters` only works on Trakt Popular lists, so it's removed from the base settings.


#### Issues Fixed or Closed by this PR
* Closes #7575

