### PR TITLE
New: Add Azerbaijani, Uzbek and Malay languages

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/LanguageParserFixture.cs
@@ -468,6 +468,24 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().Contain(Language.Turkish);
         }
 
+        [TestCase("series.title.s01e01.2023.[Azerbaijan.Dubbed].1080p.WEB-DLRip.TeeWee")]
+        [TestCase("Series s02e04 (2023) [Azerbaijani Dubbed] 1080p WEB-DLRip TeeWee")]
+        public void should_parse_azerbaijani(string postTitle)
+        {
+            var result = Parser.Parser.ParseTitle(postTitle);
+            result.Languages.Count.Should().Be(1);
+            result.Languages.Should().Contain(Language.Azerbaijani);
+        }
+
+        [TestCase("series.title.s01e01.2023.[Uzbekistan.Dubbed].1080p.WEB-DLRip.TeeWee")]
+        [TestCase("Sweet.Series.S02E08.2023.[Uzbek.Dubbed].1080p.WEB-DLRip.TeeWee")]
+        public void should_parse_uzbek(string postTitle)
+        {
+            var result = Parser.Parser.ParseTitle(postTitle);
+            result.Languages.Count.Should().Be(1);
+            result.Languages.Should().Contain(Language.Uzbek);
+        }
+
         [TestCase("Name (2020) - S01E20 - [AAC 2.0].testtitle.default.eng.forced.ass", new[] { "default", "forced" }, "testtitle", "English")]
         [TestCase("Name (2020) - S01E20 - [AAC 2.0].eng.default.testtitle.forced.ass", new[] { "default", "forced" }, "testtitle", "English")]
         [TestCase("Name (2020) - S01E20 - [AAC 2.0].default.eng.testtitle.forced.ass", new[] { "default", "forced" }, "testtitle", "English")]

--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -117,6 +117,9 @@ namespace NzbDrone.Core.Languages
         public static Language Indonesian => new Language(44, "Indonesian");
         public static Language Macedonian => new Language(45, "Macedonian");
         public static Language Slovenian => new Language(46, "Slovenian");
+        public static Language Azerbaijani => new Language(47, "Azerbaijani");
+        public static Language Uzbek => new Language(48, "Uzbek");
+        public static Language Malay => new Language(49, "Malay");
         public static Language Original => new Language(-2, "Original");
 
         public static List<Language> All
@@ -172,6 +175,9 @@ namespace NzbDrone.Core.Languages
                     Indonesian,
                     Macedonian,
                     Slovenian,
+                    Azerbaijani,
+                    Uzbek,
+                    Malay,
                     Original
                 };
             }

--- a/src/NzbDrone.Core/Parser/IsoLanguages.cs
+++ b/src/NzbDrone.Core/Parser/IsoLanguages.cs
@@ -57,6 +57,9 @@ namespace NzbDrone.Core.Parser
                                                                new IsoLanguage("id", "", "ind", Language.Indonesian),
                                                                new IsoLanguage("mk", "", "mkd", Language.Macedonian),
                                                                new IsoLanguage("sl", "", "slv", Language.Slovenian),
+                                                               new IsoLanguage("az", "", "aze", Language.Azerbaijani),
+                                                               new IsoLanguage("uz", "", "uzb", Language.Uzbek),
+                                                               new IsoLanguage("ms", "", "msa", Language.Malay),
                                                            };
 
         private static readonly Dictionary<string, Language> AlternateIsoCodeMappings = new Dictionary<string, Language>

--- a/src/NzbDrone.Core/Parser/LanguageParser.cs
+++ b/src/NzbDrone.Core/Parser/LanguageParser.cs
@@ -179,6 +179,16 @@ namespace NzbDrone.Core.Parser
                 languages.Add(Language.Latvian);
             }
 
+            if (lowerTitle.Contains("azerbaijani") || lowerTitle.Contains("azerbaijan"))
+            {
+                languages.Add(Language.Azerbaijani);
+            }
+
+            if (lowerTitle.Contains("uzbek") || lowerTitle.Contains("uzbekistan"))
+            {
+                languages.Add(Language.Uzbek);
+            }
+
             var regexLanguages = RegexLanguage(title);
 
             if (regexLanguages.Any())


### PR DESCRIPTION
#### Description

Adds Azerbaijani, Uzbek and Malay languages. Malay will only be used for translations/metadata (in the future).

#### Issues Fixed or Closed by this PR
* Closes #6285
* Closes #7560

