### PR TITLE
Fixed: Unexpected languages stored in DB will be treated as Unknown

### DIFF
--- a/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
+++ b/src/NzbDrone.Core/Datastore/Converters/LanguageIntConverter.cs
@@ -34,8 +34,15 @@ namespace NzbDrone.Core.Datastore.Converters
 
     public class LanguageIntConverter : JsonConverter<Language>
     {
+        public override bool HandleNull => true;
+
         public override Language Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return Language.Unknown;
+            }
+
             var item = reader.GetInt32();
             return (Language)item;
         }


### PR DESCRIPTION
#### Description

Not sure whether this was corruption or something weird done in a migration, but instead of returning `null` which breaks the UI, return `Unknown` so it can be displayed properly.

#### Issues Fixed or Closed by this PR
* Closes #8482

