### PR TITLE
Fixed: Quality sliders on some browsers

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/QualityProfileItemSize.tsx
+++ b/frontend/src/Settings/Profiles/Quality/QualityProfileItemSize.tsx
@@ -183,6 +183,7 @@ export default function QualityProfileItemSize({
         // @ts-ignore allowCross is still available in the version currently used
         allowCross={false}
         snapDragDisabled={true}
+        pearling={true}
         renderThumb={thumbRenderer}
         renderTrack={trackRenderer}
         onChange={handleSliderChange}


### PR DESCRIPTION
#### Description
Due to the poorly z-index support for the sliders sometimes you're unable to change the max value if preferred value is set as max as well, without carefully trying to slide from the edge of the thumb.

Enabling pearling allows moving max value, and pushing preferred value in the same time.