### PR TITLE
Fixed: formatBitrate call to filesize.

### DIFF
--- a/frontend/src/Utilities/Number/formatBitrate.ts
+++ b/frontend/src/Utilities/Number/formatBitrate.ts
@@ -7,8 +7,9 @@ function formatBitrate(input: string | number) {
     return '';
   }
 
-  const { value, symbol } = filesize(size, {
+  const { value, symbol } = filesize(size / 8, {
     base: 10,
+    bits: true,
     round: 1,
     output: 'object',
   });


### PR DESCRIPTION
#### Description
Correct the issue with the display for Video and Audio Bitrate on the MediaInfo control.
The filesize package was being passed bits (per-second) where the bytes are expected, resulting in the value and accompaying units to appear incorrect.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
Before
![before](https://github.com/user-attachments/assets/93cf059c-35b0-46a9-999b-5db88fb858d4)

After fix - same raw bitrate, correctly converted to mega-**bits** per second. 
![after2](https://github.com/user-attachments/assets/12dfb972-8ba3-4c85-bc92-ed63d05fed35)

#### Database Migration
No


#### Issues Fixed or Closed by this PR
* Closes #7879

