### PR TITLE
Fixed: Ensure trailing slash is removed from drive letters when updating Plex Media Server

### DIFF
--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
@@ -141,8 +141,9 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             var separator = location.Path.Contains('\\') ? "\\" : "/";
             var locationRelativePath = seriesRelativePath.Replace("\\", separator).Replace("/", separator);
 
-            // Plex location paths trim trailing extraneous separator characters, so it doesn't need to be trimmed
-            var pathToUpdate = $"{location.Path}{separator}{locationRelativePath}";
+            // Plex location paths trim trailing extraneous separator characters,
+            // unless it's a Windows drive letter (S:\) that needs to be trimmed.
+            var pathToUpdate = $"{location.Path.TrimEnd(separator)}{separator}{locationRelativePath}";
 
             _logger.Debug("Updating section location, {0}", location.Path);
             _plexServerProxy.Update(section.Id, pathToUpdate, settings);


### PR DESCRIPTION
#### Description

Most of the time Plex doesn't return trailing slashes, except when it's necessary for drive letters, so make sure we trim them off when building paths to update Plex Media Server.

#### Issues Fixed or Closed by this PR
* Closes #8414

