### PR TITLE
Issue #7960 mvp for replacing service --status-all with systemctl is-active to ensure app is stopped

### DIFF
--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -167,11 +167,10 @@ if ! getent group "$app_guid" | grep -qw "$app_uid"; then
     echo "Added User [$app_uid] to Group [$app_guid]"
 fi
 
-# Stop the App if running
-if service --status-all | grep -Fq "$app"; then
-    systemctl stop "$app"
-    systemctl disable "$app".service
-    echo "Stopped existing $app"
+# Stop and disable the App if running
+if [ $(systemctl is-active "$app") = "active" ]; then
+    systemctl disable --now -q "$app"
+    echo "Stopped and disabled existing $app"
 fi
 
 # Create Appdata Directory

--- a/frontend/src/RootFolder/RootFolderRow.tsx
+++ b/frontend/src/RootFolder/RootFolderRow.tsx
@@ -83,7 +83,7 @@ function RootFolderRow(props: RootFolderRowProps) {
         isOpen={isDeleteModalOpen}
         kind={kinds.DANGER}
         title={translate('RemoveRootFolder')}
-        message={translate('RemoveRootFolderMessageText', { path })}
+        message={translate('RemoveRootFolderWithSeriesMessageText', { path })}
         confirmLabel={translate('Remove')}
         onConfirm={onConfirmDelete}
         onCancel={onDeleteModalClose}

--- a/frontend/src/Settings/Tags/Tag.tsx
+++ b/frontend/src/Settings/Tags/Tag.tsx
@@ -55,12 +55,12 @@ function Tag({ id, label }: TagProps) {
   }, []);
 
   const handleConfirmDeleteTag = useCallback(() => {
-    setIsDeleteTagModalOpen(false);
-  }, []);
-
-  const handleDeleteTagModalClose = useCallback(() => {
     dispatch(deleteTag({ id }));
   }, [id, dispatch]);
+
+  const handleDeleteTagModalClose = useCallback(() => {
+    setIsDeleteTagModalOpen(false);
+  }, []);
 
   return (
     <Card

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -209,9 +209,20 @@ namespace NzbDrone.Core.Configuration
                     return AuthenticationType.Forms;
                 }
 
-                return Enum.TryParse<AuthenticationType>(_authOptions.Method, out var enumValue)
+                var value = Enum.TryParse<AuthenticationType>(_authOptions.Method, out var enumValue)
                     ? enumValue
                     : GetValueEnum("AuthenticationMethod", AuthenticationType.None);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (value == AuthenticationType.Basic)
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    SetValue("AuthenticationMethod", AuthenticationType.Forms);
+
+                    return AuthenticationType.Forms;
+                }
+
+                return value;
             }
         }
 
@@ -385,6 +396,12 @@ namespace NzbDrone.Core.Configuration
             if (EnableSsl && (GetValue("SslCertHash", string.Empty, false).IsNotNullOrWhiteSpace() || SslCertPath.IsNullOrWhiteSpace()))
             {
                 SetValue("EnableSsl", false);
+            }
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (AuthenticationMethod == AuthenticationType.Basic)
+#pragma warning restore CS0618 // Type or member is obsolete
+            {
+                SetValue("AuthenticationMethod", AuthenticationType.Forms);
             }
         }
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1739,7 +1739,7 @@
   "RemoveQueueItemRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the download and the file(s) from the download client.",
   "RemoveQueueItemsRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the downloads and the files from the download client.",
   "RemoveRootFolder": "Remove Root Folder",
-  "RemoveRootFolderMessageText": "Are you sure you want to remove the root folder '{path}'? Files and folders will not be deleted from disk, and series in this root folder will not be removed from {appName}.",
+  "RemoveRootFolderWithSeriesMessageText": "Are you sure you want to remove the root folder '{path}'? Files and folders will not be deleted from disk, and series in this root folder will not be removed from {appName}.",
   "RemoveSelected": "Remove Selected",
   "RemoveSelectedBlocklistMessageText": "Are you sure you want to remove the selected items from the blocklist?",
   "RemoveSelectedItem": "Remove Selected Item",

--- a/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Sonarr.Http.Authentication
 
         public static AuthenticationBuilder AddAppAuthentication(this IServiceCollection services)
         {
-            services.AddOptions<CookieAuthenticationOptions>(AuthenticationType.Forms.ToString())
+            services.AddOptions<CookieAuthenticationOptions>(nameof(AuthenticationType.Forms))
                 .Configure<IConfigFileProvider>((options, configFileProvider) =>
                 {
                     // Replace diacritics and replace non-word characters to ensure cookie name doesn't contain any valid URL characters not allowed in cookie names
@@ -47,12 +47,9 @@ namespace Sonarr.Http.Authentication
                 });
 
             return services.AddAuthentication()
-                .AddNone(AuthenticationType.None.ToString())
-                .AddExternal(AuthenticationType.External.ToString())
-#pragma warning disable CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Basic.ToString())
-#pragma warning restore CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Forms.ToString())
+                .AddNone(nameof(AuthenticationType.None))
+                .AddExternal(nameof(AuthenticationType.External))
+                .AddCookie(nameof(AuthenticationType.Forms))
                 .AddApiKey("API", options =>
                 {
                     options.HeaderName = "X-Api-Key";

--- a/src/Sonarr.Http/Authentication/UiAuthorizationPolicyProvider.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationPolicyProvider.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Http.Authentication
 {
     public class UiAuthorizationPolicyProvider : IAuthorizationPolicyProvider
     {
-        private const string POLICY_NAME = "UI";
+        private const string PolicyName = "UI";
         private readonly IConfigFileProvider _config;
 
         public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
@@ -26,7 +26,7 @@ namespace NzbDrone.Http.Authentication
 
         public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
         {
-            if (policyName.Equals(POLICY_NAME, StringComparison.OrdinalIgnoreCase))
+            if (policyName.Equals(PolicyName, StringComparison.OrdinalIgnoreCase))
             {
                 var policy = new AuthorizationPolicyBuilder(_config.AuthenticationMethod.ToString())
                     .AddRequirements(new BypassableDenyAnonymousAuthorizationRequirement());


### PR DESCRIPTION
#### Description
service --status-all does not return a status for sonarr unit. 

also see 7960 for discussion on if stopping is required at all.  Upgrade worked for me despite this bug.  If so, we can simply remove this check and restart the unit at the end.
<!-- Remove any of the following sections if they are not used -->
#### Issues Fixed or Closed by this PR
* Closes #7960

