### PR TITLE
Fixed: Downloads failed for file contents will be removed from client

### DIFF
--- a/frontend/src/Settings/DownloadClients/DownloadClients/EditDownloadClientModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/EditDownloadClientModalContent.tsx
@@ -67,7 +67,6 @@ function EditDownloadClientModalContent({
     implementationName,
     name,
     enable,
-    protocol,
     priority,
     removeCompletedDownloads,
     removeFailedDownloads,
@@ -218,19 +217,17 @@ function EditDownloadClientModalContent({
                 />
               </FormGroup>
 
-              {protocol.value === 'torrent' ? null : (
-                <FormGroup>
-                  <FormLabel>{translate('RemoveFailed')}</FormLabel>
+              <FormGroup>
+                <FormLabel>{translate('RemoveFailed')}</FormLabel>
 
-                  <FormInputGroup
-                    type={inputTypes.CHECK}
-                    name="removeFailedDownloads"
-                    helpText={translate('RemoveFailedDownloadsHelpText')}
-                    {...removeFailedDownloads}
-                    onChange={handleInputChange}
-                  />
-                </FormGroup>
-              )}
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="removeFailedDownloads"
+                  helpText={translate('RemoveFailedDownloadsHelpText')}
+                  {...removeFailedDownloads}
+                  onChange={handleInputChange}
+                />
+              </FormGroup>
             </FieldSet>
           </Form>
         ) : null}

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -40,6 +40,9 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         {
             Status = TrackedDownloadStatus.Error;
             State = TrackedDownloadState.FailedPending;
+
+            // Set CanBeRemoved to allow the failed item to be removed from the client
+            DownloadItem.CanBeRemoved = true;
         }
     }
 


### PR DESCRIPTION
#### Description

The first change enables torrents failed for potentially dangerous or executable files to be removed from the client instead of seeding forever.

The second change is for the UI to show the `Remove Failed` option for torrent clients.

Back porting the backend change to v4 makes sense.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
![image](https://github.com/user-attachments/assets/7a6deb08-0dc3-42ed-992d-10796a749b66)
