### PR TITLE
New: Bump minimum Postgres version to 15 for FluentMigrator 

### DIFF
--- a/src/NzbDrone.Core.Test/Datastore/Migration/071_unknown_quality_in_profileFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/071_unknown_quality_in_profileFixture.cs
@@ -18,7 +18,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = new List<object>

--- a/src/NzbDrone.Core.Test/Datastore/Migration/101_add_ultrahd_quality_in_profilesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/101_add_ultrahd_quality_in_profilesFixture.cs
@@ -16,7 +16,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = "[ { \"quality\": 1, \"allowed\": true } ]",

--- a/src/NzbDrone.Core.Test/Datastore/Migration/117_add_webrip_qualites_in_profileFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/117_add_webrip_qualites_in_profileFixture.cs
@@ -22,7 +22,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = $"[{GenerateQualityJson(1, true)}, {GenerateQualityJson((int)Quality.WEBRip480p, false)}, {GenerateQualityJson((int)Quality.WEBRip720p, false)}, {GenerateQualityJson((int)Quality.WEBRip1080p, false)}, {GenerateQualityJson((int)Quality.WEBRip2160p, false)}]"
@@ -45,7 +44,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = $"[{GenerateQualityJson(1, true)}, {GenerateQualityJson((int)Quality.DVD, false)}, {GenerateQualityJson((int)Quality.Bluray480p, false)}]"
@@ -68,7 +66,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = $"[{GenerateQualityJson(1, true)}, {GenerateQualityJson((int)Quality.WEBRip480p, false)}, {GenerateQualityJson((int)Quality.WEBRip720p, false)}, {GenerateQualityJson((int)Quality.WEBRip1080p, false)}]"
@@ -91,7 +88,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "SDTV",
                     Cutoff = 1,
                     Items = $"[{GenerateQualityJson(1, true)}, {GenerateQualityJson((int)Quality.WEBRip480p, false)}, {GenerateQualityJson((int)Quality.WEBRip720p, false)}, {GenerateQualityJson((int)Quality.WEBRip1080p, false)}, {GenerateQualityJson((int)Quality.WEBRip2160p, false)}]"

