### PR TITLE
Fix: xvid not getting recognized correctly

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -210,7 +210,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (videoFormat == "mpeg4" || videoFormat.Contains("msmpeg4"))
             {
-                if (videoCodecID == "XVID")
+                if (videoCodecID.ToUpperInvariant() == "XVID")
                 {
                     return "XviD";
                 }


### PR DESCRIPTION
#### Description
This fixes cases where the ffprobe output is not `XVID` in all caps but rather `xvid` in all lowercase.
ffprobe output using the Sonarr built binary here:

```
$ docker exec sonarr /app/bin/ffprobe /data/media/tv-hd/Celebrity\ Deathmatch\ \(1998\)/Season\ 03/Celebrity\ Deathmatch\ \(1998\)\ -\ S03E13\ -\ \[SDTV\]\[MP3\ 2.0\]-NOGRP.avi
ffprobe version 5.1.4 Copyright (c) 2007-2023 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.2)
  configuration: --prefix=/ffmpeg/build --bindir=/ffmpeg/bin --logfile=/ffmpeg/bin/log.txt --disable-autodetect --disable-iconv --enable-libdav1d --disable-programs --enable-ffprobe --disable-avdevice --disable-swresample --disable-swscale --disable-postproc --disable-avfilter --disable-network --disable-everything --enable-protocol=file --enable-demuxers --enable-parsers --enable-decoders --enable-bsf=av1_frame_split --enable-bsf=av1_frame_merge --enable-bsf=av1_metadata --pkg-config-flags=--static --extra-ldexeflags=-static --extra-libs='-lpthread -lm'
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
Input #0, avi, from '/data/media/tv-hd/Celebrity Deathmatch (1998)/Season 03/Celebrity Deathmatch (1998) - S03E13 - [SDTV][MP3 2.0]-NOGRP.avi':
  Metadata:
    software        : Lavf51.12.1
  Duration: 00:21:19.06, start: 0.000000, bitrate: 1920 kb/s
  Stream #0:0: Video: mpeg4 (Simple Profile) (xvid / 0x64697678), yuv420p, 640x480 [SAR 1:1 DAR 4:3], 1780 kb/s, 23.98 fps, 23.98 tbr, 23.98 tbn
  Stream #0:1: Audio: mp3 (U[0][0][0] / 0x0055), 44100 Hz, stereo, fltp, 128 kb/s

$ docker exec sonarr /app/bin/ffprobe /data/media/tv-hd/Celebrity\ Deathmatch\ \(1998\)/Season\ 03/Celebrity\ Deathmatch\ \(1998\)\ -\ S03E14\ -\ \[SDTV\]\[MP3\ 2.0\]\[XviD\]-NOGRP.avi
ffprobe version 5.1.4 Copyright (c) 2007-2023 the FFmpeg developers
  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.2)
  configuration: --prefix=/ffmpeg/build --bindir=/ffmpeg/bin --logfile=/ffmpeg/bin/log.txt --disable-autodetect --disable-iconv --enable-libdav1d --disable-programs --enable-ffprobe --disable-avdevice --disable-swresample --disable-swscale --disable-postproc --disable-avfilter --disable-network --disable-everything --enable-protocol=file --enable-demuxers --enable-parsers --enable-decoders --enable-bsf=av1_frame_split --enable-bsf=av1_frame_merge --enable-bsf=av1_metadata --pkg-config-flags=--static --extra-ldexeflags=-static --extra-libs='-lpthread -lm'
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
Input #0, avi, from '/data/media/tv-hd/Celebrity Deathmatch (1998)/Season 03/Celebrity Deathmatch (1998) - S03E14 - [SDTV][MP3 2.0][XviD]-NOGRP.avi':
  Duration: 00:21:35.74, start: 0.000000, bitrate: 1093 kb/s
  Stream #0:0: Video: mpeg4 (Advanced Simple Profile) (XVID / 0x44495658), yuv420p, 640x480 [SAR 1:1 DAR 4:3], 956 kb/s, 23.87 fps, 23.87 tbr, 23.87 tbn
  Stream #0:1: Audio: mp3 (U[0][0][0] / 0x0055), 48000 Hz, stereo, fltp, 128 kb/s
```