### PR TITLE
Always generate API docs

### DIFF
--- a/.github/workflows/api_docs.yml
+++ b/.github/workflows/api_docs.yml
@@ -1,12 +1,7 @@
 name: "API Docs"
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
   push:
-    branches:
-      - v5-develop
     paths:
       - ".github/workflows/api_docs.yml"
       - "docs.sh"
@@ -22,9 +17,6 @@ concurrency:
 jobs:
   api_docs:
     runs-on: ubuntu-latest
-    if: github.repository == 'Sonarr/Sonarr'
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,31 +27,8 @@ jobs:
       - name: Create openapi.json
         run: ./scripts/docs.sh Linux x64
 
-      - name: Commit API Docs Change
-        continue-on-error: true
-        run: |
-          git config --global user.email "development@sonarr.tv"
-          git config --global user.name "Sonarr"
-          git checkout -b api-docs
-          git add src
-          if git status | grep -q modified
-          then
-            git commit -am 'Automated API Docs update' -m "ignore-downstream"
-            git push -f --set-upstream origin api-docs
-            curl -X POST -H "Authorization: Bearer ${{ secrets.OPENAPI_PAT }}" -H "Accept: application/vnd.github+json" https://api.github.com/repos/sonarr/sonarr/pulls -d '{"head":"api-docs","base":"v5-develop","title":"Update API docs"}'
-          else
-            echo "No changes since last run"
-          fi
-
-      - name: Notify
-        if: failure()
-        uses: tsickert/discord-webhook@v6.0.0
+      - name: Upload openapi.json
+        uses: actions/upload-artifact@v4
+        path: src/Sonarr.Api.V5/openapi.json
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          username: "GitHub Actions"
-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-          embed-title: "${{ github.workflow }}: Failure"
-          embed-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          embed-description: |
-            Failed to update API docs
-          embed-color: "15158332"
+          name: openapi.json


### PR DESCRIPTION
#### Description

~This PR will change the "API Docs" GitHub action to run on all branches and upload the generated `openapi.json`.~

Sorry. I wanted to create a PR to my fork of Sonarr. 🤦‍♂️