### PR TITLE
Fixed: First column reordering

### DIFF
--- a/frontend/src/Components/Table/TableOptions/TableOptionsModal.tsx
+++ b/frontend/src/Components/Table/TableOptions/TableOptionsModal.tsx
@@ -110,7 +110,7 @@ function TableOptionsModal({
 
   const handleColumnDragEnd = useCallback(
     (didDrop: boolean) => {
-      if (didDrop && dragIndex && dropIndex !== null) {
+      if (didDrop && dragIndex !== null && dropIndex !== null) {
         const newColumns = [...columns];
         const items = newColumns.splice(dragIndex, 1);
         newColumns.splice(dropIndex, 0, items[0]);


### PR DESCRIPTION
#### Description
Minor bug fix. The first column of a table could not be re-ordered since the index `0` evaluated to `false`.

**Steps to reproduce**

1. Navigate to Wanted -> Missing -> Options
2. Select the first column and drag it down

Expected: The column is reordered
Actual: The column snaps back into first (original) place

This only seems to impact V5.

#### Screenshots for UI Changes

**Before**

![ColumnReorder-Before](https://github.com/user-attachments/assets/9e7a6b7e-d58e-43ae-af7e-a96835d00144)

**After**

![ColumnReorder-After](https://github.com/user-attachments/assets/ba6b1f2a-de2e-4912-9d92-c21b38f3dae7)
