### PR TITLE
Correctly parse backslashes from Transmission

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/TransmissionTests/TransmissionFixture.cs
@@ -273,6 +273,35 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.TransmissionTests
             items.First().OutputPath.Should().Be(@"C:\Downloads\Finished\transmission\" + _title);
         }
 
+        [Test]
+        public void should_fix_backward_slashes()
+        {
+            WindowsOnly();
+
+            _downloading.DownloadDir = @"C:/Downloads/Finished/transmission";
+
+            GivenTorrents(new List<TransmissionTorrent>
+                {
+                    new TransmissionTorrent
+                    {
+                        HashString = "HASH",
+                        IsFinished = false,
+                        Status = TransmissionTorrentStatus.Downloading,
+                        Name = "Don\'t Look Back in Anger",
+                        TotalSize = 1000,
+                        LeftUntilDone = 100,
+                        DownloadDir = "Can\'t touch this"
+                    };
+                });
+
+            var items = Subject.GetItems().ToList();
+
+            items.Should().HaveCount(1);
+            items.First().OutputPath.Should().Be(
+                    @"C:\Downloads\Finished\transmission\" + \
+                    @"Can\'t touch this\Don't Look Back in Anger");
+        }
+
         [TestCase("2.84 ()")]
         [TestCase("2.84+ ()")]
         [TestCase("2.84 (other info)")]

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -258,7 +258,8 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
         protected virtual OsPath GetOutputPath(OsPath outputPath, TransmissionTorrent torrent)
         {
-            return outputPath + torrent.Name.Replace(":", "_");
+            var safeName = torrent.Name.Replace(":", "_");
+            return outputPath + new OsPath(safeName, OsPathKind.Unknown);
         }
 
         protected string GetDownloadDirectory()


### PR DESCRIPTION
#### Description

Attempting to fix the issue where the Transmission download client responds with backslashes to escape characters and we mistake it for mixed platform paths.

Example from the system status page:
```
Unable to communicate with Transmission. Cannot combine OsPaths of different platforms ('/mnt/downloads/Sonarr' + 'Don\'t+Fail+Me+Now')
```

#### Database Migration
NO


