### PR TITLE
Avoid varying logging message template between calls

### DIFF
--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Notifications.Apprise
             {
                 if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    _logger.Error(ex, $"HTTP Auth credentials are invalid: {0}", ex.Message);
+                    _logger.Error(ex, "HTTP Auth credentials are invalid: {0}", ex.Message);
                     return new ValidationFailure("AuthUsername", _localizationService.GetLocalizedString("NotificationsValidationInvalidHttpCredentials", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
                 }
 
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Notifications.Apprise
                 {
                     var error = Json.Deserialize<AppriseError>(httpException.Response.Content);
 
-                    _logger.Error(ex, $"Unable to send test message. Response from API: {0}", error.Error);
+                    _logger.Error(ex, "Unable to send test message. Response from API: {0}", error.Error);
                     return new ValidationFailure(string.Empty, _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessageApiResponse", new Dictionary<string, object> { { "error", error.Error } }));
                 }
 


### PR DESCRIPTION
#### Description
CA2254 seems to be an IDE error now, so fixing the `The logging message template should not vary between calls to 'void NzbDrone.Common.Instrumentation.Extensions.LoggerExtensions.ProgressInfo(this Logger, string, params object[])'` where possible.

It remains for https://github.com/Sonarr/Sonarr/blob/ae7f73208a5db30c98cb7b0e7841ab0a87793d12/src/NzbDrone.Common/Instrumentation/Extensions/SentryLoggerExtensions.cs#L49 