### PR TITLE
Remove Custom Filters from fetch server collection

### DIFF
--- a/frontend/src/Store/Actions/Creators/createFetchServerSideCollectionHandler.js
+++ b/frontend/src/Store/Actions/Creators/createFetchServerSideCollectionHandler.js
@@ -6,8 +6,6 @@ import getSectionState from 'Utilities/State/getSectionState';
 import { set, updateServerSideCollection } from '../baseActions';
 
 function createFetchServerSideCollectionHandler(section, url, fetchDataAugmenter) {
-  const [baseSection] = section.split('.');
-
   return function(getState, payload, dispatch) {
     dispatch(set({ section, isFetching: true }));
 
@@ -30,11 +28,7 @@ function createFetchServerSideCollectionHandler(section, url, fetchDataAugmenter
       filters
     } = sectionState;
 
-    const customFilters = getState().customFilters.items.filter((customFilter) => {
-      return customFilter.type === section || customFilter.type === baseSection;
-    });
-
-    const selectedFilters = findSelectedFilters(selectedFilterKey, filters, customFilters);
+    const selectedFilters = findSelectedFilters(selectedFilterKey, filters);
 
     selectedFilters.forEach((filter) => {
       data[filter.key] = filter.value;


### PR DESCRIPTION
#### Description

The last thing to use Server Side collections is Import List Exclusions, which looks for Custom Filters which no longer exist in Redux state. Import list exclusions don't have custom filters so nothing of value was lost and will get ported to React Query soon enough.

