### PR TITLE
Fixed: Manual importing queued items with seriesId to avoid title parsing

### DIFF
--- a/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
@@ -25,7 +25,7 @@ namespace Sonarr.Api.V3.ManualImport
         [Produces("application/json")]
         public List<ManualImportResource> GetMediaFiles(string folder, string downloadId, int? seriesId, int? seasonNumber, bool filterExistingFiles = true)
         {
-            if (seriesId.HasValue)
+            if (seriesId.HasValue && downloadId.IsNullOrWhiteSpace())
             {
                 return _manualImportService.GetMediaFiles(seriesId.Value, seasonNumber).ToResource().Select(AddQualityWeight).ToList();
             }


### PR DESCRIPTION
#### Description

Allows the `manualimport` endpoint to be used with a `seriesId` coupled with a `downloadId` to avoid series detection by parsing title.

https://github.com/Sonarr/Sonarr/blob/8c67a3bdee65aa35bdd82ac8614be875236d88de/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs#L241-L255

Reference https://github.com/Radarr/Radarr/issues/10931 where the user is using a script to assign movieId for queue items.