### PR TITLE
added 'libicu72' as a required package

### DIFF
--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -33,7 +33,7 @@ fi
 
 app="sonarr"
 app_port="8989"
-app_prereq="curl sqlite3 wget"
+app_prereq="curl sqlite3 wget libicu72"
 app_umask="0002"
 branch="main"
 


### PR DESCRIPTION
Sonarr refushed to start on Debian 12.11 without this package present. So, I added it to the required packages.

#### Description
When I ran install.sh on my pretty bare installed Debian 12.11 VM Sonarr failed to start afterwards with this error:
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manag
er and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.

So, I installed the package `libicu72` and it started without issue. So to make life easier for other people, I added this to the prereq list in the install script.

