### PR TITLE
Prevent command-line data paths with multiple consecutive slashes from causing backups to fail

### DIFF
--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -580,6 +580,21 @@ namespace NzbDrone.Common.Test.DiskTests
         }
 
         [Test]
+        public void TransferFile_should_find_files_with_multiple_slashes_within_their_path()
+        {
+            WithRealDiskProvider();
+
+            var root = GetFilledTempFolder();
+            var rootDir = root.FullName;
+            var from = Path.Combine(rootDir, "source-file");
+            var toRootDir = rootDir.Replace(Path.DirectorySeparatorChar.ToString(), new string(Path.DirectorySeparatorChar, 3));
+            var to = Path.Combine(toRootDir, "destination-file");
+            File.WriteAllText(from, "Source file");
+            var mode = Subject.TransferFile(from, to, TransferMode.Copy);
+            mode.Should().Be(TransferMode.Copy);
+        }
+
+        [Test]
         public void should_throw_if_destination_is_readonly()
         {
             Mocker.GetMock<IDiskProvider>()

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -28,15 +28,15 @@ namespace NzbDrone.Common.Disk
 
         private string ResolveRealParentPath(string path)
         {
-            var parentPath = path.GetParentPath();
-            if (!_diskProvider.FolderExists(parentPath))
+            if (!_diskProvider.FolderExists(path.GetParentPath()))
             {
                 return path;
             }
 
+            var cleanPath = path.GetCleanPath();
+            var parentPath = cleanPath.GetParentPath();
             var realParentPath = parentPath.GetActualCasing();
-
-            var partialChildPath = path.Substring(parentPath.Length);
+            var partialChildPath = cleanPath.Substring(parentPath.Length);
 
             return realParentPath + partialChildPath;
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/RQBitTests/RQBitFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/RQBitTests/RQBitFixture.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.Clients.RQBit;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.Download.DownloadClientTests.RQBitTests
 {
@@ -212,6 +213,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.RQBitTests
 
             items.Should().HaveCount(1);
             items.First().Title.Should().Be("Test2");
+
+            ExceptionVerification.ExpectedWarns(1);
         }
 
         [Test]
@@ -229,6 +232,8 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.RQBitTests
 
             items.Should().HaveCount(1);
             items.First().Title.Should().Be("Test2");
+
+            ExceptionVerification.ExpectedWarns(1);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -145,6 +145,8 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode);
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localEpisode.Episodes.Single().EpisodeFile, DeleteMediaFileReason.Upgrade), Times.Once());
+
+            ExceptionVerification.ExpectedWarns(1);
         }
 
         [Test]
@@ -159,6 +161,8 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode);
 
             Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+
+            ExceptionVerification.ExpectedWarns(1);
         }
 
         [Test]


### PR DESCRIPTION
#### Description
This PR addresses [Issue 8221](https://github.com/Sonarr/Sonarr/issues/8221) by checking a path is 'clean' before resolving its parent path. Specifically, in this case, that the path doesn't include any multiple path separators. If it does, a warning is issued to the logger and a 'clean' copy of the path is used instead.

#### Database Migration
NO


#### Issues Fixed or Closed by this PR
* Closes #8221 

