### PR TITLE
Expose total space in root folder endpoint

### DIFF
--- a/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="111.0.5563.6400" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="134.0.6998.16500" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/NzbDrone.Integration.Test/ApiTests/RootFolderFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/RootFolderFixture.cs
@@ -29,6 +29,7 @@ namespace NzbDrone.Integration.Test.ApiTests
 
             postResponse.Id.Should().NotBe(0);
             postResponse.FreeSpace.Should().NotBe(0);
+            postResponse.TotalSpace.Should().NotBe(0);
 
             RootFolders.All().Should().OnlyContain(c => c.Id == postResponse.Id);
 

--- a/src/Sonarr.Api.V3/RootFolders/RootFolderResource.cs
+++ b/src/Sonarr.Api.V3/RootFolders/RootFolderResource.cs
@@ -11,6 +11,7 @@ namespace Sonarr.Api.V3.RootFolders
         public string Path { get; set; }
         public bool Accessible { get; set; }
         public long? FreeSpace { get; set; }
+        public long? TotalSpace { get; set; }
 
         public List<UnmappedFolder> UnmappedFolders { get; set; }
     }
@@ -31,6 +32,7 @@ namespace Sonarr.Api.V3.RootFolders
                 Path = model.Path.GetCleanPath(),
                 Accessible = model.Accessible,
                 FreeSpace = model.FreeSpace,
+                TotalSpace = model.TotalSpace,
                 UnmappedFolders = model.UnmappedFolders
             };
         }


### PR DESCRIPTION
I thought about adding a check that the field was there in the integration tests, since the check is just that it's not 0. But seemed like overkill since we didn't do that elsewhere. 
#### Description
Expose the total space field in the `RootFolder` endpoint. Also, update the ChromeDriver package to support latest. 


#### Issues Fixed or Closed by this PR
* Closes #7769

