### PR TITLE
Remove redundant code in selecting with click on poster

### DIFF
--- a/frontend/src/Series/Index/Overview/SeriesIndexOverview.tsx
+++ b/frontend/src/Series/Index/Overview/SeriesIndexOverview.tsx
@@ -144,7 +144,10 @@ function SeriesIndexOverview(props: SeriesIndexOverviewProps) {
         <div className={styles.poster}>
           <div className={styles.posterContainer}>
             {isSelectMode ? (
-              <SeriesIndexPosterSelect seriesId={seriesId} />
+              <SeriesIndexPosterSelect
+                seriesId={seriesId}
+                titleSlug={titleSlug}
+              />
             ) : null}
 
             {status === 'ended' ? (

--- a/frontend/src/Series/Index/Posters/SeriesIndexPoster.tsx
+++ b/frontend/src/Series/Index/Posters/SeriesIndexPoster.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import React, { SyntheticEvent, useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useSelect } from 'App/SelectContext';
 import { REFRESH_SERIES, SERIES_SEARCH } from 'Commands/commandNames';
 import Label from 'Components/Label';
 import IconButton from 'Components/Link/IconButton';
@@ -123,30 +122,7 @@ function SeriesIndexPoster(props: SeriesIndexPosterProps) {
     setIsDeleteSeriesModalOpen(false);
   }, [setIsDeleteSeriesModalOpen]);
 
-  const [selectState, selectDispatch] = useSelect();
-
-  const onSelectPress = useCallback(
-    (event: SyntheticEvent<HTMLElement, MouseEvent>) => {
-      if (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey) {
-        window.open(`/series/${titleSlug}`, '_blank');
-        return;
-      }
-
-      const shiftKey = event.nativeEvent.shiftKey;
-
-      selectDispatch({
-        type: 'toggleSelected',
-        id: seriesId,
-        isSelected: !selectState.selectedState[seriesId],
-        shiftKey,
-      });
-    },
-    [seriesId, selectState.selectedState, selectDispatch, titleSlug]
-  );
-
   const link = `/series/${titleSlug}`;
-
-  const linkProps = isSelectMode ? { onPress: onSelectPress } : { to: link };
 
   const elementStyle = {
     width: `${posterWidth}px`,
@@ -156,7 +132,9 @@ function SeriesIndexPoster(props: SeriesIndexPosterProps) {
   return (
     <div className={styles.content}>
       <div className={styles.posterContainer} title={title}>
-        {isSelectMode ? <SeriesIndexPosterSelect seriesId={seriesId} /> : null}
+        {isSelectMode ? (
+          <SeriesIndexPosterSelect seriesId={seriesId} titleSlug={titleSlug} />
+        ) : null}
 
         <Label className={styles.controls}>
           <SpinnerIconButton
@@ -199,7 +177,7 @@ function SeriesIndexPoster(props: SeriesIndexPosterProps) {
           />
         ) : null}
 
-        <Link className={styles.link} style={elementStyle} {...linkProps}>
+        <Link className={styles.link} style={elementStyle} to={link}>
           <SeriesPoster
             style={elementStyle}
             images={images}

--- a/frontend/src/Series/Index/Select/SeriesIndexPosterSelect.css
+++ b/frontend/src/Series/Index/Select/SeriesIndexPosterSelect.css
@@ -3,8 +3,8 @@
   top: 0;
   left: 0;
   z-index: 3;
-  width: 36px;
-  height: 36px;
+  width: 100%;
+  height: 100%;
 }
 
 .checkContainer {

--- a/frontend/src/Series/Index/Select/SeriesIndexPosterSelect.tsx
+++ b/frontend/src/Series/Index/Select/SeriesIndexPosterSelect.tsx
@@ -7,15 +7,23 @@ import styles from './SeriesIndexPosterSelect.css';
 
 interface SeriesIndexPosterSelectProps {
   seriesId: number;
+  titleSlug: string;
 }
 
-function SeriesIndexPosterSelect(props: SeriesIndexPosterSelectProps) {
-  const { seriesId } = props;
+function SeriesIndexPosterSelect({
+  seriesId,
+  titleSlug,
+}: SeriesIndexPosterSelectProps) {
   const [selectState, selectDispatch] = useSelect();
   const isSelected = selectState.selectedState[seriesId];
 
   const onSelectPress = useCallback(
     (event: SyntheticEvent<HTMLElement, PointerEvent>) => {
+      if (event.nativeEvent.ctrlKey || event.nativeEvent.metaKey) {
+        window.open(`${window.Sonarr.urlBase}/series/${titleSlug}`, '_blank');
+        return;
+      }
+
       const shiftKey = event.nativeEvent.shiftKey;
 
       selectDispatch({
@@ -25,7 +33,7 @@ function SeriesIndexPosterSelect(props: SeriesIndexPosterSelectProps) {
         shiftKey,
       });
     },
-    [seriesId, isSelected, selectDispatch]
+    [seriesId, titleSlug, isSelected, selectDispatch]
   );
 
   return (


### PR DESCRIPTION
Mainly removing duplicated logic, with a fix to use the urlbase to avoid relying on the redirect from `/`.