### PR TITLE
Fixed: Default runtime to 45 minutes if unavailable when importing episode files

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/DetectSampleFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/DetectSampleFixture.cs
@@ -213,5 +213,16 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
 
             Subject.IsSample(_localEpisode).Should().Be(DetectSampleResult.Sample);
         }
+
+        [Test]
+        public void should_default_to_45_minutes_if_runtime_is_zero()
+        {
+            GivenRuntime(120);
+
+            _localEpisode.Series.Runtime = 0;
+            _localEpisode.Episodes.First().Runtime = 0;
+
+            Subject.IsSample(_localEpisode).Should().Be(DetectSampleResult.Sample);
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -66,6 +66,12 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                 return DetectSampleResult.Indeterminate;
             }
 
+            if (runtime == 0)
+            {
+                _logger.Debug("Series runtime is 0, defaulting runtime to 45 minutes");
+                runtime = 45;
+            }
+
             return IsSample(localEpisode.Path, localEpisode.MediaInfo.RunTime, runtime);
         }
 


### PR DESCRIPTION
#### Description

Similar to `AcceptableSizeSpecification` we use a default of 45 minutes as the runtime if it's zero at time of import.

#### Issues Fixed or Closed by this PR
* Closes #7780

