### PR TITLE
Truncate Button Text / Better Sidebar Text Wrapping

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
+++ b/frontend/src/Components/Page/Sidebar/PageSidebarItem.css
@@ -24,6 +24,7 @@
   composes: link;
 
   padding: 10px 24px;
+  padding-left: 35px;
 }
 
 .isActiveLink {
@@ -39,10 +40,6 @@
   margin-right: 7px;
   width: 18px;
   text-align: center;
-}
-
-.noIcon {
-  margin-left: 25px;
 }
 
 .status {

--- a/frontend/src/Components/Page/Sidebar/PageSidebarItem.css.d.ts
+++ b/frontend/src/Components/Page/Sidebar/PageSidebarItem.css.d.ts
@@ -8,7 +8,6 @@ interface CssExports {
   'isActiveParentLink': string;
   'item': string;
   'link': string;
-  'noIcon': string;
   'status': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Components/Page/Sidebar/PageSidebarItem.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebarItem.tsx
@@ -54,9 +54,7 @@ function PageSidebarItem({
           </span>
         )}
 
-        <span className={isChildItem ? styles.noIcon : undefined}>
-          {typeof title === 'function' ? title() : title}
-        </span>
+        {typeof title === 'function' ? title() : title}
 
         {!!StatusComponent && (
           <span className={styles.status}>

--- a/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
@@ -22,11 +22,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
   height: 24px;
 }
 
 .label {
   padding: 0 3px;
+  max-width: 100%;
+  max-height: 100%;
   color: var(--toolbarLabelColor);
   font-size: $extraSmallFontSize;
   line-height: calc($extraSmallFontSize + 1px);

--- a/frontend/src/Components/Page/Toolbar/PageToolbarButton.tsx
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarButton.tsx
@@ -31,6 +31,7 @@ function PageToolbarButton({
         isDisabled && styles.isDisabled
       )}
       isDisabled={isDisabled || isSpinning}
+      title={label}
       {...otherProps}
     >
       <Icon


### PR DESCRIPTION
#### Description
Truncates toolbar button text to a maximum width and lines, translations may need to be changed to correctly fit in that spacing, but using the search button example on Calendar that should fit if `Search Missing` was used as the reference.

The sidebar wraps text correctly when too long to fit on one row, those it wasn't forced to wrap for me.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
![image](https://github.com/user-attachments/assets/741433bf-a683-4626-a5fc-9fc2274d99e6)
![image](https://github.com/user-attachments/assets/0ac54f9b-0128-48c2-aacd-1c49a582fa80)

#### Issues Fixed or Closed by this PR
* Closes #7691

