### PR TITLE
New: Add `{Season Year}` renaming token

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -200,6 +200,7 @@ const seriesIdTokens = [
 const seasonTokens = [
   { token: '{season:0}', example: '1' },
   { token: '{season:00}', example: '01' },
+  { token: '{Season Year}', example: '2010' },
 ];
 
 const episodeTokens = [

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
                   .Returns(@"C:\Test\TV\Series\Season 01\File Name.avi".AsOsAgnostic());
 
             Mocker.GetMock<IBuildFileNames>()
-                  .Setup(s => s.BuildSeasonPath(It.IsAny<Series>(), It.IsAny<int>()))
+                  .Setup(s => s.BuildSeasonPath(It.IsAny<Series>(), It.IsAny<int>(), It.IsAny<int>()))
                   .Returns(@"C:\Test\TV\Series\Season 01".AsOsAgnostic());
 
             var rootFolder = @"C:\Test\TV\".AsOsAgnostic();
@@ -110,6 +110,18 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
                   .Verify(s => s.PublishEvent<EpisodeFolderCreatedEvent>(It.Is<EpisodeFolderCreatedEvent>(p =>
                       p.SeasonFolder.IsNotNullOrWhiteSpace())),
                       Times.Once());
+        }
+
+        [Test]
+        public void should_use_first_episode_season_and_year()
+        {
+            Subject.MoveEpisodeFile(_episodeFile, _localEpisode);
+
+            Mocker.GetMock<IBuildFileNames>()
+                .Verify(s => s.BuildSeasonPath(
+                    _series,
+                    _localEpisode.Episodes.First().SeasonNumber,
+                    _localEpisode.Episodes.First().AirDateUtc.Value.Year));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/ReservedDeviceNameFixture.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _series.Title = title;
             _namingConfig.SeasonFolderFormat = "{Series.Title} - Season {Season:00}";
 
-            Subject.GetSeasonFolder(_series, 1).Should().Be($"{expected} - Season 01");
+            Subject.GetSeasonFolder(_series, 1, 2025).Should().Be($"{expected} - Season 01");
         }
 
         [TestCase("Con Game", "Con_Game")]

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetSeasonFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetSeasonFolderFixture.cs
@@ -23,8 +23,8 @@ namespace NzbDrone.Core.Test.OrganizerTests
         [TestCase("Venture Bros.", 1, null, "{Series.Title}.{season:00}", "Venture.Bros.01")]
         [TestCase("Venture Bros.", 1, null, "{Series Title} Season {season:00}", "Venture Bros. Season 01")]
         [TestCase("Series Title?", 1, null, "{Series Title} Season {season:00}", "Series Title! Season 01")]
-        [TestCase("Series Title?", 1, null, "{Series Title} Season {season:00} ({Season Year})", "Series Title! Season 01 (Unknown)")]
-        [TestCase("Series Title?", 1, 2025, "{Series Title} Season {season:00} ({Season Year})", "Series Title! Season 01 (2025)")]
+        [TestCase("Series Title?", 1, null, "{Series Title} Season {season:00} {(Season Year)}", "Series Title! Season 01")]
+        [TestCase("Series Title?", 1, 2025, "{Series Title} Season {season:00} {(Season Year)}", "Series Title! Season 01 (2025)")]
         public void should_use_seriesFolderFormat_to_build_folder_name(string seriesTitle, int seasonNumber, int? seasonYear, string format, string expected)
         {
             _namingConfig.SeasonFolderFormat = format;

--- a/src/NzbDrone.Core.Test/OrganizerTests/GetSeasonFolderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/GetSeasonFolderFixture.cs
@@ -20,16 +20,18 @@ namespace NzbDrone.Core.Test.OrganizerTests
                   .Setup(c => c.GetConfig()).Returns(_namingConfig);
         }
 
-        [TestCase("Venture Bros.", 1, "{Series.Title}.{season:00}", "Venture.Bros.01")]
-        [TestCase("Venture Bros.", 1, "{Series Title} Season {season:00}", "Venture Bros. Season 01")]
-        [TestCase("Series Title?", 1, "{Series Title} Season {season:00}", "Series Title! Season 01")]
-        public void should_use_seriesFolderFormat_to_build_folder_name(string seriesTitle, int seasonNumber, string format, string expected)
+        [TestCase("Venture Bros.", 1, null, "{Series.Title}.{season:00}", "Venture.Bros.01")]
+        [TestCase("Venture Bros.", 1, null, "{Series Title} Season {season:00}", "Venture Bros. Season 01")]
+        [TestCase("Series Title?", 1, null, "{Series Title} Season {season:00}", "Series Title! Season 01")]
+        [TestCase("Series Title?", 1, null, "{Series Title} Season {season:00} ({Season Year})", "Series Title! Season 01 (Unknown)")]
+        [TestCase("Series Title?", 1, 2025, "{Series Title} Season {season:00} ({Season Year})", "Series Title! Season 01 (2025)")]
+        public void should_use_seriesFolderFormat_to_build_folder_name(string seriesTitle, int seasonNumber, int? seasonYear, string format, string expected)
         {
             _namingConfig.SeasonFolderFormat = format;
 
             var series = new Series { Title = seriesTitle };
 
-            Subject.GetSeasonFolder(series, seasonNumber, _namingConfig).Should().Be(expected);
+            Subject.GetSeasonFolder(series, seasonNumber, seasonYear, _namingConfig).Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -73,7 +73,8 @@ namespace NzbDrone.Core.MediaFiles
         {
             var filePath = _buildFileNames.BuildFilePath(episodes, series, episodeFile, Path.GetExtension(episodeFile.RelativePath));
 
-            EnsureEpisodeFolder(episodeFile, series, episodes.Select(v => v.SeasonNumber).First(), filePath);
+            var firstEpisode = episodes.First();
+            EnsureEpisodeFolder(episodeFile, series, firstEpisode.SeasonNumber, firstEpisode.AirDateUtc?.Year, filePath);
 
             _logger.Debug("Renaming episode file: {0} to {1}", episodeFile, filePath);
 
@@ -176,13 +177,13 @@ namespace NzbDrone.Core.MediaFiles
 
         private void EnsureEpisodeFolder(EpisodeFile episodeFile, LocalEpisode localEpisode, string filePath)
         {
-            EnsureEpisodeFolder(episodeFile, localEpisode.Series, localEpisode.SeasonNumber, filePath);
+            EnsureEpisodeFolder(episodeFile, localEpisode.Series, localEpisode.SeasonNumber, localEpisode.Episodes.First().AirDateUtc?.Year, filePath);
         }
 
-        private void EnsureEpisodeFolder(EpisodeFile episodeFile, Series series, int seasonNumber, string filePath)
+        private void EnsureEpisodeFolder(EpisodeFile episodeFile, Series series, int seasonNumber, int? seasonYear, string filePath)
         {
             var episodeFolder = Path.GetDirectoryName(filePath);
-            var seasonFolder = _buildFileNames.BuildSeasonPath(series, seasonNumber);
+            var seasonFolder = _buildFileNames.BuildSeasonPath(series, seasonNumber, seasonYear);
             var seriesFolder = series.Path;
             var rootFolder = _rootFolderService.GetBestRootFolderPath(seriesFolder);
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -23,9 +23,9 @@ namespace NzbDrone.Core.Organizer
     {
         string BuildFileName(List<Episode> episodes, Series series, EpisodeFile episodeFile, string extension = "", NamingConfig namingConfig = null, List<CustomFormat> customFormats = null);
         string BuildFilePath(List<Episode> episodes, Series series, EpisodeFile episodeFile, string extension, NamingConfig namingConfig = null, List<CustomFormat> customFormats = null);
-        string BuildSeasonPath(Series series, int seasonNumber);
+        string BuildSeasonPath(Series series, int seasonNumber, int? seasonYear);
         string GetSeriesFolder(Series series, NamingConfig namingConfig = null);
-        string GetSeasonFolder(Series series, int seasonNumber, NamingConfig namingConfig = null);
+        string GetSeasonFolder(Series series, int seasonNumber, int? seasonYear, NamingConfig namingConfig = null);
         bool RequiresEpisodeTitle(Series series, List<Episode> episodes);
         bool RequiresAbsoluteEpisodeNumber();
     }
@@ -233,20 +233,21 @@ namespace NzbDrone.Core.Organizer
         {
             Ensure.That(extension, () => extension).IsNotNullOrWhiteSpace();
 
-            var seasonPath = BuildSeasonPath(series, episodes.First().SeasonNumber);
+            var firstEpisode = episodes.First();
+            var seasonPath = BuildSeasonPath(series, firstEpisode.SeasonNumber, firstEpisode.AirDateUtc?.Year);
             var remainingPathLength = LongPathSupport.MaxFilePathLength - seasonPath.GetByteCount() - 1;
             var fileName = BuildFileName(episodes, series, episodeFile, extension, remainingPathLength, namingConfig, customFormats);
 
             return Path.Combine(seasonPath, fileName);
         }
 
-        public string BuildSeasonPath(Series series, int seasonNumber)
+        public string BuildSeasonPath(Series series, int seasonNumber, int? seasonYear)
         {
             var path = series.Path;
 
             if (series.SeasonFolder)
             {
-                var seasonFolder = GetSeasonFolder(series, seasonNumber);
+                var seasonFolder = GetSeasonFolder(series, seasonNumber, seasonYear);
 
                 seasonFolder = CleanFileName(seasonFolder);
 
@@ -277,7 +278,7 @@ namespace NzbDrone.Core.Organizer
             return folderName;
         }
 
-        public string GetSeasonFolder(Series series, int seasonNumber, NamingConfig namingConfig = null)
+        public string GetSeasonFolder(Series series, int seasonNumber, int? seasonYear, NamingConfig namingConfig = null)
         {
             if (namingConfig == null)
             {
@@ -288,7 +289,7 @@ namespace NzbDrone.Core.Organizer
 
             AddSeriesTokens(tokenHandlers, series);
             AddIdTokens(tokenHandlers, series);
-            AddSeasonTokens(tokenHandlers, seasonNumber);
+            AddSeasonTokens(tokenHandlers, seasonNumber, seasonYear);
 
             var format = seasonNumber == 0 ? namingConfig.SpecialsFolderFormat : namingConfig.SeasonFolderFormat;
             var folderName = ReplaceTokens(format, tokenHandlers, namingConfig);
@@ -516,7 +517,9 @@ namespace NzbDrone.Core.Organizer
                 tokenHandlers[token] = m => seasonEpisodePattern;
             }
 
-            AddSeasonTokens(tokenHandlers, episodes.First().SeasonNumber);
+            var firstEpisode = episodes.First();
+
+            AddSeasonTokens(tokenHandlers, firstEpisode.SeasonNumber, firstEpisode.AirDateUtc?.Year);
 
             if (episodes.Count > 1)
             {
@@ -593,9 +596,10 @@ namespace NzbDrone.Core.Organizer
             return pattern;
         }
 
-        private void AddSeasonTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, int seasonNumber)
+        private void AddSeasonTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, int seasonNumber, int? seasonYear)
         {
             tokenHandlers["{Season}"] = m => seasonNumber.ToString(m.CustomFormat);
+            tokenHandlers["{Season Year}"] = m => seasonYear?.ToString(m.CustomFormat) ?? "Unknown";
         }
 
         private void AddEpisodeTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Episode> episodes)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -599,7 +599,7 @@ namespace NzbDrone.Core.Organizer
         private void AddSeasonTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, int seasonNumber, int? seasonYear)
         {
             tokenHandlers["{Season}"] = m => seasonNumber.ToString(m.CustomFormat);
-            tokenHandlers["{Season Year}"] = m => seasonYear?.ToString(m.CustomFormat) ?? "Unknown";
+            tokenHandlers["{Season Year}"] = m => seasonYear?.ToString(m.CustomFormat) ?? string.Empty;
         }
 
         private void AddEpisodeTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Episode> episodes)

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
@@ -80,6 +81,7 @@ namespace NzbDrone.Core.Organizer
                 EpisodeNumber = 1,
                 Title = "Episode Title (1)",
                 AirDate = "2013-10-30",
+                AirDateUtc = DateTime.Parse("2013-10-30"),
                 AbsoluteEpisodeNumber = 1,
             };
 
