### PR TITLE
Fixed: Login with credentials on Qbittorrent 5.2

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -422,13 +422,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 _authCookieCache.Remove(authKey);
 
                 var authRequestBuilder = BuildRequest(settings);
-                authRequestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
 
                 var authLoginRequest = authRequestBuilder.Resource("/api/v2/auth/login")
-                                                             .Post()
-                                                             .AddFormParameter("username", settings.Username ?? string.Empty)
-                                                             .AddFormParameter("password", settings.Password ?? string.Empty)
-                                                             .Build();
+                    .Post()
+                    .AddFormParameter("username", settings.Username ?? string.Empty)
+                    .AddFormParameter("password", settings.Password ?? string.Empty)
+                    .Build();
 
                 HttpResponse response;
                 try
@@ -438,6 +437,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 catch (HttpException ex)
                 {
                     _logger.Debug(ex, "qbitTorrent authentication failed.");
+
                     if (ex.Response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                     {
                         throw new DownloadClientAuthenticationException("Failed to authenticate with qBittorrent.", ex);


### PR DESCRIPTION
#### Description
According to https://github.com/qbittorrent/qBittorrent/blob/9d5a8270cf8fb72775c6e5e1a96925a7c1ab2773/src/webui/webapplication.cpp#L648, now the API key is sent via the Authorization header which fails while we send the credentials as basic auth along with the form data.

The basic auth seems to be implement a decade ago with 0552b56 even after the split to the 2 proxies, so might be safe to remove with the new versions of the API.

#### Issues Fixed or Closed by this PR
* Closes https://github.com/Radarr/Radarr/issues/11339

