### PR TITLE
New: Support for multiple seriesIds in Rename API endpoint

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -8,7 +8,9 @@ namespace NzbDrone.Core.MediaFiles
     public interface IMediaFileRepository : IBasicRepository<EpisodeFile>
     {
         List<EpisodeFile> GetFilesBySeries(int seriesId);
+        List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
+        List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<EpisodeFile> GetFilesWithRelativePath(int seriesId, string relativePath);
         void DeleteForSeries(List<int> seriesIds);
@@ -26,9 +28,19 @@ namespace NzbDrone.Core.MediaFiles
             return Query(c => c.SeriesId == seriesId).ToList();
         }
 
+        public List<EpisodeFile> GetFilesBySeries(List<int> seriesIds)
+        {
+            return Query(c => seriesIds.Contains(c.SeriesId)).ToList();
+        }
+
         public List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber)
         {
             return Query(c => c.SeriesId == seriesId && c.SeasonNumber == seasonNumber).ToList();
+        }
+
+        public List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber)
+        {
+            return Query(c => seriesIds.Contains(c.SeriesId) && c.SeasonNumber == seasonNumber).ToList();
         }
 
         public List<EpisodeFile> GetFilesWithoutMediaInfo()

--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -10,7 +10,6 @@ namespace NzbDrone.Core.MediaFiles
         List<EpisodeFile> GetFilesBySeries(int seriesId);
         List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
-        List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<EpisodeFile> GetFilesWithRelativePath(int seriesId, string relativePath);
         void DeleteForSeries(List<int> seriesIds);
@@ -36,11 +35,6 @@ namespace NzbDrone.Core.MediaFiles
         public List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber)
         {
             return Query(c => c.SeriesId == seriesId && c.SeasonNumber == seasonNumber).ToList();
-        }
-
-        public List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber)
-        {
-            return Query(c => seriesIds.Contains(c.SeriesId) && c.SeasonNumber == seasonNumber).ToList();
         }
 
         public List<EpisodeFile> GetFilesWithoutMediaInfo()

--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.MediaFiles
     public interface IMediaFileRepository : IBasicRepository<EpisodeFile>
     {
         List<EpisodeFile> GetFilesBySeries(int seriesId);
-        List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
+        List<EpisodeFile> GetFilesBySeriesIds(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<EpisodeFile> GetFilesWithRelativePath(int seriesId, string relativePath);
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.MediaFiles
             return Query(c => c.SeriesId == seriesId).ToList();
         }
 
-        public List<EpisodeFile> GetFilesBySeries(List<int> seriesIds)
+        public List<EpisodeFile> GetFilesBySeriesIds(List<int> seriesIds)
         {
             return Query(c => seriesIds.Contains(c.SeriesId)).ToList();
         }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -19,7 +19,6 @@ namespace NzbDrone.Core.MediaFiles
         List<EpisodeFile> GetFilesBySeries(int seriesId);
         List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
-        List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber);
         List<EpisodeFile> GetFiles(IEnumerable<int> ids);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<string> FilterExistingFiles(List<string> files, Series series);
@@ -81,11 +80,6 @@ namespace NzbDrone.Core.MediaFiles
         public List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber)
         {
             return _mediaFileRepository.GetFilesBySeason(seriesId, seasonNumber);
-        }
-
-        public List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber)
-        {
-            return _mediaFileRepository.GetFilesBySeason(seriesIds, seasonNumber);
         }
 
         public List<EpisodeFile> GetFiles(IEnumerable<int> ids)

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -17,7 +17,9 @@ namespace NzbDrone.Core.MediaFiles
         void Update(List<EpisodeFile> episodeFiles);
         void Delete(EpisodeFile episodeFile, DeleteMediaFileReason reason);
         List<EpisodeFile> GetFilesBySeries(int seriesId);
+        List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
+        List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber);
         List<EpisodeFile> GetFiles(IEnumerable<int> ids);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
         List<string> FilterExistingFiles(List<string> files, Series series);
@@ -71,9 +73,19 @@ namespace NzbDrone.Core.MediaFiles
             return _mediaFileRepository.GetFilesBySeries(seriesId);
         }
 
+        public List<EpisodeFile> GetFilesBySeries(List<int> seriesIds)
+        {
+            return _mediaFileRepository.GetFilesBySeries(seriesIds);
+        }
+
         public List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber)
         {
             return _mediaFileRepository.GetFilesBySeason(seriesId, seasonNumber);
+        }
+
+        public List<EpisodeFile> GetFilesBySeason(List<int> seriesIds, int seasonNumber)
+        {
+            return _mediaFileRepository.GetFilesBySeason(seriesIds, seasonNumber);
         }
 
         public List<EpisodeFile> GetFiles(IEnumerable<int> ids)

