### PR TITLE
New: Skip series search for seasons with files if profile doesn't allow upgrades

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -332,6 +332,21 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
+        public async Task scene_seasonsearch_should_skip_search_if_no_episodes_after_filtering()
+        {
+            WithEpisodes();
+            _xemEpisodes.ForEach(e => e.EpisodeFileId = 1);
+
+            var allCriteria = WatchForSearchCriteria();
+
+            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
+
+            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
+
+            criteria.Count.Should().Be(0);
+        }
+
+        [Test]
         public async Task season_search_for_anime_should_search_for_each_monitored_episode()
         {
             WithEpisodes();

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
@@ -1,13 +1,16 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.IndexerSearch;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 
@@ -25,7 +28,8 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
                       {
                           Id = 1,
                           Title = "Title",
-                          Seasons = new List<Season>()
+                          Seasons = new List<Season>(),
+                          QualityProfile = new LazyLoaded<QualityProfile>(Builder<QualityProfile>.CreateNew().With(q => q.UpgradeAllowed = true).Build())
                       };
 
             Mocker.GetMock<ISeriesService>()
@@ -54,6 +58,23 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             Mocker.GetMock<ISearchForReleases>()
                 .Verify(v => v.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false), Times.Exactly(_series.Seasons.Count(s => s.Monitored)));
+        }
+
+        [Test]
+        public void should_only_search_missing_if_profile_does_not_allow_upgrades()
+        {
+            _series.Seasons = new List<Season>
+            {
+                new Season { SeasonNumber = 0, Monitored = false },
+                new Season { SeasonNumber = 1, Monitored = true }
+            };
+
+            _series.QualityProfile.Value.UpgradeAllowed = false;
+
+            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
+
+            Mocker.GetMock<ISearchForReleases>()
+                .Verify(v => v.SeasonSearch(_series.Id, It.IsAny<int>(), true, true, true, false), Times.Exactly(_series.Seasons.Count(s => s.Monitored)));
         }
 
         [Test]

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -102,6 +102,12 @@ namespace NzbDrone.Core.IndexerSearch
                 episodes = episodes.Where(e => !e.HasFile).ToList();
             }
 
+            if (episodes.Count == 0)
+            {
+                _logger.Debug("No wanted episodes found for season {0}", seasonNumber);
+                return new List<DownloadDecision>();
+            }
+
             return await SeasonSearch(seriesId, seasonNumber, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
         }
 

--- a/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
@@ -35,6 +35,7 @@ namespace NzbDrone.Core.IndexerSearch
             var series = _seriesService.GetSeries(message.SeriesId);
             var downloadedCount = 0;
             var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
+            var profile = series.QualityProfile.Value;
 
             if (series.Seasons.None(s => s.Monitored))
             {
@@ -64,7 +65,7 @@ namespace NzbDrone.Core.IndexerSearch
                         continue;
                     }
 
-                    var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, season.SeasonNumber, false, true, userInvokedSearch, false).GetAwaiter().GetResult();
+                    var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, season.SeasonNumber, !profile.UpgradeAllowed, true, userInvokedSearch, false).GetAwaiter().GetResult();
                     var processDecisions = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
                     downloadedCount += processDecisions.Grabbed.Count;
                 }


### PR DESCRIPTION
#### Description

Avoids searching for seasons if all episodes already have files and the profile doesn't allow upgrades.

