### PR TITLE
Fixed: Redirect loop for removed basic auth method

### DIFF
--- a/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Sonarr.Http.Authentication
 {
     public static class AuthenticationBuilderExtensions
     {
-        private static readonly Regex CookieNameRegex = new Regex(@"[^a-z0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex CookieNameRegex = new(@"[^a-z0-9]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static AuthenticationBuilder AddApiKey(this AuthenticationBuilder authenticationBuilder, string name, Action<ApiKeyAuthenticationOptions> options)
         {
@@ -30,7 +30,7 @@ namespace Sonarr.Http.Authentication
 
         public static AuthenticationBuilder AddAppAuthentication(this IServiceCollection services)
         {
-            services.AddOptions<CookieAuthenticationOptions>(AuthenticationType.Forms.ToString())
+            services.AddOptions<CookieAuthenticationOptions>(nameof(AuthenticationType.Forms))
                 .Configure<IConfigFileProvider>((options, configFileProvider) =>
                 {
                     // Replace diacritics and replace non-word characters to ensure cookie name doesn't contain any valid URL characters not allowed in cookie names
@@ -47,12 +47,9 @@ namespace Sonarr.Http.Authentication
                 });
 
             return services.AddAuthentication()
-                .AddNone(AuthenticationType.None.ToString())
-                .AddExternal(AuthenticationType.External.ToString())
-#pragma warning disable CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Basic.ToString())
-#pragma warning restore CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Forms.ToString())
+                .AddNone(nameof(AuthenticationType.None))
+                .AddExternal(nameof(AuthenticationType.External))
+                .AddCookie(nameof(AuthenticationType.Forms))
                 .AddApiKey("API", options =>
                 {
                     options.HeaderName = "X-Api-Key";

--- a/src/Sonarr.Http/Authentication/UiAuthorizationPolicyProvider.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationPolicyProvider.cs
@@ -2,22 +2,27 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
+using NLog;
+using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 
 namespace NzbDrone.Http.Authentication
 {
     public class UiAuthorizationPolicyProvider : IAuthorizationPolicyProvider
     {
-        private const string POLICY_NAME = "UI";
+        private const string PolicyName = "UI";
         private readonly IConfigFileProvider _config;
+        private readonly Logger _logger;
 
         public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
 
         public UiAuthorizationPolicyProvider(IOptions<AuthorizationOptions> options,
-            IConfigFileProvider config)
+            IConfigFileProvider config,
+            Logger logger)
         {
             FallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
             _config = config;
+            _logger = logger;
         }
 
         public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => FallbackPolicyProvider.GetDefaultPolicyAsync();
@@ -26,9 +31,21 @@ namespace NzbDrone.Http.Authentication
 
         public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
         {
-            if (policyName.Equals(POLICY_NAME, StringComparison.OrdinalIgnoreCase))
+            if (policyName.Equals(PolicyName, StringComparison.OrdinalIgnoreCase))
             {
-                var policy = new AuthorizationPolicyBuilder(_config.AuthenticationMethod.ToString())
+                var authenticationMethod = _config.AuthenticationMethod;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (authenticationMethod == AuthenticationType.Basic)
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    _logger.Error("Basic authentication method was removed, use Forms authentication instead.");
+
+                    authenticationMethod = AuthenticationType.Forms;
+                }
+
+                var policy = new AuthorizationPolicyBuilder()
+                    .AddAuthenticationSchemes(authenticationMethod.ToString())
                     .AddRequirements(new BypassableDenyAnonymousAuthorizationRequirement());
 
                 return Task.FromResult(policy.Build());


### PR DESCRIPTION
#### Description
With the removal of basic auth in 0f9e063e2146812f6e963363eee70a524612f354, using `AddCookie(AuthenticationType.Basic.ToString())` simply adds the default cookie with the library defaults which lead to a redirect loop. 

We'll force Forms in UiAuthorizationPolicyProvider, and trigger an error in the same time to switch from Basic.


