### PR TITLE
New: Ignore torrents from Flood with matching Post-Import Tags

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -116,9 +116,14 @@ namespace NzbDrone.Core.Download.Clients.Flood
                     continue;
                 }
 
+                if (Settings.PostImportTags.All(tag => properties.Tags.Contains(tag)))
+                {
+                    continue;
+                }
+
                 var item = new DownloadClientItem
                 {
-                    DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, false),
+                    DownloadClientInfo = DownloadClientItemClientInfo.FromDownloadClient(this, Settings.PostImportTags.Any()),
                     DownloadId = torrent.Key,
                     Title = properties.Name,
                     OutputPath = _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(properties.Directory)),

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Download.Clients.Flood.Models;
 using NzbDrone.Core.Validation;
@@ -13,6 +14,9 @@ namespace NzbDrone.Core.Download.Clients.Flood
         {
             RuleFor(c => c.Host).ValidHost();
             RuleFor(c => c.Port).InclusiveBetween(1, 65535);
+            RuleFor(c => c.PostImportTags)
+                .Must((settings, postImportTags) => postImportTags.Intersect(settings.Tags).Empty())
+                .WithMessage("Post-Import Tags must not include any tags in the Tags list.");
         }
     }
 

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -450,7 +450,7 @@
   "DownloadClientFloodSettingsAdditionalTags": "Additional Tags",
   "DownloadClientFloodSettingsAdditionalTagsHelpText": "Adds properties of media as tags. Hints are examples.",
   "DownloadClientFloodSettingsPostImportTags": "Post-Import Tags",
-  "DownloadClientFloodSettingsPostImportTagsHelpText": "Appends tags after a download is imported.",
+  "DownloadClientFloodSettingsPostImportTagsHelpText": "Appends tags after a download is imported. Torrents with all these tags will be filtered from the queue and will not removed automatically.",
   "DownloadClientFloodSettingsRemovalInfo": "{appName} will handle automatic removal of torrents based on the current seed criteria in Settings -> Indexers",
   "DownloadClientFloodSettingsStartOnAdd": "Start on Add",
   "DownloadClientFloodSettingsTagsHelpText": "Initial tags of a download. To be recognized, a download must have all initial tags. This avoids conflicts with unrelated downloads.",


### PR DESCRIPTION
#### Description

Untested the Flood integration, but the approach matches other clients, using multiple tags instead of a single label.

#### Issues Fixed or Closed by this PR
* Closes #8147

