### PR TITLE
Fixed: Don't allow pushed releases to bypass pending releases that recently expired

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AcceptableSizeSpecificationFixture.cs
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().Id = 5;
             _parseResultSingle.Episodes.First().Runtime = runtime;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 250, true)]
@@ -158,7 +158,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().Id = _episodes.First().Id;
             _parseResultSingle.Episodes.First().Runtime = _episodes.First().Runtime;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 250, true)]
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().Id = _episodes.Last().Id;
             _parseResultSingle.Episodes.First().Runtime = _episodes.First().Runtime;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 50 * 2, false)]
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultMulti.Release.Size = sizeInMegaBytes.Megabytes();
             _parseResultMulti.Episodes.ForEach(e => e.Runtime = runtime);
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().Be(expectedResult);
         }
 
         [TestCase(30, 50 * 6, false)]
@@ -205,7 +205,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultMultiSet.Release.Size = sizeInMegaBytes.Megabytes();
             _parseResultMultiSet.Episodes.ForEach(e => e.Runtime = runtime);
 
-            Subject.IsSatisfiedBy(_parseResultMultiSet, null).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultMultiSet, new()).Accepted.Should().Be(expectedResult);
         }
 
         [Test]
@@ -218,7 +218,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 0;
             _parseResultSingle.Episodes.First().Runtime = 30;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 18457280000;
             _parseResultSingle.Episodes.First().Runtime = 30;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -244,7 +244,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 36857280000;
             _parseResultSingle.Episodes.First().Runtime = 60;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 300.Megabytes();
             _parseResultSingle.Episodes.First().Runtime = 60;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -270,7 +270,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 500.Megabytes();
             _parseResultSingle.Episodes.First().Runtime = 30;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -284,7 +284,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Release.Size = 8000.Megabytes();
             _parseResultSingle.Episodes.First().Runtime = 30;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -292,7 +292,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _parseResultSingle.ParsedEpisodeInfo.Special = true;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().SeasonNumber = 2;
             _parseResultSingle.Episodes.First().Runtime = 0;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(false);
         }
 
         [Test]
@@ -321,7 +321,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().AirDateUtc = _episodes.First().AirDateUtc.Value.AddDays(7);
             _parseResultSingle.Episodes.First().Runtime = 0;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(false);
         }
 
         [Test]
@@ -337,7 +337,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.First().AirDateUtc = _episodes.First().AirDateUtc.Value.AddHours(1);
             _parseResultSingle.Episodes.First().Runtime = 0;
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(true);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(true);
         }
 
         [Test]
@@ -352,7 +352,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 e.Runtime = 0;
             });
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().Be(false);
         }
 
         [Test]
@@ -371,7 +371,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 e.Runtime = 0;
             });
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().Be(false);
         }
 
         [Test]
@@ -390,7 +390,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 e.Runtime = 0;
             });
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().Be(true);
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().Be(true);
         }
 
         [Test]
@@ -409,7 +409,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 e.Runtime = 0;
             });
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().Be(true);
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().Be(true);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AlreadyImportedSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AlreadyImportedSpecificationFixture.cs
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenCdhDisabled();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -100,13 +100,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.Episodes.First().EpisodeFileId = 0;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_accepted_if_episode_does_not_have_grabbed_event()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenHistoryItem(Guid.NewGuid().ToString().ToUpper(), TITLE, _hdtv720p, EpisodeHistoryEventType.Grabbed);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenHistoryItem(downloadId, TITLE, _hdtv720p, EpisodeHistoryEventType.Grabbed);
             GivenHistoryItem(downloadId, TITLE, _hdtv720p, EpisodeHistoryEventType.DownloadFolderImported);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -141,7 +141,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                          .With(t => t.InfoHash = null)
                                                          .Build();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                          .With(t => t.InfoHash = downloadId)
                                                          .Build();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                          .With(t => t.InfoHash = downloadId)
                                                          .Build();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                          .With(t => t.InfoHash = downloadId)
                                                          .Build();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/AnimeVersionUpgradeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/AnimeVersionUpgradeSpecificationFixture.cs
@@ -65,21 +65,21 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.Episodes.First().EpisodeFileId = 0;
 
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_true_if_series_is_not_anime()
         {
             GivenStandardSeries();
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_true_if_is_not_a_version_upgrade_for_existing_file()
         {
             GivenNoVersionUpgrade();
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -87,27 +87,27 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _episodeFile.ReleaseGroup = _remoteEpisode.ParsedEpisodeInfo.ReleaseGroup;
 
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_false_when_existing_file_doesnt_have_a_release_group()
         {
             _episodeFile.ReleaseGroup = string.Empty;
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_should_be_false_when_release_doesnt_have_a_release_group()
         {
             _remoteEpisode.ParsedEpisodeInfo.ReleaseGroup = string.Empty;
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_false_when_release_group_does_not_match()
         {
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Setup(s => s.DownloadPropersAndRepacks)
                 .Returns(ProperDownloadTypes.DoNotPrefer);
 
-            _subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            _subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/BlockedIndexerSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/BlockedIndexerSpecificationFixture.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_return_true_if_no_blocked_indexer()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithBlockedIndexer();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
             Subject.Type.Should().Be(RejectionType.Temporary);
         }
     }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/CustomFormatAllowedByProfileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/CustomFormatAllowedByProfileSpecificationFixture.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Series.QualityProfile.Value.FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems(_format1.Name);
             _remoteEpisode.CustomFormatScore = _remoteEpisode.Series.QualityProfile.Value.CalculateCustomFormatScore(_remoteEpisode.CustomFormats);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             Console.WriteLine(_remoteEpisode.CustomFormatScore);
             Console.WriteLine(_remoteEpisode.Series.QualityProfile.Value.MinFormatScore);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Series.QualityProfile.Value.FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems(_format1.Name);
             _remoteEpisode.CustomFormatScore = _remoteEpisode.Series.QualityProfile.Value.CalculateCustomFormatScore(_remoteEpisode.CustomFormats);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Series.QualityProfile.Value.FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems(_format1.Name, _format2.Name);
             _remoteEpisode.CustomFormatScore = _remoteEpisode.Series.QualityProfile.Value.CalculateCustomFormatScore(_remoteEpisode.CustomFormats);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Series.QualityProfile.Value.FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems(_format1.Name, _format2.Name);
             _remoteEpisode.CustomFormatScore = _remoteEpisode.Series.QualityProfile.Value.CalculateCustomFormatScore(_remoteEpisode.CustomFormats);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Series.QualityProfile.Value.MinFormatScore = 0;
             _remoteEpisode.CustomFormatScore = _remoteEpisode.Series.QualityProfile.Value.CalculateCustomFormatScore(_remoteEpisode.CustomFormats);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -45,15 +45,15 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             _failDelayed1 = new Mock<IDownloadDecisionEngineSpecification>();
 
-            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Accept);
-            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Accept);
-            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Accept);
+            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Accept);
+            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Accept);
+            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Accept);
 
