### PR TITLE
Reduce log noise in HttpHappyEyeballs

### DIFF
--- a/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
@@ -38,7 +38,7 @@ public class HttpHappyEyeballs
 
         var happyEyeballs = CreateHappyEyeballs(endPoint);
         var socket = await happyEyeballs.Connect(resolvedAddresses, cancellationToken).ConfigureAwait(false);
-        _logger.Trace("Successfully connected {0} to address: {1}", endPoint.HostPort, socket.RemoteEndPoint);
+        _logger.Trace("Successfully connected to {0} for host {1}", socket.RemoteEndPoint, endPoint.HostPort);
 
         return new NetworkStream(socket, ownsSocket: true);
     }
@@ -47,14 +47,13 @@ public class HttpHappyEyeballs
     {
         return new HappyEyeballs<Socket>(
             (ipAddress, cancel) => ConnectSocket(ipAddress, endPoint, cancel),
-            cancel => TaskDelay(endPoint, cancel));
+            TaskDelay);
     }
 
-    private async Task TaskDelay(DnsEndPoint endPoint, CancellationToken cancellationToken)
+    private async Task TaskDelay(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var timeSpan = TimeSpan.FromMilliseconds(ConnectionAttemptDelay);
-        _logger.Trace("Waiting on {0} connection attempt delay for {1}", endPoint.HostPort, timeSpan);
 
         await Task.Delay(timeSpan, cancellationToken).ConfigureAwait(false);
     }
@@ -84,7 +83,7 @@ public class HttpHappyEyeballs
         catch (Exception e)
         {
             socket.Dispose();
-            _logger.Trace(e, "Happy Eyeballs connection to {0} for host {1} failed", ipAddress, endPoint.HostPort);
+            _logger.Trace("Failed Happy Eyeballs connection to {0} for host {1} ({2})", ipAddress, endPoint.HostPort, e.Message);
             throw;
         }
 


### PR DESCRIPTION
#### Description

Reduces log noise, the entire exception was logged for each failed connection before this change.
See https://github.com/Sonarr/Sonarr/pull/8153#issuecomment-3803944230

Example log after this change:
```
2026-01-28 13:34:54.3|Trace|HttpClient|Req: [GET] https://services.sonarr.tv/v1/notification?version=10.0.0.24435&os=linux&arch=Arm64&branch=main
2026-01-28 13:34:54.4|Trace|ConfigService|Using default config value for 'proxyenabled' defaultValue:'False'                
2026-01-28 13:34:54.5|Trace|ManagedHttpDispatcher|Trying Happy Eyeballs connection to 2606:4700:20::ac43:4662 for host services.sonarr.tv:443                 
2026-01-28 13:34:54.6|Trace|ManagedHttpDispatcher|Failed Happy Eyeballs connection to 2606:4700:20::ac43:4662 for host services.sonarr.tv:443 (No route to host)
2026-01-28 13:34:54.6|Trace|ManagedHttpDispatcher|Trying Happy Eyeballs connection to 104.26.0.163 for host services.sonarr.tv:443                                                                                              
2026-01-28 13:34:54.6|Trace|ManagedHttpDispatcher|Successfully connected to [::ffff:104.26.0.163]:443 for host services.sonarr.tv:443
2026-01-28 13:34:54.7|Trace|HttpClient|Res: HTTP/2.0 [GET] https://services.sonarr.tv/v1/notification?version=10.0.0.24435&os=linux&arch=Arm64&branch=main: 200.OK (2 bytes) (398 ms)
```