### PR TITLE
Fixed: Sending Manual Interaction Needed for Custom Script with unparsed series

### DIFF
--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -484,7 +484,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
         {
             if (series == null)
             {
-                return null;
+                return new List<string>();
             }
 
             return _tagRepository.GetTags(series.Tags)


### PR DESCRIPTION
#### Description
Defaulting to empty string list to avoid argument exception on null.

#### Issues Fixed or Closed by this PR
* Closes #7807

