### PR TITLE
Prefer season search over per-episode for anime

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -7,6 +7,7 @@ using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Indexers;
@@ -60,6 +61,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             Mocker.GetMock<ISceneMappingService>()
                   .Setup(s => s.GetSceneNames(It.IsAny<int>(), It.IsAny<List<int>>(), It.IsAny<List<int>>()))
                   .Returns(new List<string>());
+
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(s => s.AnimeSeasonSearchFallback)
+                  .Returns(AnimeSeasonSearchFallback.Always);
         }
 
         private void WithEpisode(int seasonNumber, int episodeNumber, int? sceneSeasonNumber, int? sceneEpisodeNumber, string airDate = null)

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -132,7 +132,7 @@ namespace NzbDrone.Core.Configuration
 
         public AnimeSeasonSearchFallback AnimeSeasonSearchFallback
         {
-            get { return GetValueEnum("AnimeSeasonSearchFallback", AnimeSeasonSearchFallback.FullSeasonNotAired); }
+            get { return GetValueEnum("AnimeSeasonSearchFallback", AnimeSeasonSearchFallback.Always); }
 
             set { SetValue("AnimeSeasonSearchFallback", value); }
         }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -7,6 +7,7 @@ using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.Configuration.Events;
 using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.IndexerSearch;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
@@ -127,6 +128,13 @@ namespace NzbDrone.Core.Configuration
             get { return GetValueInt("MinimumAge", 0); }
 
             set { SetValue("MinimumAge", value); }
+        }
+
+        public AnimeSeasonSearchFallback AnimeSeasonSearchFallback
+        {
+            get { return GetValueEnum("AnimeSeasonSearchFallback", AnimeSeasonSearchFallback.FullSeasonNotAired); }
+
+            set { SetValue("AnimeSeasonSearchFallback", value); }
         }
 
         public ProperDownloadTypes DownloadPropersAndRepacks

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.ImportLists;
+using NzbDrone.Core.IndexerSearch;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Qualities;
@@ -51,6 +52,9 @@ namespace NzbDrone.Core.Configuration
         bool SetPermissionsLinux { get; set; }
         string ChmodFolder { get; set; }
         string ChownGroup { get; set; }
+
+        // Anime Season Search
+        AnimeSeasonSearchFallback AnimeSeasonSearchFallback { get; set; }
 
         // Indexers
         int Retention { get; set; }

--- a/src/NzbDrone.Core/IndexerSearch/AnimeSeasonSearchFallback.cs
+++ b/src/NzbDrone.Core/IndexerSearch/AnimeSeasonSearchFallback.cs
@@ -1,0 +1,10 @@
+namespace NzbDrone.Core.IndexerSearch
+{
+    public enum AnimeSeasonSearchFallback
+    {
+        Never = 0,
+        Always = 1,
+        FullSeasonAired = 2,
+        FullSeasonNotAired = 3
+    }
+}

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -421,9 +421,18 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadDecisions.AddRange(decisions);
             }
 
