### PR TITLE
New: Bump FFMpegCore to 5.4.0 and FFprobe to 8.0.1

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -4,6 +4,5 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
-    <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+using System;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Test.Common;
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     [TestFixture]
     public class FormatAudioCodecFixture : TestBase
     {
-        private static string sceneName = "My.Series.S01E01-Sonarr";
+        private const string SceneName = "My.Series.S01E01-Sonarr";
 
         [TestCase("mp2, ,  ", "droned.s01e03.swedish.720p.hdtv.x264-prince", "MP2")]
         [TestCase("vorbis, ,  ", "DB Super HDTV", "Vorbis")]
@@ -18,25 +19,33 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("truehd, thd+,  ", "Atmos", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "Atmos", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "", "TrueHD Atmos")]
         [TestCase("wmav1, , ", "Droned.wmv", "WMA")]
         [TestCase("wmav2, , ", "B.N.S04E18.720p.WEB-DL", "WMA")]
         [TestCase("opus, ,  ", "Roadkill Ep3x11 - YouTube.webm", "Opus")]
         [TestCase("mp3, ,  ", "climbing.mp4", "MP3")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS:X", "DTS-X", "DTS-X")]
+        [TestCase("dts, , DTS-HD MA + DTS:X IMAX", "DTS-X", "DTS-X")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS-ES", "DTS-ES", "DTS-ES")]
         [TestCase("dts, , DTS-ES", "DTS", "DTS-ES")]
         [TestCase("dts, , DTS-HD HRA", "DTSHD-HRA", "DTS-HD HRA")]
         [TestCase("dts, , DTS", "DTS", "DTS")]
         [TestCase("eac3, ec+3,  ", "EAC3.Atmos", "EAC3 Atmos")]
+        [TestCase("eac3, , Dolby Digital Plus + Dolby Atmos", "EAC3.Atmos", "EAC3 Atmos")]
         [TestCase("eac3, ,  ", "DDP5.1", "EAC3")]
         [TestCase("ac3, ,  ", "DD5.1", "AC3")]
+        [TestCase("aac, ,  ", "AAC2.0", "AAC")]
+        [TestCase("aac, , HE-AAC", "AAC2.0", "HE-AAC")]
+        [TestCase("aac, , xHE-AAC", "AAC2.0", "xHE-AAC")]
         [TestCase("adpcm_ima_qt, ,  ", "Custom?", "PCM")]
         [TestCase("adpcm_ms, ,  ", "Custom", "PCM")]
         public void should_format_audio_format(string audioFormatPack, string sceneName, string expectedFormat)
         {
-            var split = audioFormatPack.Split(new string[] { ", " }, System.StringSplitOptions.None);
+            var split = audioFormatPack.Split(',', StringSplitOptions.TrimEntries);
             var mediaInfoModel = new MediaInfoModel
             {
                 AudioFormat = split[0],
@@ -56,7 +65,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
                 AudioCodecID = "Other Audio Codec"
             };
 
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, sceneName).Should().Be(mediaInfoModel.AudioFormat);
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, SceneName).Should().Be(mediaInfoModel.AudioFormat);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.MediaFiles.MediaInfo;
+
+internal static class FFMpegCoreSideDataTypes
+{
+    public const string DoviConfigurationRecordSideData = "DOVI configuration record";
+    public const string HdrDynamicMetadataSpmte2094 = "HDR Dynamic Metadata SMPTE2094-40 (HDR10+)";
+    public const string MasteringDisplayMetadata = "Mastering display metadata";
+    public const string ContentLightLevelMetadata = "Content light level metadata";
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -52,7 +52,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "truehd")
             {
-                return "TrueHD";
+                return audioProfile switch
+                {
+                    "Dolby TrueHD + Dolby Atmos" => "TrueHD Atmos",
+                    _ => "TrueHD"
+                };
             }
 
             if (audioFormat == "flac")
@@ -62,37 +66,16 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "dts")
             {
-                if (audioProfile == "DTS:X")
+                return audioProfile switch
                 {
-                    return "DTS-X";
-                }
-
-                if (audioProfile == "DTS-HD MA")
-                {
-                    return "DTS-HD MA";
-                }
-
-                if (audioProfile == "DTS-ES")
-                {
-                    return "DTS-ES";
-                }
-
-                if (audioProfile == "DTS-HD HRA")
-                {
-                    return "DTS-HD HRA";
-                }
-
-                if (audioProfile == "DTS Express")
-                {
-                    return "DTS Express";
-                }
-
-                if (audioProfile == "DTS 96/24")
-                {
-                    return "DTS 96/24";
-                }
-
-                return "DTS";
+                    "DTS:X" or "DTS-HD MA + DTS:X IMAX" => "DTS-X",
+                    "DTS-HD MA" => "DTS-HD MA",
+                    "DTS-ES" => "DTS-ES",
+                    "DTS-HD HRA" => "DTS-HD HRA",
+                    "DTS Express" => "DTS Express",
+                    "DTS 96/24" => "DTS 96/24",
+                    _ => "DTS"
+                };
             }
 
             if (audioCodecID == "ec+3")
@@ -102,7 +85,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "eac3")
             {
-                return "EAC3";
+                return audioProfile switch
+                {
+                    "Dolby Digital Plus + Dolby Atmos" => "EAC3 Atmos",
+                    _ => "EAC3"
+                };
             }
 
             if (audioFormat == "ac3")
@@ -117,7 +104,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     return "HE-AAC";
                 }
 
-                return "AAC";
+                return audioProfile switch
+                {
+                    "HE-AAC" => "HE-AAC",
+                    "xHE-AAC" => "xHE-AAC",
+                    _ => "AAC"
+                };
             }
 
             if (audioFormat == "mp3")

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using FFMpegCore;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -9,7 +8,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public class MediaInfoModel : IEmbeddedDocument
     {
         public string RawStreamData { get; set; }
-        public string RawFrameData { get; set; }
+
         public int SchemaRevision { get; set; }
 
         public string ContainerFormat { get; set; }
@@ -26,8 +25,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string VideoColourPrimaries { get; set; }
 
         public string VideoTransferCharacteristics { get; set; }
-
-        public DoviConfigurationRecordSideData DoviConfigurationRecord { get; set; }
 
         public HdrFormat VideoHdrFormat { get; set; }
 

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="MailKit" Version="4.14.1" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Openur.FFMpegCore" Version="5.4.0.31" />
+    <PackageReference Include="Openur.FFprobeStatic" Version="8.0.1.289" />
     <PackageReference Include="Polly" Version="8.6.5" />
-    <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
-    <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />


### PR DESCRIPTION
#### Description
- Updating FFprobe to 8.0.1
- Support for interlaced scan type
- Support for `HE-AAC` and `xHE-AAC`
- Pixel formats dictionary is cached on library side.
- Removed RawFrameData and DoviConfigurationRecord from media info model are they are unused and not needed.

FFprobe changes:
- `DTS:X` is now `dts` + `DTS-HD MA + DTS:X IMAX`
- `ec+3` is now `eac3` + `Dolby Digital Plus + Dolby Atmos`
- `thd+` is now `truehd` + `Dolby TrueHD + Dolby Atmos`

#### Issues Fixed or Closed by this PR
* Closes #8214

