### PR TITLE
Fixed: Search input loses focus after clearing on mobile browsers

### DIFF
--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Alert from 'Components/Alert';
-import TextInput from 'Components/Form/TextInput';
+import TextInput, { TextInputHandle } from 'Components/Form/TextInput';
 import Icon from 'Components/Icon';
 import Button from 'Components/Link/Button';
 import Link from 'Components/Link/Link';
@@ -22,6 +22,7 @@ function AddNewSeries() {
   const { term: initialTerm = '' } = useQueryParams<{ term: string }>();
   const hasSeries = useHasSeries();
   const [term, setTerm] = useState(initialTerm);
+  const searchInputRef = useRef<TextInputHandle>(null);
   const [isFetching, setIsFetching] = useState(false);
   const query = useDebounce(term, term ? 300 : 0);
 
@@ -36,6 +37,7 @@ function AddNewSeries() {
   const handleClearSeriesLookupPress = useCallback(() => {
     setTerm('');
     setIsFetching(false);
+    searchInputRef.current?.focus();
   }, []);
 
   const { isFetching: isFetchingApi, error, data } = useLookupSeries(query);
@@ -57,6 +59,7 @@ function AddNewSeries() {
           </div>
 
           <TextInput
+            ref={searchInputRef}
             className={styles.searchInput}
             name="seriesLookup"
             value={term}

--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Alert from 'Components/Alert';
-import TextInput, { TextInputHandle } from 'Components/Form/TextInput';
+import TextInput from 'Components/Form/TextInput';
 import Icon from 'Components/Icon';
 import Button from 'Components/Link/Button';
 import Link from 'Components/Link/Link';
@@ -22,7 +22,7 @@ function AddNewSeries() {
   const { term: initialTerm = '' } = useQueryParams<{ term: string }>();
   const hasSeries = useHasSeries();
   const [term, setTerm] = useState(initialTerm);
-  const searchInputRef = useRef<TextInputHandle>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [isFetching, setIsFetching] = useState(false);
   const query = useDebounce(term, term ? 300 : 0);
 

--- a/frontend/src/Components/Form/TextInput.tsx
+++ b/frontend/src/Components/Form/TextInput.tsx
@@ -6,7 +6,6 @@ import React, {
   SyntheticEvent,
   useCallback,
   useEffect,
-  useImperativeHandle,
   useRef,
 } from 'react';
 import { FileInputChanged, InputChanged } from 'typings/inputs';
@@ -41,11 +40,7 @@ export interface FileInputProps extends CommonTextInputProps {
   onChange: (change: FileInputChanged) => void;
 }
 
-export interface TextInputHandle {
-  focus: () => void;
-}
-
-const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
+const TextInput = forwardRef<HTMLInputElement, TextInputProps | FileInputProps>(
   (
     {
       className = styles.input,
@@ -71,12 +66,18 @@ const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
   ) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
-    useImperativeHandle(
-      ref,
-      () => ({
-        focus: () => inputRef.current?.focus(),
-      }),
-      []
+    const setRef = useCallback(
+      (node: HTMLInputElement | null) => {
+        (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+          node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          (ref as React.MutableRefObject<HTMLInputElement | null>).current =
+            node;
+        }
+      },
+      [ref]
     );
 
     const selectionTimeout = useRef<ReturnType<typeof setTimeout>>();
@@ -171,7 +172,7 @@ const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
 
     return (
       <input
-        ref={inputRef}
+        ref={setRef}
         type={type}
         readOnly={readOnly}
         autoFocus={autoFocus}

--- a/frontend/src/Components/Form/TextInput.tsx
+++ b/frontend/src/Components/Form/TextInput.tsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
+import useCombinedRefs from 'Helpers/Hooks/useCombinedRefs';
 import { FileInputChanged, InputChanged } from 'typings/inputs';
 import styles from './TextInput.css';
 
@@ -65,21 +66,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps | FileInputProps>(
     ref
   ) => {
     const inputRef = useRef<HTMLInputElement>(null);
-
-    const setRef = useCallback(
-      (node: HTMLInputElement | null) => {
-        (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
-          node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          (ref as React.MutableRefObject<HTMLInputElement | null>).current =
-            node;
-        }
-      },
-      [ref]
-    );
-
+    const combinedRef = useCombinedRefs(ref, inputRef);
     const selectionTimeout = useRef<ReturnType<typeof setTimeout>>();
     const selectionStart = useRef<number | null>();
     const selectionEnd = useRef<number | null>();
@@ -172,7 +159,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps | FileInputProps>(
 
     return (
       <input
-        ref={setRef}
+        ref={combinedRef}
         type={type}
         readOnly={readOnly}
         autoFocus={autoFocus}

--- a/frontend/src/Components/Form/TextInput.tsx
+++ b/frontend/src/Components/Form/TextInput.tsx
@@ -2,8 +2,8 @@ import classNames from 'classnames';
 import React, {
   ChangeEvent,
   FocusEvent,
-  SyntheticEvent,
   forwardRef,
+  SyntheticEvent,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -46,7 +46,7 @@ export interface TextInputHandle {
 }
 
 const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
-  function TextInput(
+  (
     {
       className = styles.input,
       type = 'text',
@@ -68,12 +68,16 @@ const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
       onSelectionChange,
     }: TextInputProps | FileInputProps,
     ref
-  ) {
+  ) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
-    useImperativeHandle(ref, () => ({
-      focus: () => inputRef.current?.focus(),
-    }), []);
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => inputRef.current?.focus(),
+      }),
+      []
+    );
 
     const selectionTimeout = useRef<ReturnType<typeof setTimeout>>();
     const selectionStart = useRef<number | null>();

--- a/frontend/src/Components/Form/TextInput.tsx
+++ b/frontend/src/Components/Form/TextInput.tsx
@@ -3,8 +3,10 @@ import React, {
   ChangeEvent,
   FocusEvent,
   SyntheticEvent,
+  forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useRef,
 } from 'react';
 import { FileInputChanged, InputChanged } from 'typings/inputs';
@@ -39,147 +41,161 @@ export interface FileInputProps extends CommonTextInputProps {
   onChange: (change: FileInputChanged) => void;
 }
 
-function TextInput({
-  className = styles.input,
-  type = 'text',
-  readOnly = false,
-  autoFocus = false,
-  placeholder,
-  name,
-  value = '',
-  hasError,
-  hasWarning,
-  hasButton,
-  step,
-  min,
-  max,
-  onBlur,
-  onFocus,
-  onCopy,
-  onChange,
-  onSelectionChange,
-}: TextInputProps | FileInputProps): JSX.Element {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const selectionTimeout = useRef<ReturnType<typeof setTimeout>>();
-  const selectionStart = useRef<number | null>();
-  const selectionEnd = useRef<number | null>();
-  const isMouseTarget = useRef(false);
-
-  const selectionChanged = useCallback(() => {
-    if (selectionTimeout.current) {
-      clearTimeout(selectionTimeout.current);
-    }
-
-    selectionTimeout.current = setTimeout(() => {
-      if (!inputRef.current) {
-        return;
-      }
-
-      const start = inputRef.current.selectionStart;
-      const end = inputRef.current.selectionEnd;
-
-      const selectionChanged =
-        selectionStart.current !== start || selectionEnd.current !== end;
-
-      selectionStart.current = start;
-      selectionEnd.current = end;
-
-      if (selectionChanged) {
-        onSelectionChange?.(start, end);
-      }
-    }, 10);
-  }, [onSelectionChange]);
-
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      onChange({
-        name,
-        value: event.target.value,
-        files: type === 'file' ? event.target.files : undefined,
-      });
-    },
-    [name, type, onChange]
-  );
-
-  const handleFocus = useCallback(
-    (event: FocusEvent<HTMLInputElement, Element>) => {
-      onFocus?.(event);
-
-      selectionChanged();
-    },
-    [selectionChanged, onFocus]
-  );
-
-  const handleKeyUp = useCallback(() => {
-    selectionChanged();
-  }, [selectionChanged]);
-
-  const handleMouseDown = useCallback(() => {
-    isMouseTarget.current = true;
-  }, []);
-
-  const handleMouseUp = useCallback(() => {
-    selectionChanged();
-  }, [selectionChanged]);
-
-  const handleWheel = useCallback(() => {
-    if (type === 'number') {
-      inputRef.current?.blur();
-    }
-  }, [type]);
-
-  const handleDocumentMouseUp = useCallback(() => {
-    if (isMouseTarget.current) {
-      selectionChanged();
-    }
-
-    isMouseTarget.current = false;
-  }, [selectionChanged]);
-
-  useEffect(() => {
-    window.addEventListener('mouseup', handleDocumentMouseUp);
-
-    return () => {
-      window.removeEventListener('mouseup', handleDocumentMouseUp);
-    };
-  }, [handleDocumentMouseUp]);
-
-  useEffect(() => {
-    return () => {
-      clearTimeout(selectionTimeout.current);
-    };
-  }, []);
-
-  return (
-    <input
-      ref={inputRef}
-      type={type}
-      readOnly={readOnly}
-      autoFocus={autoFocus}
-      placeholder={placeholder}
-      className={classNames(
-        className,
-        readOnly && styles.readOnly,
-        hasError && styles.hasError,
-        hasWarning && styles.hasWarning,
-        hasButton && styles.hasButton
-      )}
-      name={name}
-      value={value}
-      step={step}
-      min={min}
-      max={max}
-      onChange={handleChange}
-      onFocus={handleFocus}
-      onBlur={onBlur}
-      onCopy={onCopy}
-      onCut={onCopy}
-      onKeyUp={handleKeyUp}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onWheel={handleWheel}
-    />
-  );
+export interface TextInputHandle {
+  focus: () => void;
 }
+
+const TextInput = forwardRef<TextInputHandle, TextInputProps | FileInputProps>(
+  function TextInput(
+    {
+      className = styles.input,
+      type = 'text',
+      readOnly = false,
+      autoFocus = false,
+      placeholder,
+      name,
+      value = '',
+      hasError,
+      hasWarning,
+      hasButton,
+      step,
+      min,
+      max,
+      onBlur,
+      onFocus,
+      onCopy,
+      onChange,
+      onSelectionChange,
+    }: TextInputProps | FileInputProps,
+    ref
+  ) {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+    }), []);
+
+    const selectionTimeout = useRef<ReturnType<typeof setTimeout>>();
+    const selectionStart = useRef<number | null>();
+    const selectionEnd = useRef<number | null>();
+    const isMouseTarget = useRef(false);
+
+    const selectionChanged = useCallback(() => {
+      if (selectionTimeout.current) {
+        clearTimeout(selectionTimeout.current);
+      }
+
+      selectionTimeout.current = setTimeout(() => {
+        if (!inputRef.current) {
+          return;
+        }
+
+        const start = inputRef.current.selectionStart;
+        const end = inputRef.current.selectionEnd;
+
+        const selectionChanged =
+          selectionStart.current !== start || selectionEnd.current !== end;
+
+        selectionStart.current = start;
+        selectionEnd.current = end;
+
+        if (selectionChanged) {
+          onSelectionChange?.(start, end);
+        }
+      }, 10);
+    }, [onSelectionChange]);
+
+    const handleChange = useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        onChange({
+          name,
+          value: event.target.value,
+          files: type === 'file' ? event.target.files : undefined,
+        });
+      },
+      [name, type, onChange]
+    );
+
+    const handleFocus = useCallback(
+      (event: FocusEvent<HTMLInputElement, Element>) => {
+        onFocus?.(event);
+
+        selectionChanged();
+      },
+      [selectionChanged, onFocus]
+    );
+
+    const handleKeyUp = useCallback(() => {
+      selectionChanged();
+    }, [selectionChanged]);
+
+    const handleMouseDown = useCallback(() => {
+      isMouseTarget.current = true;
+    }, []);
+
+    const handleMouseUp = useCallback(() => {
+      selectionChanged();
+    }, [selectionChanged]);
+
+    const handleWheel = useCallback(() => {
+      if (type === 'number') {
+        inputRef.current?.blur();
+      }
+    }, [type]);
+
+    const handleDocumentMouseUp = useCallback(() => {
+      if (isMouseTarget.current) {
+        selectionChanged();
+      }
+
+      isMouseTarget.current = false;
+    }, [selectionChanged]);
+
+    useEffect(() => {
+      window.addEventListener('mouseup', handleDocumentMouseUp);
+
+      return () => {
+        window.removeEventListener('mouseup', handleDocumentMouseUp);
+      };
+    }, [handleDocumentMouseUp]);
+
+    useEffect(() => {
+      return () => {
+        clearTimeout(selectionTimeout.current);
+      };
+    }, []);
+
+    return (
+      <input
+        ref={inputRef}
+        type={type}
+        readOnly={readOnly}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className={classNames(
+          className,
+          readOnly && styles.readOnly,
+          hasError && styles.hasError,
+          hasWarning && styles.hasWarning,
+          hasButton && styles.hasButton
+        )}
+        name={name}
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={onBlur}
+        onCopy={onCopy}
+        onCut={onCopy}
+        onKeyUp={handleKeyUp}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onWheel={handleWheel}
+      />
+    );
+  }
+);
 
 export default TextInput;


### PR DESCRIPTION
#### Description
On mobile browsers (Safari, Chrome), tapping the × button to clear the Add New Series search input dismisses the keyboard and drops focus. A second tap is required to resume typing — an unnecessary friction point on mobile.

The fix calls `focus()` on the search input synchronously within the clear button's press handler. Because the call happens inside a direct user gesture, mobile browsers honour it and raise the keyboard immediately.

Steps to reproduce

1. Open `/add/new` on a mobile browser
2. Type a search term
3. Tap the **×** button to clear it

**Expected:** keyboard stays up, cursor is in the input, ready to type

**Actual:** keyboard dismisses, input is unfocused, requires a second tap

**Note on `TextInput.tsx` diff**

The diff for `TextInput.tsx` looks larger than the change warrants; wrapping the component in `forwardRef` required re-indenting the entire function body. The functional change is two new imports: the `TextInputHandle` interface, and the `useImperativeHandle` call. [View without whitespace changes](https://github.com/Sonarr/Sonarr/pull/8489/files?w=1) to see the real delta.

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
* Closes #8487

