### PR TITLE
Bump coverlet.collector to official 6.0.4

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -84,8 +84,9 @@
 
     <Deterministic Condition="$(AssemblyVersion.EndsWith('*'))">False</Deterministic>
 
-    <PathMap>$(MSBuildProjectDirectory)=./$(MSBuildProjectName)/</PathMap>
+    <PathMap>$(MSBuildThisFileDirectory)=./</PathMap>
   </PropertyGroup>
+
   <!-- Set the AssemblyConfiguration attribute for projects -->
   <ItemGroup Condition="'$(SonarrProject)'=='true'">
     <AssemblyAttribute Include="System.Reflection.AssemblyConfigurationAttribute">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -122,14 +122,11 @@
 
   <!-- Standard testing packages -->
   <ItemGroup Condition="'$(TestProject)'=='true'">
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TestProject)'=='true' and '$(TargetFramework)'=='net8.0'">
-    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.27.ge7cb7c3b40" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(SonarrProject)'=='true' and '$(EnableAnalyzers)'=='false'">

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -5,7 +5,6 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-bsd-crossbuild" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/dotnet-bsd-crossbuild/nuget/v3/index.json" />
     <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
-    <add key="coverlet-nightly" value="https://pkgs.dev.azure.com/Servarr/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json" />
     <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/coverlet.runsettings
+++ b/src/coverlet.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
-          <Format>opencover</Format>
+          <Format>cobertura</Format>
           <Exclude>[Sonarr.*.Test]*,[Sonarr.Test.*]*,[Sonarr.Api*]*</Exclude>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
Switch from custom build.

- https://github.com/OpenCover/opencover is not a thing anymore.
- Avoid changing file paths with project names.