### PR TITLE
Fixed: Selecting No Change for quality profile inputs

### DIFF
--- a/frontend/src/Components/Form/Select/QualityProfileSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/QualityProfileSelectInput.tsx
@@ -88,13 +88,10 @@ function QualityProfileSelectInput({
   );
 
   const handleChange = useCallback(
-    ({ value: newValue }: EnhancedSelectInputChanged<string | number>) => {
-      onChange({
-        name,
-        value: newValue === 'noChange' ? value : newValue,
-      });
+    ({ value }: EnhancedSelectInputChanged<string | number>) => {
+      onChange({ name, value });
     },
-    [name, value, onChange]
+    [name, onChange]
   );
 
   useEffect(() => {


### PR DESCRIPTION
#### Description
Regression from 682d2b4e1b8acb74ab6e75b85e2a73aa431b5332 since previously it would allow No Change but cast the other values to int.

![image](https://github.com/user-attachments/assets/aeec676a-5e0f-4176-81cd-073263a781e7)
