### PR TITLE
Prevent duplicating providers when adding a new provider

### DIFF
--- a/frontend/src/Settings/useProviderSettings.ts
+++ b/frontend/src/Settings/useProviderSettings.ts
@@ -122,13 +122,17 @@ export const useSaveProviderSettings = <T extends ModelBase>(
     },
     onSuccess: (updatedSettings: T) => {
       queryClient.setQueryData<T[]>([path], (oldData = []) => {
-        if (id) {
-          return oldData.map((item) =>
-            item.id === updatedSettings.id ? updatedSettings : item
-          );
+        const existingIndex = oldData.findIndex(
+          (item) => item.id === updatedSettings.id
+        );
+
+        if (existingIndex === -1) {
+          return [...oldData, updatedSettings];
         }
 
-        return [...oldData, updatedSettings];
+        return oldData.map((item) =>
+          item.id === updatedSettings.id ? updatedSettings : item
+        );
       });
       onSuccess?.(updatedSettings);
     },


### PR DESCRIPTION
#### Description

When adding an indexer it would be added twice, likely from signalR and the mutation's `onSuccess` callback, this prevents the `onSuccess` callback from adding it twice if it triggers after it's already been added.