### PR TITLE
Add command-line argument support, and unattended mode

### DIFF
--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -62,7 +62,7 @@ fi
 app_uid=$(echo "$app_uid" | tr -d ' ')
 app_uid=${app_uid:-$app}
 # Prompt Group
-if [ -n "$SONARR_USER" ]; then
+if [ -n "$SONARR_GROUP" ]; then
     app_guid="$SONARR_GROUP"
 else
     read -r -p "What group should ${app^} run as? (Default: media): " app_guid < /dev/tty

--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -16,6 +16,10 @@
 #OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# Environment variables (optional, for unattended install)
+# SONARR_USER - set this to the user account Sonarr should run as
+# SONARR_GROUP - set this to the group Sonarr should run as
+
 scriptversion="1.0.3"
 scriptdate="2024-01-06"
 
@@ -50,17 +54,27 @@ if [ "$installdir" == "$(dirname -- "$( readlink -f -- "$0"; )")" ] || [ "$bindi
 fi
 
 # Prompt User
-read -r -p "What user should ${app^} run as? (Default: $app): " app_uid < /dev/tty
+if [ -n "$SONARR_USER" ]; then
+    app_uid="$SONARR_USER"
+else
+    read -r -p "What user should ${app^} run as? (Default: $app): " app_uid < /dev/tty
+fi
 app_uid=$(echo "$app_uid" | tr -d ' ')
 app_uid=${app_uid:-$app}
 # Prompt Group
-read -r -p "What group should ${app^} run as? (Default: media): " app_guid < /dev/tty
+if [ -n "$SONARR_USER" ]; then
+    app_guid="$SONARR_GROUP"
+else
+    read -r -p "What group should ${app^} run as? (Default: media): " app_guid < /dev/tty
+fi
 app_guid=$(echo "$app_guid" | tr -d ' ')
 app_guid=${app_guid:-media}
 
 echo "This will install [${app^}] to [$bindir] and use [$datadir] for the AppData Directory"
 echo "${app^} will run as the user [$app_uid] and group [$app_guid]. By continuing, you've confirmed that the selected user and group will have READ and WRITE access to your Media Library and Download Client Completed Download directories"
-read -n 1 -r -s -p $'Press enter to continue or ctrl+c to exit...\n' < /dev/tty
+if [ -z "$SONARR_USER" ] || [ -z "$SONARR_GROUP" ]; then
+    read -n 1 -r -s -p $'Press enter to continue or ctrl+c to exit...\n' < /dev/tty
+fi
 
 # Create User / Group as needed
 if [ "$app_guid" != "$app_uid" ]; then

--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -6,6 +6,7 @@
 ### Version V1.0.1 2024-01-02 - StevieTV - remove UTF8-BOM
 ### Version V1.0.2 2024-01-03 - markus101 - Get user input from /dev/tty
 ### Version V1.0.3 2024-01-06 - StevieTV - exit script when it is ran from install directory
+### Version V1.0.4 2025-04-05 - kaecyra - Allow user/group to be supplied via CLI, add unattended mode
 
 ### Boilerplate Warning
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -16,8 +17,8 @@
 #OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-scriptversion="1.0.3"
-scriptdate="2024-01-06"
+scriptversion="1.0.4"
+scriptdate="2025-04-05"
 
 set -euo pipefail
 
@@ -54,13 +55,15 @@ show_help() {
 Usage: $(basename "$0") [OPTIONS]
 
 Options:
-  --user <name>       What user will Sonarr run under?
+  --user <name>       What user will $app run under?
                       User will be created if it doesn't already exist.
 
-  --group <name>      What group will Sonarr run under?
+  --group <name>      What group will $app run under?
                       Group will be created if it doesn't already exist.
 
-  -u                  Unattended mode (requires --user and --group)
+  -u                  Unattended mode
+                      The installer will not prompt or pause, making it suitable for automated installations.
+                      This option requires the use of --user and --group to supply those inputs for the script.
 
   -h, --help          Show this help message and exit
 EOF


### PR DESCRIPTION
#### Description

This is a relatively simple change that allows the installer to take `--user` and `--group` command line arguments to satisfy its two input requirements instead of prompting the user. 

It also adds support for a `-u` (unattended) option to suppress the "are you sure" warning, as long as both `--user` and `--group` are also supplied.

Finally, considering that the script now has invocation options, a `-h`/`--help` option is added to explain the command-line options and how to use them.

This change allows the install to be performed by automation tools such as `packer`.