### PR TITLE
Fixed: Series search input when URL base is configured

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = (env) => {
 
     output: {
       path: distFolder,
-      publicPath: '/',
+      publicPath: 'auto',
       filename: isProduction ? '[name]-[contenthash].js' : '[name].js',
       sourceMapFilename: '[file].map'
     },


### PR DESCRIPTION
#### Description

Looks like this regressed in f35a274, but only when a URL Base is set as it wasn't correctly determining the correct public path for imports from workers. Setting it to `auto` instead of `/` fixes it in my testing.
