### PR TITLE
Tiny capitalization change to loading message

### DIFF
--- a/frontend/src/Components/Loading/LoadingMessage.tsx
+++ b/frontend/src/Components/Loading/LoadingMessage.tsx
@@ -15,7 +15,7 @@ const messages = [
   "Don't forget to rewind your episodes",
   'Congratulations! You are the 1000th visitor.',
   "HELP! I'm being held hostage and forced to write these stupid lines!",
-  'RE-calibrating the internet...',
+  'Re-calibrating the internet...',
   "I'll be here all week",
   "Don't forget to tip your waitress",
   'Apply directly to the forehead',


### PR DESCRIPTION
#### Description
This is such a nitpick, but I see it every so often and it bothered me enough that I finally decided to make a PR for the dang thing. If this isn't worth it, feel free to close and I'll just wallow in my own irritation lol.

There's a loading message that says "RE-calibrating the internet...". That should be "Re-calibrating".

#### Screenshots for UI Changes
<img width="992" height="339" alt="image" src="https://github.com/user-attachments/assets/6b8da16e-3467-4c5a-967a-ae728edeb072" />