### PR TITLE
Fix: Plexmatch special episode number

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Plex/PlexMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Plex/PlexMetadata.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Plex
 
                     if (episodeFile.SeasonNumber == 0)
                     {
-                        episodeFormat = $"SP{episodesInFile.First():00}";
+                        episodeFormat = $"SP{episodesInFile.First().EpisodeNumber:00}";
                     }
 
                     content.AppendLine($"Episode: {episodeFormat}: {episodeFile.RelativePath}");


### PR DESCRIPTION
#### Description
currently sonarr episode id is written to plexmatch file for specials, instead use special episode number


#### Issues Fixed or Closed by this PR
* Closes #8270