-            foreach (var episode in episodesToSearch)
+            if (downloadDecisions.Any())
             {
-                downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                _logger.Debug("Season search returned results for {0}, skipping per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
+            }
+            else
+            {
+                _logger.Debug("No season results for {0}, falling back to per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
+
+                foreach (var episode in episodesToSearch)
+                {
+                    downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                }
             }
 
             return DeDupeDecisions(downloadDecisions);

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -428,7 +428,9 @@ namespace NzbDrone.Core.IndexerSearch
             // Only skip per-episode fallback if we got approved season results.
             // Indexers like AB return all results for a title regardless of season
             // params, so raw result count alone is not reliable.
-            if (downloadDecisions.Any(d => d.Approved))
+            // For interactive search, always run per-episode so the user can see
+            // and pick individual releases regardless of whether a pack was found.
+            if (!interactiveSearch && downloadDecisions.Any(d => d.Approved))
             {
                 _logger.Debug("Season search returned approved results for {0}, skipping per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
             }
@@ -437,14 +439,14 @@ namespace NzbDrone.Core.IndexerSearch
                 var fallbackSetting = _configService.AnimeSeasonSearchFallback;
                 var allEpisodesAired = episodesToSearch.All(e => e.AirDateUtc.HasValue && e.AirDateUtc.Value.Before(DateTime.UtcNow));
 
-                var shouldFallback = fallbackSetting switch
+                var shouldFallback = interactiveSearch || (fallbackSetting switch
                 {
                     AnimeSeasonSearchFallback.Never => false,
                     AnimeSeasonSearchFallback.Always => true,
                     AnimeSeasonSearchFallback.FullSeasonAired => allEpisodesAired,
                     AnimeSeasonSearchFallback.FullSeasonNotAired => !allEpisodesAired,
                     _ => !allEpisodesAired
-                };
+                });
 
                 if (shouldFallback)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -421,13 +421,16 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadDecisions.AddRange(decisions);
             }
 
-            if (downloadDecisions.Any())
+            // Only skip per-episode fallback if we got approved season results.
+            // Indexers like AB return all results for a title regardless of season
+            // params, so raw result count alone is not reliable.
+            if (downloadDecisions.Any(d => d.Approved))
             {
-                _logger.Debug("Season search returned results for {0}, skipping per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
+                _logger.Debug("Season search returned approved results for {0}, skipping per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
             }
             else
             {
-                _logger.Debug("No season results for {0}, falling back to per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
+                _logger.Debug("No approved season results for {0}, falling back to per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
 
                 foreach (var episode in episodesToSearch)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.DataAugmentation.Scene;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Indexers;
@@ -32,6 +33,7 @@ namespace NzbDrone.Core.IndexerSearch
         private readonly ISeriesService _seriesService;
         private readonly IEpisodeService _episodeService;
         private readonly IMakeDownloadDecision _makeDownloadDecision;
+        private readonly IConfigService _configService;
         private readonly Logger _logger;
 
         public ReleaseSearchService(IIndexerFactory indexerFactory,
@@ -39,6 +41,7 @@ namespace NzbDrone.Core.IndexerSearch
                                 ISeriesService seriesService,
                                 IEpisodeService episodeService,
                                 IMakeDownloadDecision makeDownloadDecision,
+                                IConfigService configService,
                                 Logger logger)
         {
             _indexerFactory = indexerFactory;
@@ -46,6 +49,7 @@ namespace NzbDrone.Core.IndexerSearch
             _seriesService = seriesService;
             _episodeService = episodeService;
             _makeDownloadDecision = makeDownloadDecision;
+            _configService = configService;
             _logger = logger;
         }
 
@@ -430,11 +434,32 @@ namespace NzbDrone.Core.IndexerSearch
             }
             else
             {
-                _logger.Debug("No approved season results for {0}, falling back to per-episode search for {1} episodes", series.Title, episodesToSearch.Count);
+                var fallbackSetting = _configService.AnimeSeasonSearchFallback;
+                var allEpisodesAired = episodesToSearch.All(e => e.AirDateUtc.HasValue && e.AirDateUtc.Value.Before(DateTime.UtcNow));
 
-                foreach (var episode in episodesToSearch)
+                var shouldFallback = fallbackSetting switch
                 {
-                    downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                    AnimeSeasonSearchFallback.Never => false,
+                    AnimeSeasonSearchFallback.Always => true,
+                    AnimeSeasonSearchFallback.FullSeasonAired => allEpisodesAired,
+                    AnimeSeasonSearchFallback.FullSeasonNotAired => !allEpisodesAired,
+                    _ => !allEpisodesAired
+                };
+
+                if (shouldFallback)
+                {
+                    _logger.Debug("No approved season results for {0}, falling back to per-episode search for {1} episodes (fallback: {2}, allAired: {3})",
+                        series.Title, episodesToSearch.Count, fallbackSetting, allEpisodesAired);
+
+                    foreach (var episode in episodesToSearch)
+                    {
+                        downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
+                    }
+                }
+                else
+                {
+                    _logger.Debug("No approved season results for {0}, per-episode fallback skipped (fallback: {1}, allAired: {2})",
+                        series.Title, fallbackSetting, allEpisodesAired);
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -450,7 +450,7 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            if (SupportsSearch && Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+            if (SupportsSearch && searchCriteria.SeasonNumber > 0)
             {
                 AddTvIdPageableRequests(pageableRequests,
                     Settings.AnimeCategories,

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -87,9 +87,9 @@ namespace NzbDrone.Core.Indexers.Nyaa
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
+            if (searchCriteria.SeasonNumber > 0)
             {
-                if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+                foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
                 {
                     pageableRequests.Add(GetPagedRequests($"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
                 }

--- a/src/Sonarr.Api.V3/Config/IndexerConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/IndexerConfigResource.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.IndexerSearch;
 using Sonarr.Http.REST;
 
 namespace Sonarr.Api.V3.Config
@@ -9,6 +10,7 @@ namespace Sonarr.Api.V3.Config
         public int Retention { get; set; }
         public int MaximumSize { get; set; }
         public int RssSyncInterval { get; set; }
+        public AnimeSeasonSearchFallback AnimeSeasonSearchFallback { get; set; }
     }
 
     public static class IndexerConfigResourceMapper
@@ -20,7 +22,8 @@ namespace Sonarr.Api.V3.Config
                 MinimumAge = model.MinimumAge,
                 Retention = model.Retention,
                 MaximumSize = model.MaximumSize,
-                RssSyncInterval = model.RssSyncInterval
+                RssSyncInterval = model.RssSyncInterval,
+                AnimeSeasonSearchFallback = model.AnimeSeasonSearchFallback
             };
         }
     }

--- a/src/Sonarr.Api.V5/Settings/IndexerSettingsResource.cs
+++ b/src/Sonarr.Api.V5/Settings/IndexerSettingsResource.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.IndexerSearch;
 using Sonarr.Http.REST;
 
 namespace Sonarr.Api.V5.Settings
@@ -9,6 +10,7 @@ namespace Sonarr.Api.V5.Settings
         public int Retention { get; set; }
         public int MaximumSize { get; set; }
         public int RssSyncInterval { get; set; }
+        public AnimeSeasonSearchFallback AnimeSeasonSearchFallback { get; set; }
     }
 
     public static class IndexerConfigResourceMapper
@@ -20,7 +22,8 @@ namespace Sonarr.Api.V5.Settings
                 MinimumAge = model.MinimumAge,
                 Retention = model.Retention,
                 MaximumSize = model.MaximumSize,
-                RssSyncInterval = model.RssSyncInterval
+                RssSyncInterval = model.RssSyncInterval,
+                AnimeSeasonSearchFallback = model.AnimeSeasonSearchFallback
             };
         }
     }


### PR DESCRIPTION
  #### Description
  Prefer season search over per-episode for anime. When `SearchAnimeSeason` runs, try the season pack query first across all indexers. Only fall back to per-episode search if the season query returns zero results.

  Currently, `SearchAnimeSeason` always runs both: a season query followed by individual queries for every aired episode. For a 10-episode season that's 10+ extra indexer requests. On Nyaa via Prowlarr each request takes 10-15s, so a full season search can exceed 120s and trigger timeout cascades that disable indexers mid-search.

  Tested with Frieren S02 (10 episodes, 11 active indexers):

  | Approach | Duration | Results | Nyaa timeouts |
  |----------|----------|---------|---------------|
  | Before (season + per-episode) | >120s | partial, indexers disabled mid-search | 7 over a few hours |
  | After (season-first) | ~35s | 988 releases | 0 |

  Also removes the `AnimeStandardFormatSearch` gate from `NyaaRequestGenerator` and `NewznabRequestGenerator` for season-level searches. That toggle still controls per-episode format, but season pack queries should always fire so the fallback pattern works.

  **Trade-off:** Nyaa text search (`title+s02`) returns fewer results than the sum of individual episode queries due to RSS page caps and naming variants. In practice this hasn't mattered — the season query still finds the right releases.

  No UI changes, no tests yet — opening as draft to get feedback on the approach first.

  #### Issues Fixed or Closed by this PR
  * Related: indexer timeout cascades during anime season search (no existing issue found)