### PR TITLE
New: Display the series link IDs

### DIFF
--- a/frontend/src/Components/Link/ClipboardButton.css
+++ b/frontend/src/Components/Link/ClipboardButton.css
@@ -4,6 +4,10 @@
   position: relative;
 }
 
+.buttonText {
+  margin: 0 5px;
+}
+
 .stateIconContainer {
   position: absolute;
   top: 50%;

--- a/frontend/src/Components/Link/ClipboardButton.css.d.ts
+++ b/frontend/src/Components/Link/ClipboardButton.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'button': string;
+  'buttonText': string;
   'clipboardIconContainer': string;
   'showStateIcon': string;
   'stateIconContainer': string;

--- a/frontend/src/Components/Link/ClipboardButton.tsx
+++ b/frontend/src/Components/Link/ClipboardButton.tsx
@@ -8,6 +8,7 @@ import styles from './ClipboardButton.css';
 
 export interface ClipboardButtonProps extends Omit<ButtonProps, 'children'> {
   value: string;
+  label?: string | number;
 }
 
 export type ClipboardState = 'success' | 'error' | null;
@@ -15,6 +16,7 @@ export type ClipboardState = 'success' | 'error' | null;
 export default function ClipboardButton({
   id,
   value,
+  label,
   className = styles.button,
   ...otherProps
 }: ClipboardButtonProps) {
@@ -68,6 +70,7 @@ export default function ClipboardButton({
         ) : null}
 
         <span className={styles.clipboardIconContainer}>
+          {label ? <span className={styles.buttonText}>{label}</span> : null}
           <Icon name={icons.CLIPBOARD} />
         </span>
       </span>

--- a/frontend/src/Series/Details/SeriesDetailsLinks.css
+++ b/frontend/src/Series/Details/SeriesDetailsLinks.css
@@ -1,4 +1,6 @@
 .links {
+  display: flex;
+  flex-wrap: wrap;
   margin: 0;
 }
 
@@ -9,12 +11,22 @@
 .linkLabel {
   composes: label from '~Components/Label.css';
 
-  cursor: pointer;
+  margin: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.linkBlock {
+  display: flex;
+  margin: 3px;
 }
 
 @media only screen and (max-width: $breakpointExtraSmall) {
   .links {
-    display: flex;
     flex-flow: column wrap;
   }
 }

--- a/frontend/src/Series/Details/SeriesDetailsLinks.css.d.ts
+++ b/frontend/src/Series/Details/SeriesDetailsLinks.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'link': string;
+  'linkBlock': string;
   'linkLabel': string;
   'links': string;
 }

--- a/frontend/src/Series/Details/SeriesDetailsLinks.tsx
+++ b/frontend/src/Series/Details/SeriesDetailsLinks.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Label from 'Components/Label';
+import ClipboardButton from 'Components/Link/ClipboardButton';
 import Link from 'Components/Link/Link';
 import { kinds, sizes } from 'Helpers/Props';
 import Series from 'Series/Series';
+import translate from 'Utilities/String/translate';
 import styles from './SeriesDetailsLinks.css';
 
 type SeriesDetailsLinksProps = Pick<
@@ -10,96 +12,90 @@ type SeriesDetailsLinksProps = Pick<
   'tvdbId' | 'tvMazeId' | 'imdbId' | 'tmdbId'
 >;
 
+interface SeriesDetailsLink {
+  externalId: string | number;
+  name: string;
+  url: string;
+}
+
 function SeriesDetailsLinks(props: SeriesDetailsLinksProps) {
   const { tvdbId, tvMazeId, imdbId, tmdbId } = props;
 
+  const links = useMemo(() => {
+    const validLinks: SeriesDetailsLink[] = [];
+
+    if (tvdbId) {
+      validLinks.push(
+        {
+          externalId: tvdbId,
+          name: 'The TVDB',
+          url: `https://www.thetvdb.com/?tab=series&id=${tvdbId}`,
+        },
+        {
+          externalId: tvdbId,
+          name: 'Trakt',
+          url: `https://trakt.tv/search/tvdb/${tvdbId}?id_type=show`,
+        }
+      );
+    }
+
+    if (tvMazeId) {
+      validLinks.push({
+        externalId: tvMazeId,
+        name: 'TV Maze',
+        url: `https://www.tvmaze.com/shows/${tvMazeId}/_`,
+      });
+    }
+
+    if (imdbId) {
+      validLinks.push(
+        {
+          externalId: imdbId,
+          name: 'IMDB',
+          url: `https://imdb.com/title/${imdbId}/`,
+        },
+        {
+          externalId: imdbId,
+          name: 'MDBList',
+          url: `https://mdblist.com/show/${imdbId}`,
+        }
+      );
+    }
+
+    if (tmdbId) {
+      validLinks.push({
+        externalId: tmdbId,
+        name: 'TMDB',
+        url: `https://www.themoviedb.org/tv/${tmdbId}`,
+      });
+    }
+
+    return validLinks;
+  }, [tvdbId, tvMazeId, imdbId, tmdbId]);
+
   return (
     <div className={styles.links}>
-      <Link
-        className={styles.link}
-        to={`https://www.thetvdb.com/?tab=series&id=${tvdbId}`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
-        >
-          The TVDB
-        </Label>
-      </Link>
-
-      <Link
-        className={styles.link}
-        to={`https://trakt.tv/search/tvdb/${tvdbId}?id_type=show`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
-        >
-          Trakt
-        </Label>
-      </Link>
-
-      {tvMazeId ? (
-        <Link
-          className={styles.link}
-          to={`https://www.tvmaze.com/shows/${tvMazeId}/_`}
-        >
-          <Label
-            className={styles.linkLabel}
-            kind={kinds.INFO}
-            size={sizes.LARGE}
-          >
-            TV Maze
-          </Label>
-        </Link>
-      ) : null}
-
-      {imdbId ? (
-        <>
-          <Link
-            className={styles.link}
-            to={`https://imdb.com/title/${imdbId}/`}
-          >
+      {links.map((link) => (
+        <div key={link.name} className={styles.linkBlock}>
+          <Link className={styles.link} to={link.url}>
             <Label
               className={styles.linkLabel}
               kind={kinds.INFO}
               size={sizes.LARGE}
             >
-              IMDB
+              {link.name}
             </Label>
           </Link>
 
-          <Link
-            className={styles.link}
-            to={`http://mdblist.com/show/${imdbId}`}
-          >
-            <Label
-              className={styles.linkLabel}
-              kind={kinds.INFO}
-              size={sizes.LARGE}
-            >
-              MDBList
-            </Label>
-          </Link>
-        </>
-      ) : null}
-
-      {tmdbId ? (
-        <Link
-          className={styles.link}
-          to={`https://www.themoviedb.org/tv/${tmdbId}`}
-        >
-          <Label
-            className={styles.linkLabel}
-            kind={kinds.INFO}
-            size={sizes.LARGE}
-          >
-            TMDB
-          </Label>
-        </Link>
-      ) : null}
+          <ClipboardButton
+            value={`${link.externalId}`}
+            title={translate('CopyToClipboard')}
+            kind={kinds.DEFAULT}
+            size={sizes.SMALL}
+            label={link.externalId}
+          />
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
#### Description
Adding a copy button with the ID so that it can be easily copied to be used in indexers and searching tools. See #7927 for details. I've put the text in a button following the conversation [here](https://github.com/Sonarr/Sonarr/pull/7949#pullrequestreview-2995595202) and tried to make it look like existing controls.

- Add a `text` field to the ClipboardButton
- Display the link ID for `SeriesDetailsLinks`



#### Screenshots for UI Changes

##### Browser - Light Mode
![SonarrLinkCopy](https://github.com/user-attachments/assets/ba07bb82-9994-4788-869c-888c6264321b)

##### Browser - Dark Mode
<img width="1213" height="177" alt="image" src="https://github.com/user-attachments/assets/8642b34b-3f97-4e54-a250-15acac18f726" />

##### Mobile View (Emulated)
<img width="480" height="855" alt="image" src="https://github.com/user-attachments/assets/c65696d5-d1f0-473f-8218-bb2f717ca59f" />

##### iOS 26
<img width="480" alt="image" src="https://github.com/user-attachments/assets/966c9869-d7b6-47b2-a14a-be3327d6b608" />

\* Note: The background image not appearing seems to be an unrelated issue

#### Issues Fixed or Closed by this PR
* Closes: #7927


-----

Hi all, I'm new to React + Typescript and I'm trying to contribute as a learning exercise, so please let me know if I've done anything silly. I'm happy to update as necessary. Thanks in advance!