### PR TITLE
Fixed: Parsing quality and languages when manual importing item with multiple series error

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportItem.cs
@@ -18,19 +18,14 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         public int? SeasonNumber { get; set; }
         public List<Episode> Episodes { get; set; }
         public int? EpisodeFileId { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = new();
         public string ReleaseGroup { get; set; }
         public string DownloadId { get; set; }
-        public List<CustomFormat> CustomFormats { get; set; }
+        public List<CustomFormat> CustomFormats { get; set; } = new();
         public int CustomFormatScore { get; set; }
         public int IndexerFlags { get; set; }
         public ReleaseType ReleaseType { get; set; }
-        public IEnumerable<ImportRejection> Rejections { get; set; }
-
-        public ManualImportItem()
-        {
-            CustomFormats = new List<CustomFormat>();
-        }
+        public IEnumerable<ImportRejection> Rejections { get; set; } = new List<ImportRejection>();
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                     ? Parser.ReleaseGroupParser.ParseReleaseGroup(path)
                     : releaseGroup;
                 var finalQuality = quality.Quality == Quality.Unknown ? QualityParser.ParseQuality(path) : quality;
-                var finalLanguges =
+                var finalLanguages =
                     languages?.Count <= 1 && (languages?.SingleOrDefault() ?? Language.Unknown) == Language.Unknown
                         ? languageParse
                         : languages;
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 localEpisode.ExistingFile = series.Path.IsParentPath(path);
                 localEpisode.Size = _diskProvider.GetFileSize(path);
                 localEpisode.ReleaseGroup = finalReleaseGroup;
-                localEpisode.Languages = finalLanguges;
+                localEpisode.Languages = finalLanguages;
                 localEpisode.Quality = finalQuality;
                 localEpisode.IndexerFlags = (IndexerFlags)indexerFlags;
                 localEpisode.ReleaseType = releaseType;
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 localEpisode.Episodes = episodes;
                 localEpisode.ReleaseGroup = finalReleaseGroup;
                 localEpisode.Quality = finalQuality;
-                localEpisode.Languages = finalLanguges;
+                localEpisode.Languages = finalLanguages;
                 localEpisode.IndexerFlags = (IndexerFlags)indexerFlags;
                 localEpisode.ReleaseType = releaseType;
 

--- a/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Sonarr.Api.V3/ManualImport/ManualImportController.cs
@@ -67,7 +67,7 @@ namespace Sonarr.Api.V3.ManualImport
                     item.Quality = processedItem.Quality;
                 }
 
-                if (item.ReleaseGroup.IsNotNullOrWhiteSpace())
+                if (item.ReleaseGroup.IsNullOrWhiteSpace())
                 {
                     item.ReleaseGroup = processedItem.ReleaseGroup;
                 }


### PR DESCRIPTION
#### Description
If you try to manual import a season or episode for a series that throws MultipleSeriesFoundException, the fields aren't autocompleted after you pick a series.