### PR TITLE
Mark downloads failed if local episode custom format score was lower than the remote score

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -89,6 +89,29 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Callback(() => WasImportedResponse());
         }
 
+        private LocalEpisode GivenRejectedImportDecision(ImportRejectionReason reason)
+        {
+            var localEpisode = new LocalEpisode();
+
+            var imported = new List<ImportDecision>();
+            imported.Add(new ImportDecision(localEpisode, new ImportRejection(reason, "reason")));
+
+            Mocker.GetMock<IMakeImportDecision>()
+                .Setup(s => s.GetImportDecisions(It.IsAny<List<string>>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>(), It.IsAny<ParsedEpisodeInfo>(), null, true))
+                .Returns(imported);
+
+            Mocker.GetMock<ITrackedDownloadService>()
+                .Setup(s => s.Find(It.IsAny<string>()))
+                .Returns(_trackedDownload);
+
+            Mocker.GetMock<IImportApprovedEpisodes>()
+                .Setup(s => s.Import(It.IsAny<List<ImportDecision>>(), It.IsAny<bool>(), It.IsAny<DownloadClientItem>(), It.IsAny<ImportMode>()))
+                .Returns(imported.Select(i => new ImportResult(i)).ToList())
+                .Callback(() => WasImportedResponse());
+
+            return localEpisode;
+        }
+
         private void WasImportedResponse()
         {
             Mocker.GetMock<IDiskScanService>().Setup(c => c.GetVideoFiles(It.IsAny<string>(), It.IsAny<bool>()))
@@ -524,6 +547,67 @@ namespace NzbDrone.Core.Test.MediaFiles
                     Times.Never());
 
             VerifyNoImport();
+        }
+
+        [Test]
+        public void should_not_mark_download_failed_if_rejected_import_did_not_have_lower_custom_format_score_upon_download()
+        {
+            GivenValidSeries();
+
+            var localEpisode = GivenRejectedImportDecision(ImportRejectionReason.NotCustomFormatUpgrade);
+            localEpisode.CustomFormatScore = 1;
+            _trackedDownload.RemoteEpisode.CustomFormatScore = 1;
+
+            Subject.ProcessPath(_droneFactory, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
+
+            Mocker.GetMock<IFailedDownloadService>()
+                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Never());
+        }
+
+        [Test]
+        public void should_mark_download_failed_if_rejected_by_not_custom_format_upgrade_and_local_episode_score_is_lower_than_remote_when_importing_folder()
+        {
+            var folderName = @"C:\media\ba09030e-1234-1234-1234-123456789abc\Torrents\SomeFolder".AsOsAgnostic();
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FolderExists(folderName))
+                .Returns(true);
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileExists(folderName))
+                .Returns(false);
+
+            GivenValidSeries();
+
+            var localEpisode = GivenRejectedImportDecision(ImportRejectionReason.NotCustomFormatUpgrade);
+            localEpisode.CustomFormatScore = 1;
+            _trackedDownload.RemoteEpisode.CustomFormatScore = 2;
+
+            Subject.ProcessPath(folderName, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
+
+            Mocker.GetMock<IFailedDownloadService>()
+                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Once());
+        }
+
+        [Test]
+        public void should_mark_download_failed_if_rejected_by_not_custom_format_upgrade_after_rename_when_importing_file()
+        {
+            var fileName = @"C:\media\ba09030e-1234-1234-1234-123456789abc\Torrents\[HorribleSubs] Maria the Virgin Witch - 09 [720p].mkv".AsOsAgnostic();
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FolderExists(fileName))
+                .Returns(false);
+
+            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileExists(fileName))
+                .Returns(true);
+
+            GivenValidSeries();
+
+            var localEpisode = GivenRejectedImportDecision(ImportRejectionReason.NotCustomFormatUpgrade);
+            localEpisode.CustomFormatScore = 1;
+            _trackedDownload.RemoteEpisode.CustomFormatScore = 2;
+
+            Subject.ProcessPath(fileName, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
+
+            Mocker.GetMock<IFailedDownloadService>()
+                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Once());
         }
 
         private void VerifyNoImport()

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
@@ -33,6 +34,8 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IDetectSample _detectSample;
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IConfigService _configService;
+        private readonly ITrackedDownloadService _trackedDownloadService;
+        private readonly IFailedDownloadService _failedDownloadService;
         private readonly Logger _logger;
 
         public DownloadedEpisodesImportService(IDiskProvider diskProvider,
@@ -44,6 +47,8 @@ namespace NzbDrone.Core.MediaFiles
                                                IDetectSample detectSample,
                                                IRuntimeInfo runtimeInfo,
                                                IConfigService configService,
+                                               ITrackedDownloadService trackedDownloadService,
+                                               IFailedDownloadService failedDownloadService,
                                                Logger logger)
         {
             _diskProvider = diskProvider;
@@ -55,6 +60,8 @@ namespace NzbDrone.Core.MediaFiles
             _detectSample = detectSample;
             _runtimeInfo = runtimeInfo;
             _configService = configService;
+            _trackedDownloadService = trackedDownloadService;
+            _failedDownloadService = failedDownloadService;
             _logger = logger;
         }
 
