### PR TITLE
Improve scene mapping updating

### DIFF
--- a/src/NzbDrone.Core.Test/DataAugmentation/Scene/SceneMappingServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/DataAugmentation/Scene/SceneMappingServiceFixture.cs
@@ -46,6 +46,10 @@ namespace NzbDrone.Core.Test.DataAugmentation.Scene
 
             _provider2 = new Mock<ISceneMappingProvider>();
             _provider2.Setup(s => s.GetSceneMappings()).Returns(_fakeMappings);
+
+            Mocker.GetMock<ISceneMappingRepository>()
+                  .Setup(c => c.GetAllByType(It.IsAny<string>()))
+                  .Returns(new List<SceneMapping>());
         }
 
         private void GivenProviders(IEnumerable<Mock<ISceneMappingProvider>> providers)
@@ -375,15 +379,15 @@ namespace NzbDrone.Core.Test.DataAugmentation.Scene
         private void AssertNoUpdate()
         {
             _provider1.Verify(c => c.GetSceneMappings(), Times.Once());
-            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.Clear(It.IsAny<string>()), Times.Never());
-            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.InsertMany(_fakeMappings), Times.Never());
+            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.InsertMany(It.IsAny<IList<SceneMapping>>()), Times.Never());
+            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.UpdateMany(It.IsAny<IList<SceneMapping>>()), Times.Never());
+            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.DeleteMany(It.IsAny<List<SceneMapping>>()), Times.Never());
         }
 
         private void AssertMappingUpdated()
         {
             _provider1.Verify(c => c.GetSceneMappings(), Times.Once());
-            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.Clear(It.IsAny<string>()), Times.Once());
-            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.InsertMany(_fakeMappings), Times.Once());
+            Mocker.GetMock<ISceneMappingRepository>().Verify(c => c.InsertMany(It.IsAny<IList<SceneMapping>>()), Times.Once());
 
             foreach (var sceneMapping in _fakeMappings)
             {

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMapping.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMapping.cs
@@ -5,6 +5,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
 {
     public class SceneMapping : ModelBase
     {
+        public string MappingId { get; set; }
         public string Title { get; set; }
         public string ParseTerm { get; set; }
 

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingRepository.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingRepository.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
     public interface ISceneMappingRepository : IBasicRepository<SceneMapping>
     {
         List<SceneMapping> FindByTvdbid(int tvdbId);
-        void Clear(string type);
+        List<SceneMapping> GetAllByType(string type);
     }
 
     public class SceneMappingRepository : BasicRepository<SceneMapping>, ISceneMappingRepository
@@ -22,9 +22,9 @@ namespace NzbDrone.Core.DataAugmentation.Scene
             return Query(x => x.TvdbId == tvdbId);
         }
 
-        public void Clear(string type)
+        public List<SceneMapping> GetAllByType(string type)
         {
-            Delete(s => s.Type == type);
+            return Query(x => x.Type == type);
         }
     }
 }

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
 
                     if (mappings.Any())
                     {
-                        _repository.Clear(sceneMappingProvider.GetType().Name);
+                        var providerType = sceneMappingProvider.GetType().Name;
 
                         mappings.RemoveAll(sceneMapping =>
                         {
@@ -160,10 +160,45 @@ namespace NzbDrone.Core.DataAugmentation.Scene
                         foreach (var sceneMapping in mappings)
                         {
                             sceneMapping.ParseTerm = sceneMapping.Title.CleanSeriesTitle();
-                            sceneMapping.Type = sceneMappingProvider.GetType().Name;
+                            sceneMapping.Type = providerType;
                         }
 
-                        _repository.InsertMany(mappings.ToList());
+                        var existing = _repository.GetAllByType(providerType);
+                        var existingByMappingId = new Dictionary<string, SceneMapping>();
+
+                        foreach (var e in existing)
+                        {
+                            existingByMappingId[e.MappingId ?? $"{e.Id}"] = e;
+                        }
+
+                        var toInsert = new List<SceneMapping>();
+                        var toUpdate = new List<SceneMapping>();
+
+                        foreach (var mapping in mappings)
+                        {
+                            if (mapping.MappingId.IsNullOrWhiteSpace())
+                            {
+                                _logger.Warn("Scene mapping with missing MappingId found for: {0} {1}, skipping", mapping.TvdbId, mapping.Title);
+                                continue;
+                            }
+
+                            if (existingByMappingId.TryGetValue(mapping.MappingId, out var existingMapping))
+                            {
+                                mapping.Id = existingMapping.Id;
+                                toUpdate.Add(mapping);
+                                existingByMappingId.Remove(mapping.MappingId);
+                            }
+                            else
+                            {
+                                toInsert.Add(mapping);
+                            }
+                        }
+
+                        var toDelete = existingByMappingId.Values.ToList();
+
+                        _repository.DeleteMany(toDelete);
+                        _repository.UpdateMany(toUpdate);
+                        _repository.InsertMany(toInsert);
                     }
                     else
                     {

--- a/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
@@ -101,6 +101,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
                         result.Add(new SceneMapping
                                    {
+                                       MappingId = $"x-{series.Key}_S{seasonNumber}_{n.Key.Replace(' ', '_')}",
                                        Title = n.Key,
                                        SearchTerm = n.Key,
                                        SceneSeasonNumber = seasonNumber,

--- a/src/NzbDrone.Core/Datastore/Migration/230_add_mapping_id_to_scene_mappings.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/230_add_mapping_id_to_scene_mappings.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(230)]
+    public class add_mapping_id_to_scene_mappings : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("SceneMappings")
+                 .AddColumn("MappingId").AsString().Nullable();
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Instead of removing all and adding new items we should add/update/delete as required. For Services based aliases we're returning a `mappingId`, for XEM we'll create one based on the series ID/season/title.

#### Database Migration
YES - 230

#### Issues Fixed or Closed by this PR
* Closes #8452

