### PR TITLE
Fix modal widths on some screen sizes

### DIFF
--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -20,6 +20,7 @@
   position: relative;
   display: flex;
   max-height: 90%;
+  max-width: 90%;
   border-radius: 6px;
   opacity: 1;
 }

--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -19,8 +19,8 @@
 .modal {
   position: relative;
   display: flex;
-  max-height: 90%;
   max-width: 90%;
+  max-height: 90%;
   border-radius: 6px;
   opacity: 1;
 }


### PR DESCRIPTION
#### Description
Add a max width to the base modal CSS class. This prevents the fixed-width modals from being too large on some screen sizes.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
![Pre-Fix](https://github.com/user-attachments/assets/cbb98b1a-bb3f-4a73-939b-f5b0dce187d7)
![After-Fix](https://github.com/user-attachments/assets/1012dd04-5f86-481b-a277-d59a0e1e1d89)

#### Database Migration
No

#### Issues Fixed or Closed by this PR
* Closes #8085 
