### PR TITLE
Follow redirects for usenet grabs on non-prod builds

### DIFF
--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -48,6 +48,7 @@ namespace NzbDrone.Core.Download
             {
                 var request = indexer?.GetDownloadRequest(url) ?? new HttpRequest(url);
                 request.RateLimitKey = remoteEpisode?.Release?.IndexerId.ToString();
+                request.AllowAutoRedirect = true;
 
                 var response = await RetryStrategy
                     .ExecuteAsync(static async (state, _) => await state._httpClient.GetAsync(state.request), (_httpClient, request))


### PR DESCRIPTION
#### Description
While useful for debugging, this would allow nzb grabs in a dev build when in use with an indexer that requires redirects in Prowlarr.

https://github.com/Sonarr/Sonarr/blob/640e3e5d441b0f363d3b993f36dae3d22691608c/src/NzbDrone.Common/Http/HttpRequest.cs#L25-L28
