### PR TITLE
Skip per-episode anime search when season pack found

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -415,9 +415,22 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadDecisions.AddRange(decisions);
             }
 
-            foreach (var episode in episodesToSearch)
+            // Skip per-episode search if the season search already found an approved result
+            // that covers all wanted episodes (i.e. a season pack). For interactive searches,
+            // still search per-episode so the user can see all available results.
+            var hasAcceptableSeasonPack = downloadDecisions
+                .Any(d => d.Approved && d.RemoteEpisode.Episodes.Count >= episodesToSearch.Count);
+
+            if (!hasAcceptableSeasonPack || interactiveSearch)
             {
-                downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                foreach (var episode in episodesToSearch)
+                {
+                    downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                }
+            }
+            else
+            {
+                _logger.Debug("Skipping per-episode search for {0}, acceptable season pack already found", series.Title);
             }
 
             return DeDupeDecisions(downloadDecisions);


### PR DESCRIPTION
## Summary

- When searching for an anime season, Sonarr unconditionally searches for every individual episode even after the season search has already found an acceptable season pack
- This causes excessive indexer API calls (24 episodes × N indexers), long search times, and potential indexer rate-limiting/bans
- This PR adds a check after the season search: if an approved result covering all wanted episodes is found, per-episode search is skipped
- Interactive searches are unaffected — they still return all results so users can browse everything

## Changes

**`src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs`** — `SearchAnimeSeason()`:
- After the season pack search loop, check if any approved `DownloadDecision` covers all wanted episodes
- If yes and the search is automatic (not interactive), skip the per-episode search loop
- Log a debug message when skipping

## Related Issues

Fixes #7744 — "When searching for Full Seasons, it does also Search for individual episodes even when it is not necessary"
Fixes #6495 — Anime season search optimization

## Test Plan

- [x] All 25 existing `ReleaseSearchServiceFixture` tests pass
- [x] Build succeeds
- [ ] Manual test: trigger an automatic anime season search and verify per-episode search is skipped when a season pack is found
- [ ] Manual test: interactive search still returns both season packs and individual episodes