### PR TITLE
Load initial paths for file browser

### DIFF
--- a/frontend/src/Components/FileBrowser/FileBrowserModalContent.tsx
+++ b/frontend/src/Components/FileBrowser/FileBrowserModalContent.tsx
@@ -133,7 +133,11 @@ function FileBrowserModalContent({
           className={styles.scroller}
           scrollDirection="both"
         >
-          {error ? <div>{translate('ErrorLoadingContents')}</div> : null}
+          {error ? (
+            <Alert kind={kinds.DANGER}>
+              {translate('ErrorLoadingContents')}
+            </Alert>
+          ) : null}
 
           {isFetched && !error ? (
             <Table horizontalScroll={false} columns={columns}>

--- a/frontend/src/Path/usePaths.ts
+++ b/frontend/src/Path/usePaths.ts
@@ -47,7 +47,6 @@ const usePaths = ({
     path: '/filesystem',
     queryParams: { path, allowFoldersWithoutTrailingSlashes, includeFiles },
     queryOptions: {
-      enabled: path.trim().length > 0,
       placeholderData: keepPreviousData,
     },
   });

--- a/src/Sonarr.Api.V5/FileSystem/FileSystemController.cs
+++ b/src/Sonarr.Api.V5/FileSystem/FileSystemController.cs
@@ -24,7 +24,7 @@ public class FileSystemController : Controller
 
     [HttpGet]
     [Produces("application/json")]
-    public IActionResult GetContents(string path, bool includeFiles = false, bool allowFoldersWithoutTrailingSlashes = false)
+    public IActionResult GetContents(string? path, bool includeFiles = false, bool allowFoldersWithoutTrailingSlashes = false)
     {
         return Ok(_fileSystemLookupService.LookupContents(path, includeFiles, allowFoldersWithoutTrailingSlashes));
     }


### PR DESCRIPTION
#### Description
Since 91b242902d995e2cbd080b87ce289dbba84cfbdd the initial paths are no longer being loaded on opening file browser.

Reverting to previous behavior, since the placeholder still indicates that initial paths are to be expected. 

#### Screenshots for UI Changes
Before
![Screenshot Before](https://github.com/user-attachments/assets/2be36a1e-fce7-473d-b23c-02656201b759)

After
![Screenshot After](https://github.com/user-attachments/assets/e679e590-9c8e-41ac-ae97-6ccb97ec3b82)

