### PR TITLE
Fixed: Validation for SSL certificate file existence

### DIFF
--- a/src/Sonarr.Api.V3/Config/HostConfigController.cs
+++ b/src/Sonarr.Api.V3/Config/HostConfigController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
@@ -25,7 +26,7 @@ namespace Sonarr.Api.V3.Config
         public HostConfigController(IConfigFileProvider configFileProvider,
                                     IConfigService configService,
                                     IUserService userService,
-                                    FileExistsValidator fileExistsValidator)
+                                    IDiskProvider diskProvider)
         {
             _configFileProvider = configFileProvider;
             _configService = configService;
@@ -59,14 +60,14 @@ namespace Sonarr.Api.V3.Config
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .IsValidPath()
-                .SetValidator(fileExistsValidator)
+                .SetValidator(new FileExistsValidator(diskProvider))
                 .IsValidCertificate()
                 .When(c => c.EnableSsl);
 
             SharedValidator.RuleFor(c => c.SslKeyPath)
                 .NotEmpty()
                 .IsValidPath()
-                .SetValidator(fileExistsValidator)
+                .SetValidator(new FileExistsValidator(diskProvider))
                 .When(c => c.SslKeyPath.IsNotNullOrWhiteSpace());
 
             SharedValidator.RuleFor(c => c.LogSizeLimit).InclusiveBetween(1, 10);


### PR DESCRIPTION
I was testing a4a18d6121c179f87d67cf2268be32c3b290320a and I was getting a file not found exception from `X509Certificate2.GetCertContentType(certPath);` returning a 500 error and not showing anything in the UI. 

I noticed we have `FileExistsValidator`, but for some reason when it's used with DI it doesn't trigger at all. 

Feel free to test it out on your system as well.

https://redirect.github.com/FluentValidation/FluentValidation/issues/1572#issuecomment-722927849:
> PropertyValidator must be instantiated uniquely each time they are used. They are stateful and hold information that is unique per rule.
