### PR TITLE
Add series progress tag to header

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -153,6 +153,13 @@
   padding: 20px;
 }
 
+.seriesProgressLabel {
+  composes: label from '~Components/Label.css';
+
+  margin: 0;
+  font-size: 17px;
+}
+
 @media only screen and (max-width: $breakpointSmall) {
   .contentContainer {
     padding: 20px 0;

--- a/frontend/src/Series/Details/SeriesDetails.css.d.ts
+++ b/frontend/src/Series/Details/SeriesDetails.css.d.ts
@@ -24,6 +24,7 @@ interface CssExports {
   'runtime': string;
   'seriesNavigationButton': string;
   'seriesNavigationButtons': string;
+  'seriesProgressLabel': string;
   'sizeOnDisk': string;
   'statusName': string;
   'tags': string;

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -443,7 +443,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
   } = series;
 
   const {
-    episodeCount,
+    episodeCount = 0,
     episodeFileCount = 0,
     sizeOnDisk = 0,
     lastAired,

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -70,6 +70,7 @@ import toggleSelected from 'Utilities/Table/toggleSelected';
 import SeriesAlternateTitles from './SeriesAlternateTitles';
 import SeriesDetailsLinks from './SeriesDetailsLinks';
 import SeriesDetailsSeason from './SeriesDetailsSeason';
+import SeriesProgressLabel from './SeriesProgressLabel';
 import SeriesTags from './SeriesTags';
 import styles from './SeriesDetails.css';
 
@@ -441,7 +442,12 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
     isSaving = false,
   } = series;
 
-  const { episodeFileCount = 0, sizeOnDisk = 0, lastAired } = statistics;
+  const {
+    episodeCount,
+    episodeFileCount = 0,
+    sizeOnDisk = 0,
+    lastAired,
+  } = statistics;
 
   const statusDetails = getSeriesStatusDetails(status);
   const runningYears =
@@ -779,6 +785,14 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                     position={tooltipPositions.BOTTOM}
                   />
                 ) : null}
+
+                <SeriesProgressLabel
+                  className={styles.seriesProgressLabel}
+                  seriesId={seriesId}
+                  monitored={monitored}
+                  episodeCount={episodeCount}
+                  episodeFileCount={episodeFileCount}
+                />
               </div>
 
               <div ref={overviewRef} className={styles.overview}>

--- a/frontend/src/Series/Details/SeriesProgressLabel.tsx
+++ b/frontend/src/Series/Details/SeriesProgressLabel.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Label from 'Components/Label';
+import { kinds, sizes } from 'Helpers/Props';
+import createSeriesQueueItemsDetailsSelector, {
+  SeriesQueueDetails,
+} from 'Series/Index/createSeriesQueueDetailsSelector';
+
+function getEpisodeCountKind(
+  monitored: boolean,
+  episodeFileCount: number,
+  episodeCount: number,
+  isDownloading: boolean
+) {
+  if (isDownloading) {
+    return kinds.PURPLE;
+  }
+
+  if (episodeFileCount === episodeCount && episodeCount > 0) {
+    return kinds.SUCCESS;
+  }
+
+  if (!monitored) {
+    return kinds.WARNING;
+  }
+
+  return kinds.DANGER;
+}
+
+interface SeriesProgressLabelProps {
+  className: string;
+  seriesId: number;
+  monitored: boolean;
+  episodeCount: number;
+  episodeFileCount: number;
+}
+
+function SeriesProgressLabel({
+  className,
+  seriesId,
+  monitored,
+  episodeCount,
+  episodeFileCount,
+}: SeriesProgressLabelProps) {
+  const queueDetails: SeriesQueueDetails = useSelector(
+    createSeriesQueueItemsDetailsSelector(seriesId)
+  );
+
+  const newDownloads = queueDetails.count - queueDetails.episodesWithFiles;
+  const text = newDownloads
+    ? `${episodeFileCount} + ${newDownloads} / ${episodeCount}`
+    : `${episodeFileCount} / ${episodeCount}`;
+
+  return (
+    <Label
+      className={className}
+      kind={getEpisodeCountKind(
+        monitored,
+        episodeFileCount,
+        episodeCount,
+        queueDetails.count > 0
+      )}
+      size={sizes.LARGE}
+    >
+      <span>{text}</span>
+    </Label>
+  );
+}
+
+export default SeriesProgressLabel;


### PR DESCRIPTION
#### Description
Add an extra tag to the header showing total episode files / total episodes

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes

![image](https://github.com/user-attachments/assets/e9207159-413a-4db8-9d16-8d10079505d9)

![image](https://github.com/user-attachments/assets/01bcdf9c-7104-4334-94db-940361346b9c)