### PR TITLE
Cleanup series title normalizer

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/SeriesTitleNormalizerFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesTitleNormalizerFixture.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Test.TvTests
         [TestCase("A.I.C.O. -Incarnation-", "aico incarnation")]
         [TestCase("A.D. The Bible Continues", "ad the bible continues")]
         [TestCase("A.P. Bio", "ap bio")]
+        [TestCase("A-Team", "ateam")]
         [TestCase("The A-Team", "ateam")]
         [TestCase("And Just Like That", "and just like that")]
         public void should_normalize_title(string title, string expected)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -900,8 +900,7 @@ namespace NzbDrone.Core.Parser
             title = PunctuationRegex.Replace(title, " ");
             title = DuplicateSpacesRegex.Replace(title, " ");
 
-            return title.Trim()
-                        .ToLower();
+            return title.Trim().ToLower();
         }
 
         public static string NormalizeTitle(string title)

--- a/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
+++ b/src/NzbDrone.Core/Tv/SeriesTitleNormalizer.cs
@@ -4,19 +4,16 @@ namespace NzbDrone.Core.Tv
 {
     public static class SeriesTitleNormalizer
     {
-        private static readonly Dictionary<int, string> PreComputedTitles = new Dictionary<int, string>
-                                                                     {
-                                                                         { 281588, "a to z" },
-                                                                         { 289260, "ad bible continues" },
-                                                                         { 328534, "ap bio" },
-                                                                         { 77904, "ateam" }
-                                                                     };
+        private static readonly Dictionary<int, string> PreComputedTitles = new()
+        {
+            { 281588, "a to z" },
+        };
 
         public static string Normalize(string title, int tvdbId)
         {
-            if (PreComputedTitles.ContainsKey(tvdbId))
+            if (PreComputedTitles.TryGetValue(tvdbId, out var value))
             {
-                return PreComputedTitles[tvdbId];
+                return value;
             }
 
             return Parser.Parser.NormalizeTitle(title).ToLower();


### PR DESCRIPTION
#### Description
Title overrides removed in 79436149eb6869033d2263cd9558dbe75b1d3a68, reintroduced in a coding style change in 1c22a1ec0d655dbc13425edce790e858a550c797 which makes this a regression.
