### PR TITLE
Fixed: Hide separators when page toolbar shows all buttons on small screens

### DIFF
--- a/frontend/src/Components/Page/Toolbar/PageToolbarSection.tsx
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarSection.tsx
@@ -80,8 +80,12 @@ function PageToolbarSection({
     if (buttonCount - 1 === maxButtons) {
       const overflowItems: PageToolbarButtonProps[] = [];
 
+      const buttonsWithoutSeparators = validChildren.filter(
+        (child) => Object.keys(child.props).length > 0
+      );
+
       return {
-        buttons: validChildren,
+        buttons: buttonsWithoutSeparators,
         buttonCount,
         overflowItems,
       };


### PR DESCRIPTION
#### Screenshots for UI Changes

Before
![Screenshot](https://github.com/user-attachments/assets/23b92e79-b0ea-46d6-a7fd-3de66ae945f3)

After
![Screenshot](https://github.com/user-attachments/assets/e134a818-4098-4203-9695-7a0ee4e43ef1)
