### PR TITLE
Switch to FluentMigrator.Runner.Core to avoid extranous platform runners

### DIFF
--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="FluentMigrator.Runner" Version="6.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />


### PR DESCRIPTION
```diff
-FirebirdSql.Data.FirebirdClient                              10.3.1               dotnet  (+5 duplicates)
 FluentMigrator                                               6.2.0                dotnet  (+5 duplicates)
 FluentMigrator.Abstractions                                  6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Extensions.MySql                              6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Extensions.Oracle                             6.2.0                dotnet  (+5 duplicates)
 FluentMigrator.Extensions.Postgres                           6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Extensions.Snowflake                          6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Extensions.SqlServer                          6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner                                        6.2.0                dotnet  (+5 duplicates)
 FluentMigrator.Runner.Core                                   6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Db2                                    6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Firebird                               6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Hana                                   6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.MySql                                  6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Oracle                                 6.2.0                dotnet  (+5 duplicates)
 FluentMigrator.Runner.Postgres                               6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Redshift                               6.2.0                dotnet  (+5 duplicates)
 FluentMigrator.Runner.SQLite                                 6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.Snowflake                              6.2.0                dotnet  (+5 duplicates)
-FluentMigrator.Runner.SqlServer                              6.2.0                dotnet  (+5 duplicates)
 FluentValidation                                             9.5.4                dotnet  (+5 duplicates
```