### PR TITLE
Avoid unique constraints for primary keys in SQLite migrations

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/SqliteSchemaDumper.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
                 column.IsPrimaryKey = upper.Contains("PRIMARY KEY");
                 column.IsIdentity = upper.Contains("AUTOINCREMENT");
                 column.IsNullable = !upper.Contains("NOT NULL") && !upper.Contains("PRIMARY KEY");
-                column.IsUnique = upper.Contains("UNIQUE") || upper.Contains("PRIMARY KEY");
+                column.IsUnique = upper.Contains("UNIQUE");
             }
 
             return column;


### PR DESCRIPTION
#### Description
Primary keys are unique by definition, and we should avoid adding an unique index on it too as newer FM versions seems to take both into consideration. FM >=5.0.0 I suspect to have this behavior.

```diff
- CREATE TABLE "Series_temp" ("Id" INTEGER NOT NULL UNIQUE PRIMARY KEY AUTOINCREMENT, ...
+ CREATE TABLE "Series_temp" ("Id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, ...
```