### PR TITLE
Improve typings for Select Input options

### DIFF
--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import Modal from 'Components/Modal/Modal';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -79,7 +80,7 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
   }, [sourceTitle, selectedCount]);
 
   const removalMethodOptions = useMemo(() => {
-    return [
+    const options: EnhancedSelectInputValue<string>[] = [
       {
         key: 'removeFromClient',
         value: translate('RemoveFromDownloadClient'),
@@ -106,10 +107,12 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
           : translate('IgnoreDownloadHint'),
       },
     ];
+
+    return options;
   }, [canChangeCategory, canIgnore, multipleSelected]);
 
   const blocklistMethodOptions = useMemo(() => {
-    return [
+    const options: EnhancedSelectInputValue<string>[] = [
       {
         key: 'doNotBlocklist',
         value: translate('DoNotBlocklist'),
@@ -131,6 +134,8 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
           : translate('BlocklistOnlyHint'),
       },
     ];
+
+    return options;
   }, [isPending, multipleSelected]);
 
   const handleRemovalMethodChange = useCallback(

--- a/frontend/src/Components/Form/Select/UMaskInput.tsx
+++ b/frontend/src/Components/Form/Select/UMaskInput.tsx
@@ -2,10 +2,12 @@
 import React, { SyntheticEvent } from 'react';
 import { InputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
-import EnhancedSelectInput from './EnhancedSelectInput';
+import EnhancedSelectInput, {
+  EnhancedSelectInputValue,
+} from './EnhancedSelectInput';
 import styles from './UMaskInput.css';
 
-const umaskOptions = [
+const umaskOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: '755',
     get value() {

--- a/frontend/src/Components/Form/SelectInput.tsx
+++ b/frontend/src/Components/Form/SelectInput.tsx
@@ -1,9 +1,15 @@
 import classNames from 'classnames';
-import React, { ChangeEvent, SyntheticEvent, useCallback } from 'react';
+import React, {
+  ChangeEvent,
+  ComponentProps,
+  SyntheticEvent,
+  useCallback,
+} from 'react';
 import { InputChanged } from 'typings/inputs';
 import styles from './SelectInput.css';
 
-interface SelectInputOption {
+export interface SelectInputOption
+  extends Pick<ComponentProps<'option'>, 'disabled'> {
   key: string | number;
   value: string | number | (() => string | number);
 }

--- a/frontend/src/Components/Table/TablePager.tsx
+++ b/frontend/src/Components/Table/TablePager.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { useCallback, useMemo, useState } from 'react';
-import SelectInput from 'Components/Form/SelectInput';
+import SelectInput, { SelectInputOption } from 'Components/Form/SelectInput';
 import Icon from 'Components/Icon';
 import Link from 'Components/Link/Link';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
@@ -34,7 +34,7 @@ function TablePager({
   const isLastPage = page === totalPages;
 
   const pages = useMemo(() => {
-    return Array.from(new Array(totalPages), (_x, i) => {
+    return Array.from(new Array(totalPages), (_x, i): SelectInputOption => {
       const pageNumber = i + 1;
 
       return {

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
@@ -5,7 +5,7 @@ import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
 import InteractiveImportAppState from 'App/State/InteractiveImportAppState';
 import * as commandNames from 'Commands/commandNames';
-import SelectInput from 'Components/Form/SelectInput';
+import SelectInput, { SelectInputOption } from 'Components/Form/SelectInput';
 import Icon from 'Components/Icon';
 import Button from 'Components/Link/Button';
 import SpinnerButton from 'Components/Link/SpinnerButton';
@@ -164,7 +164,7 @@ const COLUMNS = [
   },
 ];
 
-const importModeOptions = [
+const importModeOptions: SelectInputOption[] = [
   {
     key: 'chooseImportMode',
     value: () => translate('ChooseImportMode'),
@@ -343,7 +343,7 @@ function InteractiveImportModalContent(
       }
     );
 
-    const options = [
+    const options: SelectInputOption[] = [
       {
         key: 'select',
         value: translate('SelectDropdown'),

--- a/frontend/src/InteractiveImport/Quality/SelectQualityModalContent.tsx
+++ b/frontend/src/InteractiveImport/Quality/SelectQualityModalContent.tsx
@@ -7,6 +7,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -69,7 +70,7 @@ function SelectQualityModalContent(props: SelectQualityModalContentProps) {
   );
 
   const qualityOptions = useMemo(() => {
-    return items.map(({ id, name }) => {
+    return items.map(({ id, name }): EnhancedSelectInputValue<number> => {
       return {
         key: id,
         value: name,

--- a/frontend/src/Series/Index/Overview/Options/SeriesIndexOverviewOptionsModalContent.tsx
+++ b/frontend/src/Series/Index/Overview/Options/SeriesIndexOverviewOptionsModalContent.tsx
@@ -4,6 +4,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -14,7 +15,7 @@ import { setSeriesOverviewOption } from 'Store/Actions/seriesIndexActions';
 import translate from 'Utilities/String/translate';
 import selectOverviewOptions from '../selectOverviewOptions';
 
-const posterSizeOptions = [
+const posterSizeOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'small',
     get value() {

--- a/frontend/src/Series/Index/Posters/Options/SeriesIndexPosterOptionsModalContent.tsx
+++ b/frontend/src/Series/Index/Posters/Options/SeriesIndexPosterOptionsModalContent.tsx
@@ -4,6 +4,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -14,7 +15,7 @@ import selectPosterOptions from 'Series/Index/Posters/selectPosterOptions';
 import { setSeriesPosterOption } from 'Store/Actions/seriesIndexActions';
 import translate from 'Utilities/String/translate';
 
-const posterSizeOptions = [
+const posterSizeOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'small',
     get value() {

--- a/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
+++ b/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -31,7 +32,7 @@ interface EditSeriesModalContentProps {
 
 const NO_CHANGE = 'noChange';
 
-const monitoredOptions = [
+const monitoredOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {
@@ -53,7 +54,7 @@ const monitoredOptions = [
   },
 ];
 
-const seasonFolderOptions = [
+const seasonFolderOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {

--- a/frontend/src/Series/Index/Select/Tags/TagsModalContent.tsx
+++ b/frontend/src/Series/Index/Select/Tags/TagsModalContent.tsx
@@ -6,6 +6,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Label from 'Components/Label';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -66,7 +67,7 @@ function TagsModalContent(props: TagsModalContentProps) {
     onApplyTagsPress(tags, applyTags);
   }, [tags, applyTags, onApplyTagsPress]);
 
-  const applyTagsOptions = [
+  const applyTagsOptions: EnhancedSelectInputValue<string>[] = [
     {
       key: 'add',
       value: translate('Add'),

--- a/frontend/src/Settings/CustomFormats/CustomFormats/Manage/Edit/ManageCustomFormatsEditModalContent.tsx
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Manage/Edit/ManageCustomFormatsEditModalContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -23,7 +24,7 @@ interface ManageCustomFormatsEditModalContentProps {
 
 const NO_CHANGE = 'noChange';
 
-const enableOptions = [
+const enableOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {

--- a/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Edit/ManageDownloadClientsEditModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Edit/ManageDownloadClientsEditModalContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -27,7 +28,7 @@ interface ManageDownloadClientsEditModalContentProps {
 
 const NO_CHANGE = 'noChange';
 
-const enableOptions = [
+const enableOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {

--- a/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Tags/TagsModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/Manage/Tags/TagsModalContent.tsx
@@ -8,6 +8,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Label from 'Components/Label';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -71,7 +72,7 @@ function TagsModalContent(props: TagsModalContentProps) {
     onApplyTagsPress(tags, applyTags);
   }, [tags, applyTags, onApplyTagsPress]);
 
-  const applyTagsOptions = [
+  const applyTagsOptions: EnhancedSelectInputValue<string>[] = [
     {
       key: 'add',
       get value() {

--- a/frontend/src/Settings/General/LoggingSettings.tsx
+++ b/frontend/src/Settings/General/LoggingSettings.tsx
@@ -3,6 +3,7 @@ import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import useShowAdvancedSettings from 'Helpers/Hooks/useShowAdvancedSettings';
 import { inputTypes } from 'Helpers/Props';
 import { InputChanged } from 'typings/inputs';
@@ -10,7 +11,7 @@ import { PendingSection } from 'typings/pending';
 import General from 'typings/Settings/General';
 import translate from 'Utilities/String/translate';
 
-const logLevelOptions = [
+const logLevelOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'info',
     get value() {

--- a/frontend/src/Settings/General/ProxySettings.tsx
+++ b/frontend/src/Settings/General/ProxySettings.tsx
@@ -3,6 +3,7 @@ import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import { inputTypes, sizes } from 'Helpers/Props';
 import { InputChanged } from 'typings/inputs';
 import { PendingSection } from 'typings/pending';
@@ -32,7 +33,7 @@ function ProxySettings({
   proxyBypassLocalAddresses,
   onInputChange,
 }: ProxySettingsProps) {
-  const proxyTypeOptions = [
+  const proxyTypeOptions: EnhancedSelectInputValue<string>[] = [
     {
       key: 'http',
       value: translate('HttpHttps'),

--- a/frontend/src/Settings/General/SecuritySettings.tsx
+++ b/frontend/src/Settings/General/SecuritySettings.tsx
@@ -6,6 +6,7 @@ import FormGroup from 'Components/Form/FormGroup';
 import FormInputButton from 'Components/Form/FormInputButton';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Icon from 'Components/Icon';
 import ClipboardButton from 'Components/Link/ClipboardButton';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
@@ -16,7 +17,7 @@ import { PendingSection } from 'typings/pending';
 import General from 'typings/Settings/General';
 import translate from 'Utilities/String/translate';
 
-export const authenticationMethodOptions = [
+export const authenticationMethodOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'none',
     get value() {
@@ -47,22 +48,23 @@ export const authenticationMethodOptions = [
   },
 ];
 
-export const authenticationRequiredOptions = [
-  {
-    key: 'enabled',
-    get value() {
-      return translate('Enabled');
+export const authenticationRequiredOptions: EnhancedSelectInputValue<string>[] =
+  [
+    {
+      key: 'enabled',
+      get value() {
+        return translate('Enabled');
+      },
     },
-  },
-  {
-    key: 'disabledForLocalAddresses',
-    get value() {
-      return translate('DisabledForLocalAddresses');
+    {
+      key: 'disabledForLocalAddresses',
+      get value() {
+        return translate('DisabledForLocalAddresses');
+      },
     },
-  },
-];
+  ];
 
-const certificateValidationOptions = [
+const certificateValidationOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'enabled',
     get value() {

--- a/frontend/src/Settings/General/UpdateSettings.tsx
+++ b/frontend/src/Settings/General/UpdateSettings.tsx
@@ -3,6 +3,7 @@ import FieldSet from 'Components/FieldSet';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import useShowAdvancedSettings from 'Helpers/Hooks/useShowAdvancedSettings';
 import { inputTypes, sizes } from 'Helpers/Props';
 import useSystemStatus from 'System/useSystemStatus';
@@ -38,7 +39,7 @@ function UpdateSettings({
 
   const usingExternalUpdateMechanism = packageUpdateMechanism !== 'builtIn';
 
-  const updateOptions = [];
+  const updateOptions: EnhancedSelectInputValue<string>[] = [];
 
   if (usingExternalUpdateMechanism) {
     updateOptions.push({

--- a/frontend/src/Settings/ImportLists/ImportLists/Manage/Edit/ManageImportListsEditModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportLists/Manage/Edit/ManageImportListsEditModalContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -26,7 +27,7 @@ interface ManageImportListsEditModalContentProps {
 
 const NO_CHANGE = 'noChange';
 
-const autoAddOptions = [
+const autoAddOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {

--- a/frontend/src/Settings/ImportLists/ImportLists/Manage/Tags/TagsModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportLists/Manage/Tags/TagsModalContent.tsx
@@ -8,6 +8,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Label from 'Components/Label';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -69,7 +70,7 @@ function TagsModalContent(props: TagsModalContentProps) {
     onApplyTagsPress(tags, applyTags);
   }, [tags, applyTags, onApplyTagsPress]);
 
-  const applyTagsOptions = [
+  const applyTagsOptions: EnhancedSelectInputValue<string>[] = [
     {
       key: 'add',
       get value() {

--- a/frontend/src/Settings/ImportLists/Options/ImportListOptions.tsx
+++ b/frontend/src/Settings/ImportLists/Options/ImportListOptions.tsx
@@ -6,6 +6,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import useShowAdvancedSettings from 'Helpers/Hooks/useShowAdvancedSettings';
 import { inputTypes, kinds } from 'Helpers/Props';
@@ -19,7 +20,7 @@ import createSettingsSectionSelector from 'Store/Selectors/createSettingsSection
 import translate from 'Utilities/String/translate';
 
 const SECTION = 'importListOptions';
-const cleanLibraryLevelOptions = [
+const cleanLibraryLevelOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'disabled',
     get value() {

--- a/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -28,7 +29,7 @@ interface ManageIndexersEditModalContentProps {
 
 const NO_CHANGE = 'noChange';
 
-const enableOptions = [
+const enableOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: NO_CHANGE,
     get value() {

--- a/frontend/src/Settings/Indexers/Indexers/Manage/Tags/TagsModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/Tags/TagsModalContent.tsx
@@ -8,6 +8,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Label from 'Components/Label';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -69,7 +70,7 @@ function TagsModalContent(props: TagsModalContentProps) {
     onApplyTagsPress(tags, applyTags);
   }, [tags, applyTags, onApplyTagsPress]);
 
-  const applyTagsOptions = [
+  const applyTagsOptions: EnhancedSelectInputValue<string>[] = [
     {
       key: 'add',
       get value() {

--- a/frontend/src/Settings/MediaManagement/MediaManagement.tsx
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.tsx
@@ -7,6 +7,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
@@ -31,7 +32,7 @@ import AddRootFolder from './RootFolder/AddRootFolder';
 
 const SECTION = 'mediaManagement';
 
-const episodeTitleRequiredOptions = [
+const episodeTitleRequiredOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'always',
     get value() {
@@ -52,7 +53,7 @@ const episodeTitleRequiredOptions = [
   },
 ];
 
-const rescanAfterRefreshOptions = [
+const rescanAfterRefreshOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'always',
     get value() {
@@ -73,7 +74,7 @@ const rescanAfterRefreshOptions = [
   },
 ];
 
-const downloadPropersAndRepacksOptions = [
+const downloadPropersAndRepacksOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'preferAndUpgrade',
     get value() {
@@ -94,7 +95,7 @@ const downloadPropersAndRepacksOptions = [
   },
 ];
 
-const fileDateOptions = [
+const fileDateOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'none',
     get value() {

--- a/frontend/src/Settings/MediaManagement/Naming/Naming.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/Naming.tsx
@@ -9,6 +9,7 @@ import FormGroup from 'Components/Form/FormGroup';
 import FormInputButton from 'Components/Form/FormInputButton';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import useModalOpenState from 'Helpers/Hooks/useModalOpenState';
 import { inputTypes, kinds, sizes } from 'Helpers/Props';
@@ -169,7 +170,7 @@ function Naming() {
   const replaceIllegalCharacters =
     hasSettings && settings.replaceIllegalCharacters.value;
 
-  const multiEpisodeStyleOptions = [
+  const multiEpisodeStyleOptions: EnhancedSelectInputValue<number>[] = [
     { key: 0, value: translate('Extend'), hint: 'S01E01-02-03' },
     { key: 1, value: translate('Duplicate'), hint: 'S01E01.S01E02' },
     { key: 2, value: translate('Repeat'), hint: 'S01E01E02E03' },
@@ -178,7 +179,7 @@ function Naming() {
     { key: 5, value: translate('PrefixedRange'), hint: 'S01E01-E03' },
   ];
 
-  const colonReplacementOptions = [
+  const colonReplacementOptions: EnhancedSelectInputValue<number>[] = [
     { key: 0, value: translate('Delete') },
     { key: 1, value: translate('ReplaceWithDash') },
     { key: 2, value: translate('ReplaceWithSpaceDash') },

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import FieldSet from 'Components/FieldSet';
-import SelectInput from 'Components/Form/SelectInput';
+import SelectInput, { SelectInputOption } from 'Components/Form/SelectInput';
 import TextInput from 'Components/Form/TextInput';
 import Button from 'Components/Link/Button';
 import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
@@ -17,7 +17,15 @@ import TokenCase from './TokenCase';
 import TokenSeparator from './TokenSeparator';
 import styles from './NamingModal.css';
 
-const separatorOptions: { key: TokenSeparator; value: string }[] = [
+type SeparatorInputOption = Omit<SelectInputOption, 'key'> & {
+  key: TokenSeparator;
+};
+
+type CaseInputOption = Omit<SelectInputOption, 'key'> & {
+  key: TokenCase;
+};
+
+const separatorOptions: SeparatorInputOption[] = [
   {
     key: ' ',
     get value() {
@@ -44,7 +52,7 @@ const separatorOptions: { key: TokenSeparator; value: string }[] = [
   },
 ];
 
-const caseOptions: { key: TokenCase; value: string }[] = [
+const caseOptions: CaseInputOption[] = [
   {
     key: 'title',
     get value() {

--- a/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.tsx
+++ b/frontend/src/Settings/Profiles/Delay/EditDelayProfileModalContent.tsx
@@ -7,6 +7,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import Button from 'Components/Link/Button';
 import SpinnerErrorButton from 'Components/Link/SpinnerErrorButton';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
@@ -41,7 +42,7 @@ const newDelayProfile: DelayProfile & { [key: string]: unknown } = {
   tags: [],
 };
 
-const protocolOptions = [
+const protocolOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'preferUsenet',
     get value() {

--- a/frontend/src/Settings/UI/UISettings.tsx
+++ b/frontend/src/Settings/UI/UISettings.tsx
@@ -6,6 +6,7 @@ import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
@@ -25,7 +26,7 @@ import translate from 'Utilities/String/translate';
 
 const SECTION = 'ui';
 
-export const firstDayOfWeekOptions = [
+export const firstDayOfWeekOptions: EnhancedSelectInputValue<number>[] = [
   {
     key: 0,
     get value() {
@@ -40,14 +41,14 @@ export const firstDayOfWeekOptions = [
   },
 ];
 
-export const weekColumnOptions = [
+export const weekColumnOptions: EnhancedSelectInputValue<string>[] = [
   { key: 'ddd M/D', value: 'Tue 3/25', hint: 'ddd M/D' },
   { key: 'ddd MM/DD', value: 'Tue 03/25', hint: 'ddd MM/DD' },
   { key: 'ddd D/M', value: 'Tue 25/3', hint: 'ddd D/M' },
   { key: 'ddd DD/MM', value: 'Tue 25/03', hint: 'ddd DD/MM' },
 ];
 
-const shortDateFormatOptions = [
+const shortDateFormatOptions: EnhancedSelectInputValue<string>[] = [
   { key: 'MMM D YYYY', value: 'Mar 25 2014', hint: 'MMM D YYYY' },
   { key: 'DD MMM YYYY', value: '25 Mar 2014', hint: 'DD MMM YYYY' },
   { key: 'MM/D/YYYY', value: '03/25/2014', hint: 'MM/D/YYYY' },
@@ -56,12 +57,12 @@ const shortDateFormatOptions = [
   { key: 'YYYY-MM-DD', value: '2014-03-25', hint: 'YYYY-MM-DD' },
 ];
 
-const longDateFormatOptions = [
+const longDateFormatOptions: EnhancedSelectInputValue<string>[] = [
   { key: 'dddd, MMMM D YYYY', value: 'Tuesday, March 25, 2014' },
   { key: 'dddd, D MMMM YYYY', value: 'Tuesday, 25 March, 2014' },
 ];
 
-export const timeFormatOptions = [
+export const timeFormatOptions: EnhancedSelectInputValue<string>[] = [
   { key: 'h(:mm)a', value: '5pm/5:30pm' },
   { key: 'HH:mm', value: '17:00/17:30' },
 ];

--- a/frontend/src/Utilities/Series/monitorNewItemsOptions.ts
+++ b/frontend/src/Utilities/Series/monitorNewItemsOptions.ts
@@ -1,6 +1,7 @@
+import { EnhancedSelectInputValue } from 'Components/Form/Select/EnhancedSelectInput';
 import translate from 'Utilities/String/translate';
 
-const monitorNewItemsOptions = [
+const monitorNewItemsOptions: EnhancedSelectInputValue<string>[] = [
   {
     key: 'all',
     get value() {


### PR DESCRIPTION
#### Description
We can easily mix the options with EnhancedSelectInput and one uses `isDisabled` and the other not.

I was debating on extending fully `ComponentProps<'option'>`, but seems cleaner to add only the options we use.

