### PR TITLE
Upgrade MonoTorrent to 3.0.2

### DIFF
--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Download
 
             try
             {
-                hash = MagnetLink.Parse(magnetUrl).InfoHash.ToHex();
+                hash = MagnetLink.Parse(magnetUrl).InfoHashes.V1OrV2.ToHex();
             }
             catch (FormatException ex)
             {

--- a/src/NzbDrone.Core/Indexers/TorrentRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRssParser.cs
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Indexers
             {
                 try
                 {
-                    return MagnetLink.Parse(magnetUrl).InfoHash.ToHex();
+                    return MagnetLink.Parse(magnetUrl).InfoHashes.V1OrV2.ToHex();
                 }
                 catch
                 {

--- a/src/NzbDrone.Core/MediaFiles/TorrentInfo/TorrentFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/TorrentInfo/TorrentFileInfoReader.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.MediaFiles.TorrentInfo
         {
             try
             {
-                return Torrent.Load(fileContents).InfoHash.ToHex();
+                return Torrent.Load(fileContents).InfoHashes.V1OrV2.ToHex();
             }
             catch
             {

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.4" />
-    <PackageReference Include="MonoTorrent" Version="2.0.7" />
+    <PackageReference Include="MonoTorrent" Version="3.0.2" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Npgsql" Version="9.0.3" />


### PR DESCRIPTION
#### Description

Upgrades MonoTorrent to 3.0.2 which should address the issues with double encoding when sending torrents/magnets to clients. Opted to fallback to v2 hashes, even if unexpected most of the time.

#### Issues Fixed or Closed by this PR
* Closes #7270

