### PR TITLE
Fixed: Escape backticks in discord notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -719,7 +719,7 @@ namespace NzbDrone.Core.Notifications.Discord
             {
                 var episode = episodes.First();
 
-                return $"{series.Title} - {episode.AirDate} - {episode.Title}";
+                return $"{series.Title} - {episode.AirDate} - {episode.Title}".Replace("`", "\\`");
             }
 
             var episodeNumbers = string.Concat(episodes.Select(e => e.EpisodeNumber)
@@ -727,9 +727,9 @@ namespace NzbDrone.Core.Notifications.Discord
 
             var episodeTitles = string.Join(" + ", episodes.Select(e => e.Title));
 
-            var title = $"{series.Title} - {episodes.First().SeasonNumber}{episodeNumbers} - {episodeTitles}";
+            var title = $"{series.Title} - {episodes.First().SeasonNumber}{episodeNumbers} - {episodeTitles}".Replace("`", "\\`");
 
-            return title.Length > 256 ? $"{title.AsSpan(0, 253)}..." : title;
+            return title.Length > 256 ? $"{title.AsSpan(0, 253).TrimEnd('\\')}..." : title;
         }
     }
 }


### PR DESCRIPTION
#### Description

Just replaces `` ` `` with `` \` `` when building the title.

#### Issues Fixed or Closed by this PR
* Closes #7836

