### PR TITLE
Fixed: Don't fail refresh for multiple series if one can't get updated information from Skyhook

### DIFF
--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -253,7 +253,7 @@ namespace NzbDrone.Core.Test.TvTests
                   .Setup(s => s.GetSeriesInfo(_series.Id))
                   .Throws(new IOException());
 
-            Assert.Throws<IOException>(() => Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id })));
+            Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
 
             Mocker.GetMock<IDiskScanService>()
                   .Verify(v => v.Scan(_series), Times.Once());

--- a/src/NzbDrone.Core/Messaging/Commands/CommandResult.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandResult.cs
@@ -4,6 +4,7 @@ namespace NzbDrone.Core.Messaging.Commands
     {
         Unknown = 0,
         Successful = 1,
-        Unsuccessful = 2
+        Unsuccessful = 2,
+        Indeterminate = 3
     }
 }


### PR DESCRIPTION
#### Description

This was a somewhat intentional result because we want to indicate it failed, but instead of failing the entire task we should allow it to continue and mark the result as such (currently not used in the UI). I've gone with `Indeterminate` because the rescan is likely successful, it's just Skyhook having issues, but open to suggestion on other naming.

#### Issues Fixed or Closed by this PR
* Closes #8250

