### PR TITLE
Log when expected episode file is missing from disk on upgrade

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -64,6 +64,10 @@ namespace NzbDrone.Core.MediaFiles
                     _logger.Debug("Removing existing episode file: {0}", file);
                     recycleBinPath = _recycleBinProvider.DeleteFile(episodeFilePath, subfolder);
                 }
+                else
+                {
+                    _logger.Warn("Existing episode file missing from disk: {0}", episodeFilePath);
+                }
 
                 moveFileResult.OldFiles.Add(new DeletedEpisodeFile(file, recycleBinPath));
                 _mediaFileService.Delete(file, DeleteMediaFileReason.Upgrade);


### PR DESCRIPTION
#### Description
Should not happen, but we should log it in case some FUSE filesystems fail to refresh fast enough.