### PR TITLE
Fixed: Local air date vs mtime compare error

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/UpdateEpisodeFileServiceTests/ChangeFileDateFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpdateEpisodeFileServiceTests/ChangeFileDateFixture.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Reflection;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.EnvironmentInfo;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MediaFiles.UpdateEpisodeFileServiceTests
+{
+    [TestFixture]
+    public class ChangeFileDateFixture : CoreTest<UpdateEpisodeFileService>
+    {
+        private const string FilePath = "dummy.file";
+        private DateTime _lastWrite;
+
+        private bool InvokePrivate(string path, DateTime airDate)
+        {
+            var method = typeof(UpdateEpisodeFileService)
+                .GetMethod("ChangeFileDateToLocalDate", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (bool)method.Invoke(Subject, [path, airDate]);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _lastWrite = new DateTime(2025, 07, 27, 12, 0, 0, 512, DateTimeKind.Utc);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(x => x.FileGetLastWrite(FilePath))
+                .Returns(() => _lastWrite);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(x => x.FileSetLastWriteTime(FilePath, It.IsAny<DateTime>()))
+                .Callback<string, DateTime>((path, dateTime) =>
+                {
+                    _lastWrite = dateTime.Kind == DateTimeKind.Utc
+                        ? dateTime
+                        : dateTime.ToUniversalTime();
+                });
+        }
+
+        [Test]
+        public void should_change_date_once_only()
+        {
+            var oldMillis = _lastWrite.Millisecond;
+
+            // Retain millis when creating localDate; a possible
+            // error case is to increment 1 second by adding prior
+            // mtime millis to a local date with non-zero millis.
+            var localDate = _lastWrite.ToLocalTime().AddDays(2);
+
+            var firstResult = InvokePrivate(FilePath, localDate);
+            Assert.IsTrue(firstResult, "First pass should update mtime");
+
+            Assert.AreEqual(
+                localDate.WithoutTicks().AddMilliseconds(oldMillis),
+                _lastWrite.ToLocalTime(),
+                "mtime should equal the supplied local datetime with last write millis");
+
+            var secondResult = InvokePrivate(FilePath, localDate);
+            Assert.IsFalse(secondResult, "Second pass shouldn't update mtime: set and get are out of parity");
+        }
+
+        [Test]
+        public void should_clamp_mtime_on_unix_and_not_on_windows()
+        {
+            var oldMillis = _lastWrite.Millisecond;
+            var oldLocal = new DateTime(1965, 1, 1, 0, 0, 0, 512, DateTimeKind.Local);
+
+            var firstResult = InvokePrivate(FilePath, oldLocal);
+            Assert.IsTrue(firstResult, "First pass should update mtime");
+
+            if (OsInfo.IsNotWindows)
+            {
+                Assert.AreEqual(
+                    UpdateEpisodeFileService.EpochTime.ToLocalTime().AddMilliseconds(oldMillis),
+                    _lastWrite.ToLocalTime(),
+                    "Unix case: mtime should clamp on epoch time (UTC) with last write millis");
+            }
+            else
+            {
+                Assert.AreEqual(
+                    oldLocal.WithoutTicks().AddMilliseconds(oldMillis),
+                    _lastWrite.ToLocalTime(),
+                    "Windows case: mtime shouldn't clamp on epoch time and needs last write millis");
+            }
+
+            var secondResult = InvokePrivate(FilePath, oldLocal);
+            Assert.IsFalse(secondResult, "Second pass shouldn't update mtime: set and get are out of parity");
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
@@ -22,11 +22,12 @@ namespace NzbDrone.Core.MediaFiles
     public class UpdateEpisodeFileService : IUpdateEpisodeFileService,
                                             IHandle<SeriesScannedEvent>
     {
+        internal static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         private readonly IDiskProvider _diskProvider;
         private readonly IConfigService _configService;
         private readonly IEpisodeService _episodeService;
         private readonly Logger _logger;
-        private static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         public UpdateEpisodeFileService(IDiskProvider diskProvider,
                                         IConfigService configService,
@@ -47,90 +48,48 @@ namespace NzbDrone.Core.MediaFiles
         private bool ChangeFileDate(EpisodeFile episodeFile, Series series, List<Episode> episodes)
         {
             var episodeFilePath = Path.Combine(series.Path, episodeFile.RelativePath);
+            var airDateUtc = episodes.First().AirDateUtc;
 
-            switch (_configService.FileDate)
+            if (!airDateUtc.HasValue)
             {
-                case FileDateType.LocalAirDate:
-                    {
-                        var airDate = episodes.First().AirDate;
-                        var airTime = series.AirTime;
-
-                        if (airDate.IsNullOrWhiteSpace() || airTime.IsNullOrWhiteSpace())
-                        {
-                            return false;
-                        }
-
-                        return ChangeFileDateToLocalAirDate(episodeFilePath, airDate, airTime);
-                    }
-
-                case FileDateType.UtcAirDate:
-                    {
-                        var airDateUtc = episodes.First().AirDateUtc;
-
-                        if (!airDateUtc.HasValue)
-                        {
-                            return false;
-                        }
-
-                        return ChangeFileDateToUtcAirDate(episodeFilePath, airDateUtc.Value);
-                    }
+                return false;
             }
 
-            return false;
+            return _configService.FileDate switch
+            {
+                FileDateType.LocalAirDate =>
+                    ChangeFileDateToLocalDate(episodeFilePath, airDateUtc.Value.ToLocalTime()),
+
+                // Intentionally pass UTC as local per user preference
+                FileDateType.UtcAirDate =>
+                    ChangeFileDateToLocalDate(
+                        episodeFilePath,
+                        DateTime.SpecifyKind(airDateUtc.Value, DateTimeKind.Local)),
+
+                _ => false,
+            };
         }
 
-        private bool ChangeFileDateToLocalAirDate(string filePath, string fileDate, string fileTime)
+        private bool ChangeFileDateToLocalDate(string filePath, DateTime localDate)
         {
-            if (DateTime.TryParse(fileDate + ' ' + fileTime, out var airDate))
-            {
-                // avoiding false +ve checks and set date skewing by not using UTC (Windows)
-                var oldLastWrite = _diskProvider.FileGetLastWrite(filePath);
+            // FileGetLastWrite returns UTC; convert to local to compare
+            var oldLastWrite = _diskProvider.FileGetLastWrite(filePath).ToLocalTime();
 
-                if (OsInfo.IsNotWindows && airDate < EpochTime)
-                {
-                    _logger.Debug("Setting date of file to 1970-01-01 as actual airdate is before that time and will not be set properly");
-                    airDate = EpochTime;
-                }
-
-                if (!DateTime.Equals(airDate.WithoutTicks(), oldLastWrite.WithoutTicks()))
-                {
-                    try
-                    {
-                        _diskProvider.FileSetLastWriteTime(filePath, airDate);
-                        _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, airDate);
-
-                        return true;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.Warn(ex, "Unable to set date of file [" + filePath + "]");
-                    }
-                }
-            }
-            else
-            {
-                _logger.Debug("Could not create valid date to change file [{0}]", filePath);
-            }
-
-            return false;
-        }
-
-        private bool ChangeFileDateToUtcAirDate(string filePath, DateTime airDateUtc)
-        {
-            var oldLastWrite = _diskProvider.FileGetLastWrite(filePath);
-
-            if (OsInfo.IsNotWindows && airDateUtc < EpochTime)
+            if (OsInfo.IsNotWindows && localDate.ToUniversalTime() < EpochTime)
             {
                 _logger.Debug("Setting date of file to 1970-01-01 as actual airdate is before that time and will not be set properly");
-                airDateUtc = EpochTime;
+                localDate = EpochTime.ToLocalTime();
             }
 
-            if (!DateTime.Equals(airDateUtc.WithoutTicks(), oldLastWrite.WithoutTicks()))
+            if (!DateTime.Equals(localDate.WithoutTicks(), oldLastWrite.WithoutTicks()))
             {
                 try
                 {
-                    _diskProvider.FileSetLastWriteTime(filePath, airDateUtc.AddMilliseconds(oldLastWrite.Millisecond));
-                    _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, airDateUtc);
+                    // Preserve prior mtime millis per https://github.com/Sonarr/Sonarr/issues/7228
+                    var mtime = localDate.WithoutTicks().AddMilliseconds(oldLastWrite.Millisecond);
+
+                    _diskProvider.FileSetLastWriteTime(filePath, mtime);
+                    _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, mtime);
 
                     return true;
                 }


### PR DESCRIPTION
#### Description
Fixes a bug I observed where Sonarr sees file mtime as +offset when comparing against the local air date, causing the file to be updated (but with the same exact time). Plex sees the file was touched however which triggers a rescan, and this spread across my whole library has been driving me bonkers for the past 10 months which is when it seems this may have been introduced.

  The problem seems to be that `DiskProvider.FileGetLastWrite()` [returns the mtime in UTC](https://github.com/Sonarr/Sonarr/blob/6f1d461dad8eb146db739191d21390a34e3ba2bc/src/NzbDrone.Common/Disk/DiskProviderBase.cs#L64) but is compared against the _local_ air date (when configured as such). A comment on [line 86](https://github.com/Sonarr/Sonarr/blob/6f1d461dad8eb146db739191d21390a34e3ba2bc/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs#L86) suggests local time should be used, that just doesn't seem to be what's happening:

```
...
2025-07-26 20:03:37.3|Debug|UpdateEpisodeFileService|Date of file [/data/tv/Sketch Comedy/Whose Line Is It Anyway (US) (1998)/Season 13/Whose Line is it Anyway (US) - S13E09 - Tony Cavalero.mkv] changed from '08/11/2017 02:00:00' to '08/10/2017 21:00:00'
2025-07-26 20:03:37.3|Debug|UpdateEpisodeFileService|Date of file [/data/tv/Sketch Comedy/Whose Line Is It Anyway (US) (1998)/Season 13/Whose Line is it Anyway (US) - S13E10 - Jillian Michaels.mkv] changed from '08/18/2017 02:00:00' to '08/17/2017 21:00:00'
2025-07-26 20:03:37.3|Debug|UpdateEpisodeFileService|Changed file date for 235 files of 235 in Whose Line Is It Anyway? (US)
```

Maybe worth noting I'm running the linuxserver.io image on Unraid, but I confirmed the actual mtime on disk is set correctly and read incorrectly per the logs, and I confirmed that running the 'Refresh Series' task in Sonarr reproducibly causes my Plex server to lose it's mind and refresh TV content in the UI at a seizure-inducing rate as shown in the video I link below.

It took staring at the code quite a bit to make sense of everything (as is often the case when dealing with time zone issues), but while fixing the bug, I saw an opportunity to simplify the implementation and also create some tests for the expected behavior.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
40-second screen capture video: [https://youtu.be/XT7RRYrSx38](https://youtu.be/XT7RRYrSx38)

#### Issues Fixed or Closed by this PR
* Closes an issue I haven't yet filed as described above