### PR TITLE
New: Fallabck to alternate download clients on failure

### DIFF
--- a/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -324,6 +325,208 @@ namespace NzbDrone.Core.Test.Download
             WithTorrentIndexer(5);
 
             Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClient(DownloadProtocol.Torrent, 1));
+        }
+
+        [Test]
+        public void should_return_all_available_clients_for_protocol()
+        {
+            WithUsenetClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent);
+
+            clients.Should().HaveCount(3);
+            clients.Select(c => c.Definition.Id).Should().BeEquivalentTo(new[] { 2, 3, 4 });
+        }
+
+        [Test]
+        public void should_return_empty_when_no_clients_available_for_protocol()
+        {
+            WithUsenetClient();
+            WithUsenetClient();
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent);
+
+            clients.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_return_clients_ordered_by_priority_then_by_last_used()
+        {
+            WithTorrentClient(priority: 1);
+            WithTorrentClient(priority: 0);
+            WithTorrentClient(priority: 0);
+            WithTorrentClient(priority: 2);
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent);
+
+            clients.Should().HaveCount(4);
+            var clientIds = clients.Select(c => c.Definition.Id).ToArray();
+            clientIds[0].Should().Be(2);
+            clientIds[1].Should().Be(3);
+            clientIds[2].Should().Be(1);
+            clientIds[3].Should().Be(4);
+        }
+
+        [Test]
+        public void should_rotate_clients_within_same_priority_based_on_last_used()
+        {
+            WithTorrentClient(priority: 0);
+            WithTorrentClient(priority: 0);
+            WithTorrentClient(priority: 0);
+
+            var clients1 = Subject.GetDownloadClients(DownloadProtocol.Torrent);
+            clients1.First().Definition.Id.Should().Be(1);
+
+            Subject.ReportSuccessfulDownloadClient(DownloadProtocol.Torrent, 2);
+
+            var clients2 = Subject.GetDownloadClients(DownloadProtocol.Torrent);
+            var clientIds = clients2.Select(c => c.Definition.Id).ToArray();
+            clientIds[0].Should().Be(3);
+            clientIds[1].Should().Be(1);
+            clientIds[2].Should().Be(2);
+        }
+
+        [Test]
+        public void should_filter_clients_by_tags()
+        {
+            var seriesTags = new HashSet<int> { 1, 2 };
+
+            WithTorrentClient(tags: new HashSet<int> { 1 });
+            WithTorrentClient(tags: new HashSet<int> { 3 });
+            WithTorrentClient(tags: new HashSet<int> { 2 });
+            WithTorrentClient();
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, tags: seriesTags);
+
+            clients.Should().HaveCount(2);
+            clients.Select(c => c.Definition.Id).Should().BeEquivalentTo(new[] { 1, 3 });
+        }
+
+        [Test]
+        public void should_return_non_tagged_clients_when_no_matching_tags()
+        {
+            var seriesTags = new HashSet<int> { 5 };
+
+            WithTorrentClient(tags: new HashSet<int> { 1 });
+            WithTorrentClient(tags: new HashSet<int> { 2 });
+            WithTorrentClient();
+            WithTorrentClient();
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, tags: seriesTags);
+
+            clients.Should().HaveCount(2);
+            clients.Select(c => c.Definition.Id).Should().BeEquivalentTo(new[] { 3, 4 });
+        }
+
+        [Test]
+        public void should_throw_when_all_clients_have_non_matching_tags()
+        {
+            var seriesTags = new HashSet<int> { 5 };
+
+            WithTorrentClient(tags: new HashSet<int> { 1 });
+            WithTorrentClient(tags: new HashSet<int> { 2 });
+
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClients(DownloadProtocol.Torrent, tags: seriesTags));
+        }
+
+        [Test]
+        public void should_return_indexer_specific_client_when_specified()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentIndexer(2);
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, indexerId: 1);
+
+            clients.Should().HaveCount(1);
+            clients.First().Definition.Id.Should().Be(2);
+        }
+
+        [Test]
+        public void should_throw_when_indexer_client_does_not_exist()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentIndexer(5);
+
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClients(DownloadProtocol.Torrent, indexerId: 1));
+        }
+
+        [Test]
+        public void should_filter_blocked_clients_when_requested()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentClient();
+
+            GivenBlockedClient(2);
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, filterBlockedClients: true);
+
+            clients.Should().HaveCount(2);
+            clients.Select(c => c.Definition.Id).Should().BeEquivalentTo(new[] { 1, 3 });
+        }
+
+        [Test]
+        public void should_throw_when_all_clients_blocked_and_filter_enabled()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+
+            GivenBlockedClient(1);
+            GivenBlockedClient(2);
+
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClients(DownloadProtocol.Torrent, filterBlockedClients: true));
+        }
+
+        [Test]
+        public void should_return_blocked_clients_when_filter_disabled()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+
+            GivenBlockedClient(1);
+            GivenBlockedClient(2);
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, filterBlockedClients: false);
+
+            clients.Should().HaveCount(2);
+            clients.Select(c => c.Definition.Id).Should().BeEquivalentTo(new[] { 1, 2 });
+        }
+
+        [Test]
+        public void should_throw_when_indexer_client_is_blocked_and_filter_enabled()
+        {
+            WithTorrentClient();
+            WithTorrentClient();
+            WithTorrentIndexer(2);
+
+            GivenBlockedClient(2);
+
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClients(DownloadProtocol.Torrent, indexerId: 1, filterBlockedClients: true));
+        }
+
+        [Test]
+        public void should_combine_tags_and_priority_filtering()
+        {
+            var seriesTags = new HashSet<int> { 1 };
+
+            WithTorrentClient(priority: 1, tags: new HashSet<int> { 1 });
+            WithTorrentClient(priority: 0, tags: new HashSet<int> { 1 });
+            WithTorrentClient(priority: 0, tags: new HashSet<int> { 2 });
+            WithTorrentClient(priority: 2);
+
+            var clients = Subject.GetDownloadClients(DownloadProtocol.Torrent, tags: seriesTags);
+
+            clients.Should().HaveCount(2);
+            var clientIds = clients.Select(c => c.Definition.Id).ToArray();
+
+            clientIds[0].Should().Be(2);
+            clientIds[1].Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
#### Description

Falls back to the next download client (either in the same priority group) or in a lower priority to handle the primary download client offline, but not yet blocked.

#### Issues Fixed or Closed by this PR
* Closes #6861

