### PR TITLE
Fix: Don't return warning in title field for rejected downloads

### DIFF
--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.Indexers;
@@ -32,7 +31,7 @@ public class RejectedImportService : IRejectedImportService
 
         if (indexerSettings == null)
         {
-            trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
+            trackedDownload.Warn(importResult.Errors.First());
             return true;
         }
 
@@ -48,7 +47,7 @@ public class RejectedImportService : IRejectedImportService
         }
         else
         {
-            trackedDownload.Warn(new TrackedDownloadStatusMessage(importResult.Errors.First(), new List<string>()));
+            trackedDownload.Warn(importResult.Errors.First());
         }
 
         return true;

--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -31,7 +31,7 @@ public class RejectedImportService : IRejectedImportService
 
         if (indexerSettings == null)
         {
-            trackedDownload.Warn(importResult.Errors.First());
+            trackedDownload.Warn(new TrackedDownloadStatusMessage(trackedDownload.DownloadItem.Title, importResult.Errors));
             return true;
         }
 
@@ -47,7 +47,7 @@ public class RejectedImportService : IRejectedImportService
         }
         else
         {
-            trackedDownload.Warn(importResult.Errors.First());
+            trackedDownload.Warn(new TrackedDownloadStatusMessage(trackedDownload.DownloadItem.Title, importResult.Errors));
         }
 
         return true;


### PR DESCRIPTION
#### Description
Due to the corrections in the logic for handling rejected downloads, warnings are now correctly constructed in the RejectedImportService.

The download warnings are currently being constructed with the message in the title field. Instead of TrackedDownloadStatusMessage directly in the service, instead we can make use of the trackedDownload.Warm(message) function to create TrackedDownloadStatusMessage properly.

#### Issues Fixed or Closed by this PR
* Closes #7663

