### PR TITLE
Fixed: Testing qBittorrent after credentials change would always pass tests

### DIFF
--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -28,6 +28,7 @@ namespace NzbDrone.Common.Http
         public TimeSpan RateLimit { get; set; }
         public bool LogResponseContent { get; set; }
         public ICredentials NetworkCredential { get; set; }
+        public bool StoreRequestCookie { get; set; }
         public Dictionary<string, string> Cookies { get; private set; }
         public List<HttpFormData> FormData { get; private set; }
         public Action<HttpRequest> PostProcess { get; set; }
@@ -44,6 +45,7 @@ namespace NzbDrone.Common.Http
             Cookies = new Dictionary<string, string>();
             FormData = new List<HttpFormData>();
             LogHttpError = true;
+            StoreRequestCookie = true;
         }
 
         public HttpRequestBuilder(bool useHttps, string host, int port, string urlBase = null)
@@ -111,6 +113,7 @@ namespace NzbDrone.Common.Http
             request.RateLimit = RateLimit;
             request.LogResponseContent = LogResponseContent;
             request.Credentials = NetworkCredential;
+            request.StoreRequestCookie = StoreRequestCookie;
 
             foreach (var header in Headers)
             {

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -352,7 +352,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             var requestBuilder = new HttpRequestBuilder(settings.UseSsl, settings.Host, settings.Port, settings.UrlBase)
             {
                 LogResponseContent = true,
-                NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password)
+                StoreRequestCookie = false
             };
             return requestBuilder;
         }
@@ -413,7 +413,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 return;
             }
 
-            var authKey = string.Format("{0}:{1}", requestBuilder.BaseUrl, settings.Password);
+            var authKey = $"{requestBuilder.BaseUrl}:{settings.Username}:{settings.Password}";
 
             var cookies = _authCookieCache.Find(authKey);
 
@@ -421,7 +421,10 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 _authCookieCache.Remove(authKey);
 
-                var authLoginRequest = BuildRequest(settings).Resource("/api/v2/auth/login")
+                var authRequestBuilder = BuildRequest(settings);
+                authRequestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
+
+                var authLoginRequest = authRequestBuilder.Resource("/api/v2/auth/login")
                                                              .Post()
                                                              .AddFormParameter("username", settings.Username ?? string.Empty)
                                                              .AddFormParameter("password", settings.Password ?? string.Empty)


### PR DESCRIPTION
#### Description

This was due to `HttpClient` storing the auth cookie for qbit along with the qbit proxy storing it, when we didn't include the cookie it was automatically added by `HttpClient`. Requests for qbit will now explicitly exclude storing cookies so this doesn't continue to happen. I also adjusted how we track which auth cookie to use for qbit by host/username/password, instead of just host and password and we'll only send network credentials for login requests.

#### Issues Fixed or Closed by this PR
* Closes #8187

