### PR TITLE
fix(connection): use ISO 8601 format specifier for Discord timestamps

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(series, episodes),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.GrabFields.Contains((int)DiscordGrabFieldType.Poster))
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(series, episodes),
                 Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Success,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -265,7 +265,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(series, episodes),
                 Color = (int)DiscordColors.Success,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -376,7 +376,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     new() { Name = "Reason", Value = reason.ToString() },
                     new() { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
                 },
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
             };
 
             var payload = CreatePayload(null, new List<Embed> { embed });
@@ -472,7 +472,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 },
                 Title = healthCheck.Source.Name,
                 Description = healthCheck.Message,
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = healthCheck.Type == HealthCheck.HealthCheckResult.Warning ? (int)DiscordColors.Warning : (int)DiscordColors.Danger
             };
 
@@ -492,7 +492,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 },
                 Title = "Health Issue Resolved: " + previousCheck.Source.Name,
                 Description = $"The following issue is now resolved: {previousCheck.Message}",
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = (int)DiscordColors.Success
             };
 
@@ -511,7 +511,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     IconUrl = "https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/256.png"
                 },
                 Title = APPLICATION_UPDATE_TITLE,
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
+                Timestamp = DateTime.UtcNow.ToString("O"),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>()
                 {
@@ -550,7 +550,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = GetTitle(series, episodes),
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>(),
-                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+                Timestamp = DateTime.UtcNow.ToString("O")
             };
 
             if (Settings.ManualInteractionFields.Contains((int)DiscordManualInteractionFieldType.Poster))


### PR DESCRIPTION
#### Description
If Sonarr is running on a system where the local DateTime format does not use colons (:) as the delimiter for time, the Discord webhook notification does not work, and are rejected by Discord with the cryptic `{"embeds": ["0"]}` error. This is because colons (:) have a special meaning when used within DateTime.ToString format strings in .NET, being converted to the time delimiter of the CurrentCulture, which may be a period. This causes the resulting strings to not follow the ISO 8601 specification, causing Discord to reject them.

An example of such a locale is da-DK. An interactive example of this problem can be viewed here: https://dotnetfiddle.net/NY2vrG

This is fixed by using `.ToString("O")`, which is a format specifier designed for the ISO 8601 standard.

- The `":"` format specifier is documented here: https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings#timeSeparator
- The `"O"` format specifier is documented here: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip

#### Issues Fixed or Closed by this PR
No open issue as far as I can tell.