### PR TITLE
New: increase organize modal to XXL

### DIFF
--- a/frontend/src/Organize/OrganizePreviewModal.tsx
+++ b/frontend/src/Organize/OrganizePreviewModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from 'Components/Modal/Modal';
+import { sizes } from 'Helpers/Props';
 import OrganizePreviewModalContent, {
   OrganizePreviewModalContentProps,
 } from './OrganizePreviewModalContent';
@@ -15,7 +16,11 @@ function OrganizePreviewModal({
   ...otherProps
 }: OrganizePreviewModalProps) {
   return (
-    <Modal isOpen={isOpen} onModalClose={onModalClose}>
+    <Modal
+      isOpen={isOpen}
+      size={sizes.EXTRA_EXTRA_LARGE}
+      onModalClose={onModalClose}
+    >
       {isOpen ? (
         <OrganizePreviewModalContent
           {...otherProps}


### PR DESCRIPTION
#### Description
increases the preview rename modal (organizer) to Extra_Extra_Large
Mirrors then the manual import modal.

#### Screenshots for UI Changes

NEW:
<img width="1894" height="723" alt="image" src="https://github.com/user-attachments/assets/96b39b78-bb5a-4e50-a2b2-9f76fb40724b" />

OLD:
<img width="1609" height="688" alt="image" src="https://github.com/user-attachments/assets/ebd5ddff-b282-430d-9805-e03f18501b97" />




#### Issues Fixed or Closed by this PR
* Closes #8356 

