### PR TITLE
remove the default indexer definitions for AnimeTosho

### DIFF
--- a/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/Newznab.cs
@@ -57,7 +57,6 @@ namespace NzbDrone.Core.Indexers.Newznab
                 yield return GetDefinition("nzbplanet.net", GetSettings("https://api.nzbplanet.net"));
                 yield return GetDefinition("SimplyNZBs", GetSettings("https://simplynzbs.com"));
                 yield return GetDefinition("Tabula Rasa", GetSettings("https://www.tabula-rasa.pw", apiPath: @"/api/v1/api"));
-                yield return GetDefinition("AnimeTosho Usenet", GetSettings("https://feed.animetosho.org", apiPath: @"/nabapi", categories: Array.Empty<int>(), animeCategories: new[] { 5070 }));
             }
         }
 

--- a/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/Torznab.cs
@@ -10,7 +10,6 @@ using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Indexers.Newznab;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.Parser;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Torznab
@@ -43,14 +42,6 @@ namespace NzbDrone.Core.Indexers.Torznab
         public override IParseIndexerResponse GetParser()
         {
             return new TorznabRssParser();
-        }
-
-        public override IEnumerable<ProviderDefinition> DefaultDefinitions
-        {
-            get
-            {
-                yield return GetDefinition("AnimeTosho Torrents", GetSettings("https://feed.animetosho.org", apiPath: @"/nabapi", categories: Array.Empty<int>(), animeCategories: new[] { 5070 }));
-            }
         }
 
         private IndexerDefinition GetDefinition(string name, TorznabSettings settings)


### PR DESCRIPTION
#### Description
AnimeTosho announced they are shutting down in may 2026
Removes the defaults for those indexers.