### PR TITLE
Fixed WantMoreControlAddACustomFormat settings/customformats for Span…

### DIFF
--- a/src/NzbDrone.Core/Localization/Core/es.json
+++ b/src/NzbDrone.Core/Localization/Core/es.json
@@ -2195,7 +2195,7 @@
     "VisitTheWikiForMoreDetails": "Visita la wiki para más detalles: ",
     "WaitingToImport": "Esperar para importar",
     "WaitingToProcess": "Esperar al proceso",
-    "WantMoreControlAddACustomFormat": "¿Quieres más control sobre qué descargas son preferidas? Añade un [formato personalizado](/opciones/formatospersonalizados)",
+    "WantMoreControlAddACustomFormat": "¿Quieres más control sobre qué descargas son preferidas? Añade un [formato personalizado](/settings/customformats)",
     "Wanted": "Buscado",
     "Warn": "Advertencia",
     "Warning": "Aviso",


### PR DESCRIPTION
…ish translation

Corrected the mistranslated URL segment for Spanish translation to ensure proper navigation, preventing redirect to non-existent page

#### Description
It should be /settings/customformats, like in other translations
Instead of /opciones/formatospersonalizados

I searched for “WantMoreControlAddACustomFormat” to see whether it was a common issue in other translations, but it seems to only affect the Spanish one.

#### Screenshots for UI Changes
<img width="1590" height="679" alt="WantMoreControlAddACustomFormat" src="https://github.com/user-attachments/assets/24591425-9ead-4dbf-8457-4f9d9339dcf2" />

#### Database Migration
NO


#### Issues Fixed or Closed by this PR
There was no open issue for this

