### PR TITLE
New: include network drive types in diskspace overview and sort all by path

### DIFF
--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -39,7 +39,10 @@ namespace NzbDrone.Core.DiskSpace
 
             var optionalRootFolders = GetFixedDisksRootPaths().Except(importantRootFolders).Distinct().ToList();
 
-            var diskSpace = GetDiskSpace(importantRootFolders).Concat(GetDiskSpace(optionalRootFolders, true)).ToList();
+            var diskSpace = GetDiskSpace(importantRootFolders)
+                .Concat(GetDiskSpace(optionalRootFolders, true))
+                .OrderBy(d => d.Path)
+                .ToList();
 
             return diskSpace;
         }
@@ -61,7 +64,7 @@ namespace NzbDrone.Core.DiskSpace
         private IEnumerable<string> GetFixedDisksRootPaths()
         {
             return _diskProvider.GetMounts()
-                .Where(d => d.DriveType == DriveType.Fixed)
+                .Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network)
                 .Where(d => !_regexSpecialDrive.IsMatch(d.RootDirectory))
                 .Select(d => d.RootDirectory);
         }
@@ -83,11 +86,11 @@ namespace NzbDrone.Core.DiskSpace
                     }
 
                     diskSpace = new DiskSpace
-                                {
-                                    Path = path,
-                                    FreeSpace = freeSpace.Value,
-                                    TotalSpace = totalSpace.Value
-                                };
+                    {
+                        Path = path,
+                        FreeSpace = freeSpace.Value,
+                        TotalSpace = totalSpace.Value
+                    };
 
                     diskSpace.Label = _diskProvider.GetVolumeLabel(path);
                 }

--- a/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
+++ b/src/NzbDrone.Core/DiskSpace/DiskSpaceService.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.DiskSpace
 
             var diskSpace = GetDiskSpace(importantRootFolders)
                 .Concat(GetDiskSpace(optionalRootFolders, true))
-                .OrderBy(d => d.Path)
+                .OrderBy(d => d.Path, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             return diskSpace;
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.DiskSpace
         private IEnumerable<string> GetFixedDisksRootPaths()
         {
             return _diskProvider.GetMounts()
-                .Where(d => d.DriveType == DriveType.Fixed || d.DriveType == DriveType.Network)
+                .Where(d => d.DriveType is DriveType.Fixed or DriveType.Network)
                 .Where(d => !_regexSpecialDrive.IsMatch(d.RootDirectory))
                 .Select(d => d.RootDirectory);
         }


### PR DESCRIPTION
#### Description
includes any network drives also in the disk space overview in Sonarr.

This may be preferred by users using remote storage

This also sorts the disk space list by path.

#### Issues Fixed or Closed by this PR
* Closes #7902

