### PR TITLE
improve acceptable size rejection messaging for multi-episode releases

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 // If the parsed size is smaller than minSize we don't want it
                 if (subject.Release.Size < minSize)
                 {
-                    var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes with a total {runtime}min";
+                    var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes totalling {runtime}min";
 
                     _logger.Debug("Item: {0}, Size: {1} is smaller than minimum allowed size ({2} bytes for {3}), rejecting.", subject, subject.Release.Size, minSize, runtimeMessage);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.BelowMinimumSize, "{0} is smaller than minimum allowed {1} (for {2})", subject.Release.Size.SizeSuffix(), minSize.SizeSuffix(), runtimeMessage);
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 // If the parsed size is greater than maxSize we don't want it
                 if (subject.Release.Size > maxSize)
                 {
-                    var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes with a total {runtime}min";
+                    var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes totalling {runtime}min";
 
                     _logger.Debug("Item: {0}, Size: {1} is greater than maximum allowed size ({2} for {3}), rejecting", subject, subject.Release.Size, maxSize, runtimeMessage);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.AboveMaximumSize, "{0} is larger than maximum allowed {1} (for {2})", subject.Release.Size.SizeSuffix(), maxSize.SizeSuffix(), runtimeMessage);


### PR DESCRIPTION
#### Description
Improved the messaging for multi-episode releases rejected due to filesize to clarify that the size was related to all episodes and a total runtime, to prevent this:

<img width="1245" height="710" alt="image" src="https://github.com/user-attachments/assets/50e5d48f-b9b1-4381-a8d7-ced6f6d87c9e" />

