### PR TITLE
Pass messages with arguments to NLog in LoggerExtensions

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/Extensions/LoggerExtensions.cs
+++ b/src/NzbDrone.Common/Instrumentation/Extensions/LoggerExtensions.cs
@@ -4,27 +4,27 @@ namespace NzbDrone.Common.Instrumentation.Extensions
 {
     public static class LoggerExtensions
     {
+        [MessageTemplateFormatMethod("message")]
         public static void ProgressInfo(this Logger logger, string message, params object[] args)
         {
-            var formattedMessage = string.Format(message, args);
-            LogProgressMessage(logger, LogLevel.Info, formattedMessage);
+            LogProgressMessage(logger, LogLevel.Info, message, args);
         }
 
+        [MessageTemplateFormatMethod("message")]
         public static void ProgressDebug(this Logger logger, string message, params object[] args)
         {
-            var formattedMessage = string.Format(message, args);
-            LogProgressMessage(logger, LogLevel.Debug, formattedMessage);
+            LogProgressMessage(logger, LogLevel.Debug, message, args);
         }
 
+        [MessageTemplateFormatMethod("message")]
         public static void ProgressTrace(this Logger logger, string message, params object[] args)
         {
-            var formattedMessage = string.Format(message, args);
-            LogProgressMessage(logger, LogLevel.Trace, formattedMessage);
+            LogProgressMessage(logger, LogLevel.Trace, message, args);
         }
 
-        private static void LogProgressMessage(Logger logger, LogLevel level, string message)
+        private static void LogProgressMessage(Logger logger, LogLevel level, string message, object[] parameters)
         {
-            var logEvent = new LogEventInfo(level, logger.Name, message);
+            var logEvent = new LogEventInfo(level, logger.Name, null, message, parameters);
             logEvent.Properties.Add("Status", "");
 
             logger.Log(logEvent);

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.ImportLists
 
         private void SyncList(ImportListDefinition definition)
         {
-            _logger.ProgressInfo(string.Format("Starting Import List Refresh for List {0}", definition.Name));
+            _logger.ProgressInfo("Starting Import List Refresh for List {0}", definition.Name);
 
             var result = _listFetcherAndParser.FetchSingleList(definition);
 
@@ -214,7 +214,7 @@ namespace NzbDrone.Core.ImportLists
                 }
 
                 // Check to see if series excluded
-                var excludedSeries = listExclusions.Where(s => s.TvdbId == item.TvdbId).SingleOrDefault();
+                var excludedSeries = listExclusions.SingleOrDefault(s => s.TvdbId == item.TvdbId);
 
                 if (excludedSeries != null)
                 {
@@ -260,9 +260,7 @@ namespace NzbDrone.Core.ImportLists
 
             _addSeriesService.AddSeries(seriesToAdd, true);
 
-            var message = string.Format("Import List Sync Completed. Items found: {0}, Series added: {1}", items.Count, seriesToAdd.Count);
-
-            _logger.ProgressInfo(message);
+            _logger.ProgressInfo("Import List Sync Completed. Items found: {0}, Series added: {1}", items.Count, seriesToAdd.Count);
         }
 
         public void Execute(ImportListSyncCommand message)


### PR DESCRIPTION
#### Description
Mark message as template to improve highlight for arguments, and pass the original messages with arguments to NLog for formatting.

#### Screenshots for UI Changes
before
![before](https://github.com/user-attachments/assets/900de23a-6013-432f-8c41-39c4f7475301)

after
![after](https://github.com/user-attachments/assets/15cfecaf-878b-49b8-9fa0-d4c8bd7a0dd5)

