### PR TITLE
remove the info box about Remove settings on completed download handling

### DIFF
--- a/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
+++ b/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
@@ -137,8 +137,6 @@ function DownloadClientOptions({
                 </FormGroup>
               ) : null}
             </Form>
-
-            <Alert kind={kinds.INFO}>{translate('RemoveDownloadsAlert')}</Alert>
           </FieldSet>
         </div>
       ) : null}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1711,7 +1711,6 @@
   "RemoveCompleted": "Remove Completed",
   "RemoveCompletedDownloads": "Remove Completed Downloads",
   "RemoveCompletedDownloadsHelpText": "Remove imported downloads from download client history",
-  "RemoveDownloadsAlert": "The Remove settings were moved to the individual Download Client settings in the table above.",
   "RemoveFailed": "Remove Failed",
   "RemoveFailedDownloads": "Remove Failed Downloads",
   "RemoveFailedDownloadsHelpText": "Remove failed downloads from download client history",


### PR DESCRIPTION
#### Description
This info box can be removed in v5, no longer relevant two versions later.

#### Screenshots for UI Changes

![image](https://github.com/user-attachments/assets/8341b8b3-c9b6-48e9-b34e-e7578df332d4)

![image](https://github.com/user-attachments/assets/f87abdc5-497f-4fc1-aace-9c847cc74e74)