--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.MediaFiles
         void Update(List<EpisodeFile> episodeFiles);
         void Delete(EpisodeFile episodeFile, DeleteMediaFileReason reason);
         List<EpisodeFile> GetFilesBySeries(int seriesId);
-        List<EpisodeFile> GetFilesBySeries(List<int> seriesIds);
+        List<EpisodeFile> GetFilesBySeriesIds(List<int> seriesIds);
         List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber);
         List<EpisodeFile> GetFiles(IEnumerable<int> ids);
         List<EpisodeFile> GetFilesWithoutMediaInfo();
@@ -72,9 +72,9 @@ namespace NzbDrone.Core.MediaFiles
             return _mediaFileRepository.GetFilesBySeries(seriesId);
         }
 
-        public List<EpisodeFile> GetFilesBySeries(List<int> seriesIds)
+        public List<EpisodeFile> GetFilesBySeriesIds(List<int> seriesIds)
         {
-            return _mediaFileRepository.GetFilesBySeries(seriesIds);
+            return _mediaFileRepository.GetFilesBySeriesIds(seriesIds);
         }
 
         public List<EpisodeFile> GetFilesBySeason(int seriesId, int seasonNumber)

--- a/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.MediaFiles
         {
             var seriesList = _seriesService.GetSeries(seriesIds);
             var episodesList = _episodeService.GetEpisodesBySeries(seriesIds).ToLookup(e => e.SeriesId);
-            var filesList = _mediaFileService.GetFilesBySeries(seriesIds).ToLookup(f => f.SeriesId);
+            var filesList = _mediaFileService.GetFilesBySeriesIds(seriesIds).ToLookup(f => f.SeriesId);
 
             return seriesList.SelectMany(series =>
                 {

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -17,7 +17,6 @@ namespace NzbDrone.Core.Tv
         List<Episode> Find(int seriesId, string date);
         List<Episode> GetEpisodes(int seriesId);
         List<Episode> GetEpisodes(int seriesId, int seasonNumber);
-        List<Episode> GetEpisodes(List<int> seriesId, int seasonNumber);
         List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> GetEpisodeByFileId(int fileId);
@@ -76,11 +75,6 @@ namespace NzbDrone.Core.Tv
         public List<Episode> GetEpisodes(int seriesId, int seasonNumber)
         {
             return Query(s => s.SeriesId == seriesId && s.SeasonNumber == seasonNumber).ToList();
-        }
-
-        public List<Episode> GetEpisodes(List<int> seriesIds, int seasonNumber)
-        {
-            return Query(s => seriesIds.Contains(s.SeriesId) && s.SeasonNumber == seasonNumber).ToList();
         }
 
         public List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds)

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.Tv
         List<Episode> Find(int seriesId, string date);
         List<Episode> GetEpisodes(int seriesId);
         List<Episode> GetEpisodes(int seriesId, int seasonNumber);
+        List<Episode> GetEpisodes(List<int> seriesId, int seasonNumber);
         List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> GetEpisodeByFileId(int fileId);
@@ -75,6 +76,11 @@ namespace NzbDrone.Core.Tv
         public List<Episode> GetEpisodes(int seriesId, int seasonNumber)
         {
             return Query(s => s.SeriesId == seriesId && s.SeasonNumber == seasonNumber).ToList();
+        }
+
+        public List<Episode> GetEpisodes(List<int> seriesIds, int seasonNumber)
+        {
+            return Query(s => seriesIds.Contains(s.SeriesId) && s.SeasonNumber == seasonNumber).ToList();
         }
 
         public List<Episode> GetEpisodesBySeriesIds(List<int> seriesIds)

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -23,7 +23,9 @@ namespace NzbDrone.Core.Tv
         List<Episode> FindEpisodesBySceneNumbering(int seriesId, int sceneAbsoluteEpisodeNumber);
         Episode FindEpisode(int seriesId, string date, int? part);
         List<Episode> GetEpisodeBySeries(int seriesId);
+        List<Episode> GetEpisodesBySeries(List<int> seriesIds);
         List<Episode> GetEpisodesBySeason(int seriesId, int seasonNumber);
+        List<Episode> GetEpisodesBySeason(List<int> seriesIds, int seasonNumber);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> EpisodesWithFiles(int seriesId);
         PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec);
@@ -99,9 +101,19 @@ namespace NzbDrone.Core.Tv
             return _episodeRepository.GetEpisodes(seriesId).ToList();
         }
 
+        public List<Episode> GetEpisodesBySeries(List<int> seriesIds)
+        {
+            return _episodeRepository.GetEpisodesBySeriesIds(seriesIds).ToList();
+        }
+
         public List<Episode> GetEpisodesBySeason(int seriesId, int seasonNumber)
         {
             return _episodeRepository.GetEpisodes(seriesId, seasonNumber);
+        }
+
+        public List<Episode> GetEpisodesBySeason(List<int> seriesIds, int seasonNumber)
+        {
+            return _episodeRepository.GetEpisodes(seriesIds, seasonNumber);
         }
 
         public List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber)

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -25,7 +25,6 @@ namespace NzbDrone.Core.Tv
         List<Episode> GetEpisodeBySeries(int seriesId);
         List<Episode> GetEpisodesBySeries(List<int> seriesIds);
         List<Episode> GetEpisodesBySeason(int seriesId, int seasonNumber);
