### PR TITLE
Fix: Invisible UI Elements

### DIFF
--- a/frontend/src/Components/Menu/Menu.tsx
+++ b/frontend/src/Components/Menu/Menu.tsx
@@ -157,7 +157,7 @@ function Menu({
           {React.cloneElement(childrenArray[1] as ReactElement, {
             forwardedRef: refs.setFloating,
             style: {
-              maxHeight,
+              maxHeight: enforceMaxHeight ? maxHeight : undefined,
               ...floatingStyles,
             },
             isOpen: isMenuOpen,

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -4,6 +4,7 @@
 
 .header {
   position: relative;
+  z-index: 0;
   width: 100%;
 }
 


### PR DESCRIPTION
#### Description

- fanart/poster was rendering behind body as z-index was set to -1 but parent z-index was unset.
- Mobile action menu for seasons would not render when changing from desktop to mobile view as maxheight defaults to 0 until updateMaxHeight call is made.

#### Screenshots for UI Changes
#### Poster Before

<img width="2670" height="698" alt="image" src="https://github.com/user-attachments/assets/bf92cb7b-2db4-4147-b7a5-ea44824343e3" />

#### Poster After

<img width="2930" height="653" alt="image" src="https://github.com/user-attachments/assets/8bec2d83-0a82-4d76-9888-50d90a3923eb" />

#### Action button clicked but menu not visible

<img width="336" height="204" alt="image" src="https://github.com/user-attachments/assets/b9b053fc-cf5f-4bf0-989e-efb77e93c07b" />


