### PR TITLE
Bump Sentry to 5.16.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -109,10 +109,6 @@
     <SentryUrl></SentryUrl> <!--  If empty, assumed to be sentry.io -->
     <SentryAuthToken></SentryAuthToken> <!-- Use env var instead: SENTRY_AUTH_TOKEN -->
 
-    <!-- Upload PDBs to Sentry, enabling stack traces with line numbers and file paths
-      without the need to deploy the application with PDBs -->
-    <SentryUploadSymbols>true</SentryUploadSymbols>
-
     <!-- Source Link settings -->
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.2" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.15" />
-    <PackageReference Include="Sentry" Version="4.0.2" />
+    <PackageReference Include="Sentry" Version="5.16.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.2" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">

--- a/src/Sonarr.Api.V5/Queue/QueueStatusController.cs
+++ b/src/Sonarr.Api.V5/Queue/QueueStatusController.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using NzbDrone.Common.TPL;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.Download.Pending;
 using NzbDrone.Core.Download.TrackedDownloads;
@@ -8,6 +7,7 @@ using NzbDrone.Core.Queue;
 using NzbDrone.SignalR;
 using Sonarr.Http;
 using Sonarr.Http.REST;
+using Debouncer = NzbDrone.Common.TPL.Debouncer;
 
 namespace Sonarr.Api.V5.Queue
 {


### PR DESCRIPTION
4.0.2 is deprecated. See https://www.nuget.org/packages/Sentry/4.0.2 
