### PR TITLE
New: don't allow remote path to start with space

### DIFF
--- a/src/NzbDrone.Core/RemotePathMappings/RemotePathMappingService.cs
+++ b/src/NzbDrone.Core/RemotePathMappings/RemotePathMappingService.cs
@@ -96,6 +96,11 @@ namespace NzbDrone.Core.RemotePathMappings
                 throw new ArgumentException("Invalid Host");
             }
 
+            if (mapping.RemotePath.StartsWith(" "))
+            {
+                throw new ArgumentException("Remote Path must not start with a space");
+            }
+
             var remotePath = new OsPath(mapping.RemotePath);
             var localPath = new OsPath(mapping.LocalPath);
 

--- a/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RemotePathMappings;
+using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 using Sonarr.Http;
 using Sonarr.Http.REST;
@@ -31,6 +32,11 @@ namespace Sonarr.Api.V3.RemotePathMappings
             SharedValidator.RuleFor(c => c.RemotePath)
                 .Must(remotePath => !remotePath.IsNotNullOrWhiteSpace() && !remotePath.StartsWith(" "))
                 .WithMessage("Remote Path must not start with a space");
+
+            SharedValidator.RuleFor(c => c.RemotePath)
+                .Must(remotePath => !remotePath.IsNotNullOrWhiteSpace() && !remotePath.EndsWith(" "))
+                .WithMessage("Remote Path probably should not end with a space")
+                .AsWarning();
 
             SharedValidator.RuleFor(c => c.LocalPath)
                 .Cascade(CascadeMode.Stop)

--- a/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
+++ b/src/Sonarr.Api.V3/RemotePathMappings/RemotePathMappingController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RemotePathMappings;
 using NzbDrone.Core.Validation.Paths;
 using Sonarr.Http;
@@ -21,11 +22,15 @@ namespace Sonarr.Api.V3.RemotePathMappings
             _remotePathMappingService = remotePathMappingService;
 
             SharedValidator.RuleFor(c => c.Host)
-                           .NotEmpty();
+                .NotEmpty();
 
             // We cannot use IsValidPath here, because it's a remote path, possibly other OS.
             SharedValidator.RuleFor(c => c.RemotePath)
-                           .NotEmpty();
+                .NotEmpty();
+
+            SharedValidator.RuleFor(c => c.RemotePath)
+                .Must(remotePath => !remotePath.IsNotNullOrWhiteSpace() && !remotePath.StartsWith(" "))
+                .WithMessage("Remote Path must not start with a space");
 
             SharedValidator.RuleFor(c => c.LocalPath)
                 .Cascade(CascadeMode.Stop)


### PR DESCRIPTION
#### Description
add a validation to not allow remotePath to start with a space 

