### PR TITLE
Fixed: Free space and missing for selected root folder value

### DIFF
--- a/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
@@ -21,6 +21,7 @@ const ADD_NEW_KEY = 'addNew';
 
 export interface RootFolderSelectInputValue
   extends EnhancedSelectInputValue<string> {
+  freeSpace?: number;
   isMissing?: boolean;
 }
 
@@ -42,66 +43,58 @@ function createRootFolderOptionsSelector(
   includeNoChange: boolean,
   includeNoChangeDisabled: boolean
 ) {
-  return createSelector(
-    createRootFoldersSelector(),
-
-    (rootFolders) => {
-      const values: RootFolderSelectInputValue[] = rootFolders.items.map(
-        (rootFolder) => {
-          return {
-            key: rootFolder.path,
-            value: rootFolder.path,
-            freeSpace: rootFolder.freeSpace,
-            isMissing: false,
-          };
-        }
-      );
-
-      if (includeNoChange) {
-        values.unshift({
-          key: 'noChange',
-          get value() {
-            return translate('NoChange');
-          },
-          isDisabled: includeNoChangeDisabled,
+  return createSelector(createRootFoldersSelector(), (rootFolders) => {
+    const values: RootFolderSelectInputValue[] = rootFolders.items.map(
+      (rootFolder) => {
+        return {
+          key: rootFolder.path,
+          value: rootFolder.path,
+          freeSpace: rootFolder.freeSpace,
           isMissing: false,
-        });
+        };
       }
+    );
 
-      if (!values.length) {
-        values.push({
-          key: '',
-          value: '',
-          isDisabled: true,
-          isHidden: true,
-        });
-      }
-
-      if (
-        includeMissingValue &&
-        value &&
-        !values.find((v) => v.key === value)
-      ) {
-        values.push({
-          key: value,
-          value,
-          isMissing: true,
-          isDisabled: true,
-        });
-      }
-
-      values.push({
-        key: ADD_NEW_KEY,
-        value: translate('AddANewPath'),
+    if (includeNoChange) {
+      values.unshift({
+        key: 'noChange',
+        get value() {
+          return translate('NoChange');
+        },
+        isDisabled: includeNoChangeDisabled,
+        isMissing: false,
       });
-
-      return {
-        values,
-        isSaving: rootFolders.isSaving,
-        saveError: rootFolders.saveError,
-      };
     }
-  );
+
+    if (!values.length) {
+      values.push({
+        key: '',
+        value: '',
+        isDisabled: true,
+        isHidden: true,
+      });
+    }
+
+    if (includeMissingValue && value && !values.find((v) => v.key === value)) {
+      values.push({
+        key: value,
+        value,
+        isMissing: true,
+        isDisabled: true,
+      });
+    }
+
+    values.push({
+      key: ADD_NEW_KEY,
+      value: translate('AddANewPath'),
+    });
+
+    return {
+      values,
+      isSaving: rootFolders.isSaving,
+      saveError: rootFolders.saveError,
+    };
+  });
 }
 
 function RootFolderSelectInput({

--- a/frontend/src/Components/Form/Select/RootFolderSelectInputOption.tsx
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInputOption.tsx
@@ -18,18 +18,16 @@ interface RootFolderSelectInputOptionProps
   isWindows?: boolean;
 }
 
-function RootFolderSelectInputOption(props: RootFolderSelectInputOptionProps) {
-  const {
-    id,
-    value,
-    freeSpace,
-    isMissing,
-    seriesFolder,
-    isMobile,
-    isWindows,
-    ...otherProps
-  } = props;
-
+function RootFolderSelectInputOption({
+  id,
+  value,
+  freeSpace,
+  isMissing,
+  seriesFolder,
+  isMobile,
+  isWindows,
+  ...otherProps
+}: RootFolderSelectInputOptionProps) {
   const slashCharacter = isWindows ? '\\' : '/';
 
   return (

--- a/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.css
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.css
@@ -30,3 +30,11 @@
   text-align: right;
   font-size: $smallFontSize;
 }
+
+.isMissing {
+  flex: 0 0 auto;
+  margin-left: 15px;
+  color: var(--dangerColor);
+  text-align: right;
+  font-size: $smallFontSize;
+}

--- a/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.css.d.ts
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'freeSpace': string;
+  'isMissing': string;
   'path': string;
   'pathContainer': string;
   'selectedValue': string;

--- a/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.tsx
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInputSelectedValue.tsx
@@ -8,27 +8,23 @@ import styles from './RootFolderSelectInputSelectedValue.css';
 interface RootFolderSelectInputSelectedValueProps {
   selectedValue: string;
   values: RootFolderSelectInputValue[];
-  freeSpace?: number;
   seriesFolder?: string;
   isWindows?: boolean;
   includeFreeSpace?: boolean;
 }
 
-function RootFolderSelectInputSelectedValue(
-  props: RootFolderSelectInputSelectedValueProps
-) {
-  const {
-    selectedValue,
-    values,
-    freeSpace,
-    seriesFolder,
-    includeFreeSpace = true,
-    isWindows,
-    ...otherProps
-  } = props;
-
+function RootFolderSelectInputSelectedValue({
+  selectedValue,
+  values,
+  seriesFolder,
+  includeFreeSpace = true,
+  isWindows,
+  ...otherProps
+}: RootFolderSelectInputSelectedValueProps) {
   const slashCharacter = isWindows ? '\\' : '/';
-  const value = values.find((v) => v.key === selectedValue)?.value;
+  const { value, freeSpace, isMissing } =
+    values.find((v) => v.key === selectedValue) ||
+    ({} as RootFolderSelectInputValue);
 
   return (
     <EnhancedSelectInputSelectedValue
@@ -52,6 +48,10 @@ function RootFolderSelectInputSelectedValue(
             freeSpace: formatBytes(freeSpace),
           })}
         </div>
+      ) : null}
+
+      {isMissing ? (
+        <div className={styles.isMissing}>{translate('Missing')}</div>
       ) : null}
     </EnhancedSelectInputSelectedValue>
   );


### PR DESCRIPTION
#### Description
For the selected root folder the `freeSpace` property is not a property of RootFolderSelectInputSelectedValue.

#### Screenshots for UI Changes
Free Space
![freespace before](https://github.com/user-attachments/assets/145c15f8-af2d-4a34-b967-8cb9f688a9a8)
![freespace after](https://github.com/user-attachments/assets/e67704d3-47b3-4365-a737-cda4560f2732)

Missing
![missing before](https://github.com/user-attachments/assets/e00e9108-3702-4c58-9c8d-99954659340f)
![missing after](https://github.com/user-attachments/assets/9050178f-9662-4dec-b418-8d982322f662)