@@ -260,12 +262,12 @@ namespace NzbDrone.Core.Organizer
 
         public string GetSeasonFolderSample(NamingConfig nameSpec)
         {
-            return _buildFileNames.GetSeasonFolder(_standardSeries, _episode1.SeasonNumber, nameSpec);
+            return _buildFileNames.GetSeasonFolder(_standardSeries, _episode1.SeasonNumber, _episode1.AirDateUtc?.Year, nameSpec);
         }
 
         public string GetSpecialsFolderSample(NamingConfig nameSpec)
         {
-            return _buildFileNames.GetSeasonFolder(_standardSeries, 0, nameSpec);
+            return _buildFileNames.GetSeasonFolder(_standardSeries, 0, null, nameSpec);
         }
 
         private string BuildSample(List<Episode> episodes, Series series, EpisodeFile episodeFile, NamingConfig nameSpec, List<CustomFormat> customFormats)

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -81,7 +81,7 @@ namespace NzbDrone.Core.Organizer
                 EpisodeNumber = 1,
                 Title = "Episode Title (1)",
                 AirDate = "2013-10-30",
-                AirDateUtc = DateTime.Parse("2013-10-30"),
+                AirDateUtc = new(2013, 10, 30, 0, 0, 0, DateTimeKind.Utc),
                 AbsoluteEpisodeNumber = 1,
             };
 


### PR DESCRIPTION
#### Description

- This chooses the year the first episode in the season aired and sets it using the `{Season Year}` token.
- On seasons that span across years, only the first year will be set
- When the aired date of the first episode of the season is not available, the year will be set to `Unknown`

#### Screenshots for UI Changes

* File name samples
<img width="942" height="202" alt="image" src="https://github.com/user-attachments/assets/b0fd282c-ac3e-46a6-92ba-e2de68affe0c" />

* File renaming
<img width="927" height="438" alt="image" src="https://github.com/user-attachments/assets/9f168e1c-4a2c-4393-a9b1-80fa7eaaf202" />

* Folder Name Tokens - Help Text
<img width="1347" height="256" alt="image" src="https://github.com/user-attachments/assets/8b8e741f-1340-4d67-9d5c-d24443a91bfd" />


#### Issues Fixed or Closed by this PR
* Closes #7667