### PR TITLE
Bump BusyTimeout for SQLite to 1000ms

### DIFF
--- a/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
+++ b/src/NzbDrone.Core/Datastore/ConnectionStringFactory.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Datastore
                 JournalMode = OsInfo.IsOsx ? SQLiteJournalModeEnum.Truncate : SQLiteJournalModeEnum.Wal,
                 Pooling = true,
                 Version = 3,
-                BusyTimeout = 100
+                BusyTimeout = 1000
             };
 
             if (OsInfo.IsOsx)


### PR DESCRIPTION
#### Description
Waiting 1s might be a saner value for slower setups like Synology where config is stored on the same medium as the downloads.