### PR TITLE
New: Add HDR Type to XBMC metadata video stream details

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -353,6 +353,23 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         video.Add(new XElement("duration", episodeFile.MediaInfo.RunTime.TotalMinutes));
                         video.Add(new XElement("durationinseconds", Math.Round(episodeFile.MediaInfo.RunTime.TotalSeconds)));
 
+                        if (episodeFile.MediaInfo.VideoHdrFormat is HdrFormat.DolbyVision or HdrFormat.DolbyVisionHdr10 or HdrFormat.DolbyVisionHdr10Plus or HdrFormat.DolbyVisionHlg or HdrFormat.DolbyVisionSdr)
+                        {
+                            video.Add(new XElement("hdrtype", "dolbyvision"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat is HdrFormat.Hdr10 or HdrFormat.Hdr10Plus or HdrFormat.Pq10)
+                        {
+                            video.Add(new XElement("hdrtype", "hdr10"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat == HdrFormat.Hlg10)
+                        {
+                            video.Add(new XElement("hdrtype", "hlg"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat == HdrFormat.None)
+                        {
+                            video.Add(new XElement("hdrtype", ""));
+                        }
+
                         streamDetails.Add(video);
 
                         var audio = new XElement("audio");


### PR DESCRIPTION
Co-authored-by: Bogdan <mynameisbogdan@users.noreply.github.com>
(cherry picked from commit a7dbdadd2146b60efa7ebe8e2b65d32bc075232c)

#### Description
Add HDR Type to XBMC metadata video stream details.