### PR TITLE
New: Prevent Remote Path Mapping local folder being set to System folder or '/'

### DIFF
--- a/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -30,8 +30,11 @@ namespace Sonarr.Api.V3.RemotePathMappings
             SharedValidator.RuleFor(c => c.LocalPath)
                 .Cascade(CascadeMode.Stop)
                 .IsValidPath()
-                           .SetValidator(mappedNetworkDriveValidator)
-                           .SetValidator(pathExistsValidator);
+                .SetValidator(mappedNetworkDriveValidator)
+                .SetValidator(pathExistsValidator)
+                .SetValidator(new SystemFolderValidator())
+                .NotEqual("/")
+                .WithMessage("Cannot be set to '/'");
         }
 
         protected override RemotePathMappingResource GetResourceById(int id)


### PR DESCRIPTION
#### Description

A local path for Remote Path Mapping should never be set to a system folder or `/` 

#### Issues Fixed or Closed by this PR
* Closes #7686

