### PR TITLE
New: Improve Plex auth for Cross-Origin-Opener-Policy  support

### DIFF
--- a/frontend/src/oauth.html
+++ b/frontend/src/oauth.html
@@ -1,11 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>OAuth landing page</title>
-    <script><!--
-    	window.opener.onCompleteOauth(window.location.search, function() { window.close(); });
-    --></script>
+    <script>
+      <!--
+      if (window.opener && window.opener.onCompleteOauth) {
+        window.opener.onCompleteOauth(window.location.search, function () {
+          window.close();
+        });
+      } else {
+        window.close();
+      }
+      -->
+    </script>
   </head>
   <body>
     Shouldn't see this

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexImport.cs
@@ -81,6 +81,22 @@ namespace NzbDrone.Core.ImportLists.Plex
 
                 return _plexTvService.GetSignInUrl(query["callbackUrl"], Convert.ToInt32(query["id"]), query["code"]);
             }
+            else if (action == "pollOAuth")
+            {
+                Settings.Validate().Filter("ConsumerKey", "ConsumerSecret").ThrowOnError();
+
+                if (query["pinId"].IsNullOrWhiteSpace())
+                {
+                    throw new BadRequestException("QueryParam pinId invalid.");
+                }
+
+                var authToken = _plexTvService.GetAuthToken(Convert.ToInt32(query["pinId"]));
+
+                return new
+                {
+                    success = authToken.IsNotNullOrWhiteSpace()
+                };
+            }
             else if (action == "getOAuthToken")
             {
                 Settings.Validate().Filter("ConsumerKey", "ConsumerSecret").ThrowOnError();

--- a/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvPinUrlResponse.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvPinUrlResponse.cs
@@ -4,6 +4,7 @@ namespace NzbDrone.Core.Notifications.Plex.PlexTv
 {
     public class PlexTvPinUrlResponse
     {
+        public bool Poll { get; set; }
         public string Url { get; set; }
         public string Method => "POST";
         public Dictionary<string, string> Headers { get; set; }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvService.cs
@@ -52,6 +52,7 @@ namespace NzbDrone.Core.Notifications.Plex.PlexTv
 
             return new PlexTvPinUrlResponse
                    {
+                       Poll = true,
                        Url = request.Url.ToString(),
                        Headers = request.Headers.ToDictionary(h => h.Key, h => h.Value)
                    };

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
@@ -128,6 +128,22 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
                 return _plexTvService.GetSignInUrl(query["callbackUrl"], Convert.ToInt32(query["id"]), query["code"]);
             }
+            else if (action == "pollOAuth")
+            {
+                Settings.Validate().Filter("ConsumerKey", "ConsumerSecret").ThrowOnError();
+
+                if (query["pinId"].IsNullOrWhiteSpace())
+                {
+                    throw new BadRequestException("QueryParam pinId invalid.");
+                }
+
+                var authToken = _plexTvService.GetAuthToken(Convert.ToInt32(query["pinId"]));
+
+                return new
+                {
+                    success = authToken.IsNotNullOrWhiteSpace()
+                };
+            }
             else if (action == "getOAuthToken")
             {
                 Settings.Validate().Filter("ConsumerKey", "ConsumerSecret").ThrowOnError();


### PR DESCRIPTION
#### Description

When Plex rolled out a change for auth and started including a `Cross-Origin-Opener-Policy` header it lead to auth issues, we can avoid this being an issue for future changes by polling instead of communicating between tabs.

This should also fix whatever Safari broke in the linked issue, but OAuth for other services may still be restricted.

#### Issues Fixed or Closed by this PR
* Closes #8126
