### PR TITLE
Bump FluentMigrator to official 6.2.0

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -8,6 +8,5 @@
     <add key="SQLite" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/SQLite/nuget/v3/index.json" />
     <add key="coverlet-nightly" value="https://pkgs.dev.azure.com/Servarr/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json" />
     <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
-    <add key="FluentMigrator" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FluentMigrator/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -7,7 +7,7 @@ using NzbDrone.Common.Instrumentation;
 namespace NzbDrone.Core.Datastore.Migration
 {
     [Maintenance(MigrationStage.BeforeAll, TransactionBehavior.None)]
-    public class DatabaseEngineVersionCheck : FluentMigrator.Migration
+    public class DatabaseEngineVersionCheck : ForwardOnlyMigration
     {
         protected readonly Logger _logger;
 
@@ -20,11 +20,6 @@ namespace NzbDrone.Core.Datastore.Migration
         {
             IfDatabase("sqlite").Execute.WithConnection(LogSqliteVersion);
             IfDatabase("postgres").Execute.WithConnection(LogPostgresVersion);
-        }
-
-        public override void Down()
-        {
-            // No-op
         }
 
         private void LogSqliteVersion(IDbConnection conn, IDbTransaction tran)

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -6,7 +6,6 @@ using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Initialization;
 using FluentMigrator.Runner.Processors;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NLog;
 using NLog.Extensions.Logging;
 
@@ -20,13 +19,10 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
     public class MigrationController : IMigrationController
     {
         private readonly Logger _logger;
-        private readonly ILoggerProvider _migrationLoggerProvider;
 
-        public MigrationController(Logger logger,
-                                   ILoggerProvider migrationLoggerProvider)
+        public MigrationController(Logger logger)
         {
             _logger = logger;
-            _migrationLoggerProvider = migrationLoggerProvider;
         }
 
         public void Migrate(string connectionString, MigrationContext migrationContext, DatabaseType databaseType)
@@ -35,16 +31,13 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             _logger.Info("*** Migrating {0} ***", connectionString);
 
-            ServiceProvider serviceProvider;
-
             var db = databaseType == DatabaseType.SQLite ? "sqlite" : "postgres";
 
-            serviceProvider = new ServiceCollection()
+            var serviceProvider = new ServiceCollection()
                 .AddLogging(b => b.AddNLog())
                 .AddFluentMigratorCore()
                 .Configure<RunnerOptions>(cfg => cfg.IncludeUntaggedMaintenances = true)
-                .ConfigureRunner(
-                    builder => builder
+                .ConfigureRunner(builder => builder
                     .AddPostgres()
                     .AddNzbDroneSQLite()
                     .WithGlobalConnectionString(connectionString)

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationExtension.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationExtension.cs
@@ -4,9 +4,14 @@ using FluentMigrator.Builders.Create;
 using FluentMigrator.Builders.Create.Table;
 using FluentMigrator.Runner;
 using FluentMigrator.Runner.BatchParser;
+using FluentMigrator.Runner.Generators;
 using FluentMigrator.Runner.Generators.SQLite;
+using FluentMigrator.Runner.Initialization;
+using FluentMigrator.Runner.Processors;
 using FluentMigrator.Runner.Processors.SQLite;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace NzbDrone.Core.Datastore.Migration.Framework
 {
@@ -26,23 +31,40 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             return command;
         }
 
-        public static void AddParameter(this System.Data.IDbCommand command, object value)
+        public static void AddParameter(this IDbCommand command, object value)
         {
             var parameter = command.CreateParameter();
             parameter.Value = value;
             command.Parameters.Add(parameter);
         }
 
-        public static IMigrationRunnerBuilder AddNzbDroneSQLite(this IMigrationRunnerBuilder builder)
+        public static IMigrationRunnerBuilder AddNzbDroneSQLite(this IMigrationRunnerBuilder builder, bool binaryGuid = false, bool useStrictTables = false)
         {
             builder.Services
                 .AddTransient<SQLiteBatchParser>()
                 .AddScoped<SQLiteDbFactory>()
-                .AddScoped<NzbDroneSQLiteProcessor>()
+                .AddScoped<NzbDroneSQLiteProcessor>(sp =>
+                {
+                    var factory = sp.GetService<SQLiteDbFactory>();
+                    var logger = sp.GetService<ILogger<NzbDroneSQLiteProcessor>>();
+                    var options = sp.GetService<IOptionsSnapshot<ProcessorOptions>>();
+                    var connectionStringAccessor = sp.GetService<IConnectionStringAccessor>();
+                    var sqliteQuoter = new SQLiteQuoter(false);
+                    return new NzbDroneSQLiteProcessor(factory, sp.GetService<SQLiteGenerator>(), logger, options, connectionStringAccessor, sp, sqliteQuoter);
+                })
+                .AddScoped<ISQLiteTypeMap>(_ => new NzbDroneSQLiteTypeMap(useStrictTables))
                 .AddScoped<IMigrationProcessor>(sp => sp.GetRequiredService<NzbDroneSQLiteProcessor>())
-                .AddScoped<SQLiteQuoter>()
-                .AddScoped<SQLiteGenerator>()
+                .AddScoped(
+                    sp =>
+                    {
+                        var typeMap = sp.GetRequiredService<ISQLiteTypeMap>();
+                        return new SQLiteGenerator(
+                            new SQLiteQuoter(binaryGuid),
+                            typeMap,
+                            new OptionsWrapper<GeneratorOptions>(new GeneratorOptions()));
+                    })
                 .AddScoped<IMigrationGenerator>(sp => sp.GetRequiredService<SQLiteGenerator>());
+
             return builder;
         }
     }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSQLiteTypeMap.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSQLiteTypeMap.cs
@@ -1,0 +1,76 @@
+using System.Data;
+using FluentMigrator.Runner.Generators.Base;
+using FluentMigrator.Runner.Generators.SQLite;
+
+namespace NzbDrone.Core.Datastore.Migration.Framework;
+
+// Based on https://github.com/fluentmigrator/fluentmigrator/blob/v6.2.0/src/FluentMigrator.Runner.SQLite/Generators/SQLite/SQLiteTypeMap.cs
+public sealed class NzbDroneSQLiteTypeMap : TypeMapBase, ISQLiteTypeMap
+{
+    public bool UseStrictTables { get; }
+
+    public NzbDroneSQLiteTypeMap(bool useStrictTables = false)
+    {
+        UseStrictTables = useStrictTables;
+
+        SetupTypeMaps();
+    }
+
+    // Must be kept in sync with upstream
+    protected override void SetupTypeMaps()
+    {
+        SetTypeMap(DbType.Binary, "BLOB");
+        SetTypeMap(DbType.Byte, "INTEGER");
+        SetTypeMap(DbType.Int16, "INTEGER");
+        SetTypeMap(DbType.Int32, "INTEGER");
+        SetTypeMap(DbType.Int64, "INTEGER");
+        SetTypeMap(DbType.SByte, "INTEGER");
+        SetTypeMap(DbType.UInt16, "INTEGER");
+        SetTypeMap(DbType.UInt32, "INTEGER");
+        SetTypeMap(DbType.UInt64, "INTEGER");
+
+        if (!UseStrictTables)
+        {
+            SetTypeMap(DbType.Currency, "NUMERIC");
+            SetTypeMap(DbType.Decimal, "NUMERIC");
+            SetTypeMap(DbType.Double, "NUMERIC");
+            SetTypeMap(DbType.Single, "NUMERIC");
+            SetTypeMap(DbType.VarNumeric, "NUMERIC");
+            SetTypeMap(DbType.Date, "DATETIME");
+            SetTypeMap(DbType.DateTime, "DATETIME");
+            SetTypeMap(DbType.DateTime2, "DATETIME");
+            SetTypeMap(DbType.Time, "DATETIME");
+            SetTypeMap(DbType.Guid, "UNIQUEIDENTIFIER");
+
+            // Custom so that we can use DateTimeOffset in Postgres for appropriate DB typing
+            SetTypeMap(DbType.DateTimeOffset, "DATETIME");
+        }
+        else
+        {
+            SetTypeMap(DbType.Currency, "TEXT");
+            SetTypeMap(DbType.Decimal, "TEXT");
+            SetTypeMap(DbType.Double, "REAL");
+            SetTypeMap(DbType.Single, "REAL");
+            SetTypeMap(DbType.VarNumeric, "TEXT");
+            SetTypeMap(DbType.Date, "TEXT");
+            SetTypeMap(DbType.DateTime, "TEXT");
+            SetTypeMap(DbType.DateTime2, "TEXT");
+            SetTypeMap(DbType.Time, "TEXT");
+            SetTypeMap(DbType.Guid, "TEXT");
+
+            // Custom so that we can use DateTimeOffset in Postgres for appropriate DB typing
+            SetTypeMap(DbType.DateTimeOffset, "TEXT");
+        }
+
+        SetTypeMap(DbType.AnsiString, "TEXT");
+        SetTypeMap(DbType.String, "TEXT");
+        SetTypeMap(DbType.AnsiStringFixedLength, "TEXT");
+        SetTypeMap(DbType.StringFixedLength, "TEXT");
+        SetTypeMap(DbType.Boolean, "INTEGER");
+    }
+
+    public override string GetTypeMap(DbType type, int? size, int? precision)
+    {
+        return base.GetTypeMap(type, size: null, precision: null);
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSqliteProcessor.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneSqliteProcessor.cs
@@ -15,6 +15,8 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 {
     public class NzbDroneSQLiteProcessor : SQLiteProcessor
     {
+        private readonly SQLiteQuoter _quoter;
+
         public NzbDroneSQLiteProcessor(SQLiteDbFactory factory,
                                        SQLiteGenerator generator,
                                        ILogger<NzbDroneSQLiteProcessor> logger,
@@ -24,6 +26,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
                                        SQLiteQuoter quoter)
         : base(factory, generator, logger, options, connectionStringAccessor, serviceProvider, quoter)
         {
+            _quoter = quoter;
         }
 
         public override void Process(AlterColumnExpression expression)
@@ -35,10 +38,32 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             if (columnIndex == -1)
             {
-                throw new ApplicationException(string.Format("Column {0} does not exist on table {1}.", expression.Column.Name, expression.TableName));
+                throw new ApplicationException($"Column {expression.Column.Name} does not exist on table {expression.TableName}.");
             }
 
             columnDefinitions[columnIndex] = expression.Column;
+
+            tableDefinition.Columns = columnDefinitions;
+
+            ProcessAlterTable(tableDefinition);
+        }
+
+        public override void Process(AlterDefaultConstraintExpression expression)
+        {
+            var tableDefinition = GetTableSchema(expression.TableName);
+
+            var columnDefinitions = tableDefinition.Columns.ToList();
+            var columnIndex = columnDefinitions.FindIndex(c => c.Name == expression.ColumnName);
+
+            if (columnIndex == -1)
+            {
+                throw new ApplicationException($"Column {expression.ColumnName} does not exist on table {expression.TableName}.");
+            }
+
+            var changedColumn = columnDefinitions[columnIndex];
+            changedColumn.DefaultValue = expression.DefaultValue;
+
+            columnDefinitions[columnIndex] = changedColumn;
 
             tableDefinition.Columns = columnDefinitions;
 
@@ -62,7 +87,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             if (columnsToRemove.Any())
             {
-                throw new ApplicationException(string.Format("Column {0} does not exist on table {1}.", columnsToRemove.First(), expression.TableName));
+                throw new ApplicationException($"Column {columnsToRemove.First()} does not exist on table {expression.TableName}.");
             }
 
             ProcessAlterTable(tableDefinition);
@@ -78,12 +103,12 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             if (columnIndex == -1)
             {
-                throw new ApplicationException(string.Format("Column {0} does not exist on table {1}.", expression.OldName, expression.TableName));
+                throw new ApplicationException($"Column {expression.OldName} does not exist on table {expression.TableName}.");
             }
 
             if (columnDefinitions.Any(c => c.Name == expression.NewName))
             {
-                throw new ApplicationException(string.Format("Column {0} already exists on table {1}.", expression.NewName, expression.TableName));
+                throw new ApplicationException($"Column {expression.NewName} already exists on table {expression.TableName}.");
             }
 
             oldColumnDefinitions[columnIndex] = (ColumnDefinition)columnDefinitions[columnIndex].Clone();
@@ -128,21 +153,20 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
             }
 
             // What is the cleanest way to do this? Add function to Generator?
-            var quoter = new SQLiteQuoter();
-            var columnsToInsert = string.Join(", ", tableDefinition.Columns.Select(c => quoter.QuoteColumnName(c.Name)));
-            var columnsToFetch = string.Join(", ", (oldColumnDefinitions ?? tableDefinition.Columns).Select(c => quoter.QuoteColumnName(c.Name)));
+            var columnsToInsert = string.Join(", ", tableDefinition.Columns.Select(c => _quoter.QuoteColumnName(c.Name)));
+            var columnsToFetch = string.Join(", ", (oldColumnDefinitions ?? tableDefinition.Columns).Select(c => _quoter.QuoteColumnName(c.Name)));
 
-            Process(new CreateTableExpression() { TableName = tempTableName, Columns = tableDefinition.Columns.ToList() });
+            Process(new CreateTableExpression { TableName = tempTableName, Columns = tableDefinition.Columns.ToList() });
 
-            Process(string.Format("INSERT INTO {0} ({1}) SELECT {2} FROM {3}", quoter.QuoteTableName(tempTableName), columnsToInsert, columnsToFetch, quoter.QuoteTableName(tableName)));
+            Process($"INSERT INTO {_quoter.QuoteTableName(tempTableName)} ({columnsToInsert}) SELECT {columnsToFetch} FROM {_quoter.QuoteTableName(tableName)}");
 
-            Process(new DeleteTableExpression() { TableName = tableName });
+            Process(new DeleteTableExpression { TableName = tableName });
 
-            Process(new RenameTableExpression() { OldName = tempTableName, NewName = tableName });
+            Process(new RenameTableExpression { OldName = tempTableName, NewName = tableName });
 
             foreach (var index in tableDefinition.Indexes)
             {
-                Process(new CreateIndexExpression() { Index = index });
+                Process(new CreateIndexExpression { Index = index });
             }
         }
     }

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Servarr.FluentMigrator.Runner" Version="3.3.2.9" />
-    <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
-    <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
+    <PackageReference Include="FluentMigrator.Runner" Version="6.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
#### Description
Removing the dependency on a custom build of FluentMigrator by using a custom SQLiteTypeMap that contains a custom type map for DateTimeOffset.

- Why FM 6.2.0 and not latest 7.x? 6.x is the latest one working with Microsoft.Extensions.DependencyInjection 8.x, as 7.x releases require Microsoft.Extensions.DependencyInjection 9.x.
- Since 5.x CompatibilityMode is set to STRICT, so [no more silent failures](https://github.com/fluentmigrator/fluentmigrator/blob/1cb851622ab6f8e11f8fdf67a9804d0a75a8546b/src/FluentMigrator.Runner.Core/Generators/CompatibilityModeExtension.cs#L35-L43). 
- Sonarr doesn't require `AlterDefaultConstraintExpression` yet, but Radarr does so it's best to have it in upstream.