### PR TITLE
Remove space before period in TVDB message

### DIFF
--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1915,7 +1915,7 @@
   "SelectSeries": "Select Series",
   "SendAnonymousUsageData": "Send Anonymous Usage Data",
   "Series": "Series",
-  "SeriesAndEpisodeInformationIsProvidedByTheTVDB": "Series and episode information is provided by TheTVDB.com. [Please consider supporting them]({url}) .",
+  "SeriesAndEpisodeInformationIsProvidedByTheTVDB": "Series and episode information is provided by TheTVDB.com. [Please consider supporting them]({url}).",
   "SeriesCannotBeFound": "Sorry, that series cannot be found.",
   "SeriesDetailsCountEpisodeFiles": "{episodeFileCount} episode files",
   "SeriesDetailsGoTo": "Go to {title}",


### PR DESCRIPTION
#### Description
The english sentence shown in the Metadata Source page has a space before the period, so I removed it.
