### PR TITLE
Fixed: Trakt yearly lists no longer supported

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularListType.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularListType.cs
@@ -1,3 +1,4 @@
+using System;
 using NzbDrone.Core.Annotations;
 
 namespace NzbDrone.Core.ImportLists.Trakt.Popular
@@ -6,24 +7,36 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
     {
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeTrendingShows")]
         Trending = 0,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypePopularShows")]
         Popular = 1,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeAnticipatedShows")]
         Anticipated = 2,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeTopWeekShows")]
         TopWatchedByWeek = 3,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeTopMonthShows")]
         TopWatchedByMonth = 4,
+
+        [Obsolete]
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeTopYearShows")]
         TopWatchedByYear = 5,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeTopAllTimeShows")]
         TopWatchedByAllTime = 6,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeRecommendedWeekShows")]
         RecommendedByWeek = 7,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeRecommendedMonthShows")]
         RecommendedByMonth = 8,
+
+        [Obsolete]
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeRecommendedYearShows")]
         RecommendedByYear = 9,
+
         [FieldOption(Label = "ImportListsTraktSettingsPopularListTypeRecommendedAllTimeShows")]
         RecommendedByAllTime = 10
     }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
@@ -40,7 +40,9 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
                 case (int)TraktPopularListType.TopWatchedByMonth:
                     link += "/shows/watched/monthly";
                     break;
+#pragma warning disable CS0612
                 case (int)TraktPopularListType.TopWatchedByYear:
+#pragma warning restore CS0612
                     link += "/shows/watched/yearly";
                     break;
                 case (int)TraktPopularListType.TopWatchedByAllTime:
@@ -52,11 +54,13 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
                 case (int)TraktPopularListType.RecommendedByMonth:
                     link += "/shows/recommended/monthly";
                     break;
+#pragma warning disable CS0612
                 case (int)TraktPopularListType.RecommendedByYear:
+#pragma warning restore CS0612
                     link += "/shows/recommended/yearly";
                     break;
                 case (int)TraktPopularListType.RecommendedByAllTime:
-                    link += "/shows/recommended/yearly";
+                    link += "/shows/recommended/all";
                     break;
             }
 

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularSettings.cs
@@ -10,7 +10,14 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
     {
         public TraktPopularSettingsValidator()
         {
-            RuleFor(c => c.TraktListType).NotNull();
+            RuleFor(c => c.TraktListType)
+                .NotNull()
+#pragma warning disable CS0612
+                .NotEqual((int)TraktPopularListType.TopWatchedByYear)
+                .WithMessage("Yearly lists are longer supported")
+                .NotEqual((int)TraktPopularListType.RecommendedByYear)
+                .WithMessage("Yearly lists are longer supported");
+#pragma warning restore CS0612
 
             // Loose validation @TODO
             RuleFor(c => c.Rating)


### PR DESCRIPTION
#### Description

`RecommendedByYear` and `TopWatchedByYear` are both not supported on Trakt's side and instead return weekly results. `RecommendedByAllTime` was incorrectly using `yearly` (which was really `weekly`) so fixed that as well.


#### Issues Fixed or Closed by this PR
* Closes #7759

