### PR TITLE
add .arj & .lzh to dangerousExtensions

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
@@ -23,7 +23,9 @@ namespace NzbDrone.Core.MediaFiles
 
         private static List<string> _dangerousExtensions = new List<string>
         {
+            ".arj",
             ".lnk",
+            ".lzh",
             ".ps1",
             ".scr",
             ".vbs",


### PR DESCRIPTION
#### Description
two file archive file extensions that are frequently used for spreading malware
