### PR TITLE
Fix status for grabbed episodes part of grouped calendar events

### DIFF
--- a/frontend/src/Calendar/Events/CalendarEventGroup.tsx
+++ b/frontend/src/Calendar/Events/CalendarEventGroup.tsx
@@ -22,9 +22,9 @@ function createIsDownloadingSelector(episodeIds: number[]) {
   return createSelector(
     (state: AppState) => state.queue.details,
     (details) => {
-      return details.items.some((item) => {
-        return !!(item.episodeId && episodeIds.includes(item.episodeId));
-      });
+      return details.items.some(
+        (item) => item.episodeId && episodeIds.includes(item.episodeId)
+      );
     }
   );
 }
@@ -61,10 +61,10 @@ function CalendarEventGroup({
   const endTime = moment(lastEpisode.airDateUtc).add(series.runtime, 'minutes');
   const seasonNumber = firstEpisode.seasonNumber;
 
-  const { allDownloaded, anyQueued, anyMonitored, allAbsoluteEpisodeNumbers } =
+  const { allDownloaded, anyGrabbed, anyMonitored, allAbsoluteEpisodeNumbers } =
     useMemo(() => {
       let files = 0;
-      let queued = 0;
+      let grabbed = 0;
       let monitored = 0;
       let absoluteEpisodeNumbers = 0;
 
@@ -73,8 +73,8 @@ function CalendarEventGroup({
           files++;
         }
 
-        if (event.queued) {
-          queued++;
+        if (event.grabbed) {
+          grabbed++;
         }
 
         if (series.monitored && event.monitored) {
@@ -88,13 +88,13 @@ function CalendarEventGroup({
 
       return {
         allDownloaded: files === events.length,
-        anyQueued: queued > 0,
+        anyGrabbed: grabbed > 0,
         anyMonitored: monitored > 0,
         allAbsoluteEpisodeNumbers: absoluteEpisodeNumbers === events.length,
       };
     }, [series, events]);
 
-  const anyDownloading = isDownloading || anyQueued;
+  const anyDownloading = isDownloading || anyGrabbed;
 
   const statusStyle = getStatusStyle(
     allDownloaded,

--- a/frontend/src/Calendar/iCal/CalendarLinkModalContent.tsx
+++ b/frontend/src/Calendar/iCal/CalendarLinkModalContent.tsx
@@ -22,7 +22,12 @@ interface CalendarLinkModalContentProps {
 function CalendarLinkModalContent({
   onModalClose,
 }: CalendarLinkModalContentProps) {
-  const [state, setState] = useState({
+  const [state, setState] = useState<{
+    unmonitored: boolean;
+    premieresOnly: boolean;
+    asAllDay: boolean;
+    tags: number[];
+  }>({
     unmonitored: false,
     premieresOnly: false,
     asAllDay: false,

--- a/frontend/src/Episode/Episode.ts
+++ b/frontend/src/Episode/Episode.ts
@@ -22,10 +22,6 @@ interface Episode extends ModelBase {
   monitored: boolean;
   grabbed?: boolean;
   unverifiedSceneNumbering: boolean;
-  endTime?: string;
-  grabDate?: string;
-  seriesTitle?: string;
-  queued?: boolean;
   series?: Series;
   finaleType?: string;
 }

--- a/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
+++ b/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs
@@ -33,8 +33,6 @@ namespace Sonarr.Api.V3.Episodes
         public int? SceneEpisodeNumber { get; set; }
         public int? SceneSeasonNumber { get; set; }
         public bool UnverifiedSceneNumbering { get; set; }
-        public DateTime? EndTime { get; set; }
-        public DateTime? GrabDate { get; set; }
         public SeriesResource Series { get; set; }
         public List<MediaCover> Images { get; set; }
 


### PR DESCRIPTION
#### Description
EpisodeResource actually uses `grabbed`, not `queued`.

https://github.com/Sonarr/Sonarr/blob/14e324ee30694ae017a39fd6f66392dc2d104617/src/Sonarr.Api.V3/Episodes/EpisodeResource.cs#L44 

And removal of some unused props.

