### PR TITLE
Fixed: Avoid checking for free space if other specifications fail first

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public SpecificationPriority Priority => SpecificationPriority.Default;
+        public SpecificationPriority Priority => SpecificationPriority.Disk;
         public RejectionType Type => RejectionType.Permanent;
 
         public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)


### PR DESCRIPTION
#### Description
It ain't much, but there should be quite an improvement avoiding to check for free space if the episode/season pack is not even eligible to be grabbed anyway.

https://github.com/Sonarr/Sonarr/blob/3c8268c428688cc703af76b648c9b3385858274f/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs#L201

