### PR TITLE
Fix various typos

### DIFF
--- a/src/NzbDrone.Common/Processes/ProcessProvider.cs
+++ b/src/NzbDrone.Common/Processes/ProcessProvider.cs
@@ -343,7 +343,7 @@ namespace NzbDrone.Common.Processes
             }
             catch
             {
-                // Don't crash on gettings some log data.
+                // Don't crash on getting some log data.
             }
 
             return processes;

--- a/src/NzbDrone.Core/Datastore/ExpressionVisitor.cs
+++ b/src/NzbDrone.Core/Datastore/ExpressionVisitor.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Datastore
         }
 
         /// <summary>
-        /// Visits the lamda expression.
+        /// Visits the lambda expression.
         /// </summary>
         /// <param name="lambdaExpression"></param>
         /// <returns></returns>

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/Responses/FreeboxDownloadTask.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/Responses/FreeboxDownloadTask.cs
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload.Responses
                 { "bt_file_error", "Error accessing torrent files." },
                 { "missing_ctx_file", "Error accessing task context file." },
                 { "nzb_no_group", "Cannot find the requested group on server." },
-                { "nzb_not_found", "Article not fount on the server." },
+                { "nzb_not_found", "Article not found on the server." },
                 { "nzb_invalid_crc", "Invalid article CRC." },
                 { "nzb_invalid_size", "Invalid article size." },
                 { "nzb_invalid_filename", "Invalid filename." },

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
@@ -96,7 +96,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
                     case FreeboxDownloadTaskStatus.Starting: // task is preparing to start download
                     case FreeboxDownloadTaskStatus.Downloading:
                     case FreeboxDownloadTaskStatus.Retry: // you can set a task status to ‘retry’ to restart the download task.
-                    case FreeboxDownloadTaskStatus.Checking: // checking data before lauching download.
+                    case FreeboxDownloadTaskStatus.Checking: // checking data before launching download.
                         item.Status = DownloadItemStatus.Downloading;
                         break;
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -168,7 +168,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Unknown error occured in RemotePathMapping HealthCheck");
+                    _logger.Error(ex, "Unknown error occurred in RemotePathMapping HealthCheck");
                 }
             }
 
@@ -216,7 +216,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                         "#remote-path-file-removed");
                 }
 
-                // If the previous case did not match then the failure occured in DownloadedEpisodeImportService,
+                // If the previous case did not match then the failure occurred in DownloadedEpisodeImportService,
                 // while trying to locate the files reported by the download client
                 // Only check clients not in failure status, those get another message
                 var client = _downloadClientProvider.GetDownloadClients(true).FirstOrDefault(x => x.Definition.Name == failureMessage.DownloadClientInfo.Name);
@@ -359,7 +359,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Unknown error occured in RemotePathMapping HealthCheck");
+                    _logger.Error(ex, "Unknown error occurred in RemotePathMapping HealthCheck");
                 }
 
                 return new HealthCheck(GetType());


### PR DESCRIPTION
#### Description

Fixes some user-facing and non-user-facing typos.  
Found via `codespell -q 3 -S "./yarn.lock,./pnpm-lock.yaml,./src/NzbDrone.Core.Test,./src/NzbDrone.Core/Localization,./src/NzbDrone.Core/Parser/IsoLanguages.cs" -L abd,ect`


#### Screenshots for UI Changes
n/a

#### Database Migration
n/a

#### Issues Fixed or Closed by this PR
n/a
