### PR TITLE
fix: select all on series import

### DIFF
--- a/frontend/src/AddSeries/ImportSeries/Import/ImportSeriesTable.tsx
+++ b/frontend/src/AddSeries/ImportSeries/Import/ImportSeriesTable.tsx
@@ -13,6 +13,7 @@ import {
 } from 'Store/Actions/importSeriesActions';
 import createAllSeriesSelector from 'Store/Selectors/createAllSeriesSelector';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
+import createImportSeriesAllSelectedSelector from 'Store/Selectors/createImportSeriesAllSelectedSelector';
 import { CheckInputChanged } from 'typings/inputs';
 import { SelectStateInputProps } from 'typings/props';
 import { UnmappedFolder } from 'typings/RootFolder';
@@ -54,6 +55,7 @@ function Row({ index, style, data }: ListChildComponentProps<RowItemData>) {
   );
 }
 
+const allSelectedSelector = createImportSeriesAllSelectedSelector();
 function ImportSeriesTable({
   unmappedFolders,
   scrollerRef,
@@ -78,7 +80,10 @@ function ImportSeriesTable({
   const listRef = useRef<FixedSizeList<RowItemData>>(null);
   const initialUnmappedFolders = useRef(unmappedFolders);
   const previousItems = usePrevious(items);
-  const { allSelected, allUnselected, selectedState } = selectState;
+  const { allUnselected, selectedState } = selectState;
+  const allSelected = useSelector((state: AppState) =>
+    allSelectedSelector(state, selectedState)
+  );
 
   const handleSelectAllChange = useCallback(
     ({ value }: CheckInputChanged) => {

--- a/frontend/src/Store/Selectors/createExistingSeriesSelector.ts
+++ b/frontend/src/Store/Selectors/createExistingSeriesSelector.ts
@@ -1,5 +1,17 @@
 import { createSelector } from 'reselect';
+import Series from 'Series/Series';
 import createAllSeriesSelector from './createAllSeriesSelector';
+
+export function isExistingSeries(
+  series: Series[],
+  tvdbId: number | undefined
+): boolean {
+  if (tvdbId == null) {
+    return false;
+  }
+
+  return series.some((s) => s.tvdbId === tvdbId);
+}
 
 function createExistingSeriesSelector(tvdbId: number | undefined) {
   return createSelector(createAllSeriesSelector(), (series) => {

--- a/frontend/src/Store/Selectors/createImportSeriesAllSelectedSelector.ts
+++ b/frontend/src/Store/Selectors/createImportSeriesAllSelectedSelector.ts
@@ -1,0 +1,30 @@
+import { createSelector } from 'reselect';
+import AppState from 'App/State/AppState';
+import { SelectedState } from 'Helpers/Hooks/useSelectState';
+import createAllSeriesSelector from './createAllSeriesSelector';
+import { isExistingSeries } from './createExistingSeriesSelector';
+
+function createImportSeriesAllSelectedSelector() {
+  return createSelector(
+    (state: AppState) => state.importSeries.items,
+    createAllSeriesSelector(),
+    (_state: AppState, selectedState: SelectedState) => selectedState,
+    (importSeries, allSeries, selectedState) => {
+      const selectableImportSeries = importSeries.filter((item) => {
+        if (!item.selectedSeries) {
+          return false;
+        }
+
+        return !isExistingSeries(allSeries, item.selectedSeries.tvdbId);
+      });
+
+      return (
+        selectableImportSeries.reduce((acc, item) => {
+          return acc && selectedState[item.id];
+        }, true) && selectableImportSeries.length > 0
+      );
+    }
+  );
+}
+
+export default createImportSeriesAllSelectedSelector;


### PR DESCRIPTION
Change the behaviour of the SelectAll checkbox input in the ImportSeriesHeader to properly account for selectable rows only.

#### Description

When rows in the ImportSeriesList are a mix of selected and unselected, a null value gets passed to the CheckboxInput in the list header. Null is treated as falsy, and so when you click on the input element, the browser tries to flip the checkbox value to true which will then select all rows.

Under normal circumstances where every item is selectable, this is fine. You can click the checkbox in the list header to select everything. The checkbox value will then become true, and you can click it again to set it to false. However, in the import series list, some rows are not selectable because the series might already exist in the user's series library or because it might not match any known series.

So if the checkbox value in the header is null, and you click on it, the browser sends an event saying that it's being flipped to true. However, it can't be set to true because some items aren't selectable. So then it gets set back to null. But wait, it was null before we clicked it and null again after we clicked it. So nothing happened as a result of the user click.

To fix it, we need to make it so the value of the checkbox in the list header only accounts for the items that are selectable. Meaning, if everything that's selectable in the import series list is selected, then the checkbox in the header should be checked with a value of true.

This PR does just that.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes

##### Before (taken from the linked issue)

https://private-user-images.githubusercontent.com/1117625/452624456-35b42b3c-6567-4b8a-ba78-893b0b4de087.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTAwMzU2MTcsIm5iZiI6MTc1MDAzNTMxNywicGF0aCI6Ii8xMTE3NjI1LzQ1MjYyNDQ1Ni0zNWI0MmIzYy02NTY3LTRiOGEtYmE3OC04OTNiMGI0ZGUwODcubXA0P1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDYxNiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTA2MTZUMDA1NTE3WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTA1ODZiZWZkNmFkOGJjYzY3YTdkOTc5NWVlYzZlNzJiMjlkYmNiZTY0MzIyZmVjZmYyZmY5YTgzMjEwYWNiOCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.gNIFSnLkeEhTQb6Vo4qJqFLgtnKQlas2Pxa2ASxArBk

##### After

https://github.com/user-attachments/assets/89dcba57-9670-47e1-8c4b-b28214d09433

#### Issues Fixed or Closed by this PR
* Closes #7909 

