### PR TITLE
Log media info title used to augment quality

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -30,11 +30,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators.Augment
             var height = localEpisode.MediaInfo.Height;
             var source = QualitySource.Unknown;
             var sourceConfidence = Confidence.Default;
-            var title = localEpisode.MediaInfo.Title;
+            var title = localEpisode.MediaInfo.Title?.Trim();
 
             if (title.IsNotNullOrWhiteSpace())
             {
-                var parsedQuality = QualityParser.ParseQualityName(title.Trim());
+                _logger.Debug("Parsing quality from media info title '{0}'", title);
+
+                var parsedQuality = QualityParser.ParseQualityName(title);
 
                 // Only use the quality if it's not unknown and the source is from the name (which is MediaInfo's title in this case)
                 if (parsedQuality.Quality.Source != QualitySource.Unknown &&


### PR DESCRIPTION
#### Description
Quality can be overridden if media info contains a parsable title, but there's no way to know which title was being used in the process.