### PR TITLE
install.sh replace service --status-all with systemctl is-active to ensure app stops

### DIFF
--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -7,7 +7,7 @@
 ### Version V1.0.2 2024-01-03 - markus101 - Get user input from /dev/tty
 ### Version V1.0.3 2024-01-06 - StevieTV - exit script when it is ran from install directory
 ### Version V1.0.4 2025-04-05 - kaecyra - Allow user/group to be supplied via CLI, add unattended mode
-### Version V1.0.5 2025-07-08 - kaecyra - use systemctl instead of service for stopping app
+### Version V1.0.5 2025-07-08 - bparkin1283 - use systemctl instead of service for stopping app
 
 ### Boilerplate Warning
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,

--- a/distribution/debian/install.sh
+++ b/distribution/debian/install.sh
@@ -7,6 +7,7 @@
 ### Version V1.0.2 2024-01-03 - markus101 - Get user input from /dev/tty
 ### Version V1.0.3 2024-01-06 - StevieTV - exit script when it is ran from install directory
 ### Version V1.0.4 2025-04-05 - kaecyra - Allow user/group to be supplied via CLI, add unattended mode
+### Version V1.0.5 2025-07-08 - kaecyra - use systemctl instead of service for stopping app
 
 ### Boilerplate Warning
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
@@ -167,11 +168,10 @@ if ! getent group "$app_guid" | grep -qw "$app_uid"; then
     echo "Added User [$app_uid] to Group [$app_guid]"
 fi
 
-# Stop the App if running
-if service --status-all | grep -Fq "$app"; then
-    systemctl stop "$app"
-    systemctl disable "$app".service
-    echo "Stopped existing $app"
+# Stop and disable the App if running
+if [ $(systemctl is-active "$app") = "active" ]; then
+    systemctl disable --now -q "$app"
+    echo "Stopped and disabled existing $app"
 fi
 
 # Create Appdata Directory


### PR DESCRIPTION
service --status-all does not return a status for sonarr unit.

also see 7960 for discussion on if stopping is required at all. Upgrade worked for me despite this bug. If so, we can simply remove this check and restart the unit at the end.

#### Issues Fixed or Closed by this PR
* Closes #7960