### PR TITLE
Fix: Rejected Imports with no associated release or indexer

### DIFF
--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -22,23 +22,27 @@ public class RejectedImportService : IRejectedImportService
 
     public bool Process(TrackedDownload trackedDownload, ImportResult importResult)
     {
-        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode == null)
+        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode == null || trackedDownload.RemoteEpisode.Release == null)
         {
             return false;
         }
 
-        var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
         var rejectionReason = importResult.ImportDecision.Rejections.FirstOrDefault()?.Reason;
 
-        if (rejectionReason == ImportRejectionReason.DangerousFile &&
-            indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
+        if (trackedDownload.RemoteEpisode.Release.IndexerId != 0)
         {
-            trackedDownload.Fail();
-        }
-        else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
-            indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
-        {
-            trackedDownload.Fail();
+            var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
+
+            if (rejectionReason == ImportRejectionReason.DangerousFile &&
+                indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
+            {
+                trackedDownload.Fail();
+            }
+            else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
+                     indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
+            {
+                trackedDownload.Fail();
+            }
         }
         else
         {

--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -27,15 +27,14 @@ public class RejectedImportService : IRejectedImportService
             return false;
         }
 
+        var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
         var rejectionReason = importResult.ImportDecision.Rejections.FirstOrDefault()?.Reason;
 
-        if (trackedDownload.RemoteEpisode.Release.IndexerId == 0)
+        if (indexerSettings == null)
         {
             trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
             return true;
         }
-
-        var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
 
         if (rejectionReason == ImportRejectionReason.DangerousFile &&
             indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
@@ -43,7 +42,7 @@ public class RejectedImportService : IRejectedImportService
             trackedDownload.Fail();
         }
         else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
-                 indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
+            indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
         {
             trackedDownload.Fail();
         }
@@ -51,6 +50,7 @@ public class RejectedImportService : IRejectedImportService
         {
             trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
         }
+
         return true;
     }
 }

--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -22,7 +22,7 @@ public class RejectedImportService : IRejectedImportService
 
     public bool Process(TrackedDownload trackedDownload, ImportResult importResult)
     {
-        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode == null || trackedDownload.RemoteEpisode.Release == null)
+        if (importResult.Result != ImportResultType.Rejected || importResult.ImportDecision.LocalEpisode == null || trackedDownload.RemoteEpisode?.Release == null)
         {
             return false;
         }

--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -29,26 +29,28 @@ public class RejectedImportService : IRejectedImportService
 
         var rejectionReason = importResult.ImportDecision.Rejections.FirstOrDefault()?.Reason;
 
-        if (trackedDownload.RemoteEpisode.Release.IndexerId != 0)
+        if (trackedDownload.RemoteEpisode.Release.IndexerId == 0)
         {
-            var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
+            trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
+            return true;
+        }
 
-            if (rejectionReason == ImportRejectionReason.DangerousFile &&
-                indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
-            {
-                trackedDownload.Fail();
-            }
-            else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
-                     indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
-            {
-                trackedDownload.Fail();
-            }
+        var indexerSettings = _cachedIndexerSettingsProvider.GetSettings(trackedDownload.RemoteEpisode.Release.IndexerId);
+
+        if (rejectionReason == ImportRejectionReason.DangerousFile &&
+            indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
+        {
+            trackedDownload.Fail();
+        }
+        else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
+                 indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
+        {
+            trackedDownload.Fail();
         }
         else
         {
             trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
         }
-
         return true;
     }
 }


### PR DESCRIPTION
#### Description

RejectedImportService throws a nulref exception when no release or indexerID is available. This can happen for pushed releases or manually added torrents.

Break out when the RemoteEpisode has no release associated with it, and on only check for FailDownloads settings if the IndexerId is not 0.
