### PR TITLE
Fallback to video stream 0 when reading primary video for frame analysis

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -151,9 +151,8 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    var videoStreamIndex = analysis.VideoStreams.Count == 1 ? 0
-                        : analysis.VideoStreams.FindIndex(s => Equals(s?.Index, primaryVideoStream?.Index));
-                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{videoStreamIndex}");
+                    var videoStreamIndex = analysis.VideoStreams.FindIndex(stream => stream.Index == primaryVideoStream?.Index);
+                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{(videoStreamIndex == -1 ? 0 : videoStreamIndex)}");
                 }
 
                 var streamSideData = primaryVideoStream?.SideData ?? new();


### PR DESCRIPTION
#### Description
Since #8363 got merged quite quickly, we should fallback to index 0 since `List<T>.FindIndex()` returns -1 for no matches found.

* Related #8363

