### PR TITLE
Use the thrown exception in http timeout handling

### DIFF
--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -141,7 +141,7 @@ namespace NzbDrone.Common.Http.Dispatchers
             }
             catch (OperationCanceledException ex) when (cts.IsCancellationRequested)
             {
-                throw new WebException("Http request timed out", ex.InnerException, WebExceptionStatus.Timeout, null);
+                throw new WebException("Http request timed out", ex, WebExceptionStatus.Timeout, null);
             }
         }
 


### PR DESCRIPTION
#### Description
It's unclear why it was added in #5715 to use the inner exception, but I see no reason why we should use the direct exception.