### PR TITLE
Increase maximum backup restoration size to 5GB

### DIFF
--- a/src/Sonarr.Api.V3/System/Backup/BackupController.cs
+++ b/src/Sonarr.Api.V3/System/Backup/BackupController.cs
@@ -92,7 +92,7 @@ namespace Sonarr.Api.V3.System.Backup
         }
 
         [HttpPost("restore/upload")]
-        [RequestFormLimits(MultipartBodyLengthLimit = 500000000)]
+        [RequestFormLimits(MultipartBodyLengthLimit = 5000000000)]
         public object UploadAndRestore()
         {
             var files = Request.Form.Files;


### PR DESCRIPTION
#### Description

Add a zero, accept more bigger backups 🤷 at some point RAM or reverse proxies are going to be a problem, but should be fine.

#### Issues Fixed or Closed by this PR
* Closes #7840