-            _fail1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail1"));
-            _fail2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail2"));
-            _fail3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail3"));
+            _fail1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail1"));
+            _fail2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail2"));
+            _fail3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.Unknown, "fail3"));
 
-            _failDelayed1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null)).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumAgeDelay, "failDelayed1"));
+            _failDelayed1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>())).Returns(DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumAgeDelay, "failDelayed1"));
             _failDelayed1.SetupGet(c => c.Priority).Returns(SpecificationPriority.Disk);
 
             _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "The.Office.S03E115.DVDRip.XviD-OSiTV" } };
@@ -80,12 +80,12 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Subject.GetRssDecision(_reports).ToList();
 
-            _fail1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
-            _fail2.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
-            _fail3.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
-            _pass1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
-            _pass2.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
-            _pass3.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
+            _fail1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
+            _fail2.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
+            _fail3.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
+            _pass1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
+            _pass2.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
+            _pass3.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenSpecifications(_pass1, _failDelayed1);
 
             Subject.GetRssDecision(_reports).ToList();
-            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Once());
+            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Once());
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Subject.GetRssDecision(_reports).ToList();
 
-            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, null), Times.Never());
+            _failDelayed1.Verify(c => c.IsSatisfiedBy(_remoteEpisode, It.IsAny<ReleaseDecisionInformation>()), Times.Never());
         }
 
         [Test]
@@ -156,9 +156,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Mocker.GetMock<IParsingService>().Verify(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()), Times.Never());
 
-            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
+            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
         }
 
         [Test]
@@ -171,9 +171,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Mocker.GetMock<IParsingService>().Verify(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()), Times.Never());
 
-            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
+            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
 
             results.Should().BeEmpty();
         }
@@ -188,9 +188,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Mocker.GetMock<IParsingService>().Verify(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()), Times.Never());
 
-            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
+            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
         }
 
         [Test]
@@ -202,9 +202,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Subject.GetRssDecision(_reports);
 
