### PR TITLE
Update WikiUrl type in API docs

### DIFF
--- a/src/Sonarr.Api.V3/Health/HealthResource.cs
+++ b/src/Sonarr.Api.V3/Health/HealthResource.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using NzbDrone.Common.Http;
 using NzbDrone.Core.HealthCheck;
 using Sonarr.Http.REST;
 
@@ -11,7 +10,7 @@ namespace Sonarr.Api.V3.Health
         public string Source { get; set; }
         public HealthCheckResult Type { get; set; }
         public string Message { get; set; }
-        public HttpUri WikiUrl { get; set; }
+        public string WikiUrl { get; set; }
     }
 
     public static class HealthResourceMapper
@@ -29,7 +28,7 @@ namespace Sonarr.Api.V3.Health
                 Source = model.Source.Name,
                 Type = model.Type,
                 Message = model.Message,
-                WikiUrl = model.WikiUrl
+                WikiUrl = model.WikiUrl.FullUri
             };
         }
 


### PR DESCRIPTION
#### Description

Fixing the type of the `WikiUrl` since it's always been a string.


#### Issues Fixed or Closed by this PR
* Closes #7788