--- a/src/NzbDrone.Core.Test/Datastore/Migration/122_add_remux_qualities_in_profileFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/122_add_remux_qualities_in_profileFixture.cs
@@ -16,7 +16,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("Profiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = "[ { \"quality\": 7, \"allowed\": true }, { \"quality\": 19, \"allowed\": true } ]"
@@ -38,12 +37,11 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             var db = WithMigrationTestDb(c =>
             {
                 c.Insert.IntoTable("Profiles").Row(new
-                                                   {
-                                                       Id = 0,
-                                                       Name = "Bluray",
-                                                       Cutoff = 7,
-                                                       Items = "[ { \"id\": 1001, \"name\": \"Why?!\", \"allowed\": true, \"items\": [{ \"quality\": 8, \"allowed\": true }, { \"quality\": 7, \"allowed\": true }] }, { \"quality\": 19, \"allowed\": true } ]"
-                                                   });
+                {
+                    Name = "Bluray",
+                    Cutoff = 7,
+                    Items = "[ { \"id\": 1001, \"name\": \"Why?!\", \"allowed\": true, \"items\": [{ \"quality\": 8, \"allowed\": true }, { \"quality\": 7, \"allowed\": true }] }, { \"quality\": 19, \"allowed\": true } ]"
+                });
             });
 
             var profiles = db.Query<Profile122>("SELECT \"Items\" FROM \"Profiles\" LIMIT 1");

--- a/src/NzbDrone.Core.Test/Datastore/Migration/148_mediainfo_channel_propertiesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/148_mediainfo_channel_propertiesFixture.cs
@@ -11,12 +11,11 @@ namespace NzbDrone.Core.Test.Datastore.Migration
     [TestFixture]
     public class mediainfo_channel_propertiesFixture : MigrationTest<mediainfo_channels>
     {
-        private void AddEpisodeFile(mediainfo_channels m, int id)
+        private void AddEpisodeFile(mediainfo_channels m, int seriesId)
         {
             var episode = new
             {
-                Id = id,
-                SeriesId = id,
+                SeriesId = seriesId,
                 Quality = new { }.ToJson(),
                 Size = 0,
                 DateAdded = DateTime.UtcNow,

--- a/src/NzbDrone.Core.Test/Datastore/Migration/198_parse_titles_from_existing_subtitle_filesFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/198_parse_titles_from_existing_subtitle_filesFixture.cs
@@ -60,7 +60,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
 
                 c.Insert.IntoTable("EpisodeFiles").Row(new
                 {
-                    Id = 1,
                     SeriesId = 1,
                     RelativePath = episodePath,
                     Quality = new { }.ToJson(),

--- a/src/NzbDrone.Core.Test/Datastore/Migration/210_add_monitored_seasons_filterFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/210_add_monitored_seasons_filterFixture.cs
@@ -30,7 +30,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -67,7 +66,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -104,7 +102,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -141,7 +138,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -178,7 +174,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -215,7 +210,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -252,7 +246,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -295,7 +288,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString
@@ -335,7 +327,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("CustomFilters").Row(new
                 {
-                    Id = 1,
                     Type = "series",
                     Label = "Is Both",
                     Filters = filtersString

--- a/src/NzbDrone.Core.Test/Datastore/Migration/215_add_blurary576p_quality_in_profiles_with_grouped_blurary480pFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/215_add_blurary576p_quality_in_profiles_with_grouped_blurary480pFixture.cs
@@ -27,7 +27,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("QualityProfiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = $"[{GenerateQualityJson((int)Quality.DVD, true)}, {GenerateQualityJson((int)Quality.Bluray480p, true)}, {GenerateQualityJson((int)Quality.Bluray720p, false)}]"
@@ -50,7 +49,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("QualityProfiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = $"[{GenerateQualityJson((int)Quality.DVD, true)}, {GenerateQualityJson((int)Quality.Bluray480p, false)}, {GenerateQualityJson((int)Quality.Bluray720p, false)}]"
@@ -73,7 +71,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("QualityProfiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = $"[{GenerateQualityGroupJson(1000, "DVD", new[] { (int)Quality.DVD, (int)Quality.Bluray480p }, true)}, {GenerateQualityJson((int)Quality.Bluray720p, false)}]"
@@ -97,7 +94,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("QualityProfiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = $"[{GenerateQualityJson((int)Quality.DVD, true)}, {GenerateQualityJson((int)Quality.Bluray480p, false)}, {GenerateQualityJson((int)Quality.Bluray576p, false)}, {GenerateQualityJson((int)Quality.Bluray720p, false)}]"
@@ -120,7 +116,6 @@ namespace NzbDrone.Core.Test.Datastore.Migration
             {
                 c.Insert.IntoTable("QualityProfiles").Row(new
                 {
-                    Id = 0,
                     Name = "Bluray",
                     Cutoff = 7,
                     Items = $"[{GenerateQualityGroupJson(1000, "DVD", new[] { (int)Quality.DVD, (int)Quality.Bluray480p, (int)Quality.Bluray576p }, true)}, {GenerateQualityJson((int)Quality.Bluray720p, false)}]"

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -18,8 +18,8 @@ namespace NzbDrone.Core.Datastore.Migration
 
         public override void Up()
         {
-            IfDatabase("sqlite").Execute.WithConnection(LogSqliteVersion);
-            IfDatabase("postgresql").Execute.WithConnection(LogPostgresVersion);
+            IfDatabase(ProcessorId.SQLite).Execute.WithConnection(LogSqliteVersion);
+            IfDatabase(ProcessorId.PostgreSQL).Execute.WithConnection(LogPostgresVersion);
         }
 
         private void LogSqliteVersion(IDbConnection conn, IDbTransaction tran)

--- a/src/NzbDrone.Core/Datastore/Migration/184_remove_invalid_roksbox_metadata_images.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/184_remove_invalid_roksbox_metadata_images.cs
@@ -8,8 +8,8 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            IfDatabase("sqlite").Execute.Sql("DELETE FROM \"MetadataFiles\" WHERE \"Consumer\" = 'RoksboxMetadata' AND \"Type\" = 5 AND (\"RelativePath\" LIKE '%/metadata/%' OR \"RelativePath\" LIKE '%\\metadata\\%')");
-            IfDatabase("postgresql").Execute.Sql("DELETE FROM \"MetadataFiles\" WHERE \"Consumer\" = 'RoksboxMetadata' AND \"Type\" = 5 AND (\"RelativePath\" LIKE '%/metadata/%' OR \"RelativePath\" LIKE '%\\\\metadata\\\\%')");
+            IfDatabase(ProcessorId.SQLite).Execute.Sql("DELETE FROM \"MetadataFiles\" WHERE \"Consumer\" = 'RoksboxMetadata' AND \"Type\" = 5 AND (\"RelativePath\" LIKE '%/metadata/%' OR \"RelativePath\" LIKE '%\\metadata\\%')");
+            IfDatabase(ProcessorId.PostgreSQL).Execute.Sql("DELETE FROM \"MetadataFiles\" WHERE \"Consumer\" = 'RoksboxMetadata' AND \"Type\" = 5 AND (\"RelativePath\" LIKE '%/metadata/%' OR \"RelativePath\" LIKE '%\\\\metadata\\\\%')");
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/192_import_exclusion_type.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/192_import_exclusion_type.cs
@@ -8,10 +8,10 @@ namespace NzbDrone.Core.Datastore.Migration
     {
         protected override void MainDbUpgrade()
         {
-            IfDatabase("sqlite").Alter.Table("ImportListExclusions").AlterColumn("TvdbId").AsInt32();
+            IfDatabase(ProcessorId.SQLite).Alter.Table("ImportListExclusions").AlterColumn("TvdbId").AsInt32();
 
             // PG cannot autocast varchar to integer
-            IfDatabase("postgresql").Execute.Sql("ALTER TABLE \"ImportListExclusions\" ALTER COLUMN \"TvdbId\" TYPE INTEGER USING \"TvdbId\"::integer");
+            IfDatabase(ProcessorId.PostgreSQL).Execute.Sql("ALTER TABLE \"ImportListExclusions\" ALTER COLUMN \"TvdbId\" TYPE INTEGER USING \"TvdbId\"::integer");
         }
     }
 }

--- a/src/NzbDrone.Test.Common/Datastore/PostgresDatabase.cs
+++ b/src/NzbDrone.Test.Common/Datastore/PostgresDatabase.cs
@@ -50,7 +50,8 @@ namespace NzbDrone.Test.Common.Datastore
                 Port = options.Port,
                 Username = options.User,
                 Password = options.Password,
-                Enlist = false
+                Enlist = false,
+                IncludeErrorDetail = true,
             };
 
             return builder.ConnectionString;


### PR DESCRIPTION
Fixed the database migration fixtures to use generated values.

This should allow the bump to FM 7 with only a few changes.