@@ -214,6 +221,20 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             var decisions = _importDecisionMaker.GetImportDecisions(videoFiles.ToList(), series, downloadClientItem, downloadClientItemInfo, folderInfo, true);
+
+            if (downloadClientItem != null && decisions != null)
+            {
+                foreach (var rejectedDecision in decisions.Where(x => x.Rejections.Any(r => r.Reason == ImportRejectionReason.NotCustomFormatUpgrade)))
+                {
+                    var trackedDownload = _trackedDownloadService.Find(downloadClientItem.DownloadId);
+                    if (trackedDownload != null && trackedDownload.RemoteEpisode.CustomFormatScore > rejectedDecision.LocalEpisode.CustomFormatScore)
+                    {
+                        _failedDownloadService.MarkAsFailed(trackedDownload, "Custom score was lower upon inspection of downloaded file.");
+                        break;
+                    }
+                }
+            }
+
             var importResults = _importApprovedEpisodes.Import(decisions, true, downloadClientItem, importMode);
 
             if (importMode == ImportMode.Auto)
@@ -341,6 +362,19 @@ namespace NzbDrone.Core.MediaFiles
 
             var downloadClientItemInfo = downloadClientItem == null ? null : Parser.Parser.ParseTitle(downloadClientItem.Title);
             var decisions = _importDecisionMaker.GetImportDecisions(new List<string>() { fileInfo.FullName }, series, downloadClientItem, downloadClientItemInfo, null, true);
+
+            if (downloadClientItem != null)
+            {
+                foreach (var rejectedDecision in decisions.Where(x => x.Rejections.Any(r => r.Reason == ImportRejectionReason.NotCustomFormatUpgrade)))
+                {
+                    var trackedDownload = _trackedDownloadService.Find(downloadClientItem.DownloadId);
+                    if (trackedDownload != null && trackedDownload.RemoteEpisode.CustomFormatScore > rejectedDecision.LocalEpisode.CustomFormatScore)
+                    {
+                        _failedDownloadService.MarkAsFailed(trackedDownload, "Custom score was lower upon inspection of downloaded file.");
+                        break;
+                    }
+                }
+            }
 
             return _importApprovedEpisodes.Import(decisions, true, downloadClientItem, importMode);
         }


### PR DESCRIPTION
Sometimes the custom format score calculated for a remote episode does not match the reality when the episode is downloaded and media-info is analyzed for the downloaded file.

For example, if an episode appears to have English language before it is downloaded, but upon analyzing the files, it turns out to not have English language.

This could reduce the custom score for the episode and potentially could cause an import rejection based on custom format score.

If such an import is rejected, there is nothing preventing Sonarr from downloading the same release again if a search is initiated for that episode. The RemoteEpisode will still appear as having a high enough custom score to replace the existing file.

This change checks for this and marks a download failed preventing it from being downloaded again.

If a import was rejected based on it not being a custom-format upgrade AND the remote episode custom format score is *higher* than the one from the analyzed local episode, then and only then do we mark the download failed.
