### PR TITLE
Block releases if custom score rejection during import

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedEpisodesImportServiceFixture.cs
@@ -8,6 +8,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.MediaFiles;
@@ -560,8 +561,8 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.ProcessPath(_droneFactory, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
 
-            Mocker.GetMock<IFailedDownloadService>()
-                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Never());
+            Mocker.GetMock<IBlocklistService>()
+                .Verify(v => v.Block(_trackedDownload.RemoteEpisode, "Custom score was lower upon inspection of downloaded file.", null), Times.Never());
         }
 
         [Test]
@@ -583,8 +584,8 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.ProcessPath(folderName, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
 
-            Mocker.GetMock<IFailedDownloadService>()
-                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Once());
+            Mocker.GetMock<IBlocklistService>()
+                .Verify(v => v.Block(_trackedDownload.RemoteEpisode, "Custom score was lower upon inspection of downloaded file.", null), Times.Once());
         }
 
         [Test]
@@ -606,8 +607,8 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Subject.ProcessPath(fileName, ImportMode.Move, _trackedDownload.RemoteEpisode.Series, _trackedDownload.DownloadItem);
 
-            Mocker.GetMock<IFailedDownloadService>()
-                .Verify(v => v.MarkAsFailed(_trackedDownload, "Custom score was lower upon inspection of downloaded file.", null, false), Times.Once());
+            Mocker.GetMock<IBlocklistService>()
+                .Verify(v => v.Block(_trackedDownload.RemoteEpisode, "Custom score was lower upon inspection of downloaded file.", null), Times.Once());
         }
 
         private void VerifyNoImport()

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
@@ -35,7 +36,7 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IRuntimeInfo _runtimeInfo;
         private readonly IConfigService _configService;
         private readonly ITrackedDownloadService _trackedDownloadService;
-        private readonly IFailedDownloadService _failedDownloadService;
+        private readonly IBlocklistService _blocklistService;
         private readonly Logger _logger;
 
         public DownloadedEpisodesImportService(IDiskProvider diskProvider,
@@ -48,7 +49,7 @@ namespace NzbDrone.Core.MediaFiles
                                                IRuntimeInfo runtimeInfo,
                                                IConfigService configService,
                                                ITrackedDownloadService trackedDownloadService,
-                                               IFailedDownloadService failedDownloadService,
+                                               IBlocklistService blocklistService,
                                                Logger logger)
         {
             _diskProvider = diskProvider;
@@ -61,7 +62,7 @@ namespace NzbDrone.Core.MediaFiles
             _runtimeInfo = runtimeInfo;
             _configService = configService;
             _trackedDownloadService = trackedDownloadService;
-            _failedDownloadService = failedDownloadService;
+            _blocklistService = blocklistService;
             _logger = logger;
         }
 
@@ -229,7 +230,7 @@ namespace NzbDrone.Core.MediaFiles
                     var trackedDownload = _trackedDownloadService.Find(downloadClientItem.DownloadId);
                     if (trackedDownload != null && trackedDownload.RemoteEpisode.CustomFormatScore > rejectedDecision.LocalEpisode.CustomFormatScore)
                     {
-                        _failedDownloadService.MarkAsFailed(trackedDownload, "Custom score was lower upon inspection of downloaded file.");
+                        _blocklistService.Block(trackedDownload.RemoteEpisode, "Custom score was lower upon inspection of downloaded file.", null);
                         break;
                     }
                 }
@@ -370,7 +371,7 @@ namespace NzbDrone.Core.MediaFiles
                     var trackedDownload = _trackedDownloadService.Find(downloadClientItem.DownloadId);
                     if (trackedDownload != null && trackedDownload.RemoteEpisode.CustomFormatScore > rejectedDecision.LocalEpisode.CustomFormatScore)
                     {
-                        _failedDownloadService.MarkAsFailed(trackedDownload, "Custom score was lower upon inspection of downloaded file.");
+                        _blocklistService.Block(trackedDownload.RemoteEpisode, "Custom score was lower upon inspection of downloaded file.", null);
                         break;
                     }
                 }


### PR DESCRIPTION
Sometimes the custom format score calculated for a remote episode does not match the reality when the episode is downloaded and media-info is analyzed for the downloaded file.

For example, if an episode appears to have English language before it is downloaded, but upon analyzing the files, it turns out to not have English language.

This could reduce the custom score for the episode and potentially could cause an import rejection based on custom format score.

If such an import is rejected, there is nothing preventing Sonarr from downloading the same release again if a search is initiated for that episode. The RemoteEpisode will still appear as having a high enough custom score to replace the existing file.

This change checks for this and blocklists the associated release preventing it from being downloaded again.

If a import was rejected based on it not being a custom-format upgrade AND the remote episode custom format score is higher than the one from the analyzed local episode, then and only then do we blocklist.

(Sorry this is back so similar to the previous one, but I couldn't update the other pull request)