### PR TITLE
Fallback to host sqlite3 on FreeBSD and Linux

### DIFF
--- a/src/NzbDrone.Common/Composition/AssemblyLoader.cs
+++ b/src/NzbDrone.Common/Composition/AssemblyLoader.cs
@@ -69,11 +69,19 @@ namespace NzbDrone.Common.Composition
 
         private static IntPtr LoadNativeLib(string libraryName, Assembly assembly, DllImportSearchPath? dllImportSearchPath)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(libraryName);
+
             var mappedName = libraryName;
-            if (OsInfo.IsLinux)
+
+            if (libraryName is "sqlite3" or "e_sqlite3")
             {
-                if (libraryName == "sqlite3")
+                if (OsInfo.IsLinux)
                 {
+                    if (NativeLibrary.TryLoad(libraryName, assembly, dllImportSearchPath, out var libHandle))
+                    {
+                        return libHandle;
+                    }
+
                     mappedName = "libsqlite3.so.0";
                 }
             }


### PR DESCRIPTION
#### Description
Fix for FreeBSD due to lack of a runtime in https://nuget.info/packages/SourceGear.sqlite3.

We attempt to load the library requested, as it's available for linux runtimes in SourceGear.sqlite3, with fallback to `libsqlite3.so.0` which should be available from `sqlite-libs` package.