### PR TITLE
Adjust series details title line height to account for descenders

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -57,11 +57,12 @@
 
 .title {
   overflow: auto;
-  max-height: calc(3 * 50px);
+  max-height: calc(3 * 60px);
   text-wrap: balance;
   font-weight: 300;
   font-size: 50px;
-  line-height: 50px;
+  line-height: 60px;
+  -webkit-line-clamp: 3;
   line-clamp: 3;
 }
 
@@ -82,6 +83,7 @@
 
 .alternateTitlesIconContainer {
   align-self: flex-end;
+  margin-bottom: 10px;
   margin-left: 20px;
 }
 


### PR DESCRIPTION
#### Description

My FF 143.0.1 was mostly happy with things as it was before, but was showing a scroller when text had descenders.

A few things here:

1. The line height/maximum height didn't account for descenders, which wasn't a problem for Silo, but was for other things, it needs to be around 58px.
2. `line-clamp` support in FF exists, but only with the `-webkit` prefix, so I've included that
3. The alternate titles anchor needed to be adjusted up, it was a little low at 50px line height, but really low at 60px.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
<img width="1129" height="427" alt="image" src="https://github.com/user-attachments/assets/279f27af-85e7-4f7c-94d5-1f03f54c1853" />