### PR TITLE
Add HasSubtitles indexer flag to BTN

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/BroadcastheNet/RecentFeed.json
+++ b/src/NzbDrone.Core.Test/Files/Indexers/BroadcastheNet/RecentFeed.json
@@ -27,6 +27,7 @@
 "TvrageID":"4055",
 "ImdbID":"0320037",
 "InfoHash":"123",
+"Tags": ["Subtitles"],
 "DownloadURL":"https:\/\/broadcasthe.net\/torrents.php?action=download&id=123&authkey=123&torrent_pass=123"
 },
 "1234":{
@@ -54,6 +55,7 @@
 "TvrageID":"38472",
 "ImdbID":"2377081",
 "InfoHash":"1234",
+"Tags": [],
 "DownloadURL":"https:\/\/broadcasthe.net\/torrents.php?action=download&id=1234&authkey=1234&torrent_pass=1234"
 }},
 "results":"117927"

--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             torrentInfo.Codec.Should().Be("x264");
             torrentInfo.Resolution.Should().Be("SD");
 
-            torrentInfo.Tags.Should().Contain("Subtitles");
+            torrentInfo.IndexerFlags.Should().HaveFlag(IndexerFlags.IncludesSubtitles);
         }
 
         private void VerifyBackOff()

--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -64,6 +64,8 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             torrentInfo.Container.Should().Be("MP4");
             torrentInfo.Codec.Should().Be("x264");
             torrentInfo.Resolution.Should().Be("SD");
+
+            torrentInfo.Tags.Should().Contain("Subtitles");
         }
 
         private void VerifyBackOff()

--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             torrentInfo.Codec.Should().Be("x264");
             torrentInfo.Resolution.Should().Be("SD");
 
-            torrentInfo.IndexerFlags.Should().HaveFlag(IndexerFlags.IncludesSubtitles);
+            torrentInfo.IndexerFlags.Should().HaveFlag(IndexerFlags.IncludeSubtitles);
         }
 
         private void VerifyBackOff()

--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
             torrentInfo.Codec.Should().Be("x264");
             torrentInfo.Resolution.Should().Be("SD");
 
-            torrentInfo.IndexerFlags.Should().HaveFlag(IndexerFlags.IncludeSubtitles);
+            torrentInfo.IndexerFlags.Should().HaveFlag(IndexerFlags.Subtitles);
         }
 
         private void VerifyBackOff()

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
@@ -121,6 +121,11 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                     break;
             }
 
+            if (item.Tags?.Contains("Subtitles") == true)
+            {
+                flags |= IndexerFlags.HasSubtitles;
+            }
+
             return flags;
         }
 

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
             if (item.Tags?.Contains("Subtitles") == true)
             {
-                flags |= IndexerFlags.HasSubtitles;
+                flags |= IndexerFlags.IncludesSubtitles;
             }
 
             return flags;

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
             if (item.Tags?.Contains("Subtitles") == true)
             {
-                flags |= IndexerFlags.IncludesSubtitles;
+                flags |= IndexerFlags.IncludeSubtitles;
             }
 
             return flags;

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetParser.cs
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
 
             if (item.Tags?.Contains("Subtitles") == true)
             {
-                flags |= IndexerFlags.IncludeSubtitles;
+                flags |= IndexerFlags.Subtitles;
             }
 
             return flags;

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetTorrent.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetTorrent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace NzbDrone.Core.Indexers.BroadcastheNet
 {
     public class BroadcastheNetTorrent
@@ -26,6 +28,7 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
         public int? TvrageID { get; set; }
         public string ImdbID { get; set; }
         public string InfoHash { get; set; }
+        public List<string> Tags { get; set; }
         public string DownloadURL { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
+++ b/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
@@ -43,6 +43,11 @@ namespace NzbDrone.Core.Parser.Model
         /// <summary>
         /// The release is nuked
         /// </summary>
-        Nuked = 128
+        Nuked = 128,
+
+        /// <summary>
+        /// The release contains subtitles
+        /// </summary>
+        HasSubtitles = 256
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
+++ b/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
@@ -48,6 +48,6 @@ namespace NzbDrone.Core.Parser.Model
         /// <summary>
         /// The release contains subtitles
         /// </summary>
-        HasSubtitles = 256
+        IncludesSubtitles = 256
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
+++ b/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
@@ -48,6 +48,6 @@ namespace NzbDrone.Core.Parser.Model
         /// <summary>
         /// The release contains subtitles
         /// </summary>
-        IncludesSubtitles = 256
+        IncludeSubtitles = 256
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
+++ b/src/NzbDrone.Core/Parser/Model/IndexerFlags.cs
@@ -48,6 +48,6 @@ namespace NzbDrone.Core.Parser.Model
         /// <summary>
         /// The release contains subtitles
         /// </summary>
-        IncludeSubtitles = 256
+        Subtitles = 256
     }
 }


### PR DESCRIPTION
#### Description

Allows prioritization of BTN torrents that have subtitles in them.

Although https://apidocs.broadcasthe.net/ does not list `Tags` in the response, a test requests against the API will demonstrate that it is present.

<img width="473" height="458" alt="b" src="https://github.com/user-attachments/assets/e5e7c1d6-a298-4b6e-839f-edc830cbfdac" />
<img width="422" height="439" alt="a" src="https://github.com/user-attachments/assets/1004f094-d230-4056-9be2-de98cb4445d5" />
