### PR TITLE
Handle HTTP 410 for failed download similarly to HTTP 404

### DIFF
--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.Download
             }
             catch (HttpException ex)
             {
-                if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.Response.StatusCode == HttpStatusCode.NotFound || ex.Response.StatusCode == HttpStatusCode.Gone)
                 {
                     _logger.Error(ex, "Downloading torrent file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, torrentUrl);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading torrent failed", ex);

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.Download
             }
             catch (HttpException ex)
             {
-                if (ex.Response.StatusCode == HttpStatusCode.NotFound || ex.Response.StatusCode == HttpStatusCode.Gone)
+                if (ex.Response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
                 {
                     _logger.Error(ex, "Downloading torrent file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, torrentUrl);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading torrent failed", ex);

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Download
             }
             catch (HttpException ex)
             {
-                if (ex.Response.StatusCode == HttpStatusCode.NotFound || ex.Response.StatusCode == HttpStatusCode.Gone)
+                if (ex.Response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
                 {
                     _logger.Error(ex, "Downloading nzb file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, url);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading nzb failed", ex);

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Download
             }
             catch (HttpException ex)
             {
-                if (ex.Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.Response.StatusCode == HttpStatusCode.NotFound || ex.Response.StatusCode == HttpStatusCode.Gone)
                 {
                     _logger.Error(ex, "Downloading nzb file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, url);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading nzb failed", ex);


### PR DESCRIPTION
#### Description
Prowlarr issues 410 for failing to download releases (see https://github.com/Prowlarr/Prowlarr/blob/5cc4c3f302d006df2458789530f89a097a9d1fc7/src/Prowlarr.Api.V1/Indexers/NewznabController.cs#L280C26-L280C27)

While there is specific handling for missing/deleted releases, it only checks for HTTP 404. This PR is simply to also handle HTTP 410 the same way.

Example of the issue manifesting with current implementation:
```
2025-05-07 08:25:23.5|Warn|HttpClient|HTTP Error - Res: HTTP/1.1 [GET] http://systemd-prowlarr:9696/prowlarr/4/download?apikey=(removed)&link=(removed)&file=(removed): 410.Gone (89 bytes)
<?xml version="1.0" encoding="UTF-8"?>
<error code="410" description="Download failed" />
2025-05-07 08:25:23.5|Error|QBittorrent|Downloading torrent file for episode '(removed)' failed (http://systemd-prowlarr:9696/prowlarr/4/download?apikey=(removed)&link=(removed)&file=(removed))

[v4.0.14.2939] NzbDrone.Common.Http.HttpException: HTTP request failed: [410:Gone] [GET] at [http://systemd-prowlarr:9696/prowlarr/4/download?apikey=(removed)&link=(removed)&file=(removed)]
   at NzbDrone.Common.Http.HttpClient.ExecuteAsync(HttpRequest request) in ./Sonarr.Common/Http/HttpClient.cs:line 119
   at NzbDrone.Core.Download.TorrentClientBase`1.<>c.<<DownloadFromWebUrl>b__11_0>d.MoveNext() in ./Sonarr.Core/Download/TorrentClientBase.cs:line 143
--- End of stack trace from previous location ---
   at Polly.ResiliencePipeline.<>c__9`2.<<ExecuteAsync>b__9_0>d.MoveNext()
--- End of stack trace from previous location ---
   at Polly.Outcome`1.GetResultOrRethrow()
   at Polly.ResiliencePipeline.ExecuteAsync[TResult,TState](Func`3 callback, TState state, CancellationToken cancellationToken)
   at NzbDrone.Core.Download.TorrentClientBase`1.DownloadFromWebUrl(RemoteEpisode remoteEpisode, IIndexer indexer, String torrentUrl) in ./Sonarr.Core/Download/TorrentClientBase.cs:line 215
<?xml version="1.0" encoding="UTF-8"?>
<error code="410" description="Download failed" />
```
