### PR TITLE
New: Subtitles indexer flag to indicate releases with subtitles

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/Newznab/newznab_indexerflags.xml
+++ b/src/NzbDrone.Core.Test/Files/Indexers/Newznab/newznab_indexerflags.xml
@@ -124,5 +124,34 @@
 			<newznab:attr name="nuked" value="0"/>
 		</item>
 
+		<item>
+			<title>title</title>
+			<guid isPermaLink="true">subs=eng</guid>
+			<link>link</link>
+			<comments>comments</comments>
+			<pubDate>Sat, 31 Aug 2024 12:28:40 +0300</pubDate>
+			<category>category</category>
+			<description>description</description>
+			<enclosure url="url" length="500" type="application/x-nzb"/>
+
+			<newznab:attr name="haspretime" value="0"/>
+			<newznab:attr name="nuked" value="0"/>
+			<newznab:attr name="subs" value="Eng"/>
+		</item>
+
+		<item>
+			<title>title</title>
+			<guid isPermaLink="true">subs=''</guid>
+			<link>link</link>
+			<comments>comments</comments>
+			<pubDate>Sat, 31 Aug 2024 12:28:40 +0300</pubDate>
+			<category>category</category>
+			<description>description</description>
+			<enclosure url="url" length="500" type="application/x-nzb"/>
+
+			<newznab:attr name="haspretime" value="0"/>
+			<newznab:attr name="nuked" value="0"/>
+			<newznab:attr name="subs" value=""/>
+		</item>
 	</channel>
 </rss>

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
@@ -165,6 +165,8 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         [TestCase("nuked=0 attribute")]
         [TestCase("prematch=1 and nuked=1 attributes", IndexerFlags.Scene, IndexerFlags.Nuked)]
         [TestCase("haspretime=0 and nuked=0 attributes")]
+        [TestCase("subs=eng", IndexerFlags.Subtitles)]
+        [TestCase("subs=''")]
         public async Task should_parse_indexer_flags(string releaseGuid, params IndexerFlags[] indexerFlags)
         {
             var feed = ReadAllText(@"Files/Indexers/Newznab/newznab_indexerflags.xml");

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -210,6 +210,11 @@ namespace NzbDrone.Core.Indexers.Newznab
                 flags |= IndexerFlags.Nuked;
             }
 
+            if (TryGetNewznabAttribute(item, "subs").IsNotNullOrWhiteSpace())
+            {
+                flags |= IndexerFlags.Subtitles;
+            }
+
             return flags;
         }
 


### PR DESCRIPTION
#### Description

If the `subs` attribute is present the `Subtitles` indexer flag will be enabled and usable in 

#### Issues Fixed or Closed by this PR
* Closes #7625

