### PR TITLE
Add focus border to buttons

### DIFF
--- a/frontend/src/Components/Link/Button.css
+++ b/frontend/src/Components/Link/Button.css
@@ -23,6 +23,10 @@
   background-color: var(--dangerBackgroundColor);
   color: var(--white);
 
+  &:focus {
+    border-color: var(--dangerHoverBorderColor);
+  }
+
   &:hover {
     border-color: var(--dangerHoverBorderColor);
     background-color: var(--dangerHoverBackgroundColor);
@@ -34,6 +38,10 @@
   border-color: var(--defaultBorderColor);
   background-color: var(--defaultBackgroundColor);
   color: var(--defaultColor);
+
+  &:focus {
+    border-color: var(--defaultHoverBorderColor);
+  }
 
   &:hover {
     border-color: var(--defaultHoverBorderColor);
@@ -47,6 +55,10 @@
   background-color: var(--primaryBackgroundColor);
   color: var(--white);
 
+  &:focus {
+    border-color: var(--primaryHoverBorderColor);
+  }
+
   &:hover {
     border-color: var(--primaryHoverBorderColor);
     background-color: var(--primaryHoverBackgroundColor);
@@ -59,6 +71,10 @@
   background-color: var(--successBackgroundColor);
   color: var(--white);
 
+  &:focus {
+    border-color: var(--successHoverBorderColor);
+  }
+
   &:hover {
     border-color: var(--successHoverBorderColor);
     background-color: var(--successHoverBackgroundColor);
@@ -70,6 +86,10 @@
   border-color: var(--warningBorderColor);
   background-color: var(--warningBackgroundColor);
   color: var(--white);
+
+  &:focus {
+    border-color: var(--warningHoverBorderColor);
+  }
 
   &:hover {
     border-color: var(--warningHoverBorderColor);

--- a/frontend/src/Components/keyboardShortcuts.tsx
+++ b/frontend/src/Components/keyboardShortcuts.tsx
@@ -35,13 +35,6 @@ export const shortcuts: Record<string, Shortcut> = {
     },
   },
 
-  ACCEPT_CONFIRM_MODAL: {
-    key: 'Enter',
-    get name() {
-      return translate('KeyboardShortcutsConfirmModal');
-    },
-  },
-
   SERIES_SEARCH_INPUT: {
     key: 's',
     get name() {


### PR DESCRIPTION
#### Description
Similar to on hover, changes the border colour of buttons so you can tell when it's focused.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes

Save is focused:

<img width="1282" height="630" alt="image" src="https://github.com/user-attachments/assets/d87748c0-7576-4f78-a0a4-a9aa96aaf147" />


#### Issues Fixed or Closed by this PR
* Closes #8344

