### PR TITLE
Fix: Fix ffprobe call causing unnecessary disk reads

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -108,7 +108,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}");
+                    var videoStreamIndex = analysis.VideoStreams.Count == 1 ? 0
+                        : analysis.VideoStreams.FindIndex(s => Equals(s?.Index, primaryVideoStream?.Index));
+                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{videoStreamIndex}");
                 }
 
                 var streamSideData = primaryVideoStream?.SideData ?? new();


### PR DESCRIPTION
#### Description
- We currently pass the global stream index of the primary video stream with v:index.
- ffprobe expects the index to be filtered by the stream type. If the video appears at index 2 but is the only video stream in the file, we should pass v:0. Passing v:2 will cause ffprobe to unnecessarily read the entire file during analysis to find a video stream at index 2 which doesn't exist

#### Steps to reproduce bug
1. Find a video file where the video stream is at a non-zero global index, let's say it's at index 2.
2. Current behavior: Run `ffprobe -loglevel error -print_format json -show_frames -v verbose -sexagesimal -read_intervals %+#1 -select_streams v:2 <filename>`. Notice the total bytes read equals the size of the file.
4. Repeat with `v:0` assuming the file only has one video stream. The total bytes read will be a lot lower (<100KB usually)
