### PR TITLE
Clickable poster in bulk edit mode

### DIFF
--- a/frontend/src/Series/Index/Posters/SeriesIndexPoster.tsx
+++ b/frontend/src/Series/Index/Posters/SeriesIndexPoster.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
-import React, { useCallback, useState } from 'react';
+import React, { SyntheticEvent, useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useSelect } from 'App/SelectContext';
 import { REFRESH_SERIES, SERIES_SEARCH } from 'Commands/commandNames';
 import Label from 'Components/Label';
 import IconButton from 'Components/Link/IconButton';
@@ -122,7 +123,30 @@ function SeriesIndexPoster(props: SeriesIndexPosterProps) {
     setIsDeleteSeriesModalOpen(false);
   }, [setIsDeleteSeriesModalOpen]);
 
+  const [selectState, selectDispatch] = useSelect();
+
+  const onSelectPress = useCallback(
+    (event: SyntheticEvent<HTMLElement, MouseEvent>) => {
+      if (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey) {
+        window.open(`/series/${titleSlug}`, '_blank');
+        return;
+      }
+
+      const shiftKey = event.nativeEvent.shiftKey;
+
+      selectDispatch({
+        type: 'toggleSelected',
+        id: seriesId,
+        isSelected: !selectState.selectedState[seriesId],
+        shiftKey,
+      });
+    },
+    [seriesId, selectState.selectedState, selectDispatch, titleSlug]
+  );
+
   const link = `/series/${titleSlug}`;
+
+  const linkProps = isSelectMode ? { onPress: onSelectPress } : { to: link };
 
   const elementStyle = {
     width: `${posterWidth}px`,
@@ -175,7 +199,7 @@ function SeriesIndexPoster(props: SeriesIndexPosterProps) {
           />
         ) : null}
 
-        <Link className={styles.link} style={elementStyle} to={link}>
+        <Link className={styles.link} style={elementStyle} {...linkProps}>
           <SeriesPoster
             style={elementStyle}
             images={images}


### PR DESCRIPTION
#### Description
Make posters clickable on bulk edit mode :
- Left-click: Toggles movie selection
- Shift+click: Multi-selects movies
- Ctrl+click (or Cmd+click on Mac): Opens movie page in a new tab

#### Screenshots for UI Changes

https://github.com/user-attachments/assets/ac7ddc63-c2a1-4007-abef-2e398655a3f4



#### Database Migration
NO
