### PR TITLE
Update remove series contraints migration to include TvRageId

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/034_remove_series_contraints.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/034_remove_series_contraints.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.Datastore.Migration
         protected override void MainDbUpgrade()
         {
             Alter.Table("Series")
+                .AlterColumn("TvRageId").AsInt32()
                 .AlterColumn("ImdbId").AsString().Nullable()
                 .AlterColumn("TitleSlug").AsString().Nullable();
         }


### PR DESCRIPTION
#### Description
Fixing uniqueness for TvRageId after FM 5.0.0 changed behavior.

Related PR #8308

