### PR TITLE
Allow Auto Redirects when Fetching Custom Lists

### DIFF
--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -390,5 +390,12 @@ namespace NzbDrone.Common.Http
 
             return this;
         }
+
+        public virtual HttpRequestBuilder AllowRedirect(bool allowAutoRedirect = true)
+        {
+            AllowAutoRedirect = allowAutoRedirect;
+
+            return this;
+        }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomImportProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomImportProxy.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.ImportLists.Custom
             }
 
             var baseUrl = settings.BaseUrl.TrimEnd('/');
-            var request = new HttpRequestBuilder(baseUrl).Accept(HttpAccept.Json).Build();
+            var request = new HttpRequestBuilder(baseUrl).Accept(HttpAccept.Json).AllowRedirect().Build();
             var response = _httpClient.Get(request);
             var results = JsonConvert.DeserializeObject<List<TResource>>(response.Content);
 


### PR DESCRIPTION
#### Description
A useful scenario: Using Google Sheets to maintain a list and leveraging Apps Script to provide Restful API. Due to security reasons, Google Apps Script will redirects the client to another URL in order to fetch the correct JSON results.