### PR TITLE
Fixed: qBittorrent /login API success check

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -434,8 +434,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
                 catch (HttpException ex)
                 {
-                    _logger.Debug("qbitTorrent authentication failed.");
-                    if (ex.Response.StatusCode == HttpStatusCode.Forbidden)
+                    _logger.Debug(ex, "qbitTorrent authentication failed.");
+                    if (ex.Response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                     {
                         throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);
                     }
@@ -447,7 +447,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     throw new DownloadClientUnavailableException("Failed to connect to qBittorrent, please check your settings.", ex);
                 }
 
-                if (response.Content != "Ok.")
+                if (response.Content.IsNotNullOrWhiteSpace() && response.Content != "Ok.")
                 {
                     // returns "Fails." on bad login
                     _logger.Debug("qbitTorrent authentication failed.");


### PR DESCRIPTION
#### Description
qBittorrent has recently pushed an update to their /login API which caused Radarr authentication check to fail. This change handles both the old and the new authentication response.

More info of qBittorrent change here:
https://github.com/qbittorrent/qBittorrent/pull/23202

Discussion on this fix here:
https://github.com/Radarr/Radarr/pull/11258