-            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
-            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
+            _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+            _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/FreeSpaceSpecificationFixture.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithAvailableSpace(200);
             WithSize(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithAvailableSpace(200);
             WithSize(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithAvailableSpace(200);
             WithSize(1000);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithAvailableSpace(200);
             WithSize(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithAvailableSpace(200);
             WithSize(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Mocker.GetMock<IDiskProvider>().Setup(s => s.GetAvailableSpace(It.IsAny<string>())).Throws<DirectoryNotFoundException>();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/FullSeasonSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/FullSeasonSpecificationFixture.cs
@@ -48,13 +48,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = false;
             _remoteEpisode.Episodes.Last().AirDateUtc = DateTime.UtcNow.AddDays(+2);
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_all_episodes_have_aired()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -62,21 +62,21 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.Episodes.Last().AirDateUtc = DateTime.UtcNow.AddHours(23);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_one_episode_has_not_aired()
         {
             _remoteEpisode.Episodes.Last().AirDateUtc = DateTime.UtcNow.AddDays(+2);
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_false_if_an_episode_does_not_have_an_air_date()
         {
             _remoteEpisode.Episodes.Last().AirDateUtc = null;
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MaximumSizeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MaximumSizeSpecificationFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMaximumSize(0);
             WithSize(1000);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMaximumSize(2000);
             WithSize(1999);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMaximumSize(2000);
             WithSize(2000);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMaximumSize(2000);
             WithSize(2001);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMaximumSize(2000);
             WithSize(0);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MinimumAgeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MinimumAgeSpecificationFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMinimumAge(0);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMinimumAge(30);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMinimumAge(30);
             WithAge(10);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MonitoredEpisodeSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MonitoredEpisodeSpecificationFixture.cs
@@ -2,6 +2,7 @@
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -63,22 +64,22 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void setup_should_return_monitored_episode_should_return_true()
         {
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void not_monitored_series_should_be_skipped()
         {
             _fakeSeries.Monitored = false;
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void only_episode_not_monitored_should_return_false()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -86,55 +87,55 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithFirstEpisodeUnmonitored();
             WithSecondEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void only_first_episode_not_monitored_should_return_false()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void only_second_episode_not_monitored_should_return_false()
         {
             WithSecondEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_true_for_single_episode_search()
         {
             _fakeSeries.Monitored = false;
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria()).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria())).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_episode_is_monitored_for_season_search()
         {
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SeasonSearchCriteria())).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_episode_is_not_monitored_for_season_search()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new SeasonSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SeasonSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_true_if_episode_is_not_monitored_and_monitoredEpisodesOnly_flag_is_false()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = false }).Accepted.Should().BeTrue();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = false })).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_episode_is_not_monitored_and_monitoredEpisodesOnly_flag_is_true()
         {
             WithFirstEpisodeUnmonitored();
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -146,7 +147,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                     FullSeason = true
                                                   };
 
-            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _monitoredEpisodeSpecification.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs
@@ -48,13 +48,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _remoteEpisode.ParsedEpisodeInfo.IsMultiSeason = false;
             _remoteEpisode.Episodes.Last().AirDateUtc = DateTime.UtcNow.AddDays(+2);
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_is_a_multi_season_release()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/ProtocolSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/ProtocolSpecificationFixture.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenProtocol(DownloadProtocol.Usenet);
             _delayProfile.EnableUsenet = true;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().Be(true);
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().Be(true);
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenProtocol(DownloadProtocol.Torrent);
             _delayProfile.EnableTorrent = true;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().Be(true);
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().Be(true);
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenProtocol(DownloadProtocol.Usenet);
             _delayProfile.EnableUsenet = false;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().Be(false);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenProtocol(DownloadProtocol.Torrent);
             _delayProfile.EnableTorrent = false;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().Be(false);
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().Be(false);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/QualityAllowedByProfileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/QualityAllowedByProfileSpecificationFixture.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.ParsedEpisodeInfo.Quality.Quality = qualityType;
             _remoteEpisode.Series.QualityProfile.Value.Items = Qualities.QualityFixture.GetDefaultQualities(Quality.DVD, Quality.HDTV720p, Quality.Bluray1080p);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.ParsedEpisodeInfo.Quality.Quality = qualityType;
             _remoteEpisode.Series.QualityProfile.Value.Items = Qualities.QualityFixture.GetDefaultQualities(Quality.DVD, Quality.HDTV720p, Quality.Bluray1080p);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/QueueSpecificationFixture.cs
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_true_when_queue_is_empty()
         {
             GivenEmptyQueue();
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -167,7 +167,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -206,7 +206,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -235,7 +235,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -254,7 +254,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -275,7 +275,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -294,7 +294,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -315,7 +315,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Episodes.Add(_otherEpisode);
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -336,7 +336,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _remoteEpisode.Episodes.Add(_otherEpisode);
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             _remoteEpisode.Episodes.Add(_otherEpisode);
             GivenQueue(remoteEpisodes);
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -384,7 +384,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -403,7 +403,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -425,7 +425,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                 .Build();
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -447,7 +447,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode }, TrackedDownloadState.FailedPending);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -474,7 +474,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenQueue(new List<RemoteEpisode> { remoteEpisode });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RawDiskSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RawDiskSpecificationFixture.cs
@@ -34,42 +34,42 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         [Test]
         public void should_return_true_if_no_container_specified_and_does_not_match_disc_release_pattern()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_mkv()
         {
             WithContainer("MKV");
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_vob()
         {
             WithContainer("VOB");
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_false_if_iso()
         {
             WithContainer("ISO");
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_false_if_m2ts()
         {
             WithContainer("M2TS");
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_compare_case_insensitive()
         {
             WithContainer("vob");
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [TestCase("Series Title S02 Disc 1 1080i Blu-ray DTS-HD MA 2.0 AVC-TrollHD")]
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_false_if_matches_disc_format(string title)
         {
             _remoteEpisode.Release.Title = title;
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [TestCase("Series Title EP50 USLT NTSC DVDRemux DD2.0")]
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_true_if_dvdrip(string title)
         {
             _remoteEpisode.Release.Title = title;
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/ReleaseRestrictionsSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/ReleaseRestrictionsSpecificationFixture.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                   .Setup(s => s.EnabledForTags(It.IsAny<HashSet<int>>(), It.IsAny<int>()))
                   .Returns(new List<ReleaseProfile>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(new List<string> { "WEBRip" }, new List<string>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(new List<string> { "doesnt", "exist" }, new List<string>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(new List<string>(), new List<string> { "ignored" });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(new List<string>(), new List<string> { "edited" });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [TestCase("EdiTED")]
@@ -98,7 +98,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(required.Split(',').ToList(), new List<string>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [TestCase("EdiTED")]
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(new List<string>(), ignored.Split(',').ToList());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                }
                            });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [TestCase("/WEB/", true)]
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             GivenRestictions(pattern.Split(',').ToList(), new List<string>());
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().Be(expected);
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RepackSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RepackSpecificationFixture.cs
@@ -192,7 +192,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .With(e => e.Episodes = _episodes)
                                                       .Build();
 
-            Subject.IsSatisfiedBy(remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .With(e => e.Episodes = _episodes)
                                                       .Build();
 
-            Subject.IsSatisfiedBy(remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
                                                       .With(e => e.Episodes = _episodes)
                                                       .Build();
 
-            Subject.IsSatisfiedBy(remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RetentionSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RetentionSpecificationFixture.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(0);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(1000);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(100);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(10);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(0);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithRetention(10);
             WithAge(100);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DelaySpecificationFixture.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         [Test]
         public void should_be_true_when_user_invoked_search()
         {
-            Subject.IsSatisfiedBy(new RemoteEpisode(), new SingleEpisodeSearchCriteria { UserInvokedSearch = true }).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(new RemoteEpisode(), new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { UserInvokedSearch = true })).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, new SingleEpisodeSearchCriteria()).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria())).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             _delayProfile.UsenetDelay = 0;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _remoteEpisode.ParsedEpisodeInfo.Quality = new QualityModel(Quality.Bluray720p);
             _remoteEpisode.ParsedEpisodeInfo.Languages = new List<Language> { Language.French };
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 60;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -177,7 +177,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             _delayProfile.UsenetDelay = 720;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _delayProfile.UsenetDelay = 720;
             _delayProfile.MinimumCustomFormatScore = 50;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -233,7 +233,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _delayProfile.BypassIfAboveCustomFormatScore = true;
             _delayProfile.MinimumCustomFormatScore = 50;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _delayProfile.BypassIfAboveCustomFormatScore = true;
             _delayProfile.MinimumCustomFormatScore = 50;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DeletedEpisodeFileSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/DeletedEpisodeFileSpecificationFixture.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.MediaFiles;
@@ -94,13 +95,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenUnmonitorDeletedEpisodes(false);
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_when_searching()
         {
-            Subject.IsSatisfiedBy(_parseResultSingle, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SeasonSearchCriteria())).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -108,13 +109,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             WithExistingFile(_firstFile);
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_false_if_file_is_missing()
         {
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -123,7 +124,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             WithExistingFile(_firstFile);
             WithExistingFile(_secondFile);
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -131,7 +132,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             WithExistingFile(_firstFile);
 
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/HistorySpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/HistorySpecificationFixture.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
 using NzbDrone.Core.History;
@@ -106,42 +107,42 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         [Test]
         public void should_return_true_if_it_is_a_search()
         {
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new SeasonSearchCriteria()).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SeasonSearchCriteria())).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_latest_history_item_is_null()
         {
             Mocker.GetMock<IHistoryService>().Setup(s => s.MostRecentForEpisode(It.IsAny<int>())).Returns((EpisodeHistory)null);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_return_true_if_latest_history_item_is_not_grabbed()
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.DownloadFailed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
 // [Test]
 //        public void should_return_true_if_latest_history_has_a_download_id_and_cdh_is_enabled()
 //        {
 //            GivenMostRecentForEpisode(FIRST_EPISODE_ID, "test", _notupgradableQuality, DateTime.UtcNow, HistoryEventType.Grabbed);
-//            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+//            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
 //        }
 
         [Test]
         public void should_return_true_if_latest_history_item_is_older_than_twelve_hours()
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow.AddHours(-13), EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_upgradable_if_only_episode_is_upgradable()
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -149,7 +150,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
             GivenMostRecentForEpisode(SECOND_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -157,7 +158,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
             GivenMostRecentForEpisode(SECOND_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -165,7 +166,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -173,7 +174,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
             GivenMostRecentForEpisode(SECOND_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -185,7 +186,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -197,14 +198,14 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _upgradableQuality, DateTime.UtcNow, EpisodeHistoryEventType.Grabbed);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_false_if_latest_history_item_is_only_one_hour_old()
         {
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, string.Empty, _notupgradableQuality, DateTime.UtcNow.AddHours(-1), EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -212,7 +213,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenCdhDisabled();
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, "test", _upgradableQuality, DateTime.UtcNow.AddDays(-100), EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeHistory.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -225,7 +226,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
 
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, "test", _upgradableQuality, DateTime.UtcNow.AddDays(-100), EpisodeHistoryEventType.Grabbed);
 
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -233,7 +234,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
         {
             GivenCdhDisabled();
             GivenMostRecentForEpisode(FIRST_EPISODE_ID, "test", _notupgradableQuality, DateTime.UtcNow.AddDays(-100), EpisodeHistoryEventType.Grabbed);
-            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeHistory.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/IndexerTagSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/IndexerTagSpecificationFixture.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Datastore;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -74,7 +75,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeIndexerDefinition.Tags = new HashSet<int>();
             _fakeSeries.Tags = new HashSet<int>();
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeTrue();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -83,7 +84,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeIndexerDefinition.Tags = new HashSet<int> { 123 };
             _fakeSeries.Tags = new HashSet<int>();
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeFalse();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -92,7 +93,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeIndexerDefinition.Tags = new HashSet<int>();
             _fakeSeries.Tags = new HashSet<int> { 123 };
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeTrue();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -101,7 +102,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeIndexerDefinition.Tags = new HashSet<int> { 123, 456 };
             _fakeSeries.Tags = new HashSet<int> { 123, 789 };
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeTrue();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -110,7 +111,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeIndexerDefinition.Tags = new HashSet<int> { 456 };
             _fakeSeries.Tags = new HashSet<int> { 123, 789 };
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeFalse();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -120,7 +121,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeSeries.Tags = new HashSet<int> { 123, 789 };
             _fakeRelease.IndexerId = 0;
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeTrue();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -130,7 +131,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _fakeSeries.Tags = new HashSet<int> { 123, 789 };
             _fakeRelease.IndexerId = 2;
 
-            _specification.IsSatisfiedBy(_parseResultMulti, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true }).Accepted.Should().BeTrue();
+            _specification.IsSatisfiedBy(_parseResultMulti, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria { MonitoredEpisodesOnly = true })).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/PendingSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/PendingSpecificationFixture.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
+using NzbDrone.Core.Download.Pending;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.CustomFormats;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
+{
+    [TestFixture]
+    public class PendingSpecificationFixture : CoreTest<PendingSpecification>
+    {
+        private Series _series;
+        private Episode _episode;
+        private RemoteEpisode _remoteEpisode;
+
+        private Series _otherSeries;
+        private Episode _otherEpisode;
+
+        private ReleaseInfo _releaseInfo;
+        private ReleaseDecisionInformation _information = new(false, null);
+
+        [SetUp]
+        public void Setup()
+        {
+            CustomFormatsTestHelpers.GivenCustomFormats();
+
+            _series = Builder<Series>.CreateNew()
+                                     .With(e => e.QualityProfile = new QualityProfile
+                                                                {
+                                                                    UpgradeAllowed = true,
+                                                                    Items = Qualities.QualityFixture.GetDefaultQualities(),
+                                                                    FormatItems = CustomFormatsTestHelpers.GetSampleFormatItems(),
+                                                                    MinFormatScore = 0
+                                                                })
+                                     .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                                       .With(e => e.SeriesId = _series.Id)
+                                       .Build();
+
+            _otherSeries = Builder<Series>.CreateNew()
+                                          .With(s => s.Id = 2)
+                                          .Build();
+
+            _otherEpisode = Builder<Episode>.CreateNew()
+                                            .With(e => e.SeriesId = _otherSeries.Id)
+                                            .With(e => e.Id = 2)
+                                            .With(e => e.SeasonNumber = 2)
+                                            .With(e => e.EpisodeNumber = 2)
+                                            .Build();
+
+            _releaseInfo = Builder<ReleaseInfo>.CreateNew()
+                                               .Build();
+
+            _remoteEpisode = Builder<RemoteEpisode>.CreateNew()
+                                                   .With(r => r.Series = _series)
+                                                   .With(r => r.Episodes = new List<Episode> { _episode })
+                                                   .With(r => r.ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = new QualityModel(Quality.DVD), Languages = new List<Language> { Language.Spanish } })
+                                                   .With(r => r.CustomFormats = new List<CustomFormat>())
+                                                   .Build();
+
+            Mocker.GetMock<ICustomFormatCalculationService>()
+                  .Setup(x => x.ParseCustomFormat(It.IsAny<RemoteEpisode>(), It.IsAny<long>()))
+                  .Returns(new List<CustomFormat>());
+        }
+
+        private void GivenEmptyPendingQueue()
+        {
+            Mocker.GetMock<IPendingReleaseService>()
+                .Setup(s => s.GetPendingQueue())
+                .Returns(new List<Queue.Queue>());
+        }
+
+        private void GivenPendingQueue(IEnumerable<RemoteEpisode> remoteEpisodes)
+        {
+            var queue = remoteEpisodes.Select(remoteEpisode => new Queue.Queue
+            {
+                RemoteEpisode = remoteEpisode
+            });
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Setup(s => s.GetPendingQueue())
+                .Returns(queue.ToList());
+        }
+
+        [Test]
+        public void should_return_true_when_pending_queue_is_empty()
+        {
+            GivenEmptyPendingQueue();
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Verify(s => s.GetPendingQueue(), Times.Once);
+        }
+
+        [Test]
+        public void should_return_true_when_not_pushed_release()
+        {
+            _remoteEpisode.ReleaseSource = ReleaseSourceType.Rss;
+
+            GivenEmptyPendingQueue();
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Verify(s => s.GetPendingQueue(), Times.Never);
+        }
+
+        [Test]
+        public void should_return_true_when_series_and_episode_is_not_pending()
+        {
+            GivenEmptyPendingQueue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Setup(s => s.GetPendingQueue())
+                .Returns(new List<Queue.Queue>
+                {
+                    new()
+                    {
+                        RemoteEpisode = new RemoteEpisode
+                        {
+                            Series = _otherSeries,
+                            Episodes = new List<Episode> { _otherEpisode }
+                        }
+                    }
+                });
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Verify(s => s.GetPendingQueue(), Times.Once);
+        }
+
+        [Test]
+        public void should_return_true_when_episode_is_not_pending()
+        {
+            GivenEmptyPendingQueue();
+
+            _otherEpisode.SeriesId = _series.Id;
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Setup(s => s.GetPendingQueue())
+                .Returns(new List<Queue.Queue>
+                {
+                    new()
+                    {
+                        RemoteEpisode = new RemoteEpisode
+                        {
+                            Series = _series,
+                            Episodes = new List<Episode> { _otherEpisode }
+                        }
+                    }
+                });
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Verify(s => s.GetPendingQueue(), Times.Once);
+        }
+
+        [Test]
+        public void should_return_false_when_episode_is_pending()
+        {
+            GivenEmptyPendingQueue();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Setup(s => s.GetPendingQueue())
+                .Returns(new List<Queue.Queue>
+                {
+                    new()
+                    {
+                        RemoteEpisode = new RemoteEpisode
+                        {
+                            Series = _series,
+                            Episodes = new List<Episode> { _episode }
+                        }
+                    }
+                });
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
+
+            Mocker.GetMock<IPendingReleaseService>()
+                .Verify(s => s.GetPendingQueue(), Times.Once);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/ProperSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/RssSync/ProperSpecificationFixture.cs
@@ -4,6 +4,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.DecisionEngine.Specifications.RssSync;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -66,7 +67,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -76,7 +77,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _secondFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -86,7 +87,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _secondFile.Quality.Quality = Quality.DVD;
 
             _secondFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -95,7 +96,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             WithFirstFileUpgradable();
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -104,7 +105,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             WithFirstFileUpgradable();
 
             _firstFile.DateAdded = DateTime.Today.AddDays(-30);
-            Subject.IsSatisfiedBy(_parseResultSingle, new SingleEpisodeSearchCriteria()).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new ReleaseDecisionInformation(false, new SingleEpisodeSearchCriteria())).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -117,7 +118,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today;
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -130,7 +131,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today;
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -143,7 +144,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.RssSync
             _firstFile.Quality.Quality = Quality.DVD;
 
             _firstFile.DateAdded = DateTime.Today;
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeriesSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeriesSpecificationFixture.cs
@@ -1,6 +1,7 @@
 ﻿using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.Search;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -14,8 +15,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
     {
         private Series _series1;
         private Series _series2;
-        private RemoteEpisode _remoteEpisode = new RemoteEpisode();
+        private RemoteEpisode _remoteEpisode = new();
         private SearchCriteriaBase _searchCriteria = new SingleEpisodeSearchCriteria();
+        private ReleaseDecisionInformation _information;
 
         [SetUp]
         public void Setup()
@@ -24,6 +26,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
             _series2 = Builder<Series>.CreateNew().With(s => s.Id = 2).Build();
 
             _remoteEpisode.Series = _series1;
+            _information = new ReleaseDecisionInformation(false, _searchCriteria);
         }
 
         [Test]
@@ -31,7 +34,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             _searchCriteria.Series = _series2;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -39,7 +42,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             _searchCriteria.Series = _series1;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/AnimeSearchFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/AnimeSearchFixture.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.Search;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -10,13 +11,15 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
     [TestFixture]
     public class AnimeSearchFixture : TestBase<SingleEpisodeSearchMatchSpecification>
     {
-        private RemoteEpisode _remoteEpisode = new RemoteEpisode();
-        private AnimeEpisodeSearchCriteria _searchCriteria = new AnimeEpisodeSearchCriteria();
+        private RemoteEpisode _remoteEpisode = new();
+        private AnimeEpisodeSearchCriteria _searchCriteria = new();
+        private ReleaseDecisionInformation _information;
 
         [SetUp]
         public void Setup()
         {
             _remoteEpisode.ParsedEpisodeInfo = new ParsedEpisodeInfo();
+            _information = new ReleaseDecisionInformation(false, _searchCriteria);
         }
 
         [Test]
@@ -24,7 +27,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
         {
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -32,7 +35,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
         {
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = false;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -41,7 +44,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
             _searchCriteria.IsSeasonSearch = true;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/StandardEpisodeSearch.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/StandardEpisodeSearch.cs
@@ -1,6 +1,7 @@
 using System;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.Search;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -11,8 +12,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
     [TestFixture]
     public class StandardEpisodeSearch : TestBase<SingleEpisodeSearchMatchSpecification>
     {
-        private RemoteEpisode _remoteEpisode = new RemoteEpisode();
-        private SingleEpisodeSearchCriteria _searchCriteria = new SingleEpisodeSearchCriteria();
+        private RemoteEpisode _remoteEpisode = new();
+        private SingleEpisodeSearchCriteria _searchCriteria = new();
+        private ReleaseDecisionInformation _information;
 
         [SetUp]
         public void Setup()
@@ -24,6 +26,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
 
             _searchCriteria.SeasonNumber = 5;
             _searchCriteria.EpisodeNumber = 1;
+            _information = new ReleaseDecisionInformation(false, _searchCriteria);
         }
 
         [Test]
@@ -32,7 +35,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
             _remoteEpisode.ParsedEpisodeInfo.SeasonNumber = 10;
             _remoteEpisode.MappedSeasonNumber = 10;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -42,7 +45,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
             _remoteEpisode.MappedSeasonNumber = 5; // 10 -> 5 mapping
             _searchCriteria.SeasonNumber = 10; // searching by tvdb 5 = 10 scene
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -52,7 +55,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
             _remoteEpisode.MappedSeasonNumber = 6; // 9 -> 5 mapping
             _searchCriteria.SeasonNumber = 9; // searching by tvdb 5 = 9 scene
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -60,7 +63,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
         {
             _remoteEpisode.ParsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -68,13 +71,13 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
         {
             _remoteEpisode.ParsedEpisodeInfo.EpisodeNumbers = new[] { 2 };
 
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_return_true_if_full_season_result_for_full_season_search()
         {
-            Subject.IsSatisfiedBy(_remoteEpisode, _searchCriteria).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/TorrentSeedingSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/TorrentSeedingSpecificationFixture.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
                 Title = "Series.Title.S01.720p.BluRay.X264-RlsGrp"
             };
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             _remoteEpisode.Release.IndexerId = 0;
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
                   .Setup(v => v.Get(It.IsAny<int>()))
                   .Callback<int>(i => { throw new ModelNotFoundException(typeof(IndexerDefinition), i); });
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             GivenReleaseSeeders(null);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [TestCase(5)]
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             GivenReleaseSeeders(seeders);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeTrue();
         }
 
         [TestCase(0)]
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search
         {
             GivenReleaseSeeders(seeders);
 
-            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_remoteEpisode, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/SingleEpisodeAgeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/SingleEpisodeAgeDownloadDecisionFixture.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
@@ -21,6 +22,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         private Series _series;
         private List<Episode> _episodes;
         private SeasonSearchCriteria _multiSearch;
+        private ReleaseDecisionInformation _multiInfo;
 
         [SetUp]
         public void Setup()
@@ -39,6 +41,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _multiSearch = new SeasonSearchCriteria();
             _multiSearch.Episodes = _episodes.ToList();
             _multiSearch.SeasonNumber = 1;
+            _multiInfo = new ReleaseDecisionInformation(false, _multiSearch);
 
             _parseResultMulti = new RemoteEpisode
             {
@@ -79,7 +82,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _parseResultSingle.Episodes.Clear();
             _parseResultSingle.Episodes.Add(_episodes.Find(e => e.EpisodeNumber == episode));
 
-            Subject.IsSatisfiedBy(_parseResultSingle, _multiSearch).Accepted.Should().Be(expectedResult);
+            Subject.IsSatisfiedBy(_parseResultSingle, _multiInfo).Accepted.Should().Be(expectedResult);
         }
 
         // should always accept all season packs
@@ -91,7 +94,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _parseResultMulti.Release.SeasonSearchMaximumSingleEpisodeAge = seasonSearchMaximumSingleEpisodeAge;
 
-            Subject.IsSatisfiedBy(_parseResultMulti, _multiSearch).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultMulti, _multiInfo).Accepted.Should().BeTrue();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/UpgradeDiskSpecificationFixture.cs
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_return_true_if_episode_has_no_existing_file()
         {
             _parseResultSingle.Episodes.ForEach(c => c.EpisodeFileId = 0);
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -136,14 +136,14 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _parseResultSingle.Episodes = new List<Episode>();
 
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_upgradable_if_only_episode_is_upgradable()
         {
             WithFirstFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -151,27 +151,27 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             WithFirstFileUpgradable();
             WithSecondFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeTrue();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
         public void should_be_not_upgradable_if_both_episodes_are_not_upgradable()
         {
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_first_episodes_is_upgradable()
         {
             WithFirstFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
         public void should_be_not_upgradable_if_only_second_episodes_is_upgradable()
         {
             WithSecondFileUpgradable();
-            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, null).Accepted.Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultMulti, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         {
             _firstFile.Quality = new QualityModel(Quality.WEBDL1080p);
             _parseResultSingle.ParsedEpisodeInfo.Quality = new QualityModel(Quality.WEBDL1080p);
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             _firstFile.Quality = new QualityModel(Quality.WEBDL1080p, new Revision(2));
             _parseResultSingle.ParsedEpisodeInfo.Quality = new QualityModel(Quality.WEBDL1080p);
-            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            _upgradeDisk.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             });
 
             GivenFileQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             });
 
             GivenFileQuality(new QualityModel(Quality.Bluray1080p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -236,7 +236,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 1)));
             GivenNewQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -251,7 +251,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 2)));
             GivenNewQuality(new QualityModel(Quality.Bluray1080p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -266,7 +266,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 2)));
             GivenNewQuality(new QualityModel(Quality.Bluray1080p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -281,7 +281,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.HDTV720p, new Revision(version: 2)));
             GivenNewQuality(new QualityModel(Quality.Bluray1080p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -296,7 +296,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             GivenFileQuality(new QualityModel(Quality.SDTV, new Revision(version: 2)));
             GivenNewQuality(new QualityModel(Quality.Bluray1080p, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -310,7 +310,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             });
 
             GivenFileQuality(new QualityModel(Quality.SDTV, new Revision(version: 2)));
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -333,7 +333,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenOldCustomFormats(new List<CustomFormat>());
             GivenNewCustomFormats(new List<CustomFormat> { customFormat });
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -349,7 +349,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenFileQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 1)));
             GivenNewQuality(new QualityModel(Quality.WEBDL1080p, new Revision(version: 2)));
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeTrue();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeTrue();
         }
 
         [Test]
@@ -365,7 +365,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenFileQuality(new QualityModel(Quality.WEBDL1080p));
             GivenNewQuality(new QualityModel(Quality.Bluray1080p));
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -398,7 +398,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenOldCustomFormats(new List<CustomFormat>());
             GivenNewCustomFormats(new List<CustomFormat> { customFormat });
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
 
         [Test]
@@ -435,7 +435,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             GivenOldCustomFormats(new List<CustomFormat>());
             GivenNewCustomFormats(new List<CustomFormat> { customFormat });
 
-            Subject.IsSatisfiedBy(_parseResultSingle, null).Accepted.Should().BeFalse();
+            Subject.IsSatisfiedBy(_parseResultSingle, new()).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
@@ -10,6 +10,7 @@ public enum DownloadRejectionReason
     Error,
     DecisionError,
     MinimumAgeDelay,
+    MinimumAgeDelayPushed,
     SeriesNotMonitored,
     EpisodeNotMonitored,
     HistoryRecentCutoffMet,

--- a/src/NzbDrone.Core/DecisionEngine/ReleaseDecisionInformation.cs
+++ b/src/NzbDrone.Core/DecisionEngine/ReleaseDecisionInformation.cs
@@ -1,0 +1,21 @@
+using NzbDrone.Core.IndexerSearch.Definitions;
+
+namespace NzbDrone.Core.DecisionEngine;
+
+public class ReleaseDecisionInformation
+{
+    public bool PushedRelease { get; set; }
+    public SearchCriteriaBase SearchCriteria { get; set; }
+
+    public ReleaseDecisionInformation()
+    {
+        PushedRelease = false;
+        SearchCriteria = null;
+    }
+
+    public ReleaseDecisionInformation(bool pushedRelease, SearchCriteriaBase searchCriteria)
+    {
+        PushedRelease = pushedRelease;
+        SearchCriteria = searchCriteria;
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
@@ -21,7 +20,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             _logger.Debug("Beginning size check for: {0}", subject);
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AlreadyImportedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AlreadyImportedSpecification.cs
@@ -4,7 +4,6 @@ using NLog;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -27,7 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var cdhEnabled = _configService.EnableCompletedDownloadHandling;
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Tv;
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var releaseGroup = subject.ParsedEpisodeInfo.ReleaseGroup;
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/BlockedIndexerSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/BlockedIndexerSpecification.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Cache;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -27,7 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Temporary;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var status = _blockedIndexerCache.Find(subject.Release.IndexerId.ToString());
             if (status != null)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/BlocklistSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/BlocklistSpecification.cs
@@ -1,6 +1,5 @@
 using NLog;
 using NzbDrone.Core.Blocklisting;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -19,7 +18,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (_blocklistService.Blocklisted(subject.Series.Id, subject.Release))
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
@@ -1,6 +1,5 @@
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -17,7 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var minScore = subject.Series.QualityProfile.Value.MinFormatScore;
             var score = subject.CustomFormatScore;

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -3,7 +3,6 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -24,7 +23,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Disk;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (_configService.SkipFreeSpaceCheckWhenImporting)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -19,7 +18,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.ParsedEpisodeInfo.FullSeason)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/IDownloadDecisionEngineSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/IDownloadDecisionEngineSpecification.cs
@@ -1,4 +1,3 @@
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -9,6 +8,6 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
         SpecificationPriority Priority { get; }
 
-        DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria);
+        DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information);
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MaximumSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MaximumSizeSpecification.cs
@@ -1,7 +1,6 @@
 ﻿using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -20,7 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var size = subject.Release.Size;
             var maximumSize = _configService.MaximumSize.Megabytes();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NLog;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -20,7 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Temporary;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.Release.DownloadProtocol != Indexers.DownloadProtocol.Usenet)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
@@ -1,5 +1,4 @@
 ﻿using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -16,7 +15,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.ParsedEpisodeInfo.IsMultiSeason)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/NotSampleSpecification.cs
@@ -1,6 +1,5 @@
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -17,7 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.Release.Title.ToLower().Contains("sample") && subject.Release.Size < 70.Megabytes())
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
@@ -1,6 +1,5 @@
 using NLog;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles.Delay;
 
@@ -21,7 +20,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var delayProfile = _delayProfileService.BestForTags(subject.Series.Tags);
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
@@ -1,5 +1,4 @@
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -16,7 +15,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             _logger.Debug("Checking if report meets quality requirements. {0}", subject.ParsedEpisodeInfo.Quality);
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -3,7 +3,6 @@ using NLog;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Download.TrackedDownloads;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Queue;
@@ -34,7 +33,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var queue = _queueService.GetQueue();
             var matchingEpisode = queue.Where(q => q.RemoteEpisode?.Series != null &&

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RawDiskSpecification.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -29,7 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.Release == null)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles.Releases;
 
@@ -24,7 +23,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             _logger.Debug("Checking if release meets restrictions: {0}", subject);
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RepackSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RepackSpecification.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (!subject.ParsedEpisodeInfo.Quality.Revision.IsRepack)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
@@ -1,6 +1,5 @@
 ﻿using NLog;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -19,7 +18,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.Release.DownloadProtocol != Indexers.DownloadProtocol.Usenet)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using NLog;
 using NzbDrone.Core.Download.Pending;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Profiles.Delay;
 using NzbDrone.Core.Qualities;
@@ -26,9 +25,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Temporary;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            if (searchCriteria != null && searchCriteria.UserInvokedSearch)
+            if (information.SearchCriteria is { UserInvokedSearch: true })
             {
                 _logger.Debug("Ignoring delay for user invoked search");
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
@@ -26,14 +25,14 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Disk;
         public RejectionType Type => RejectionType.Temporary;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (!_configService.AutoUnmonitorPreviouslyDownloadedEpisodes)
             {
                 return DownloadSpecDecision.Accept();
             }
 
-            if (searchCriteria != null)
+            if (information.SearchCriteria != null)
             {
                 _logger.Debug("Skipping deleted episodefile check during search");
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -4,7 +4,6 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.History;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
@@ -33,9 +32,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Database;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            if (searchCriteria != null)
+            if (information.SearchCriteria != null)
             {
                 _logger.Debug("Skipping history check during search");
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/IndexerTagSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/IndexerTagSpecification.cs
@@ -3,7 +3,6 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
@@ -22,7 +21,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.Release == null || subject.Series?.Tags == null || subject.Release.IndexerId == 0)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
@@ -17,15 +16,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            if (searchCriteria != null)
+            if (information.SearchCriteria is { MonitoredEpisodesOnly: false })
             {
-                if (!searchCriteria.MonitoredEpisodesOnly)
-                {
-                    _logger.Debug("Skipping monitored check during search");
-                    return DownloadSpecDecision.Accept();
-                }
+                _logger.Debug("Skipping monitored check during search");
+                return DownloadSpecDecision.Accept();
             }
 
             if (!subject.Series.Monitored)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/PendingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/PendingSpecification.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using NLog;
+using NzbDrone.Core.Download.Pending;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
+{
+    public class PendingSpecification : IDownloadDecisionEngineSpecification
+    {
+        private readonly IPendingReleaseService _pendingReleaseService;
+        private readonly Logger _logger;
+
+        public PendingSpecification(IPendingReleaseService pendingReleaseService,
+                                  Logger logger)
+        {
+            _pendingReleaseService = pendingReleaseService;
+            _logger = logger;
+        }
+
+        public SpecificationPriority Priority => SpecificationPriority.Database;
+        public RejectionType Type => RejectionType.Temporary;
+
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
+        {
+            // Skip this check for RSS sync and interactive searches,
+
+            if (subject.ReleaseSource == ReleaseSourceType.Rss)
+            {
+                return DownloadSpecDecision.Accept();
+            }
+
+            if (information.SearchCriteria is { UserInvokedSearch: true })
+            {
+                _logger.Debug("Ignoring delay for user invoked search");
+                return DownloadSpecDecision.Accept();
+            }
+
+            var pending = _pendingReleaseService.GetPendingQueue();
+
+            var matchingEpisode = pending.Where(q => q.RemoteEpisode?.Series != null &&
+                                                     q.RemoteEpisode.Series.Id == subject.Series.Id &&
+                                                     q.RemoteEpisode.Episodes.Select(e => e.Id).Intersect(subject.Episodes.Select(e => e.Id)).Any())
+                                       .ToList();
+
+            if (matchingEpisode.Any())
+            {
+                _logger.Debug("Release containing at least one matching episode is already pending. Delaying pushed release");
+                return DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumAgeDelayPushed, "Release containing at least one matching episode is already pending, delaying pushed release");
+            }
+
+            return DownloadSpecDecision.Accept();
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using NLog;
 using NzbDrone.Core.Configuration;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 
@@ -24,9 +23,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            if (searchCriteria != null)
+            if (information.SearchCriteria != null)
             {
                 return DownloadSpecDecision.Accept();
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SameEpisodesGrabSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SameEpisodesGrabSpecification.cs
@@ -1,5 +1,4 @@
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -18,7 +17,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (_sameEpisodesSpecification.IsSatisfiedBy(subject.Episodes))
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SceneMappingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SceneMappingSpecification.cs
@@ -1,6 +1,5 @@
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -17,7 +16,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Temporary; // Temporary till there's a mapping
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
             if (remoteEpisode.SceneMapping == null)
             {
@@ -33,7 +32,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             var split = remoteEpisode.SceneMapping.SceneOrigin.Split(':');
 
-            var isInteractive = searchCriteria != null && searchCriteria.InteractiveSearch;
+            var isInteractive = information.SearchCriteria is { InteractiveSearch: true };
 
             if (remoteEpisode.SceneMapping.Comment.IsNotNullOrWhiteSpace())
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.Search
@@ -17,14 +16,14 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
-            if (searchCriteria == null)
+            if (information.SearchCriteria == null)
             {
                 return DownloadSpecDecision.Accept();
             }
 
-            var criteriaEpisodes = searchCriteria.Episodes.Select(v => v.Id).ToList();
+            var criteriaEpisodes = information.SearchCriteria.Episodes.Select(v => v.Id).ToList();
             var remoteEpisodes = remoteEpisode.Episodes.Select(v => v.Id).ToList();
 
             if (!criteriaEpisodes.Intersect(remoteEpisodes).Any())

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
@@ -19,14 +19,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
-            if (searchCriteria == null)
+            if (information.SearchCriteria == null)
             {
                 return DownloadSpecDecision.Accept();
             }
 
-            var singleEpisodeSpec = searchCriteria as SeasonSearchCriteria;
+            var singleEpisodeSpec = information.SearchCriteria as SeasonSearchCriteria;
+
             if (singleEpisodeSpec == null)
             {
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
@@ -1,5 +1,4 @@
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications.Search
@@ -16,8 +15,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
+            var searchCriteria = information.SearchCriteria;
+
             if (searchCriteria == null)
             {
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
@@ -20,21 +20,21 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
+            var searchCriteria = information.SearchCriteria;
+
             if (searchCriteria == null)
             {
                 return DownloadSpecDecision.Accept();
             }
 
-            var singleEpisodeSpec = searchCriteria as SingleEpisodeSearchCriteria;
-            if (singleEpisodeSpec != null)
+            if (searchCriteria is SingleEpisodeSearchCriteria singleEpisodeSpec)
             {
                 return IsSatisfiedBy(remoteEpisode, singleEpisodeSpec);
             }
 
-            var animeEpisodeSpec = searchCriteria as AnimeEpisodeSearchCriteria;
-            if (animeEpisodeSpec != null)
+            if (searchCriteria is AnimeEpisodeSearchCriteria animeEpisodeSpec)
             {
                 return IsSatisfiedBy(remoteEpisode, animeEpisodeSpec);
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SeasonPackOnlySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SeasonPackOnlySpecification.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Tv;
 
@@ -20,8 +19,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
+            var searchCriteria = information.SearchCriteria;
+
             if (searchCriteria == null || searchCriteria.Episodes.Count == 1)
             {
                 return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SplitEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SplitEpisodeSpecification.cs
@@ -1,5 +1,4 @@
 using NLog;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -16,7 +15,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             if (subject.ParsedEpisodeInfo.IsSplitEpisode)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/TorrentSeedingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/TorrentSeedingSpecification.cs
@@ -1,7 +1,6 @@
 ﻿using NLog;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Indexers;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -20,7 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, SearchCriteriaBase searchCriteria)
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, ReleaseDecisionInformation information)
         {
             var torrentInfo = remoteEpisode.Release as TorrentInfo;
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeAllowedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeAllowedSpecification.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using NLog;
 using NzbDrone.Core.CustomFormats;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -24,7 +23,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var qualityProfile = subject.Series.QualityProfile.Value;
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using NLog;
 using NzbDrone.Core.CustomFormats;
-using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.DecisionEngine.Specifications
@@ -24,7 +23,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         public SpecificationPriority Priority => SpecificationPriority.Default;
         public RejectionType Type => RejectionType.Permanent;
 
-        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)
+        public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
             var qualityProfile = subject.Series.QualityProfile.Value;
 


### PR DESCRIPTION
#### Description

This required a bunch of changes so we know whether a release was pushed, came from RSS or a search, but in the future additional information will be easier to add.

`ReleaseDecisionInformation` is a bit of a mouthful; open to alternative naming suggestions.

#### Issues Fixed or Closed by this PR
* Closes #7725

