### PR TITLE
Fixed: Handling series with empty IMDB IDs in lists clean library

### DIFF
--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -303,7 +303,7 @@ namespace NzbDrone.Core.ImportLists
             {
                 var seriesExists = allListItems.Where(l =>
                     l.TvdbId == series.TvdbId ||
-                    l.ImdbId == series.ImdbId ||
+                    (l.ImdbId.IsNotNullOrWhiteSpace() && series.ImdbId.IsNotNullOrWhiteSpace() && l.ImdbId == series.ImdbId) ||
                     l.TmdbId == series.TmdbId ||
                     series.MalIds.Contains(l.MalId) ||
                     series.AniListIds.Contains(l.AniListId)).ToList();


### PR DESCRIPTION
#### Description
Fixed import list sync cleanup which was not cleaning up all series without an ImdbId if the import lists contained series without an ImdbId as well, despite no match on other criteria.