### PR TITLE
Fixed: Inherit indexer, size and release group for marked as failed history

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.tsx
+++ b/frontend/src/Activity/History/Details/HistoryDetails.tsx
@@ -174,7 +174,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
   }
 
   if (eventType === 'downloadFailed') {
-    const { message } = data as DownloadFailedHistory;
+    const { message, indexer } = data as DownloadFailedHistory;
 
     return (
       <DescriptionList>
@@ -186,6 +186,10 @@ function HistoryDetails(props: HistoryDetailsProps) {
 
         {downloadId ? (
           <DescriptionListItem title={translate('GrabId')} data={downloadId} />
+        ) : null}
+
+        {indexer ? (
+          <DescriptionListItem title={translate('Indexer')} data={indexer} />
         ) : null}
 
         {message ? (

--- a/frontend/src/typings/History.ts
+++ b/frontend/src/typings/History.ts
@@ -36,6 +36,7 @@ export interface GrabbedHistoryData {
 
 export interface DownloadFailedHistory {
   message: string;
+  indexer?: string;
 }
 
 export interface DownloadFolderImportedHistory {

--- a/src/NzbDrone.Core/History/EpisodeHistory.cs
+++ b/src/NzbDrone.Core/History/EpisodeHistory.cs
@@ -12,6 +12,9 @@ namespace NzbDrone.Core.History
         public const string DOWNLOAD_CLIENT = "downloadClient";
         public const string SERIES_MATCH_TYPE = "seriesMatchType";
         public const string RELEASE_SOURCE = "releaseSource";
+        public const string RELEASE_GROUP = "releaseGroup";
+        public const string SIZE = "size";
+        public const string INDEXER = "indexer";
 
         public EpisodeHistory()
         {

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -249,8 +249,9 @@ namespace NzbDrone.Core.History
                 history.Data.Add("DownloadClient", message.DownloadClient);
                 history.Data.Add("DownloadClientName", message.TrackedDownload?.DownloadItem.DownloadClientInfo.Name);
                 history.Data.Add("Message", message.Message);
-                history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup);
-                history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString());
+                history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup ?? message.Data.GetValueOrDefault(EpisodeHistory.RELEASE_GROUP));
+                history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString() ?? message.Data.GetValueOrDefault(EpisodeHistory.SIZE));
+                history.Data.Add("Indexer", message.TrackedDownload?.RemoteEpisode?.Release?.Indexer ?? message.Data.GetValueOrDefault(EpisodeHistory.INDEXER));
 
                 _historyRepository.Insert(history);
             }
@@ -348,6 +349,7 @@ namespace NzbDrone.Core.History
                 history.Data.Add("Message", message.Message);
                 history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup);
                 history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString());
+                history.Data.Add("Indexer", message.TrackedDownload?.RemoteEpisode?.Release?.Indexer);
                 history.Data.Add("ReleaseType", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseType.ToString());
 
                 historyToAdd.Add(history);


### PR DESCRIPTION
#### Description
When using marked as failed from history, we're losing the indexer name/size/release group information.

Since `Data` is available in FailedDownloadService, let's inherit the fields from here.
 https://github.com/Sonarr/Sonarr/blob/c9027359271690f7d374d1330fa39776e2b8ec40/src/NzbDrone.Core/Download/FailedDownloadService.cs#L136