### PR TITLE
Don't allow to set episode files with 'Original' language

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -38,7 +38,7 @@ dotnet clean $slnFile -c Release
 dotnet msbuild -restore $slnFile -p:Configuration=Debug -p:Platform=$platform -p:RuntimeIdentifiers=$RUNTIME -t:PublishAllRids
 
 dotnet new tool-manifest
-dotnet tool install --version 6.6.2 Swashbuckle.AspNetCore.Cli
+dotnet tool install --version 8.0.0 Swashbuckle.AspNetCore.Cli
 
 # Remove the openapi.json file so we can check if it was created
 rm $outputFile

--- a/src/NzbDrone.Host/Sonarr.Host.csproj
+++ b/src/NzbDrone.Host/Sonarr.Host.csproj
@@ -9,7 +9,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.0.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
 		<PackageReference Include="DryIoc.dll" Version="5.4.3" />

--- a/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileController.cs
+++ b/src/Sonarr.Api.V3/EpisodeFiles/EpisodeFileController.cs
@@ -109,6 +109,7 @@ namespace Sonarr.Api.V3.EpisodeFiles
             return Accepted(episodeFile.Id);
         }
 
+        [Obsolete("Use bulk endpoint instead")]
         [HttpPut("editor")]
         [Consumes("application/json")]
         public object SetQuality([FromBody] EpisodeFileListResource resource)

--- a/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
+++ b/src/Sonarr.Api.V3/Sonarr.Api.V3.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
     <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
+++ b/src/Sonarr.Api.V5/Sonarr.Api.V5.csproj
@@ -13,7 +13,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.0.0" />
 		<PackageReference Remove="StyleCop.Analyzers" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
#### Description
- Bump Swashbuckle to 8.0.0
- `/api/v3/episodefile/editor` isn't not in use anymore since `/api/v3/episodefile/bulk` as added.
- Don't allow to set episode files with 'Original' language. Maybe we can add some validation here too in the future.