-        List<Episode> GetEpisodesBySeason(List<int> seriesIds, int seasonNumber);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> EpisodesWithFiles(int seriesId);
         PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec);
@@ -109,11 +108,6 @@ namespace NzbDrone.Core.Tv
         public List<Episode> GetEpisodesBySeason(int seriesId, int seasonNumber)
         {
             return _episodeRepository.GetEpisodes(seriesId, seasonNumber);
-        }
-
-        public List<Episode> GetEpisodesBySeason(List<int> seriesIds, int seasonNumber)
-        {
-            return _episodeRepository.GetEpisodes(seriesIds, seasonNumber);
         }
 
         public List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber)

--- a/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
@@ -18,16 +18,23 @@ namespace Sonarr.Api.V3.Episodes
 
         [HttpGet]
         [Produces("application/json")]
-        public List<RenameEpisodeResource> GetEpisodes([FromQuery(Name = "seriesId")] List<int> seriesIds, int? seasonNumber)
+        public List<RenameEpisodeResource> GetEpisodes(int seriesId, int? seasonNumber)
+        {
+            if (seasonNumber.HasValue)
+            {
+                return _renameEpisodeFileService.GetRenamePreviews(seriesId, seasonNumber.Value).ToResource();
+            }
+
+            return _renameEpisodeFileService.GetRenamePreviews(seriesId).ToResource();
+        }
+
+        [HttpGet("multiple")]
+        [Produces("application/json")]
+        public List<RenameEpisodeResource> GetEpisodes(List<int> seriesIds)
         {
             if (seriesIds is not { Count: not 0 })
             {
                 throw new BadRequestException("seriesIds must be provided");
-            }
-
-            if (seasonNumber.HasValue)
-            {
-                return _renameEpisodeFileService.GetRenamePreviews(seriesIds, seasonNumber.Value).ToResource();
             }
 
             return _renameEpisodeFileService.GetRenamePreviews(seriesIds).ToResource();

--- a/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.MediaFiles;
 using Sonarr.Http;
+using Sonarr.Http.REST;
 
 namespace Sonarr.Api.V3.Episodes
 {
@@ -17,14 +18,19 @@ namespace Sonarr.Api.V3.Episodes
 
         [HttpGet]
         [Produces("application/json")]
-        public List<RenameEpisodeResource> GetEpisodes(int seriesId, int? seasonNumber)
+        public List<RenameEpisodeResource> GetEpisodes([FromQuery(Name = "seriesId")] List<int> seriesIds, int? seasonNumber)
         {
-            if (seasonNumber.HasValue)
+            if (seriesIds is not { Count: not 0 })
             {
-                return _renameEpisodeFileService.GetRenamePreviews(seriesId, seasonNumber.Value).ToResource();
+                throw new BadRequestException("seriesIds must be provided");
             }
 
-            return _renameEpisodeFileService.GetRenamePreviews(seriesId).ToResource();
+            if (seasonNumber.HasValue)
+            {
+                return _renameEpisodeFileService.GetRenamePreviews(seriesIds, seasonNumber.Value).ToResource();
+            }
+
+            return _renameEpisodeFileService.GetRenamePreviews(seriesIds).ToResource();
         }
     }
 }

--- a/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
+++ b/src/Sonarr.Api.V3/Episodes/RenameEpisodeController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.MediaFiles;
 using Sonarr.Http;
@@ -28,13 +29,18 @@ namespace Sonarr.Api.V3.Episodes
             return _renameEpisodeFileService.GetRenamePreviews(seriesId).ToResource();
         }
 
-        [HttpGet("multiple")]
+        [HttpGet("bulk")]
         [Produces("application/json")]
-        public List<RenameEpisodeResource> GetEpisodes(List<int> seriesIds)
+        public List<RenameEpisodeResource> GetEpisodes([FromQuery] List<int> seriesIds)
         {
-            if (seriesIds is not { Count: not 0 })
+            if (seriesIds is { Count: 0 })
             {
                 throw new BadRequestException("seriesIds must be provided");
+            }
+
+            if (seriesIds.Any(seriesId => seriesId <= 0))
+            {
+                throw new BadRequestException("seriesIds must be positive integers");
             }
 
             return _renameEpisodeFileService.GetRenamePreviews(seriesIds).ToResource();


### PR DESCRIPTION
#### Description
This adds functionality to the API to retrieve any number of series that need renames at once. This removes the need to make a call for each movie individually when you want to know the rename status for multiple series.