### PR TITLE
New: Replace HTML Encoded values in release titles

### DIFF
--- a/src/NzbDrone.Core.Test/Files/Indexers/encoded_title.xml
+++ b/src/NzbDrone.Core.Test/Files/Indexers/encoded_title.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+
+  <channel>
+
+    <item>
+      <title>Series.&amp;amp;.Title.S02E19.EAC3.5.1.1080p.WEBRip.x265-iVy</title>
+      <guid isPermaLink="true">https://my.indexer.com/info.php?guid=abc123</guid>
+      <link>https://my.indexer.com/api?t=get&amp;id=abc123&amp;apikey=secret</link>
+      <comments>https://my.indexer.com/info.php?guid=abc123</comments>
+      <pubDate>Fri, 20 Dec 2024 05:16:34 +0000</pubDate>
+      <category>TV > HD</category>
+      <description>Series.&amp;.Title.S02E19.EAC3.5.1.1080p.WEBRip.x265-iVy</description>
+      <enclosure url="https://my.indexer.com/api?t=get&amp;id=abc123&amp;apikey=secret" length="724655000" type="application/x-nzb"/>
+    </item>
+
+  </channel>
+</rss>

--- a/src/NzbDrone.Core.Test/IndexerTests/BasicRssParserFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BasicRssParserFixture.cs
@@ -58,5 +58,16 @@ namespace NzbDrone.Core.Test.IndexerTests
             result.First().CommentUrl.Should().Be("http://my.indexer.com/details/123#comments");
             result.First().DownloadUrl.Should().Be("http://my.indexer.com/getnzb/123.nzb&i=782&r=123");
         }
+
+        [Test]
+        public void should_decode_html_entities_in_item_title()
+        {
+            var xml = ReadAllText("Files/Indexers/encoded_title.xml");
+
+            var result = Subject.ParseResponse(CreateResponse("http://my.indexer.com/rss", xml));
+
+            result.Should().HaveCount(1);
+            result.First().Title.Should().Be("Series.&.Title.S02E19.EAC3.5.1.1080p.WEBRip.x265-iVy");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj
@@ -18,5 +18,8 @@
     <None Update="Files\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Files\Indexers\encoded_title.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -186,7 +186,9 @@ namespace NzbDrone.Core.Indexers
 
         protected virtual string GetTitle(XElement item)
         {
-            return item.TryGetValue("title", "Unknown");
+            var title = item.TryGetValue("title", "Unknown");
+
+            return WebUtility.HtmlDecode(title);
         }
 
         protected virtual DateTime GetPublishDate(XElement item)


### PR DESCRIPTION
#### Description

Cleans up double encoded titles from indexers so they are logged and parsed correctly. 