### PR TITLE
Use structured log message templates throughout

### DIFF
--- a/src/NzbDrone.Common/ArchiveService.cs
+++ b/src/NzbDrone.Common/ArchiveService.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Common
 
         public void Extract(string compressedFile, string destination)
         {
-            _logger.Debug("Extracting archive [{0}] to [{1}]", compressedFile, destination);
+            _logger.Debug("Extracting archive [{ArchivePath}] to [{Destination}]", compressedFile, destination);
 
             if (compressedFile.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -42,7 +42,7 @@ namespace NzbDrone.Common
 
         public void CreateZip(string path, IEnumerable<string> files)
         {
-            _logger.Debug("Creating archive {0}", path);
+            _logger.Debug("Creating archive {ArchivePath}", path);
 
             using var zipFile = ZipFile.Create(path);
 
@@ -62,7 +62,7 @@ namespace NzbDrone.Common
             {
                 var zipFile = new ZipFile(fileStream);
 
-                _logger.Debug("Validating Archive {0}", compressedFile);
+                _logger.Debug("Validating Archive {ArchivePath}", compressedFile);
 
                 if (!zipFile.TestArchive(true, TestStrategy.FindFirstError, OnZipError))
                 {
@@ -121,7 +121,7 @@ namespace NzbDrone.Common
         {
             if (!string.IsNullOrWhiteSpace(message))
             {
-                _logger.Error("File {0} failed zip validation. {1}", status.File.Name, message);
+                _logger.Error("File {FileName} failed zip validation. {ValidationMessage}", status.File.Name, message);
             }
         }
     }

--- a/src/NzbDrone.Common/Disk/DiskTransferService.cs
+++ b/src/NzbDrone.Common/Disk/DiskTransferService.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Common.Disk
             sourcePath = ResolveRealParentPath(sourcePath);
             targetPath = ResolveRealParentPath(targetPath);
 
-            _logger.Debug("{0} Directory [{1}] > [{2}]", mode, sourcePath, targetPath);
+            _logger.Debug("{TransferMode} Directory [{SourcePath}] > [{TargetPath}]", mode, sourcePath, targetPath);
 
             if (sourcePath == targetPath)
             {
@@ -60,19 +60,19 @@ namespace NzbDrone.Common.Disk
             {
                 // Move folder out of the way to allow case-insensitive renames
                 var tempPath = sourcePath + ".backup~";
-                _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", sourcePath, tempPath);
+                _logger.Trace("Rename Intermediate Directory [{SourcePath}] > [{TargetPath}]", sourcePath, tempPath);
                 _diskProvider.MoveFolder(sourcePath, tempPath);
 
                 if (!_diskProvider.FolderExists(targetPath))
                 {
-                    _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", tempPath, targetPath);
-                    _logger.Debug("Rename Directory [{0}] > [{1}]", sourcePath, targetPath);
+                    _logger.Trace("Rename Intermediate Directory [{SourcePath}] > [{TargetPath}]", tempPath, targetPath);
+                    _logger.Debug("Rename Directory [{SourcePath}] > [{TargetPath}]", sourcePath, targetPath);
                     _diskProvider.MoveFolder(tempPath, targetPath);
                     return mode;
                 }
 
                 // There were two separate folders, revert the intermediate rename and let the recursion deal with it
-                _logger.Trace("Rename Intermediate Directory [{0}] > [{1}]", tempPath, sourcePath);
+                _logger.Trace("Rename Intermediate Directory [{SourcePath}] > [{TargetPath}]", tempPath, sourcePath);
                 _diskProvider.MoveFolder(tempPath, sourcePath);
             }
 
@@ -84,7 +84,7 @@ namespace NzbDrone.Common.Disk
                 // If we're on the same mount, do a simple folder move.
                 if (sourceMount != null && targetMount != null && sourceMount.RootDirectory == targetMount.RootDirectory)
                 {
-                    _logger.Debug("Rename Directory [{0}] > [{1}]", sourcePath, targetPath);
+                    _logger.Debug("Rename Directory [{SourcePath}] > [{TargetPath}]", sourcePath, targetPath);
                     _diskProvider.MoveFolder(sourcePath, targetPath);
                     return mode;
                 }
@@ -146,7 +146,7 @@ namespace NzbDrone.Common.Disk
             sourcePath = ResolveRealParentPath(sourcePath);
             targetPath = ResolveRealParentPath(targetPath);
 
-            _logger.Debug("Mirror Folder [{0}] > [{1}]", sourcePath, targetPath);
+            _logger.Debug("Mirror Folder [{SourcePath}] > [{TargetPath}]", sourcePath, targetPath);
 
             if (!_diskProvider.FolderExists(targetPath))
             {
@@ -261,7 +261,7 @@ namespace NzbDrone.Common.Disk
             sourcePath = ResolveRealParentPath(sourcePath);
             targetPath = ResolveRealParentPath(targetPath);
 
-            _logger.Debug("{0} [{1}] > [{2}]", mode, sourcePath, targetPath);
+            _logger.Debug("{TransferMode} [{SourcePath}] > [{TargetPath}]", mode, sourcePath, targetPath);
 
             var originalSize = _diskProvider.GetFileSize(sourcePath);
 
@@ -351,9 +351,9 @@ namespace NzbDrone.Common.Disk
             {
                 if (isCifs && !isSameMount)
                 {
-                    _logger.Trace("On cifs mount. Starting verified copy [{0}] to [{1}].", sourcePath, targetPath);
+                    _logger.Trace("On cifs mount. Starting verified copy [{SourcePath}] to [{TargetPath}].", sourcePath, targetPath);
                     TryCopyFileVerified(sourcePath, targetPath, originalSize);
-                    _logger.Trace("Copy successful, deleting source [{0}].", sourcePath);
+                    _logger.Trace("Copy successful, deleting source [{SourcePath}].", sourcePath);
                     _diskProvider.DeleteFile(sourcePath);
                     return TransferMode.Move;
                 }
@@ -384,7 +384,7 @@ namespace NzbDrone.Common.Disk
         {
             try
             {
-                _logger.Debug("Rolling back incomplete file move [{0}] to [{1}].", sourcePath, targetPath);
+                _logger.Debug("Rolling back incomplete file move [{SourcePath}] to [{TargetPath}].", sourcePath, targetPath);
 
                 WaitForIO();
 
@@ -394,12 +394,12 @@ namespace NzbDrone.Common.Disk
                 }
                 else
                 {
-                    _logger.Error("Failed to properly rollback the file move [{0}] to [{1}], incomplete file may be left in target path.", sourcePath, targetPath);
+                    _logger.Error("Failed to properly rollback the file move [{SourcePath}] to [{TargetPath}], incomplete file may be left in target path.", sourcePath, targetPath);
                 }
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to properly rollback the file move [{0}] to [{1}], incomplete file may be left in target path.", sourcePath, targetPath);
+                _logger.Error(ex, "Failed to properly rollback the file move [{SourcePath}] to [{TargetPath}], incomplete file may be left in target path.", sourcePath, targetPath);
             }
         }
 
@@ -407,7 +407,7 @@ namespace NzbDrone.Common.Disk
         {
             try
             {
-                _logger.Debug("Rolling back file move [{0}] to [{1}].", sourcePath, targetPath);
+                _logger.Debug("Rolling back file move [{SourcePath}] to [{TargetPath}].", sourcePath, targetPath);
 
                 WaitForIO();
 
@@ -415,7 +415,7 @@ namespace NzbDrone.Common.Disk
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to properly rollback the file move [{0}] to [{1}], file may be left in target path.", sourcePath, targetPath);
+                _logger.Error(ex, "Failed to properly rollback the file move [{SourcePath}] to [{TargetPath}], file may be left in target path.", sourcePath, targetPath);
             }
         }
 
@@ -423,7 +423,7 @@ namespace NzbDrone.Common.Disk
         {
             try
             {
-                _logger.Debug("Rolling back file copy [{0}] to [{1}].", sourcePath, targetPath);
+                _logger.Debug("Rolling back file copy [{SourcePath}] to [{TargetPath}].", sourcePath, targetPath);
 
                 WaitForIO();
 
@@ -434,7 +434,7 @@ namespace NzbDrone.Common.Disk
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Failed to properly rollback the file copy [{0}] to [{1}], file may be left in target path.", sourcePath, targetPath);
+                _logger.Error(ex, "Failed to properly rollback the file copy [{SourcePath}] to [{TargetPath}], file may be left in target path.", sourcePath, targetPath);
             }
         }
 
@@ -485,7 +485,7 @@ namespace NzbDrone.Common.Disk
                 return;
             }
 
-            _logger.Debug("File {0} incomplete, waiting in case filesystem is not synchronized. [{1}] was {2} bytes long instead of the expected {3}.", action, targetPath, targetSize, originalSize);
+            _logger.Debug("File {Action} incomplete, waiting in case filesystem is not synchronized. [{TargetPath}] was {ActualSize} bytes long instead of the expected {ExpectedSize}.", action, targetPath, targetSize, originalSize);
             WaitForIO();
             targetSize = _diskProvider.GetFileSize(targetPath);
 
@@ -501,7 +501,7 @@ namespace NzbDrone.Common.Disk
         {
             if (folder.Name.StartsWith(".nfs"))
             {
-                _logger.Trace("Ignoring folder {0}", folder.FullName);
+                _logger.Trace("Ignoring folder {FolderPath}", folder.FullName);
                 return true;
             }
 
@@ -512,7 +512,7 @@ namespace NzbDrone.Common.Disk
         {
             if (file.Name.StartsWith(".nfs") || file.Name == "debug.log" || file.Name.EndsWith(".socket"))
             {
-                _logger.Trace("Ignoring file {0}", file.FullName);
+                _logger.Trace("Ignoring file {FilePath}", file.FullName);
                 return true;
             }
 

--- a/src/NzbDrone.Common/EnvironmentInfo/AppFolderFactory.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/AppFolderFactory.cs
@@ -189,7 +189,7 @@ namespace NzbDrone.Common.EnvironmentInfo
 
         private void MoveSqliteDatabase(string source, string destination)
         {
-            _logger.Info("Moving {0}* to {1}*", source, destination);
+            _logger.Info("Moving {SourcePath}* to {DestinationPath}*", source, destination);
 
             var dbSuffixes = new[] { "", "-shm", "-wal", "-journal" };
 

--- a/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HttpHappyEyeballs.cs
@@ -38,7 +38,7 @@ public class HttpHappyEyeballs
 
         var happyEyeballs = CreateHappyEyeballs(endPoint);
         var socket = await happyEyeballs.Connect(resolvedAddresses, cancellationToken).ConfigureAwait(false);
-        _logger.Trace("Successfully connected to {0} for host {1}", socket.RemoteEndPoint, endPoint.HostPort);
+        _logger.Trace("Successfully connected to {RemoteEndPoint} for host {Host}", socket.RemoteEndPoint, endPoint.HostPort);
 
         return new NetworkStream(socket, ownsSocket: true);
     }
@@ -74,7 +74,7 @@ public class HttpHappyEyeballs
             NoDelay = true
         };
 
-        _logger.Trace("Trying Happy Eyeballs connection to {0} for host {1}", ipAddress, endPoint.HostPort);
+        _logger.Trace("Trying Happy Eyeballs connection to {IpAddress} for host {Host}", ipAddress, endPoint.HostPort);
 
         try
         {
@@ -83,7 +83,7 @@ public class HttpHappyEyeballs
         catch (Exception e)
         {
             socket.Dispose();
-            _logger.Trace("Failed Happy Eyeballs connection to {0} for host {1} ({2})", ipAddress, endPoint.HostPort, e.Message);
+            _logger.Trace("Failed Happy Eyeballs connection to {IpAddress} for host {Host} ({Message})", ipAddress, endPoint.HostPort, e.Message);
             throw;
         }
 

--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -77,7 +77,7 @@ namespace NzbDrone.Common.Http
                     request.Url += new HttpUri(response.Headers.GetSingleValue("Location"));
                     autoRedirectChain.Add(request.Url.ToString());
 
-                    _logger.Trace("Redirected to {0}", request.Url);
+                    _logger.Trace("Redirected to {Url}", request.Url);
 
                     if (autoRedirectChain.Count > MaxRedirects)
                     {
@@ -99,14 +99,14 @@ namespace NzbDrone.Common.Http
 
             if (response.HasHttpRedirect && !RuntimeInfo.IsProduction)
             {
-                _logger.Error("Server requested a redirect to [{0}] while in developer mode. Update the request URL to avoid this redirect.", response.Headers["Location"]);
+                _logger.Error("Server requested a redirect to [{RedirectUrl}] while in developer mode. Update the request URL to avoid this redirect.", response.Headers["Location"]);
             }
 
             if (!request.SuppressHttpError && response.HasHttpError && (request.SuppressHttpErrorStatusCodes == null || !request.SuppressHttpErrorStatusCodes.Contains(response.StatusCode)))
             {
                 if (request.LogHttpError)
                 {
-                    _logger.Warn("HTTP Error - {0}", response);
+                    _logger.Warn("HTTP Error - {Response}", response);
                 }
 
                 if ((int)response.StatusCode == 429)
@@ -159,7 +159,7 @@ namespace NzbDrone.Common.Http
 
             stopWatch.Stop();
 
-            _logger.Trace("{0} ({1} ms)", response, stopWatch.ElapsedMilliseconds);
+            _logger.Trace("{Response} ({ElapsedMs} ms)", response, stopWatch.ElapsedMilliseconds);
 
             foreach (var interceptor in _requestInterceptors)
             {
@@ -168,7 +168,7 @@ namespace NzbDrone.Common.Http
 
             if (request.LogResponseContent && response.ResponseData != null)
             {
-                _logger.Trace("Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
+                _logger.Trace("Response content ({ContentLength} bytes): {Content}", response.ResponseData.Length, response.Content);
             }
 
             return response;
@@ -256,7 +256,7 @@ namespace NzbDrone.Common.Http
                 }
                 catch (Exception ex)
                 {
-                    _logger.Debug(ex, "Invalid cookie in {0}", url);
+                    _logger.Debug(ex, "Invalid cookie in {Url}", url);
                 }
             }
         }
@@ -273,7 +273,7 @@ namespace NzbDrone.Common.Http
                     fileInfo.Directory.Create();
                 }
 
-                _logger.Debug("Downloading [{0}] to [{1}]", url, fileName);
+                _logger.Debug("Downloading [{Url}] to [{FileName}]", url, fileName);
 
                 var stopWatch = Stopwatch.StartNew();
                 await using (var fileStream = new FileStream(fileNamePart, FileMode.Create, FileAccess.ReadWrite))
@@ -298,7 +298,7 @@ namespace NzbDrone.Common.Http
                 }
 
                 File.Move(fileNamePart, fileName);
-                _logger.Debug("Downloading Completed. took {0:0}s", stopWatch.Elapsed.Seconds);
+                _logger.Debug("Downloading Completed. took {Elapsed:0}s", stopWatch.Elapsed.Seconds);
             }
             finally
             {

--- a/src/NzbDrone.Common/Processes/ProcessProvider.cs
+++ b/src/NzbDrone.Common/Processes/ProcessProvider.cs
@@ -70,17 +70,17 @@ namespace NzbDrone.Common.Processes
 
         public ProcessInfo GetProcessById(int id)
         {
-            _logger.Debug("Finding process with Id:{0}", id);
+            _logger.Debug("Finding process with Id:{ProcessId}", id);
 
             var processInfo = ConvertToProcessInfo(Process.GetProcesses().FirstOrDefault(p => p.Id == id));
 
             if (processInfo == null)
             {
-                _logger.Warn("Unable to find process with ID {0}", id);
+                _logger.Warn("Unable to find process with ID {ProcessId}", id);
             }
             else
             {
-                _logger.Debug("Found process {0}", processInfo.ToString());
+                _logger.Debug("Found process {ProcessInfo}", processInfo.ToString());
             }
 
             return processInfo;
@@ -93,7 +93,7 @@ namespace NzbDrone.Common.Processes
 
         public void OpenDefaultBrowser(string url)
         {
-            _logger.Info("Opening URL [{0}]", url);
+            _logger.Info("Opening URL [{Url}]", url);
 
             var process = new Process
             {
@@ -129,7 +129,7 @@ namespace NzbDrone.Common.Processes
                 {
                     try
                     {
-                        _logger.Trace("Setting environment variable '{0}' to '{1}'", environmentVariable.Key, environmentVariable.Value);
+                        _logger.Trace("Setting environment variable '{EnvKey}' to '{EnvValue}'", environmentVariable.Key, environmentVariable.Value);
 
                         var key = environmentVariable.Key.ToString();
                         var value = environmentVariable.Value?.ToString();
@@ -140,11 +140,11 @@ namespace NzbDrone.Common.Processes
                     {
                         if (environmentVariable.Value == null)
                         {
-                            _logger.Error(e, "Unable to set environment variable '{0}', value is null", environmentVariable.Key);
+                            _logger.Error(e, "Unable to set environment variable '{EnvKey}', value is null", environmentVariable.Key);
                         }
                         else
                         {
-                            _logger.Error(e, "Unable to set environment variable '{0}'", environmentVariable.Key);
+                            _logger.Error(e, "Unable to set environment variable '{EnvKey}'", environmentVariable.Key);
                         }
 
                         throw;
@@ -152,7 +152,7 @@ namespace NzbDrone.Common.Processes
                 }
             }
 
-            logger.Debug("Starting {0} {1}", path, args);
+            logger.Debug("Starting {ProcessPath} {ProcessArgs}", path, args);
 
             var process = new Process
             {
@@ -201,7 +201,7 @@ namespace NzbDrone.Common.Processes
         {
             (path, args) = GetPathAndArgs(path, args);
 
-            _logger.Debug("Starting {0} {1}", path, args);
+            _logger.Debug("Starting {ProcessPath} {ProcessArgs}", path, args);
 
             var startInfo = new ProcessStartInfo(path, args);
             startInfo.CreateNoWindow = noWindow;
@@ -234,7 +234,7 @@ namespace NzbDrone.Common.Processes
 
         public void WaitForExit(Process process)
         {
-            _logger.Debug("Waiting for process {0} to exit.", process.ProcessName);
+            _logger.Debug("Waiting for process {ProcessName} to exit.", process.ProcessName);
 
             process.WaitForExit();
         }
@@ -243,7 +243,7 @@ namespace NzbDrone.Common.Processes
         {
             var process = Process.GetProcessById(processId);
 
-            _logger.Info("Updating [{0}] process priority from {1} to {2}",
+            _logger.Info("Updating [{ProcessName}] process priority from {CurrentPriority} to {NewPriority}",
                         process.ProcessName,
                         process.PriorityClass,
                         priority);
@@ -257,7 +257,7 @@ namespace NzbDrone.Common.Processes
 
             if (process == null)
             {
-                _logger.Warn("Cannot find process with id: {0}", processId);
+                _logger.Warn("Cannot find process with id: {ProcessId}", processId);
                 return;
             }
 
@@ -269,28 +269,28 @@ namespace NzbDrone.Common.Processes
                 return;
             }
 
-            _logger.Info("[{0}]: Killing process", process.Id);
+            _logger.Info("[{ProcessId}]: Killing process", process.Id);
             process.Kill();
-            _logger.Info("[{0}]: Waiting for exit", process.Id);
+            _logger.Info("[{ProcessId}]: Waiting for exit", process.Id);
             process.WaitForExit();
-            _logger.Info("[{0}]: Process terminated successfully", process.Id);
+            _logger.Info("[{ProcessId}]: Process terminated successfully", process.Id);
         }
 
         public void KillAll(string processName)
         {
             var processes = GetProcessesByName(processName);
 
-            _logger.Debug("Found {0} processes to kill", processes.Count);
+            _logger.Debug("Found {ProcessCount} processes to kill", processes.Count);
 
             foreach (var processInfo in processes)
             {
                 if (processInfo.Id == GetCurrentProcessId())
                 {
-                    _logger.Debug("Tried killing own process, skipping: {0} [{1}]", processInfo.Id, processInfo.ProcessName);
+                    _logger.Debug("Tried killing own process, skipping: {ProcessId} [{ProcessName}]", processInfo.Id, processInfo.ProcessName);
                     continue;
                 }
 
-                _logger.Debug("Killing process: {0} [{1}]", processInfo.Id, processInfo.ProcessName);
+                _logger.Debug("Killing process: {ProcessId} [{ProcessName}]", processInfo.Id, processInfo.ProcessName);
                 Kill(processInfo.Id);
             }
         }
@@ -335,13 +335,13 @@ namespace NzbDrone.Common.Processes
         {
             var processes = Process.GetProcessesByName(name).ToList();
 
-            _logger.Debug("Found {0} processes with the name: {1}", processes.Count, name);
+            _logger.Debug("Found {ProcessCount} processes with the name: {ProcessName}", processes.Count, name);
 
             try
             {
                 foreach (var process in processes)
                 {
-                    _logger.Debug(" - [{0}] {1}", process.Id, process.ProcessName);
+                    _logger.Debug(" - [{ProcessId}] {ProcessName}", process.Id, process.ProcessName);
                 }
             }
             catch

--- a/src/NzbDrone.Common/ServiceProvider.cs
+++ b/src/NzbDrone.Common/ServiceProvider.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Common
 
         public virtual bool ServiceExist(string name)
         {
-            _logger.Debug("Checking if service {0} exists.", name);
+            _logger.Debug("Checking if service {ServiceName} exists.", name);
             return
                 ServiceController.GetServices().Any(
                     s => string.Equals(s.ServiceName, name, StringComparison.InvariantCultureIgnoreCase));
@@ -45,7 +45,7 @@ namespace NzbDrone.Common
 
         public virtual bool IsServiceRunning(string name)
         {
-            _logger.Debug("Checking if '{0}' service is running", name);
+            _logger.Debug("Checking if '{ServiceName}' service is running", name);
 
             var service = ServiceController.GetServices()
                 .SingleOrDefault(s => string.Equals(s.ServiceName, name, StringComparison.InvariantCultureIgnoreCase));
@@ -59,7 +59,7 @@ namespace NzbDrone.Common
 
         public virtual void Install(string serviceName)
         {
-            _logger.Info("Installing service '{0}'", serviceName);
+            _logger.Info("Installing service '{ServiceName}'", serviceName);
 
             var args = $"create {serviceName} " +
                 $"DisplayName= \"{serviceName}\" " +
@@ -94,14 +94,14 @@ namespace NzbDrone.Common
 
         public virtual void Uninstall(string serviceName)
         {
-            _logger.Info("Uninstalling {0} service", serviceName);
+            _logger.Info("Uninstalling {ServiceName} service", serviceName);
 
             Stop(serviceName);
 
             var output = _processProvider.StartAndCapture("sc.exe", $"delete {serviceName}");
             _logger.Info(output.Lines.Select(x => x.Content).ConcatToString("\n"));
 
-            _logger.Info("{0} successfully uninstalled", serviceName);
+            _logger.Info("{ServiceName} successfully uninstalled", serviceName);
         }
 
         public virtual void Run(ServiceBase service)
@@ -116,15 +116,15 @@ namespace NzbDrone.Common
 
         public virtual void Stop(string serviceName)
         {
-            _logger.Info("Stopping {0} Service...", serviceName);
+            _logger.Info("Stopping {ServiceName} Service...", serviceName);
             var service = GetService(serviceName);
             if (service == null)
             {
-                _logger.Warn("Unable to stop {0}. no service with that name exists.", serviceName);
+                _logger.Warn("Unable to stop {ServiceName}. no service with that name exists.", serviceName);
                 return;
             }
 
-            _logger.Info("Service is currently {0}", service.Status);
+            _logger.Info("Service is currently {ServiceStatus}", service.Status);
 
             if (service.Status != ServiceControllerStatus.Stopped)
             {
@@ -134,16 +134,16 @@ namespace NzbDrone.Common
                 service.Refresh();
                 if (service.Status == ServiceControllerStatus.Stopped)
                 {
-                    _logger.Info("{0} has stopped successfully.", serviceName);
+                    _logger.Info("{ServiceName} has stopped successfully.", serviceName);
                 }
                 else
                 {
-                    _logger.Error("Service stop request has timed out. {0}", service.Status);
+                    _logger.Error("Service stop request has timed out. {ServiceStatus}", service.Status);
                 }
             }
             else
             {
-                _logger.Warn("Service {0} is already in stopped state.", service.ServiceName);
+                _logger.Warn("Service {ServiceName} is already in stopped state.", service.ServiceName);
             }
         }
 
@@ -154,17 +154,17 @@ namespace NzbDrone.Common
 
         public void Start(string serviceName)
         {
-            _logger.Info("Starting {0} Service...", serviceName);
+            _logger.Info("Starting {ServiceName} Service...", serviceName);
             var service = GetService(serviceName);
             if (service == null)
             {
-                _logger.Warn("Unable to start '{0}' no service with that name exists.", serviceName);
+                _logger.Warn("Unable to start '{ServiceName}' no service with that name exists.", serviceName);
                 return;
             }
 
             if (service.Status != ServiceControllerStatus.Paused && service.Status != ServiceControllerStatus.Stopped)
             {
-                _logger.Warn("Service is in a state that can't be started. Current status: {0}", service.Status);
+                _logger.Warn("Service is in a state that can't be started. Current status: {ServiceStatus}", service.Status);
             }
 
             service.Start();
@@ -174,11 +174,11 @@ namespace NzbDrone.Common
 
             if (service.Status == ServiceControllerStatus.Running)
             {
-                _logger.Info("{0} has started successfully.", serviceName);
+                _logger.Info("{ServiceName} has started successfully.", serviceName);
             }
             else
             {
-                _logger.Error("Service start request has timed out. {0}", service.Status);
+                _logger.Error("Service start request has timed out. {ServiceStatus}", service.Status);
             }
         }
 

--- a/src/NzbDrone.Common/TPL/RateLimitService.cs
+++ b/src/NzbDrone.Common/TPL/RateLimitService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Common.TPL
 
             if (delay.TotalSeconds > 0.0)
             {
-                _logger.Trace("Rate Limit triggered, delaying '{0}' for {1:0.000} sec", key, delay.TotalSeconds);
+                _logger.Trace("Rate Limit triggered, delaying '{RateLimitKey}' for {DelaySeconds:0.000} sec", key, delay.TotalSeconds);
                 System.Threading.Thread.Sleep(delay);
             }
         }
@@ -53,7 +53,7 @@ namespace NzbDrone.Common.TPL
 
             if (delay.TotalSeconds > 0.0)
             {
-                _logger.Trace("Rate Limit triggered, delaying '{0}' for {1:0.000} sec", key, delay.TotalSeconds);
+                _logger.Trace("Rate Limit triggered, delaying '{RateLimitKey}' for {DelaySeconds:0.000} sec", key, delay.TotalSeconds);
                 await Task.Delay(delay);
             }
         }

--- a/src/NzbDrone.Core.Test/InstrumentationTests/DatabaseTargetFixture.cs
+++ b/src/NzbDrone.Core.Test/InstrumentationTests/DatabaseTargetFixture.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Test.InstrumentationTests
         public void null_string_as_arg_should_not_fail()
         {
             var epFile = new EpisodeFile();
-            _logger.Debug("File {0} no longer exists on disk. removing from database.", epFile.RelativePath);
+            _logger.Debug("File {RelativePath} no longer exists on disk. removing from database.", epFile.RelativePath);
 
             Thread.Sleep(1000);
 

--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -229,7 +229,7 @@ namespace NzbDrone.Core.Backup
         {
             var retention = _configService.BackupRetention;
 
-            _logger.Debug("Cleaning up backup files older than {0} days", retention);
+            _logger.Debug("Cleaning up backup files older than {RetentionDays} days", retention);
             var files = GetBackupFiles(GetBackupFolder(backupType));
 
             foreach (var file in files)
@@ -238,7 +238,7 @@ namespace NzbDrone.Core.Backup
 
                 if (lastWriteTime.AddDays(retention) < DateTime.UtcNow)
                 {
-                    _logger.Debug("Deleting old backup file: {0}", file);
+                    _logger.Debug("Deleting old backup file: {BackupFile}", file);
                     _diskProvider.DeleteFile(file);
                 }
             }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -463,7 +463,7 @@ namespace NzbDrone.Core.Configuration
                 return dbValue;
             }
 
-            _logger.Trace("Using default config value for '{0}' defaultValue:'{1}'", key, defaultValue);
+            _logger.Trace("Using default config value for '{ConfigKey}' defaultValue:'{DefaultValue}'", key, defaultValue);
 
             if (persist)
             {
@@ -497,7 +497,7 @@ namespace NzbDrone.Core.Configuration
         {
             key = key.ToLowerInvariant();
 
-            _logger.Trace("Writing Setting to database. Key:'{0}' Value:'{1}'", key, value);
+            _logger.Trace("Writing Setting to database. Key:'{ConfigKey}' Value:'{ConfigValue}'", key, value);
             _repository.Upsert(key, value);
 
             ClearCache();

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -173,17 +173,17 @@ namespace NzbDrone.Core.CustomFormats
 
             if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
             {
-                _logger.Trace("Using scene name for release title: {0}", episodeFile.SceneName);
+                _logger.Trace("Using scene name for release title: {SceneName}", episodeFile.SceneName);
                 releaseTitle = episodeFile.SceneName;
             }
             else if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
             {
-                _logger.Trace("Using original file path for release title: {0}", Path.GetFileName(episodeFile.OriginalFilePath));
+                _logger.Trace("Using original file path for release title: {FileName}", Path.GetFileName(episodeFile.OriginalFilePath));
                 releaseTitle = Path.GetFileName(episodeFile.OriginalFilePath);
             }
             else if (episodeFile.RelativePath.IsNotNullOrWhiteSpace())
             {
-                _logger.Trace("Using relative path for release title: {0}", Path.GetFileName(episodeFile.RelativePath));
+                _logger.Trace("Using relative path for release title: {FileName}", Path.GetFileName(episodeFile.RelativePath));
                 releaseTitle = Path.GetFileName(episodeFile.RelativePath);
             }
 

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SceneMappingService.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
             if (distinctMappings.Count == 1)
             {
                 var mapping = distinctMappings.First();
-                _logger.Debug("Found scene mapping for: {0}. TVDB ID for mapping: {1}", seriesTitle, mapping.TvdbId);
+                _logger.Debug("Found scene mapping for: {SeriesTitle}. TVDB ID for mapping: {TvdbId}", seriesTitle, mapping.TvdbId);
                 return distinctMappings.First();
             }
 
@@ -150,7 +150,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
                             if (sceneMapping.Title.IsNullOrWhiteSpace() ||
                                 sceneMapping.SearchTerm.IsNullOrWhiteSpace())
                             {
-                                _logger.Warn("Invalid scene mapping found for: {0}, skipping", sceneMapping.TvdbId);
+                                _logger.Warn("Invalid scene mapping found for: {TvdbId}, skipping", sceneMapping.TvdbId);
                                 return true;
                             }
 
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.DataAugmentation.Scene
                         {
                             if (mapping.MappingId.IsNullOrWhiteSpace())
                             {
-                                _logger.Warn("Scene mapping with missing MappingId found for: {0} {1}, skipping", mapping.TvdbId, mapping.Title);
+                                _logger.Warn("Scene mapping with missing MappingId found for: {TvdbId} {MappingTitle}, skipping", mapping.TvdbId, mapping.Title);
                                 continue;
                             }
 

--- a/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Xem/XemProxy.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
         public List<XemSceneTvdbMapping> GetSceneTvdbMappings(int id)
         {
-            _logger.Debug("Fetching Mappings for: {0}", id);
+            _logger.Debug("Fetching Mappings for: {TvdbId}", id);
 
             var request = _xemRequestBuilder.Create()
                                             .Resource("/all")

--- a/src/NzbDrone.Core/DataAugmentation/Xem/XemService.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Xem/XemService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
         private void PerformUpdate(Series series)
         {
-            _logger.Debug("Updating scene numbering mapping for: {0}", series);
+            _logger.Debug("Updating scene numbering mapping for: {SeriesTitle}", series);
 
             try
             {
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
                 if (!mappings.Any() && !series.UseSceneNumbering)
                 {
-                    _logger.Debug("Mappings for: {0} are empty, skipping", series);
+                    _logger.Debug("Mappings for: {SeriesTitle} are empty, skipping", series);
                     return;
                 }
 
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
                 foreach (var mapping in mappings)
                 {
-                    _logger.Debug("Setting scene numbering mappings for {0} S{1:00}E{2:00}", series, mapping.Tvdb.Season, mapping.Tvdb.Episode);
+                    _logger.Debug("Setting scene numbering mappings for {SeriesTitle} S{SeasonNumber:00}E{EpisodeNumber:00}", series, mapping.Tvdb.Season, mapping.Tvdb.Episode);
 
                     var episode = episodes.SingleOrDefault(e => e.SeasonNumber == mapping.Tvdb.Season && e.EpisodeNumber == mapping.Tvdb.Episode);
 
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
                         mapping.Scene.Season == 0 &&
                         mapping.Scene.Episode == 0)
                     {
-                        _logger.Debug("Mapping for {0} S{1:00}E{2:00} is invalid, skipping", series, mapping.Tvdb.Season, mapping.Tvdb.Episode);
+                        _logger.Debug("Mapping for {SeriesTitle} S{SeasonNumber:00}E{EpisodeNumber:00} is invalid, skipping", series, mapping.Tvdb.Season, mapping.Tvdb.Episode);
                         continue;
                     }
 
@@ -89,11 +89,11 @@ namespace NzbDrone.Core.DataAugmentation.Xem
                 series.UseSceneNumbering = mappings.Any();
                 _seriesService.UpdateSeries(series);
 
-                _logger.Debug("XEM mapping updated for {0}", series);
+                _logger.Debug("XEM mapping updated for {SeriesTitle}", series);
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Error updating scene numbering mappings for {0}", series);
+                _logger.Error(ex, "Error updating scene numbering mappings for {SeriesTitle}", series);
             }
         }
 
@@ -247,7 +247,7 @@ namespace NzbDrone.Core.DataAugmentation.Xem
 
             if (!_cache.Find(message.Series.TvdbId.ToString()) && !message.Series.UseSceneNumbering)
             {
-                _logger.Debug("Scene numbering is not available for {0} [{1}]", message.Series.Title, message.Series.TvdbId);
+                _logger.Debug("Scene numbering is not available for {SeriesTitle} [{TvdbId}]", message.Series.Title, message.Series.TvdbId);
                 return;
             }
 

--- a/src/NzbDrone.Core/Datastore/Database.cs
+++ b/src/NzbDrone.Core/Datastore/Database.cs
@@ -70,13 +70,13 @@ namespace NzbDrone.Core.Datastore
         {
             try
             {
-                _logger.Info("Vacuuming {0} database", _databaseName);
+                _logger.Info("Vacuuming {DatabaseName} database", _databaseName);
                 using (var db = _datamapperFactory())
                 {
                     db.Execute("Vacuum;");
                 }
 
-                _logger.Info("{0} database compressed", _databaseName);
+                _logger.Info("{DatabaseName} database compressed", _databaseName);
             }
             catch (Exception e)
             {

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Datastore.Migration
                     {
                         var version = reader.GetString(0);
 
-                        _logger.Info("SQLite {0}", version);
+                        _logger.Info("SQLite {Version}", version);
                     }
                 }
             }
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Datastore.Migration
                         var version = reader.GetString(0);
                         var cleanVersion = Regex.Replace(version, @"\(.*?\)", "");
 
-                        _logger.Info("Postgres {0}", cleanVersion);
+                        _logger.Info("Postgres {Version}", cleanVersion);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Datastore/Migration/051_download_client_import.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/051_download_client_import.cs
@@ -246,7 +246,7 @@ namespace NzbDrone.Core.Datastore.Migration
                 }
             }
 
-            _logger.Info("Updated old History items. {0}/{1} old ImportedEvents were associated with GrabbedEvents.", historyItemsToAssociate.Count, numHistoryItemsNotAssociated);
+            _logger.Info("Updated old History items. {AssociatedCount}/{NotAssociatedCount} old ImportedEvents were associated with GrabbedEvents.", historyItemsToAssociate.Count, numHistoryItemsNotAssociated);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
         {
             var sw = Stopwatch.StartNew();
 
-            _logger.Info("*** Migrating {0} ***", connectionString);
+            _logger.Info("*** Migrating {ConnectionString} ***", connectionString);
 
             var db = databaseType switch
             {
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             sw.Stop();
 
-            _logger.Debug("Took: {0}", sw.Elapsed);
+            _logger.Debug("Took: {Elapsed}", sw.Elapsed);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneMigrationBase.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/NzbDroneMigrationBase.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
         private void LogMigrationMessage(MigrationType type)
         {
-            _logger.Info("Starting migration of {0} DB to {1}", type.ToString(), Version);
+            _logger.Info("Starting migration of {DatabaseType} DB to {Version}", type.ToString(), Version);
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.DecisionEngine
         {
             if (reports.Any())
             {
-                _logger.ProgressInfo("Processing {0} releases", reports.Count);
+                _logger.ProgressInfo("Processing {ReleaseCount} releases", reports.Count);
             }
             else
             {
@@ -71,8 +71,8 @@ namespace NzbDrone.Core.DecisionEngine
             foreach (var report in reports)
             {
                 DownloadDecision decision = null;
-                _logger.ProgressTrace("Processing release {0}/{1}", reportNumber, reports.Count);
-                _logger.Debug("Processing release '{0}' from '{1}'", report.Title, report.Indexer);
+                _logger.ProgressTrace("Processing release {ReleaseNumber}/{ReleaseCount}", reportNumber, reports.Count);
+                _logger.Debug("Processing release '{ReleaseTitle}' from '{Indexer}'", report.Title, report.Indexer);
 
                 try
                 {
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.DecisionEngine
                             remoteEpisode.CustomFormats = _formatCalculator.ParseCustomFormat(remoteEpisode, remoteEpisode.Release.Size);
                             remoteEpisode.CustomFormatScore = remoteEpisode?.Series?.QualityProfile?.Value.CalculateCustomFormatScore(remoteEpisode.CustomFormats) ?? 0;
 
-                            _logger.Trace("Custom Format Score of '{0}' [{1}] calculated for '{2}'", remoteEpisode.CustomFormatScore, remoteEpisode.CustomFormats?.ConcatToString(), report.Title);
+                            _logger.Trace("Custom Format Score of '{CustomFormatScore}' [{CustomFormats}] calculated for '{ReleaseTitle}'", remoteEpisode.CustomFormatScore, remoteEpisode.CustomFormats?.ConcatToString(), report.Title);
 
                             remoteEpisode.DownloadAllowed = remoteEpisode.Episodes.Any();
                             decision = GetDecisionForReport(remoteEpisode, new ReleaseDecisionInformation(pushedRelease, searchCriteria));
@@ -165,11 +165,11 @@ namespace NzbDrone.Core.DecisionEngine
                 {
                     if (decision.Rejections.Any())
                     {
-                        _logger.Debug("Release '{0}' from '{1}' rejected for the following reasons: {2}", report.Title, report.Indexer, string.Join(", ", decision.Rejections));
+                        _logger.Debug("Release '{ReleaseTitle}' from '{Indexer}' rejected for the following reasons: {RejectionReasons}", report.Title, report.Indexer, string.Join(", ", decision.Rejections));
                     }
                     else
                     {
-                        _logger.Debug("Release '{0}' from '{1}' accepted", report.Title, report.Indexer);
+                        _logger.Debug("Release '{ReleaseTitle}' from '{Indexer}' accepted", report.Title, report.Indexer);
                     }
 
                     yield return decision;
@@ -211,7 +211,7 @@ namespace NzbDrone.Core.DecisionEngine
             {
                 e.Data.Add("report", remoteEpisode.Release.ToJson());
                 e.Data.Add("parsed", remoteEpisode.ParsedEpisodeInfo.ToJson());
-                _logger.Error(e, "Couldn't evaluate decision on {0}", remoteEpisode.Release.Title);
+                _logger.Error(e, "Couldn't evaluate decision on {ReleaseTitle}", remoteEpisode.Release.Title);
                 return new DownloadRejection(DownloadRejectionReason.DecisionError, $"{spec.GetType().Name}: {e.Message}");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AcceptableSizeSpecification.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
         public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            _logger.Debug("Beginning size check for: {0}", subject);
+            _logger.Debug("Beginning size check for: {ReleaseTitle}", subject);
 
             var quality = subject.ParsedEpisodeInfo.Quality.Quality;
 
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 {
                     var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes totalling {runtime}min";
 
-                    _logger.Debug("Item: {0}, Size: {1} is smaller than minimum allowed size ({2} bytes for {3}), rejecting.", subject, subject.Release.Size, minSize, runtimeMessage);
+                    _logger.Debug("Item: {ReleaseTitle}, Size: {ReleaseSize} is smaller than minimum allowed size ({MinSize} bytes for {RuntimeMessage}), rejecting.", subject, subject.Release.Size, minSize, runtimeMessage);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.BelowMinimumSize, "{0} is smaller than minimum allowed {1} (for {2})", subject.Release.Size.SizeSuffix(), minSize.SizeSuffix(), runtimeMessage);
                 }
             }
@@ -112,12 +112,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 {
                     var runtimeMessage = subject.Episodes.Count == 1 ? $"{runtime}min" : $"{subject.Episodes.Count} episodes totalling {runtime}min";
 
-                    _logger.Debug("Item: {0}, Size: {1} is greater than maximum allowed size ({2} for {3}), rejecting", subject, subject.Release.Size, maxSize, runtimeMessage);
+                    _logger.Debug("Item: {ReleaseTitle}, Size: {ReleaseSize} is greater than maximum allowed size ({MaxSize} for {RuntimeMessage}), rejecting", subject, subject.Release.Size, maxSize, runtimeMessage);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.AboveMaximumSize, "{0} is larger than maximum allowed {1} (for {2})", subject.Release.Size.SizeSuffix(), maxSize.SizeSuffix(), runtimeMessage);
                 }
             }
 
-            _logger.Debug("Item: {0}, meets size constraints", subject);
+            _logger.Debug("Item: {ReleaseTitle}, meets size constraints", subject);
             return DownloadSpecDecision.Accept();
         }
     }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AirDateSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AirDateSpecification.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
         public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            _logger.Debug("Checking if release meets air date restrictions: {0}", subject);
+            _logger.Debug("Checking if release meets air date restrictions: {ReleaseTitle}", subject);
 
             var releaseProfiles = _releaseProfileService.EnabledForTags(subject.Series.Tags, subject.Release.IndexerId);
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/AnimeVersionUpgradeSpecification.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                     if (file.ReleaseGroup != releaseGroup)
                     {
-                        _logger.Debug("Existing Release group is: {0} - release's release group is: {1}", file.ReleaseGroup, releaseGroup);
+                        _logger.Debug("Existing Release group is: {ExistingReleaseGroup} - release's release group is: {ReleaseGroup}", file.ReleaseGroup, releaseGroup);
                         return DownloadSpecDecision.Reject(DownloadRejectionReason.ReleaseGroupDoesNotMatch, "{0} does not match existing release group {1}", releaseGroup, file.ReleaseGroup);
                     }
                 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/BlocklistSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/BlocklistSpecification.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         {
             if (_blocklistService.Blocklisted(subject.Series.Id, subject.Release))
             {
-                _logger.Debug("{0} is blocklisted, rejecting.", subject.Release.Title);
+                _logger.Debug("{ReleaseTitle} is blocklisted, rejecting.", subject.Release.Title);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.Blocklisted, "Release is blocklisted");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/CustomFormatAllowedByProfileSpecification.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.CustomFormatMinimumScore, "Custom Formats {0} have score {1} below Series profile minimum {2}", subject.CustomFormats.ConcatToString(), score, minScore);
             }
 
-            _logger.Trace("Custom Format Score of {0} [{1}] above Series profile minimum {2}", score, subject.CustomFormats.ConcatToString(), minScore);
+            _logger.Trace("Custom Format Score of {CustomFormatScore} [{CustomFormats}] above Series profile minimum {MinimumScore}", score, subject.CustomFormats.ConcatToString(), minScore);
 
             return DownloadSpecDecision.Accept();
         }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (!freeSpace.HasValue)
             {
-                _logger.Debug("Unable to get available space for {0}. Skipping", path);
+                _logger.Debug("Unable to get available space for {FolderPath}. Skipping", path);
 
                 return DownloadSpecDecision.Accept();
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FullSeasonSpecification.cs
@@ -22,11 +22,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         {
             if (subject.ParsedEpisodeInfo.FullSeason)
             {
-                _logger.Debug("Checking if all episodes in full season release have aired. {0}", subject.Release.Title);
+                _logger.Debug("Checking if all episodes in full season release have aired. {ReleaseTitle}", subject.Release.Title);
 
                 if (subject.Episodes.Any(e => !e.AirDateUtc.HasValue || e.AirDateUtc.Value.After(DateTime.UtcNow.AddHours(24))))
                 {
-                    _logger.Debug("Full season release {0} rejected. All episodes haven't aired yet.", subject.Release.Title);
+                    _logger.Debug("Full season release {ReleaseTitle} rejected. All episodes haven't aired yet.", subject.Release.Title);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.FullSeasonNotAired, "Full season release rejected. All episodes haven't aired yet.");
                 }
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MaximumSizeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MaximumSizeSpecification.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return DownloadSpecDecision.Accept();
             }
 
-            _logger.Debug("Checking if release meets maximum size requirements. {0}", size.SizeSuffix());
+            _logger.Debug("Checking if release meets maximum size requirements. {ReleaseSize}", size.SizeSuffix());
 
             if (size > maximumSize)
             {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MinimumAgeSpecification.cs
@@ -37,15 +37,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return DownloadSpecDecision.Accept();
             }
 
-            _logger.Debug("Checking if report meets minimum age requirements. {0}", ageRounded);
+            _logger.Debug("Checking if report meets minimum age requirements. {AgeMinutes}", ageRounded);
 
             if (age < minimumAge)
             {
-                _logger.Debug("Only {0} minutes old, minimum age is {1} minutes", ageRounded, minimumAge);
+                _logger.Debug("Only {AgeMinutes} minutes old, minimum age is {MinimumAge} minutes", ageRounded, minimumAge);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumAge, "Only {0} minutes old, minimum age is {1} minutes", ageRounded, minimumAge);
             }
 
-            _logger.Debug("Release is {0} minutes old, greater than minimum age of {1} minutes", ageRounded, minimumAge);
+            _logger.Debug("Release is {AgeMinutes} minutes old, greater than minimum age of {MinimumAge} minutes", ageRounded, minimumAge);
 
             return DownloadSpecDecision.Accept();
         }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         {
             if (subject.ParsedEpisodeInfo.IsMultiSeason)
             {
-                _logger.Debug("Multi-season release {0} rejected. Not supported", subject.Release.Title);
+                _logger.Debug("Multi-season release {ReleaseTitle} rejected. Not supported", subject.Release.Title);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.MultiSeason, "Multi-season releases are not supported");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ProtocolSpecification.cs
@@ -26,13 +26,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (subject.Release.DownloadProtocol == DownloadProtocol.Usenet && !delayProfile.EnableUsenet)
             {
-                _logger.Debug("[{0}] Usenet is not enabled for this series", subject.Release.Title);
+                _logger.Debug("[{ReleaseTitle}] Usenet is not enabled for this series", subject.Release.Title);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.ProtocolDisabled, "Usenet is not enabled for this series");
             }
 
             if (subject.Release.DownloadProtocol == DownloadProtocol.Torrent && !delayProfile.EnableTorrent)
             {
-                _logger.Debug("[{0}] Torrent is not enabled for this series", subject.Release.Title);
+                _logger.Debug("[{ReleaseTitle}] Torrent is not enabled for this series", subject.Release.Title);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.ProtocolDisabled, "Torrent is not enabled for this series");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QualityAllowedByProfileSpecification.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
         public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            _logger.Debug("Checking if report meets quality requirements. {0}", subject.ParsedEpisodeInfo.Quality);
+            _logger.Debug("Checking if report meets quality requirements. {Quality}", subject.ParsedEpisodeInfo.Quality);
 
             var profile = subject.Series.QualityProfile.Value;
             var qualityIndex = profile.GetIndex(subject.ParsedEpisodeInfo.Quality.Quality);
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (!qualityOrGroup.Allowed)
             {
-                _logger.Debug("Quality {0} rejected by Series' quality profile", subject.ParsedEpisodeInfo.Quality);
+                _logger.Debug("Quality {Quality} rejected by Series' quality profile", subject.ParsedEpisodeInfo.Quality);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.QualityNotWanted, "{0} is not wanted in profile", subject.ParsedEpisodeInfo.Quality.Quality);
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/QueueSpecification.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 var queuedItemCustomFormats = _formatService.ParseCustomFormat(remoteEpisode, (long)queueItem.Size);
 
-                _logger.Debug("Checking if existing release in queue meets cutoff. Queued: {0}", remoteEpisode.ParsedEpisodeInfo.Quality);
+                _logger.Debug("Checking if existing release in queue meets cutoff. Queued: {QueuedQuality}", remoteEpisode.ParsedEpisodeInfo.Quality);
 
                 if (!_upgradableSpecification.CutoffNotMet(qualityProfile,
                     remoteEpisode.ParsedEpisodeInfo.Quality,
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.QueueCutoffMet, "Release in queue already meets cutoff: {0}", remoteEpisode.ParsedEpisodeInfo.Quality);
                 }
 
-                _logger.Debug("Checking if release is higher quality than queued release. Queued: {0}", remoteEpisode.ParsedEpisodeInfo.Quality);
+                _logger.Debug("Checking if release is higher quality than queued release. Queued: {QueuedQuality}", remoteEpisode.ParsedEpisodeInfo.Quality);
 
                 var upgradeableRejectReason = _upgradableSpecification.IsUpgradable(qualityProfile,
                     remoteEpisode.ParsedEpisodeInfo.Quality,

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ReleaseRestrictionsSpecification.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
         public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
         {
-            _logger.Debug("Checking if release meets restrictions: {0}", subject);
+            _logger.Debug("Checking if release meets restrictions: {ReleaseTitle}", subject);
 
             var title = subject.Release.Title;
             var releaseProfiles = _releaseProfileService.EnabledForTags(subject.Series.Tags, subject.Release.IndexerId);
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 if (foundTerms.Empty())
                 {
                     var terms = string.Join(", ", requiredTerms);
-                    _logger.Debug("[{0}] does not contain one of the required terms: {1}", title, terms);
+                    _logger.Debug("[{ReleaseTitle}] does not contain one of the required terms: {RequiredTerms}", title, terms);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.MustContainMissing, "Does not contain one of the required terms: {0}", terms);
                 }
             }
@@ -54,12 +54,12 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 if (foundTerms.Any())
                 {
                     var terms = string.Join(", ", foundTerms);
-                    _logger.Debug("[{0}] contains these ignored terms: {1}", title, terms);
+                    _logger.Debug("[{ReleaseTitle}] contains these ignored terms: {IgnoredTerms}", title, terms);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.MustNotContainPresent, "Contains these ignored terms: {0}", terms);
                 }
             }
 
-            _logger.Debug("[{0}] No restrictions apply, allowing", subject);
+            _logger.Debug("[{ReleaseTitle}] No restrictions apply, allowing", subject);
             return DownloadSpecDecision.Accept();
         }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RetentionSpecification.cs
@@ -29,10 +29,10 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             var age = subject.Release.Age;
             var retention = _configService.Retention;
 
-            _logger.Debug("Checking if report meets retention requirements. {0}", age);
+            _logger.Debug("Checking if report meets retention requirements. {AgeDays}", age);
             if (retention > 0 && age > retention)
             {
-                _logger.Debug("Report age: {0} rejected by user's retention limit", age);
+                _logger.Debug("Report age: {AgeDays} rejected by user's retention limit", age);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.MaximumAge, "Older than configured retention");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DelaySpecification.cs
@@ -45,11 +45,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
             if (delay == 0)
             {
-                _logger.Debug("Delay Profile does not require a waiting period before download for {0}.", subject.Release.DownloadProtocol);
+                _logger.Debug("Delay Profile does not require a waiting period before download for {DownloadProtocol}.", subject.Release.DownloadProtocol);
                 return DownloadSpecDecision.Accept();
             }
 
-            _logger.Debug("Delay Profile requires a waiting period of {0} minutes for {1}", delay, subject.Release.DownloadProtocol);
+            _logger.Debug("Delay Profile requires a waiting period of {DelayMinutes} minutes for {DownloadProtocol}", delay, subject.Release.DownloadProtocol);
 
             var qualityComparer = new QualityModelComparer(qualityProfile);
 
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
                 if (score >= minimum && isPreferredProtocol)
                 {
-                    _logger.Debug("Custom format score ({0}) meets minimum ({1}) for preferred protocol, will not delay", score, minimum);
+                    _logger.Debug("Custom format score ({CustomFormatScore}) meets minimum ({MinimumScore}) for preferred protocol, will not delay", score, minimum);
                     return DownloadSpecDecision.Accept();
                 }
             }
@@ -101,13 +101,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
             if (oldest != null && oldest.Release.AgeMinutes > delay)
             {
-                _logger.Debug("Oldest pending release {0} has been delayed for {1}, longer than the set delay of {2}. Release will be accepted", oldest.Release.Title, oldest.Release.AgeMinutes, delay);
+                _logger.Debug("Oldest pending release {ReleaseTitle} has been delayed for {AgeMinutes}, longer than the set delay of {DelayMinutes}. Release will be accepted", oldest.Release.Title, oldest.Release.AgeMinutes, delay);
                 return DownloadSpecDecision.Accept();
             }
 
             if (subject.Release.AgeMinutes < delay)
             {
-                _logger.Debug("Waiting for better quality release, There is a {0} minute delay on {1}", delay, subject.Release.DownloadProtocol);
+                _logger.Debug("Waiting for better quality release, There is a {DelayMinutes} minute delay on {DownloadProtocol}", delay, subject.Release.DownloadProtocol);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumAgeDelay, "Waiting for better quality release");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/DeletedEpisodeFileSpecification.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             {
                 foreach (var missingEpisodeFile in missingEpisodeFiles)
                 {
-                    _logger.Trace("Episode file {0} is missing from disk.", missingEpisodeFile.RelativePath);
+                    _logger.Trace("Episode file {RelativePath} is missing from disk.", missingEpisodeFile.RelativePath);
                 }
 
                 _logger.Debug("Files for this episode exist in the database but not on disk, will be unmonitored on next diskscan. skipping.");

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/HistorySpecification.cs
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
             foreach (var episode in subject.Episodes)
             {
-                _logger.Debug("Checking current status of episode [{0}] in history", episode.Id);
+                _logger.Debug("Checking current status of episode [{EpisodeId}] in history", episode.Id);
                 var mostRecent = _historyService.MostRecentForEpisode(episode.Id);
 
                 if (mostRecent != null && mostRecent.EventType == EpisodeHistoryEventType.Grabbed)

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/IndexerTagSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/IndexerTagSpecification.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             }
             catch (ModelNotFoundException)
             {
-                _logger.Debug("Indexer with id {0} does not exist, skipping indexer tags check", subject.Release.IndexerId);
+                _logger.Debug("Indexer with id {IndexerId} does not exist, skipping indexer tags check", subject.Release.IndexerId);
                 return DownloadSpecDecision.Accept();
             }
 
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
             if (indexerTags.Any() && indexerTags.Intersect(subject.Series.Tags).Empty())
             {
-                _logger.Debug("Indexer {0} has tags. None of these are present on series {1}. Rejecting", subject.Release.Indexer, subject.Series);
+                _logger.Debug("Indexer {Indexer} has tags. None of these are present on series {SeriesTitle}. Rejecting", subject.Release.Indexer, subject.Series);
 
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.NoMatchingTag, "Series tags do not match any of the indexer tags");
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/MonitoredEpisodeSpecification.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
             if (!subject.Series.Monitored)
             {
-                _logger.Debug("{0} is present in the DB but not tracked. Rejecting", subject.Series);
+                _logger.Debug("{SeriesTitle} is present in the DB but not tracked. Rejecting", subject.Series);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.SeriesNotMonitored, "Series is not monitored");
             }
 
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
             }
             else
             {
-                _logger.Debug("Only {0}/{1} episodes in the release are monitored. Rejecting", monitoredCount, subject.Episodes.Count);
+                _logger.Debug("Only {MonitoredCount}/{EpisodeCount} episodes in the release are monitored. Rejecting", monitoredCount, subject.Episodes.Count);
             }
 
             return DownloadSpecDecision.Reject(DownloadRejectionReason.EpisodeNotMonitored, "One or more episodes is not monitored");

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/RssSync/ProperSpecification.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.RssSync
 
                     if (file.DateAdded < DateTime.Today.AddDays(-7))
                     {
-                        _logger.Debug("Proper for old file, rejecting: {0}", subject);
+                        _logger.Debug("Proper for old file, rejecting: {ReleaseTitle}", subject);
                         return DownloadSpecDecision.Reject(DownloadRejectionReason.ProperForOldFile, "Proper for old file");
                     }
                 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SceneMappingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SceneMappingSpecification.cs
@@ -36,11 +36,11 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (remoteEpisode.SceneMapping.Comment.IsNotNullOrWhiteSpace())
             {
-                _logger.Debug("SceneMapping has origin {0} with comment '{1}'.", remoteEpisode.SceneMapping.SceneOrigin, remoteEpisode.SceneMapping.Comment);
+                _logger.Debug("SceneMapping has origin {SceneOrigin} with comment '{Comment}'.", remoteEpisode.SceneMapping.SceneOrigin, remoteEpisode.SceneMapping.Comment);
             }
             else
             {
-                _logger.Debug("SceneMapping has origin {0}.", remoteEpisode.SceneMapping.SceneOrigin);
+                _logger.Debug("SceneMapping has origin {SceneOrigin}.", remoteEpisode.SceneMapping.SceneOrigin);
             }
 
             if (split[0] == "mixed")
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             {
                 var type = split.Length >= 2 ? split[1] : "scene";
 
-                _logger.Debug("SceneMapping origin is explicitly unknown, unsure what numbering scheme it uses but '{0}' will be assumed. Provide full release title to Sonarr/TheXEM team.", type);
+                _logger.Debug("SceneMapping origin is explicitly unknown, unsure what numbering scheme it uses but '{NumberingType}' will be assumed. Provide full release title to Sonarr/TheXEM team.", type);
             }
 
             return DownloadSpecDecision.Accept();

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/EpisodeRequestedSpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
 
             if (!criteriaEpisodes.Intersect(remoteEpisodes).Any())
             {
-                _logger.Debug("Release rejected since the episode wasn't requested: {0}", remoteEpisode.ParsedEpisodeInfo);
+                _logger.Debug("Release rejected since the episode wasn't requested: {ParsedEpisodeInfo}", remoteEpisode.ParsedEpisodeInfo);
 
                 if (remoteEpisodes.Any())
                 {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeriesSpecification.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
 
             if (remoteEpisode.Series.Id != searchCriteria.Series.Id)
             {
-                _logger.Debug("Series {0} does not match {1}", remoteEpisode.Series, searchCriteria.Series);
+                _logger.Debug("Series {RemoteSeriesTitle} does not match {SearchSeriesTitle}", remoteEpisode.Series, searchCriteria.Series);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeries, "Wrong series");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SeasonPackOnlySpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SeasonPackOnlySpecification.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                     if (subset.Count > 0 && subset.Max(e => e.AirDateUtc).Value.Before(DateTime.UtcNow - TimeSpan.FromDays(subject.Release.SeasonSearchMaximumSingleEpisodeAge)))
                     {
-                        _logger.Debug("Release {0}: last episode in this season aired more than {1} days ago, season pack required.", subject.Release.Title, subject.Release.SeasonSearchMaximumSingleEpisodeAge);
+                        _logger.Debug("Release {ReleaseTitle}: last episode in this season aired more than {MaxAgeDays} days ago, season pack required.", subject.Release.Title, subject.Release.SeasonSearchMaximumSingleEpisodeAge);
                         return DownloadSpecDecision.Reject(DownloadRejectionReason.NotSeasonPack, "Last episode in this season aired more than {0} days ago, season pack required.", subject.Release.SeasonSearchMaximumSingleEpisodeAge);
                     }
                 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SplitEpisodeSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SplitEpisodeSpecification.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         {
             if (subject.ParsedEpisodeInfo.IsSplitEpisode)
             {
-                _logger.Debug("Split episode release {0} rejected. Not supported", subject.Release.Title);
+                _logger.Debug("Split episode release {ReleaseTitle} rejected. Not supported", subject.Release.Title);
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.SplitEpisode, "Split episode releases are not supported");
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/TorrentSeedingSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/TorrentSeedingSpecification.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             }
             catch (ModelNotFoundException)
             {
-                _logger.Debug("Indexer with id {0} does not exist, skipping seeders check", torrentInfo.IndexerId);
+                _logger.Debug("Indexer with id {IndexerId} does not exist, skipping seeders check", torrentInfo.IndexerId);
                 return DownloadSpecDecision.Accept();
             }
 
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 if (torrentInfo.Seeders.HasValue && torrentInfo.Seeders.Value < minimumSeeders)
                 {
-                    _logger.Debug("Not enough seeders: {0}. Minimum seeders: {1}", torrentInfo.Seeders, minimumSeeders);
+                    _logger.Debug("Not enough seeders: {Seeders}. Minimum seeders: {MinimumSeeders}", torrentInfo.Seeders, minimumSeeders);
                     return DownloadSpecDecision.Reject(DownloadRejectionReason.MinimumSeeders, "Not enough seeders: {0}. Minimum seeders: {1}", torrentInfo.Seeders, minimumSeeders);
                 }
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradableSpecification.cs
@@ -36,13 +36,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (qualityCompare > 0 && QualityCutoffNotMet(qualityProfile, currentQuality, newQuality))
             {
-                _logger.Debug("New item has a better quality. Existing: {0}. New: {1}", currentQuality, newQuality);
+                _logger.Debug("New item has a better quality. Existing: {ExistingQuality}. New: {NewQuality}", currentQuality, newQuality);
                 return UpgradeableRejectReason.None;
             }
 
             if (qualityCompare < 0)
             {
-                _logger.Debug("Existing item has better quality, skipping. Existing: {0}. New: {1}", currentQuality, newQuality);
+                _logger.Debug("Existing item has better quality, skipping. Existing: {ExistingQuality}. New: {NewQuality}", currentQuality, newQuality);
                 return UpgradeableRejectReason.BetterQuality;
             }
 
@@ -53,13 +53,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                 qualityRevisionCompare > 0)
             {
-                _logger.Debug("New item has a better quality revision, skipping. Existing: {0}. New: {1}", currentQuality, newQuality);
+                _logger.Debug("New item has a better quality revision, skipping. Existing: {ExistingQuality}. New: {NewQuality}", currentQuality, newQuality);
                 return UpgradeableRejectReason.None;
             }
 
             if (!qualityProfile.UpgradeAllowed)
             {
-                _logger.Debug("Quality profile '{0}' does not allow upgrading. Skipping.", qualityProfile.Name);
+                _logger.Debug("Quality profile '{ProfileName}' does not allow upgrading. Skipping.", qualityProfile.Name);
 
                 return UpgradeableRejectReason.UpgradesNotAllowed;
             }
@@ -68,13 +68,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             if (downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                 qualityRevisionCompare < 0)
             {
-                _logger.Debug("Existing item has a better quality revision, skipping. Existing: {0}. New: {1}", currentQuality, newQuality);
+                _logger.Debug("Existing item has a better quality revision, skipping. Existing: {ExistingQuality}. New: {NewQuality}", currentQuality, newQuality);
                 return UpgradeableRejectReason.BetterRevision;
             }
 
             if (qualityCompare > 0)
             {
-                _logger.Debug("Existing item meets cut-off for quality, skipping. Existing: {0}. Cutoff: {1}",
+                _logger.Debug("Existing item meets cut-off for quality, skipping. Existing: {ExistingQuality}. Cutoff: {CutoffQuality}",
                     currentQuality,
                     qualityProfile.Items[qualityProfile.GetIndex(qualityProfile.Cutoff).Index]);
                 return UpgradeableRejectReason.QualityCutoff;
@@ -85,7 +85,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (newFormatScore <= currentFormatScore)
             {
-                _logger.Debug("New item's custom formats [{0}] ({1}) do not improve on [{2}] ({3}), skipping",
+                _logger.Debug("New item's custom formats [{NewCustomFormats}] ({NewFormatScore}) do not improve on [{CurrentCustomFormats}] ({CurrentFormatScore}), skipping",
                     newCustomFormats.ConcatToString(),
                     newFormatScore,
                     currentCustomFormats.ConcatToString(),
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (currentFormatScore >= qualityProfile.CutoffFormatScore)
             {
-                _logger.Debug("Existing item meets cut-off for custom formats, skipping. Existing: [{0}] ({1}). Cutoff score: {2}",
+                _logger.Debug("Existing item meets cut-off for custom formats, skipping. Existing: [{CurrentCustomFormats}] ({CurrentFormatScore}). Cutoff score: {CutoffFormatScore}",
                     currentCustomFormats.ConcatToString(),
                     currentFormatScore,
                     qualityProfile.CutoffFormatScore);
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (newFormatScore < currentFormatScore + qualityProfile.MinUpgradeFormatScore)
             {
-                _logger.Debug("New item's custom formats [{0}] ({1}) do not meet minimum custom format score increment of {3} required for upgrade, skipping. Existing: [{4}] ({5}).",
+                _logger.Debug("New item's custom formats [{NewCustomFormats}] ({NewFormatScore}) do not meet minimum custom format score increment of {MinUpgradeFormatScore} required for upgrade, skipping. Existing: [{CurrentCustomFormats}] ({CurrentFormatScore}).",
                               newCustomFormats.ConcatToString(),
                               newFormatScore,
                               qualityProfile.MinUpgradeFormatScore,
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return UpgradeableRejectReason.MinCustomFormatScore;
             }
 
-            _logger.Debug("New item's custom formats [{0}] ({1}) improve on [{2}] ({3}), accepting",
+            _logger.Debug("New item's custom formats [{NewCustomFormats}] ({NewFormatScore}) improve on [{CurrentCustomFormats}] ({CurrentFormatScore}), accepting",
                 newCustomFormats.ConcatToString(),
                 newFormatScore,
                 currentCustomFormats.ConcatToString(),
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return true;
             }
 
-            _logger.Debug("Existing item meets cut-off, skipping. Existing: {0} [{1}] ({2})",
+            _logger.Debug("Existing item meets cut-off, skipping. Existing: {ExistingQuality} [{CurrentCustomFormats}] ({CurrentFormatScore})",
                 currentQuality,
                 currentFormats.ConcatToString(),
                 profile.CalculateCustomFormatScore(currentFormats));
@@ -174,7 +174,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             // Comparing the quality directly because we don't want to upgrade to a proper for a webrip from a webdl or vice versa
             if (currentQuality.Quality == newQuality.Quality && compare > 0)
             {
-                _logger.Debug("New quality is a better revision for existing quality. Existing: {0}. New: {1}", currentQuality, newQuality);
+                _logger.Debug("New quality is a better revision for existing quality. Existing: {ExistingQuality}. New: {NewQuality}", currentQuality, newQuality);
                 return true;
             }
 
@@ -188,7 +188,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             if (IsRevisionUpgrade(currentQuality, newQuality))
             {
-                _logger.Debug("New quality '{0}' is a revision upgrade for '{1}'", newQuality, currentQuality);
+                _logger.Debug("New quality '{NewQuality}' is a revision upgrade for '{ExistingQuality}'", newQuality, currentQuality);
                 return true;
             }
 

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeAllowedSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeAllowedSpecification.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 var fileCustomFormats = _formatService.ParseCustomFormat(file, subject.Series);
 
-                _logger.Debug("Comparing file quality with report. Existing file is {0}", file.Quality);
+                _logger.Debug("Comparing file quality with report. Existing file is {ExistingQuality}", file.Quality);
 
                 if (!_upgradableSpecification.IsUpgradeAllowed(qualityProfile,
                                                                file.Quality,

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 // Count missing episodes as upgradable
                 var missingEpisodesCount = subject.Episodes.Count(c => c.EpisodeFileId == 0);
                 var upgradedCount = missingEpisodesCount;
-                _logger.Debug("{0} episodes are missing from disk and are considered upgradable.", upgradedCount);
+                _logger.Debug("{MissingEpisodesCount} episodes are missing from disk and are considered upgradable.", upgradedCount);
 
                 // Filter for episodes that already exist on disk to check for quality upgrades
                 var existingEpisodeFiles = subject.Episodes.Where(c => c.EpisodeFileId != 0)
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 // Check if any of the existing files can also be upgraded
                 foreach (var file in existingEpisodeFiles)
                 {
-                    _logger.Debug("Comparing file quality with report. Existing file is {0}.", file.Quality);
+                    _logger.Debug("Comparing file quality with report. Existing file is {ExistingQuality}.", file.Quality);
 
                     if (!_upgradableSpecification.CutoffNotMet(qualityProfile,
                             file.Quality,
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
                 var seasonPackUpgrade = _configService.SeasonPackUpgrade;
                 var seasonPackUpgradeThreshold = _configService.SeasonPackUpgradeThreshold;
-                _logger.Debug("Total upgradable episodes: {0} out of {1}. Season import setting: {2}, Threshold: {3}%", upgradedCount, totalEpisodesInPack, seasonPackUpgrade, seasonPackUpgradeThreshold);
+                _logger.Debug("Total upgradable episodes: {UpgradedCount} out of {TotalEpisodesCount}. Season import setting: {SeasonPackUpgrade}, Threshold: {ThresholdPercent}%", upgradedCount, totalEpisodesInPack, seasonPackUpgrade, seasonPackUpgradeThreshold);
                 var upgradablePercentage = (double)upgradedCount / totalEpisodesInPack * 100;
                 if (seasonPackUpgrade == SeasonPackUpgradeType.Any)
                 {
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 return null;
             }
 
-            _logger.Debug("Comparing file quality with report. Existing file is {0}.", file.Quality);
+            _logger.Debug("Comparing file quality with report. Existing file is {ExistingQuality}.", file.Quality);
 
             if (!_upgradableSpecification.CutoffNotMet(qualityProfile,
                     file.Quality,

--- a/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
+++ b/src/NzbDrone.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
 
             if (series == null)
             {
-                _logger.Debug("Unable to aggregate languages, using parsed values: {0}", string.Join(", ", languages.ToList()));
+                _logger.Debug("Unable to aggregate languages, using parsed values: {Languages}", string.Join(", ", languages.ToList()));
 
                 remoteEpisode.Languages = releaseInfo != null && releaseInfo.Languages.Any() ? releaseInfo.Languages : languages;
 
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
 
             if (releaseInfo != null && releaseInfo.Languages.Any())
             {
-                _logger.Debug("Languages provided by indexer, using release values: {0}", string.Join(", ", releaseInfo.Languages));
+                _logger.Debug("Languages provided by indexer, using release values: {Languages}", string.Join(", ", releaseInfo.Languages));
 
                 // Use languages from release (given by indexer or user) if available
                 languages = releaseInfo.Languages;
@@ -108,7 +108,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
             if (languages.Count == 0 || (languages.Count == 1 && languages.First() == Language.Unknown))
             {
                 languages = new List<Language> { series.OriginalLanguage };
-                _logger.Debug("Language couldn't be parsed from release, fallback to series original language: {0}", series.OriginalLanguage.Name);
+                _logger.Debug("Language couldn't be parsed from release, fallback to series original language: {OriginalLanguage}", series.OriginalLanguage.Name);
             }
 
             if (languages.Contains(Language.Original))
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Download.Aggregation.Aggregators
                 }
             }
 
-            _logger.Debug("Selected languages: {0}", string.Join(", ", languages.ToList()));
+            _logger.Debug("Selected languages: {Languages}", string.Join(", ", languages.ToList()));
 
             remoteEpisode.Languages = languages;
 

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
                 Thread.Sleep(retryDelay);
             }
 
-            _logger.Debug("Could not find hash {0} in {1} tries at {2} ms intervals.", hash, tries, retryDelay);
+            _logger.Debug("Could not find hash {InfoHash} in {Tries} tries at {RetryDelay} ms intervals.", hash, tries, retryDelay);
 
             return false;
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/ScanWatchFolder.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/ScanWatchFolder.cs
@@ -170,7 +170,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             }
             catch (Exception ex)
             {
-                _logger.Trace(ex, "Ignored hashing error during scan for {0}", folder);
+                _logger.Trace(ex, "Ignored hashing error during scan for {FolderPath}", folder);
             }
 
             foreach (var file in files.OrderBy(v => v))
@@ -193,7 +193,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             }
             catch (Exception ex)
             {
-                _logger.Trace(ex, "Ignored hashing error during scan for {0}", file);
+                _logger.Trace(ex, "Ignored hashing error during scan for {FilePath}", file);
             }
 
             return HashConverter.GetHash(data.ToString()).ToHexString();

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                 stream.Write(fileContent, 0, fileContent.Length);
             }
 
-            _logger.Debug("Saving magnet link succeeded, saved to: {0}", filepath);
+            _logger.Debug("Saving magnet link succeeded, saved to: {FilePath}", filepath);
 
             return null;
         }
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                 stream.Write(fileContent, 0, fileContent.Length);
             }
 
-            _logger.Debug("Torrent Download succeeded, saved to: {0}", filepath);
+            _logger.Debug("Torrent Download succeeded, saved to: {FilePath}", filepath);
 
             return null;
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackhole.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                 stream.Write(fileContent, 0, fileContent.Length);
             }
 
-            _logger.Debug("NZB Download succeeded, saved to: {0}", filepath);
+            _logger.Debug("NZB Download succeeded, saved to: {FilePath}", filepath);
 
             return null;
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 }
                 catch (DownloadClientUnavailableException)
                 {
-                    _logger.Warn("Failed to set torrent post-import label \"{0}\" for {1} in Deluge. Does the label exist?",
+                    _logger.Warn("Failed to set torrent post-import label \"{ImportedCategory}\" for {DownloadTitle} in Deluge. Does the label exist?",
                         Settings.TvImportedCategory,
                         downloadClientItem.Title);
                 }
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                 }
                 catch (OverflowException ex)
                 {
-                    _logger.Debug(ex, "ETA for {0} is too long: {1}", torrent.Name, torrent.Eta);
+                    _logger.Debug(ex, "ETA for {TorrentName} is too long: {Eta}", torrent.Name, torrent.Eta);
                     item.RemainingTime = TimeSpan.MaxValue;
                 }
 
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
             {
                 if (_hasAttemptedReconnecting)
                 {
-                    _logger.Warn("{0} torrent(s) were ignored because they did not have a hash or title. Deluge may have disconnected from it's daemon. If you continue to see this error, check Deluge for invalid torrents.", ignoredCount);
+                    _logger.Warn("{IgnoredCount} torrent(s) were ignored because they did not have a hash or title. Deluge may have disconnected from it's daemon. If you continue to see this error, check Deluge for invalid torrents.", ignoredCount);
                 }
                 else
                 {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
                 throw new DownloadClientUnavailableException("Unable to connect to Diskstation, please check your settings", ex);
             }
 
-            _logger.Debug("Trying to {0}", operation);
+            _logger.Debug("Trying to {Operation}", operation);
 
             if (response.StatusCode == HttpStatusCode.OK)
             {
@@ -251,7 +251,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation.Proxies
                 {
                     if (api == DiskStationApi.DownloadStation2Task)
                     {
-                        _logger.Warn("Info of {0} not found on {1}:{2}", api, settings.Host, settings.Port);
+                        _logger.Warn("Info of {ApiType} not found on {Host}:{Port}", api, settings.Host, settings.Port);
                     }
                     else
                     {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/SerialNumberProvider.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/SerialNumberProvider.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
             catch (Exception ex)
             {
-                _logger.Warn(ex, "Could not get the serial number from Download Station {0}:{1}", settings.Host, settings.Port);
+                _logger.Warn(ex, "Could not get the serial number from Download Station {Host}:{Port}", settings.Host, settings.Port);
                 throw;
             }
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/SharedFolderResolver.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/SharedFolderResolver.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
             catch (Exception ex)
             {
-                _logger.Warn(ex, "Failed to get shared folder {0} from Disk Station {1}:{2}", sharedFolder, settings.Host, settings.Port);
+                _logger.Warn(ex, "Failed to get shared folder {SharedFolder} from Disk Station {Host}:{Port}", sharedFolder, settings.Host, settings.Port);
 
                 throw;
             }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
 
             DsTaskProxy.RemoveTask(ParseDownloadId(item.DownloadId), Settings);
-            _logger.Debug("{0} removed correctly", item.DownloadId);
+            _logger.Debug("{DownloadId} removed correctly", item.DownloadId);
         }
 
         protected OsPath GetOutputPath(OsPath outputPath, DownloadStationTask torrent, string serialNumber)
@@ -173,11 +173,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (item != null)
             {
-                _logger.Debug("{0} added correctly", remoteEpisode);
+                _logger.Debug("{DownloadTitle} added correctly", remoteEpisode);
                 return CreateDownloadId(item.Id, hashedSerialNumber);
             }
 
-            _logger.Debug("No such task {0} in Download Station", magnetLink);
+            _logger.Debug("No such task {MagnetLink} in Download Station", magnetLink);
 
             throw new DownloadClientException("Failed to add magnet task to Download Station");
         }
@@ -194,11 +194,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (item != null)
             {
-                _logger.Debug("{0} added correctly", remoteEpisode);
+                _logger.Debug("{DownloadTitle} added correctly", remoteEpisode);
                 return CreateDownloadId(item.Id, hashedSerialNumber);
             }
 
-            _logger.Debug("No such task {0} in Download Station", filename);
+            _logger.Debug("No such task {Filename} in Download Station", filename);
 
             throw new DownloadClientException("Failed to add torrent task to Download Station");
         }
@@ -266,7 +266,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (downloadedString.IsNullOrWhiteSpace() || !long.TryParse(downloadedString, out var downloadedSize))
             {
-                _logger.Debug("Torrent {0} has invalid size_downloaded: {1}", torrent.Title, downloadedString);
+                _logger.Debug("Torrent {TorrentTitle} has invalid size_downloaded: {SizeDownloaded}", torrent.Title, downloadedString);
                 downloadedSize = 0;
             }
 
@@ -279,7 +279,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (speedString.IsNullOrWhiteSpace() || !long.TryParse(speedString, out var downloadSpeed))
             {
-                _logger.Debug("Torrent {0} has invalid speed_download: {1}", torrent.Title, speedString);
+                _logger.Debug("Torrent {TorrentTitle} has invalid speed_download: {SpeedDownload}", torrent.Title, speedString);
                 downloadSpeed = 0;
             }
 
@@ -399,7 +399,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             var info = DsTaskProxy.GetApiInfo(Settings);
 
-            _logger.Debug("Download Station api version information: Min {0} - Max {1}", info.MinVersion, info.MaxVersion);
+            _logger.Debug("Download Station api version information: Min {MinVersion} - Max {MaxVersion}", info.MinVersion, info.MaxVersion);
 
             if (info.MinVersion > 2 || info.MaxVersion < 2)
             {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             }
 
             DsTaskProxy.RemoveTask(ParseDownloadId(item.DownloadId), Settings);
-            _logger.Debug("{0} removed correctly", item.DownloadId);
+            _logger.Debug("{DownloadId} removed correctly", item.DownloadId);
         }
 
         protected override string AddFromNzbFile(RemoteEpisode remoteEpisode, string filename, byte[] fileContent)
@@ -186,11 +186,11 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (item != null)
             {
-                _logger.Debug("{0} added correctly", remoteEpisode);
+                _logger.Debug("{DownloadTitle} added correctly", remoteEpisode);
                 return CreateDownloadId(item.Id, hashedSerialNumber);
             }
 
-            _logger.Debug("No such task {0} in Download Station", filename);
+            _logger.Debug("No such task {Filename} in Download Station", filename);
 
             throw new DownloadClientException("Failed to add NZB task to Download Station");
         }
@@ -301,7 +301,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         {
             var info = DsTaskProxy.GetApiInfo(Settings);
 
-            _logger.Debug("Download Station api version information: Min {0} - Max {1}", info.MinVersion, info.MaxVersion);
+            _logger.Debug("Download Station api version information: Min {MinVersion} - Max {MaxVersion}", info.MinVersion, info.MaxVersion);
 
             if (info.MinVersion > 2 || info.MaxVersion < 2)
             {
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (downloadedString.IsNullOrWhiteSpace() || !long.TryParse(downloadedString, out var downloadedSize))
             {
-                _logger.Debug("Task {0} has invalid size_downloaded: {1}", task.Title, downloadedString);
+                _logger.Debug("Task {TaskTitle} has invalid size_downloaded: {SizeDownloaded}", task.Title, downloadedString);
                 downloadedSize = 0;
             }
 
@@ -375,7 +375,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
             if (speedString.IsNullOrWhiteSpace() || !long.TryParse(speedString, out var downloadSpeed))
             {
-                _logger.Debug("Task {0} has invalid speed_download: {1}", task.Title, speedString);
+                _logger.Debug("Task {TaskTitle} has invalid speed_download: {SpeedDownload}", task.Title, speedString);
                 downloadSpeed = 0;
             }
 

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetProxy.cs
@@ -98,7 +98,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
             var editResult = EditQueue("GroupSetParameter", 0, "drone=" + droneId, item.NzbId, settings);
             if (editResult)
             {
-                _logger.Debug("Nzbget download drone parameter set to: {0}", droneId);
+                _logger.Debug("Nzbget download drone parameter set to: {DroneId}", droneId);
             }
 
             return droneId;
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
             if (editResult)
             {
-                _logger.Debug("Nzbget download drone parameter set to: {0}", droneId);
+                _logger.Debug("Nzbget download drone parameter set to: {DroneId}", droneId);
             }
 
             return droneId;
@@ -184,19 +184,19 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
             {
                 if (!EditQueue("GroupFinalDelete", 0, "", queueItem.NzbId, settings))
                 {
-                    _logger.Warn("Failed to remove item from nzbget queue, {0} [{1}]", queueItem.NzbName, queueItem.NzbId);
+                    _logger.Warn("Failed to remove item from nzbget queue, {NzbName} [{NzbId}]", queueItem.NzbName, queueItem.NzbId);
                 }
             }
             else if (historyItem != null)
             {
                 if (!EditQueue("HistoryDelete", 0, "", historyItem.Id, settings))
                 {
-                    _logger.Warn("Failed to remove item from nzbget history, {0} [{1}]", historyItem.Name, historyItem.Id);
+                    _logger.Warn("Failed to remove item from nzbget history, {NzbName} [{NzbId}]", historyItem.Name, historyItem.Id);
                 }
             }
             else
             {
-                _logger.Warn("Unable to remove item from nzbget, Unknown ID: {0}", id);
+                _logger.Warn("Unable to remove item from nzbget, Unknown ID: {DownloadId}", id);
                 return;
             }
         }
@@ -208,13 +208,13 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
             if (item == null)
             {
-                _logger.Warn("Unable to return item to queue, Unknown ID: {0}", id);
+                _logger.Warn("Unable to return item to queue, Unknown ID: {DownloadId}", id);
                 return;
             }
 
             if (!EditQueue("HistoryRedownload", 0, "", item.Id, settings))
             {
-                _logger.Warn("Failed to return item to queue from history, {0} [{1}]", item.Name, item.Id);
+                _logger.Warn("Failed to return item to queue from history, {NzbName} [{NzbId}]", item.Name, item.Id);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/Pneumatic.cs
@@ -50,10 +50,10 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
             // Save to the Pneumatic directory (The user will need to ensure its accessible by XBMC)
             var nzbFile = Path.Combine(Settings.NzbFolder, title + ".nzb");
 
-            _logger.Debug("Downloading NZB from: {0} to: {1}", url, nzbFile);
+            _logger.Debug("Downloading NZB from: {Url} to: {FilePath}", url, nzbFile);
             await _httpClient.DownloadFileAsync(url, nzbFile);
 
-            _logger.Debug("NZB Download succeeded, saved to: {0}", nzbFile);
+            _logger.Debug("NZB Download succeeded, saved to: {FilePath}", nzbFile);
 
             var strmFile = WriteStrmFile(title, nzbFile);
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 }
                 catch (DownloadClientException)
                 {
-                    _logger.Warn("Failed to set post-import torrent label \"{0}\" for {1} in qBittorrent. Does the label exist?",
+                    _logger.Warn("Failed to set post-import torrent label \"{ImportedCategory}\" for {DownloadTitle} in qBittorrent. Does the label exist?",
                         Settings.TvImportedCategory,
                         downloadClientItem.Title);
                 }
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set the torrent seed criteria for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set the torrent seed criteria for {InfoHash}.", hash);
                     }
                 }
 
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set the torrent priority for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set the torrent priority for {InfoHash}.", hash);
                     }
                 }
 
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set ForceStart for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set ForceStart for {InfoHash}.", hash);
                     }
                 }
 
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to add tags for {0}.", hash);
+                        _logger.Warn(ex, "Failed to add tags for {InfoHash}.", hash);
                     }
                 }
             }
@@ -171,7 +171,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set the torrent seed criteria for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set the torrent seed criteria for {InfoHash}.", hash);
                     }
                 }
 
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set the torrent priority for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set the torrent priority for {InfoHash}.", hash);
                     }
                 }
 
@@ -195,7 +195,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to set ForceStart for {0}.", hash);
+                        _logger.Warn(ex, "Failed to set ForceStart for {InfoHash}.", hash);
                     }
                 }
 
@@ -207,7 +207,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to add tags for {0}.", hash);
+                        _logger.Warn(ex, "Failed to add tags for {InfoHash}.", hash);
                     }
                 }
             }
@@ -232,12 +232,12 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                 {
                 }
 
-                _logger.Trace("Torrent '{0}' not yet visible in qbit, waiting 100ms.", hash);
+                _logger.Trace("Torrent '{InfoHash}' not yet visible in qbit, waiting 100ms.", hash);
                 System.Threading.Thread.Sleep(100);
                 count--;
             }
 
-            _logger.Warn("Failed to load torrent '{0}' within 500 ms, skipping additional parameters.", hash);
+            _logger.Warn("Failed to load torrent '{InfoHash}' within 500 ms, skipping additional parameters.", hash);
             return false;
         }
 
@@ -412,7 +412,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                     if (savePath.StartsWith("//"))
                     {
-                        _logger.Trace("Replacing double forward slashes in path '{0}'. If this is not meant to be a Windows UNC path fix the 'Save Path' in qBittorrent's {1} category", savePath, Settings.TvCategory);
+                        _logger.Trace("Replacing double forward slashes in path '{SavePath}'. If this is not meant to be a Windows UNC path fix the 'Save Path' in qBittorrent's {TvCategory} category", savePath, Settings.TvCategory);
                         savePath = savePath.Replace('/', '\\');
                     }
 

--- a/src/NzbDrone.Core/Download/Clients/RQBit/RQBit.cs
+++ b/src/NzbDrone.Core/Download/Clients/RQBit/RQBit.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Download.Clients.RQBit
         {
             var torrents = _proxy.GetTorrents(Settings);
 
-            _logger.Debug("Retrieved metadata of {0} torrents in client", torrents.Count);
+            _logger.Debug("Retrieved metadata of {TorrentCount} torrents in client", torrents.Count);
 
             var items = new List<DownloadClientItem>();
             foreach (var torrent in torrents)
@@ -50,13 +50,13 @@ namespace NzbDrone.Core.Download.Clients.RQBit
                 // Ignore torrents with an empty path
                 if (torrent.Path.IsNullOrWhiteSpace())
                 {
-                    _logger.Warn("Torrent '{0}' has an empty download path and will not be processed", torrent.Name);
+                    _logger.Warn("Torrent '{TorrentName}' has an empty download path and will not be processed", torrent.Name);
                     continue;
                 }
 
                 if (torrent.Path.StartsWith("."))
                 {
-                    _logger.Warn("Torrent '{0}' has a download path starting with '.' and will not be processed", torrent.Name);
+                    _logger.Warn("Torrent '{TorrentName}' has a download path starting with '.' and will not be processed", torrent.Name);
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Download/Clients/RQBit/RQbitProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/RQBit/RQbitProxy.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Core.Download.Clients.RQBit
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error(ex, "Failed to process torrent {0}", torrentWithStats.InfoHash);
+                        _logger.Error(ex, "Failed to process torrent {InfoHash}", torrentWithStats.InfoHash);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdProxy.cs
@@ -190,7 +190,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
             HttpResponse response;
 
-            _logger.Debug("Url: {0}", httpRequest.Url);
+            _logger.Debug("Url: {Url}", httpRequest.Url);
 
             try
             {

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
                 if (torrent == null)
                 {
-                    _logger.Warn("Could not find torrent with hash \"{0}\" in Transmission.", hash);
+                    _logger.Warn("Could not find torrent with hash \"{InfoHash}\" in Transmission.", hash);
                     return;
                 }
 
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Warn(ex, "Failed to set post-import torrent label \"{0}\" for {1} in Transmission.", Settings.TvImportedCategory, downloadClientItem.Title);
+                    _logger.Warn(ex, "Failed to set post-import torrent label \"{ImportedCategory}\" for {DownloadTitle} in Transmission.", Settings.TvImportedCategory, downloadClientItem.Title);
                 }
             }
         }
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         {
             var versionString = _proxy.GetClientVersion(Settings, true);
 
-            _logger.Debug("Transmission version information: {0}", versionString);
+            _logger.Debug("Transmission version information: {Version}", versionString);
 
             var versionResult = Regex.Match(versionString, @"(?<!\(|(\d|\.)+)(\d|\.)+(?!\)|(\d|\.)+)").Value;
             var version = Version.Parse(versionResult);

--- a/src/NzbDrone.Core/Download/Clients/Tribler/TriblerDownloadClientProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Tribler/TriblerDownloadClientProxy.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Download.Clients.Tribler
         {
             var httpRequest = requestBuilder;
 
-            _logger.Debug("Url: {0}", httpRequest.Url);
+            _logger.Debug("Url: {Url}", httpRequest.Url);
 
             try
             {
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Download.Clients.Tribler
                     throw new DownloadClientAuthenticationException("Unauthorized - AuthToken is invalid", ex);
                 }
 
-                throw new DownloadClientUnavailableException("Unable to connect to Tribler. Status Code: {0}", ex.Response.StatusCode, ex);
+                throw new DownloadClientUnavailableException("Unable to connect to Tribler. Status Code: {StatusCode}", ex.Response.StatusCode, ex);
             }
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -44,12 +44,12 @@ namespace NzbDrone.Core.Download.Clients.Vuze
             // We have to make sure the return value points to the job folder OR file.
             if (outputPath.FileName == torrent.Name || torrent.FileCount > 1)
             {
-                _logger.Trace("Vuze output directory: {0}", outputPath);
+                _logger.Trace("Vuze output directory: {OutputPath}", outputPath);
             }
             else
             {
                 outputPath = outputPath + torrent.Name;
-                _logger.Trace("Vuze output file: {0}", outputPath);
+                _logger.Trace("Vuze output file: {OutputPath}", outputPath);
             }
 
             return outputPath;
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Download.Clients.Vuze
         {
             var versionString = _proxy.GetProtocolVersion(Settings);
 
-            _logger.Debug("Vuze protocol version information: {0}", versionString);
+            _logger.Debug("Vuze protocol version information: {Version}", versionString);
 
             if (!int.TryParse(versionString, out var version) || version < MINIMUM_SUPPORTED_PROTOCOL_VERSION)
             {

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 catch (Exception ex)
                 {
                     _logger.Warn(ex,
-                        "Failed to set torrent post-import label \"{0}\" for {1} in rTorrent. Does the label exist?",
+                        "Failed to set torrent post-import label \"{ImportedCategory}\" for {DownloadTitle} in rTorrent. Does the label exist?",
                         Settings.TvImportedCategory,
                         downloadClientItem.Title);
                 }
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             catch (Exception ex)
             {
                 _logger.Warn(ex,
-                    "Failed to set torrent post-import view \"{0}\" for {1} in rTorrent.",
+                    "Failed to set torrent post-import view \"{ImportedView}\" for {DownloadTitle} in rTorrent.",
                     _imported_view,
                     downloadClientItem.Title);
             }
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             // Wait a bit for the magnet to be resolved.
             if (!WaitForTorrent(hash, tries, retryDelay))
             {
-                _logger.Warn("rTorrent could not resolve magnet within {0} seconds, download may remain stuck: {1}.", tries * retryDelay / 1000, magnetLink);
+                _logger.Warn("rTorrent could not resolve magnet within {Seconds} seconds, download may remain stuck: {MagnetLink}.", tries * retryDelay / 1000, magnetLink);
 
                 return hash;
             }
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
             var retryDelay = 500;
             if (!WaitForTorrent(hash, tries, retryDelay))
             {
-                _logger.Debug("rTorrent didn't add the torrent within {0} seconds: {1}.", tries * retryDelay / 1000, filename);
+                _logger.Debug("rTorrent didn't add the torrent within {Seconds} seconds: {Filename}.", tries * retryDelay / 1000, filename);
 
                 throw new ReleaseDownloadException(remoteEpisode.Release, "Downloading torrent failed");
             }
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         {
             var torrents = _proxy.GetTorrents(Settings);
 
-            _logger.Debug("Retrieved metadata of {0} torrents in client", torrents.Count);
+            _logger.Debug("Retrieved metadata of {TorrentCount} torrents in client", torrents.Count);
 
             var items = new List<DownloadClientItem>();
             foreach (var torrent in torrents)
@@ -139,13 +139,13 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 // Ignore torrents with an empty path
                 if (torrent.Path.IsNullOrWhiteSpace())
                 {
-                    _logger.Warn("Torrent '{0}' has an empty download path and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
+                    _logger.Warn("Torrent '{TorrentName}' has an empty download path and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
                     continue;
                 }
 
                 if (torrent.Path.StartsWith("."))
                 {
-                    _logger.Warn("Torrent '{0}' has a download path starting with '.' and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
+                    _logger.Warn("Torrent '{TorrentName}' has a download path starting with '.' and will not be processed. Adjust this to an absolute path in rTorrent", torrent.Name);
                     continue;
                 }
 
@@ -316,7 +316,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                 Thread.Sleep(retryDelay);
             }
 
-            _logger.Debug("Could not find hash {0} in {1} tries at {2} ms intervals.", hash, tries, retryDelay);
+            _logger.Debug("Could not find hash {InfoHash} in {Tries} tries at {RetryDelay} ms intervals.", hash, tries, retryDelay);
 
             return false;
         }

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -159,7 +159,7 @@ namespace NzbDrone.Core.Download
 
             if (importResults.Empty())
             {
-                trackedDownload.Warn("No files found are eligible for import in {0}", outputPath);
+                trackedDownload.Warn("No files found are eligible for import in {OutputPath}", outputPath);
 
                 return;
             }
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.Download
 
             if (allEpisodesImported)
             {
-                _logger.Debug("All episodes were imported for {0}", trackedDownload.DownloadItem.Title);
+                _logger.Debug("All episodes were imported for {DownloadTitle}", trackedDownload.DownloadItem.Title);
                 trackedDownload.State = TrackedDownloadState.Imported;
 
                 _eventAggregator.PublishEvent(new DownloadCompletedEvent(trackedDownload,
@@ -250,7 +250,7 @@ namespace NzbDrone.Core.Download
 
                 if (atLeastOneEpisodeImported)
                 {
-                    _logger.Debug("All episodes were imported in history for {0}", trackedDownload.DownloadItem.Title);
+                    _logger.Debug("All episodes were imported in history for {DownloadTitle}", trackedDownload.DownloadItem.Title);
                 }
                 else
                 {
@@ -273,7 +273,7 @@ namespace NzbDrone.Core.Download
                 return true;
             }
 
-            _logger.Debug("Not all episodes have been imported for the release '{0}'", trackedDownload.DownloadItem.Title);
+            _logger.Debug("Not all episodes have been imported for the release '{DownloadTitle}'", trackedDownload.DownloadItem.Title);
             return false;
         }
 
@@ -312,7 +312,7 @@ namespace NzbDrone.Core.Download
             if ((OsInfo.IsWindows && !downloadItemOutputPath.IsWindowsPath) ||
                 (OsInfo.IsNotWindows && !downloadItemOutputPath.IsUnixPath))
             {
-                trackedDownload.Warn("[{0}] is not a valid local path. You may need a Remote Path Mapping. Check the download troubleshooting entry on the wiki for details.", downloadItemOutputPath);
+                trackedDownload.Warn("[{OutputPath}] is not a valid local path. You may need a Remote Path Mapping. Check the download troubleshooting entry on the wiki for details.", downloadItemOutputPath);
                 return false;
             }
 

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -47,11 +47,11 @@ namespace NzbDrone.Core.Download
 
                     if (exception is not null)
                     {
-                        _logger.Info(exception, "Request for {0} failed with exception '{1}'. Retrying in {2}s.", Definition.Name, exception.Message, args.RetryDelay.TotalSeconds);
+                        _logger.Info(exception, "Request for {ClientName} failed with exception '{Message}'. Retrying in {RetryDelay}s.", Definition.Name, exception.Message, args.RetryDelay.TotalSeconds);
                     }
                     else
                     {
-                        _logger.Info("Request for {0} failed with status {1}. Retrying in {2}s.", Definition.Name, args.Outcome.Result?.StatusCode, args.RetryDelay.TotalSeconds);
+                        _logger.Info("Request for {ClientName} failed with status {StatusCode}. Retrying in {RetryDelay}s.", Definition.Name, args.Outcome.Result?.StatusCode, args.RetryDelay.TotalSeconds);
                     }
 
                     return default;
@@ -116,7 +116,7 @@ namespace NzbDrone.Core.Download
 
             if (item.OutputPath.IsEmpty)
             {
-                _logger.Trace("[{0}] Doesn't have an outputPath, skipping delete data.", item.Title);
+                _logger.Trace("[{DownloadTitle}] Doesn't have an outputPath, skipping delete data.", item.Title);
                 return;
             }
 
@@ -124,24 +124,24 @@ namespace NzbDrone.Core.Download
             {
                 if (_diskProvider.FolderExists(item.OutputPath.FullPath))
                 {
-                    _logger.Debug("[{0}] Deleting folder '{1}'.", item.Title, item.OutputPath);
+                    _logger.Debug("[{DownloadTitle}] Deleting folder '{OutputPath}'.", item.Title, item.OutputPath);
 
                     _diskProvider.DeleteFolder(item.OutputPath.FullPath, true);
                 }
                 else if (_diskProvider.FileExists(item.OutputPath.FullPath))
                 {
-                    _logger.Debug("[{0}] Deleting file '{1}'.", item.Title, item.OutputPath);
+                    _logger.Debug("[{DownloadTitle}] Deleting file '{OutputPath}'.", item.Title, item.OutputPath);
 
                     _diskProvider.DeleteFile(item.OutputPath.FullPath);
                 }
                 else
                 {
-                    _logger.Trace("[{0}] File or folder '{1}' doesn't exist, skipping cleanup.", item.Title, item.OutputPath);
+                    _logger.Trace("[{DownloadTitle}] File or folder '{OutputPath}' doesn't exist, skipping cleanup.", item.Title, item.OutputPath);
                 }
             }
             catch (Exception ex)
             {
-                _logger.Warn(ex, string.Format("[{0}] Error occurred while trying to delete data from '{1}'.", item.Title, item.OutputPath));
+                _logger.Warn(ex, "[{DownloadTitle}] Error occurred while trying to delete data from '{OutputPath}'.", item.Title, item.OutputPath);
             }
         }
 
@@ -176,7 +176,7 @@ namespace NzbDrone.Core.Download
 
             if (mustBeWritable && !_diskProvider.FolderWritable(folder))
             {
-                _logger.Error("Folder '{0}' is not writable.", folder);
+                _logger.Error("Folder '{FolderPath}' is not writable.", folder);
                 return new NzbDroneValidationFailure(propertyName, "Unable to write to folder")
                 {
                     DetailedDescription = string.Format("The folder you specified is not writable. Please verify the folder permissions for the user account '{0}', which is used to execute Sonarr.", Environment.UserName)

--- a/src/NzbDrone.Core/Download/DownloadClientFactory.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientFactory.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Download
             {
                 if (blockedClients.TryGetValue(client.Definition.Id, out var downloadClientStatus))
                 {
-                    _logger.Debug("Temporarily ignoring download client {0} till {1} due to recent failures.", client.Definition.Name, downloadClientStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring download client {ClientName} till {DisabledTill} due to recent failures.", client.Definition.Name, downloadClientStatus.DisabledTill.Value.ToLocalTime());
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Download/DownloadClientProvider.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientProvider.cs
@@ -165,7 +165,7 @@ namespace NzbDrone.Core.Download
             {
                 if (blockedClients.TryGetValue(client.Definition.Id, out var blockedClientStatus))
                 {
-                    _logger.Debug("Temporarily ignoring client {0} till {1} due to recent failures.", client.Definition.Name, blockedClientStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring client {ClientName} till {DisabledTill} due to recent failures.", client.Definition.Name, blockedClientStatus.DisabledTill.Value.ToLocalTime());
                     continue;
                 }
 
@@ -234,7 +234,7 @@ namespace NzbDrone.Core.Download
                 }
                 else
                 {
-                    _logger.Trace("No non-blocked Download Client available{0}.", forSingleClient ? ", retrying blocked one" : $" for {downloadProtocol}, returning all clients");
+                    _logger.Trace("No non-blocked Download Client available{Suffix}.", forSingleClient ? ", retrying blocked one" : $" for {downloadProtocol}, returning all clients");
                 }
             }
 

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -88,17 +88,17 @@ namespace NzbDrone.Core.Download
         {
             try
             {
-                _logger.Debug("[{0}] Removing download from {1} history", trackedDownload.DownloadItem.Title, trackedDownload.DownloadItem.DownloadClientInfo.Name);
+                _logger.Debug("[{DownloadTitle}] Removing download from {ClientName} history", trackedDownload.DownloadItem.Title, trackedDownload.DownloadItem.DownloadClientInfo.Name);
                 downloadClient.RemoveItem(trackedDownload.DownloadItem, true);
                 trackedDownload.DownloadItem.Removed = true;
             }
             catch (NotSupportedException)
             {
-                _logger.Warn("Removing item not supported by your download client ({0}).", downloadClient.Definition.Name);
+                _logger.Warn("Removing item not supported by your download client ({ClientName}).", downloadClient.Definition.Name);
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Couldn't remove item {0} from client {1}", trackedDownload.DownloadItem.Title, downloadClient.Name);
+                _logger.Error(e, "Couldn't remove item {DownloadTitle} from client {ClientName}", trackedDownload.DownloadItem.Title, downloadClient.Name);
             }
         }
 
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Download
         {
             try
             {
-                _logger.Debug("[{0}] Marking download as imported from {1}", trackedDownload.DownloadItem.Title, trackedDownload.DownloadItem.DownloadClientInfo.Name);
+                _logger.Debug("[{DownloadTitle}] Marking download as imported from {ClientName}", trackedDownload.DownloadItem.Title, trackedDownload.DownloadItem.DownloadClientInfo.Name);
                 downloadClient.MarkItemAsImported(trackedDownload.DownloadItem);
             }
             catch (NotSupportedException e)
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Download
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Couldn't mark item {0} as imported from client {1}", trackedDownload.DownloadItem.Title, downloadClient.Name);
+                _logger.Error(e, "Couldn't mark item {DownloadTitle} as imported from client {ClientName}", trackedDownload.DownloadItem.Title, downloadClient.Name);
             }
         }
     }

--- a/src/NzbDrone.Core/Download/DownloadProcessingService.cs
+++ b/src/NzbDrone.Core/Download/DownloadProcessingService.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Download
                 }
                 catch (Exception e)
                 {
-                    _logger.Debug(e, "Failed to process download: {0}", trackedDownload.DownloadItem.Title);
+                    _logger.Debug(e, "Failed to process download: {DownloadTitle}", trackedDownload.DownloadItem.Title);
                 }
             }
 

--- a/src/NzbDrone.Core/Download/DownloadSeedConfigProvider.cs
+++ b/src/NzbDrone.Core/Download/DownloadSeedConfigProvider.cs
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Download
 
             if (historyItem == null)
             {
-                _logger.Debug("No download history item for infohash {0}, unable to provide seed configuration", infoHash);
+                _logger.Debug("No download history item for infohash {InfoHash}, unable to provide seed configuration", infoHash);
                 return null;
             }
 
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.Download
 
             if (parsedEpisodeInfo == null)
             {
-                _logger.Debug("No parsed title in download history item for infohash {0}, unable to provide seed configuration", infoHash);
+                _logger.Debug("No parsed title in download history item for infohash {InfoHash}, unable to provide seed configuration", infoHash);
                 return null;
             }
 

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Download
 
                 try
                 {
-                    _logger.Debug("Attempting download with client: {0}", downloadClient.Definition.Name);
+                    _logger.Debug("Attempting download with client: {ClientName}", downloadClient.Definition.Name);
                     await DownloadReport(remoteEpisode, downloadClient);
 
                     _downloadClientProvider.ReportSuccessfulDownloadClient(
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.Download
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Trace(ex, "Unable to add report to download client: {0}", downloadClient.Definition.Name);
+                    _logger.Trace(ex, "Unable to add report to download client: {ClientName}", downloadClient.Definition.Name);
                     triedClients.Add(downloadClient.Definition.Id);
                 }
                 catch (Exception ex)
@@ -110,12 +110,12 @@ namespace NzbDrone.Core.Download
                         throw;
                     }
 
-                    _logger.Trace(ex, "Unable to add report to download client: {0}", downloadClient.Definition.Name);
+                    _logger.Trace(ex, "Unable to add report to download client: {ClientName}", downloadClient.Definition.Name);
                     triedClients.Add(downloadClient.Definition.Id);
                 }
             }
 
-            throw new DownloadClientUnavailableException("All '{0}' download clients failed", remoteEpisode.Release.DownloadProtocol);
+            throw new DownloadClientUnavailableException("All '{DownloadProtocol}' download clients failed", remoteEpisode.Release.DownloadProtocol);
         }
 
         private async Task DownloadReport(RemoteEpisode remoteEpisode, IDownloadClient downloadClient)
@@ -156,17 +156,17 @@ namespace NzbDrone.Core.Download
             }
             catch (ReleaseUnavailableException)
             {
-                _logger.Trace("Release {0} no longer available on indexer.", remoteEpisode);
+                _logger.Trace("Release {DownloadTitle} no longer available on indexer.", remoteEpisode);
                 throw;
             }
             catch (ReleaseBlockedException)
             {
-                _logger.Trace("Release {0} previously added to blocklist, not sending to download client again.", remoteEpisode);
+                _logger.Trace("Release {DownloadTitle} previously added to blocklist, not sending to download client again.", remoteEpisode);
                 throw;
             }
             catch (DownloadClientRejectedReleaseException)
             {
-                _logger.Trace("Release {0} rejected by download client, possible duplicate.", remoteEpisode);
+                _logger.Trace("Release {DownloadTitle} rejected by download client, possible duplicate.", remoteEpisode);
                 throw;
             }
             catch (ReleaseDownloadException ex)
@@ -193,7 +193,7 @@ namespace NzbDrone.Core.Download
                 episodeGrabbedEvent.DownloadId = downloadClientId;
             }
 
-            _logger.ProgressInfo("Report sent to {0}. Indexer {1}. {2}", downloadClient.Definition.Name, remoteEpisode.Release.Indexer, downloadTitle);
+            _logger.ProgressInfo("Report sent to {ClientName}. Indexer {Indexer}. {DownloadTitle}", downloadClient.Definition.Name, remoteEpisode.Release.Indexer, downloadTitle);
             _eventAggregator.PublishEvent(episodeGrabbedEvent);
         }
     }

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -132,23 +132,23 @@ namespace NzbDrone.Core.Download.Pending
                         {
                             if (matchingReport.Reason == PendingReleaseReason.DownloadClientUnavailable)
                             {
-                                _logger.Debug("The release {0} is already pending with reason {1}, not changing reason", decision.RemoteEpisode, matchingReport.Reason);
+                                _logger.Debug("The release {DownloadTitle} is already pending with reason {Reason}, not changing reason", decision.RemoteEpisode, matchingReport.Reason);
                             }
                             else
                             {
-                                _logger.Debug("The release {0} is already pending with reason {1}, changing to {2}", decision.RemoteEpisode, matchingReport.Reason, reason);
+                                _logger.Debug("The release {DownloadTitle} is already pending with reason {OldReason}, changing to {NewReason}", decision.RemoteEpisode, matchingReport.Reason, reason);
                                 matchingReport.Reason = reason;
                                 _repository.Update(matchingReport);
                             }
                         }
                         else
                         {
-                            _logger.Debug("The release {0} is already pending with reason {1}, not adding again", decision.RemoteEpisode, reason);
+                            _logger.Debug("The release {DownloadTitle} is already pending with reason {Reason}, not adding again", decision.RemoteEpisode, reason);
                         }
 
                         if (matchingReports.Count > 1)
                         {
-                            _logger.Debug("The release {0} had {1} duplicate pending, removing duplicates.", decision.RemoteEpisode, matchingReports.Count - 1);
+                            _logger.Debug("The release {DownloadTitle} had {DuplicateCount} duplicate pending, removing duplicates.", decision.RemoteEpisode, matchingReports.Count - 1);
 
                             foreach (var duplicate in matchingReports.Skip(1))
                             {
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Download.Pending
                         continue;
                     }
 
-                    _logger.Debug("Adding release {0} to pending releases with reason {1}", decision.RemoteEpisode, reason);
+                    _logger.Debug("Adding release {DownloadTitle} to pending releases with reason {Reason}", decision.RemoteEpisode, reason);
                     Insert(decision, reason);
                 }
             }

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -200,26 +200,26 @@ namespace NzbDrone.Core.Download
 
             try
             {
-                _logger.Trace("Grabbing release '{0}' from Indexer {1} at priority {2}.", remoteEpisode, remoteIndexer, remoteEpisode.Release.IndexerPriority);
+                _logger.Trace("Grabbing release '{DownloadTitle}' from Indexer {Indexer} at priority {IndexerPriority}.", remoteEpisode, remoteIndexer, remoteEpisode.Release.IndexerPriority);
                 await _downloadService.DownloadReport(remoteEpisode, downloadClientId);
 
                 return ProcessedDecisionResult.Grabbed;
             }
             catch (ReleaseUnavailableException)
             {
-                _logger.Warn("Failed to download release '{0}' from Indexer {1}. Release not available", remoteEpisode, remoteIndexer);
+                _logger.Warn("Failed to download release '{DownloadTitle}' from Indexer {Indexer}. Release not available", remoteEpisode, remoteIndexer);
                 return ProcessedDecisionResult.Rejected;
             }
             catch (Exception ex)
             {
                 if (ex is DownloadClientUnavailableException || ex is DownloadClientAuthenticationException)
                 {
-                    _logger.Debug(ex, "Failed to send release '{0}' from Indexer {1} to download client, storing until later.", remoteEpisode, remoteIndexer);
+                    _logger.Debug(ex, "Failed to send release '{DownloadTitle}' from Indexer {Indexer} to download client, storing until later.", remoteEpisode, remoteIndexer);
                     return ProcessedDecisionResult.Failed;
                 }
                 else
                 {
-                    _logger.Warn(ex, "Couldn't add release '{0}' from Indexer {1} to download queue.", remoteEpisode, remoteIndexer);
+                    _logger.Warn(ex, "Couldn't add release '{DownloadTitle}' from Indexer {Indexer} to download queue.", remoteEpisode, remoteIndexer);
                     return ProcessedDecisionResult.Skipped;
                 }
             }

--- a/src/NzbDrone.Core/Download/RejectedImportService.cs
+++ b/src/NzbDrone.Core/Download/RejectedImportService.cs
@@ -41,19 +41,19 @@ public class RejectedImportService : IRejectedImportService
         if (rejectionReason == ImportRejectionReason.DangerousFile &&
             indexerSettings.FailDownloads.Contains(FailDownloads.PotentiallyDangerous))
         {
-            _logger.Trace("Download '{0}' contains potentially dangerous file, marking as failed", trackedDownload.DownloadItem.Title);
+            _logger.Trace("Download '{DownloadTitle}' contains potentially dangerous file, marking as failed", trackedDownload.DownloadItem.Title);
             trackedDownload.Fail();
         }
         else if (rejectionReason == ImportRejectionReason.ExecutableFile &&
             indexerSettings.FailDownloads.Contains(FailDownloads.Executables))
         {
-            _logger.Trace("Download '{0}' contains executable file, marking as failed", trackedDownload.DownloadItem.Title);
+            _logger.Trace("Download '{DownloadTitle}' contains executable file, marking as failed", trackedDownload.DownloadItem.Title);
             trackedDownload.Fail();
         }
         else if (rejectionReason == ImportRejectionReason.UserRejectedExtension &&
                  indexerSettings.FailDownloads.Contains(FailDownloads.UserDefinedExtensions))
         {
-            _logger.Trace("Download '{0}' contains user defined rejected file extension, marking as failed", trackedDownload.DownloadItem.Title);
+            _logger.Trace("Download '{DownloadTitle}' contains user defined rejected file extension, marking as failed", trackedDownload.DownloadItem.Title);
             trackedDownload.Fail();
         }
         else

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Download
                             throw;
                         }
 
-                        _logger.Debug("Torrent download failed, trying magnet. ({0})", ex.Message);
+                        _logger.Debug("Torrent download failed, trying magnet. ({Message})", ex.Message);
                     }
                 }
 
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Download
                             throw new ReleaseDownloadException(remoteEpisode.Release, "Magnet not supported by download client. ({0})", ex.Message);
                         }
 
-                        _logger.Debug("Magnet not supported by download client, trying torrent. ({0})", ex.Message);
+                        _logger.Debug("Magnet not supported by download client, trying torrent. ({Message})", ex.Message);
                     }
                 }
 
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Download
                 {
                     var locationHeader = response.Headers.GetSingleValue("Location");
 
-                    _logger.Trace("Torrent request is being redirected to: {0}", locationHeader);
+                    _logger.Trace("Torrent request is being redirected to: {Url}", locationHeader);
 
                     if (locationHeader != null)
                     {
@@ -168,30 +168,30 @@ namespace NzbDrone.Core.Download
 
                 torrentFile = response.ResponseData;
 
-                _logger.Debug("Downloading torrent for episode '{0}' finished ({1} bytes from {2})", remoteEpisode.Release.Title, torrentFile.Length, torrentUrl);
+                _logger.Debug("Downloading torrent for episode '{EpisodeTitle}' finished ({Bytes} bytes from {Url})", remoteEpisode.Release.Title, torrentFile.Length, torrentUrl);
             }
             catch (HttpException ex)
             {
                 if (ex.Response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
                 {
-                    _logger.Error(ex, "Downloading torrent file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, torrentUrl);
+                    _logger.Error(ex, "Downloading torrent file for episode '{EpisodeTitle}' failed since it no longer exists ({Url})", remoteEpisode.Release.Title, torrentUrl);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading torrent failed", ex);
                 }
 
                 if ((int)ex.Response.StatusCode == 429)
                 {
-                    _logger.Error("API Grab Limit reached for {0}", torrentUrl);
+                    _logger.Error("API Grab Limit reached for {Url}", torrentUrl);
                 }
                 else
                 {
-                    _logger.Error(ex, "Downloading torrent file for episode '{0}' failed ({1})", remoteEpisode.Release.Title, torrentUrl);
+                    _logger.Error(ex, "Downloading torrent file for episode '{EpisodeTitle}' failed ({Url})", remoteEpisode.Release.Title, torrentUrl);
                 }
 
                 throw new ReleaseDownloadException(remoteEpisode.Release, "Downloading torrent failed", ex);
             }
             catch (WebException ex)
             {
-                _logger.Error(ex, "Downloading torrent file for episode '{0}' failed ({1})", remoteEpisode.Release.Title, torrentUrl);
+                _logger.Error(ex, "Downloading torrent file for episode '{EpisodeTitle}' failed ({Url})", remoteEpisode.Release.Title, torrentUrl);
 
                 throw new ReleaseDownloadException(remoteEpisode.Release, "Downloading torrent failed", ex);
             }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/DownloadMonitoringService.cs
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Couldn't process tracked download {0}", downloadItem.Title);
+                _logger.Error(e, "Couldn't process tracked download {DownloadTitle}", downloadItem.Title);
             }
 
             return trackedDownload;

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadAlreadyImported.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadAlreadyImported.cs
@@ -22,11 +22,11 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
         public bool IsImported(TrackedDownload trackedDownload, List<EpisodeHistory> historyItems)
         {
-            _logger.Trace("Checking if all episodes for '{0}' have been imported", trackedDownload.DownloadItem.Title);
+            _logger.Trace("Checking if all episodes for '{DownloadTitle}' have been imported", trackedDownload.DownloadItem.Title);
 
             if (historyItems.Empty())
             {
-                _logger.Trace("No history for {0}", trackedDownload.DownloadItem.Title);
+                _logger.Trace("No history for {DownloadTitle}", trackedDownload.DownloadItem.Title);
                 return false;
             }
 
@@ -36,16 +36,16 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
                 if (lastHistoryItem == null)
                 {
-                    _logger.Trace("No history for episode: S{0:00}E{1:00} [{2}]", e.SeasonNumber, e.EpisodeNumber, e.Id);
+                    _logger.Trace("No history for episode: S{SeasonNumber:00}E{EpisodeNumber:00} [{EpisodeId}]", e.SeasonNumber, e.EpisodeNumber, e.Id);
                     return false;
                 }
 
-                _logger.Trace("Last event for episode: S{0:00}E{1:00} [{2}] is: {3}", e.SeasonNumber, e.EpisodeNumber, e.Id, lastHistoryItem.EventType);
+                _logger.Trace("Last event for episode: S{SeasonNumber:00}E{EpisodeNumber:00} [{EpisodeId}] is: {EventType}", e.SeasonNumber, e.EpisodeNumber, e.Id, lastHistoryItem.EventType);
 
                 return lastHistoryItem.EventType == EpisodeHistoryEventType.DownloadFolderImported;
             });
 
-            _logger.Trace("All episodes for '{0}' have been imported: {1}", trackedDownload.DownloadItem.Title, allEpisodesImportedInHistory);
+            _logger.Trace("All episodes for '{DownloadTitle}' have been imported: {AllImported}", trackedDownload.DownloadItem.Title, allEpisodesImportedInHistory);
 
             return allEpisodesImportedInHistory;
         }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -187,7 +187,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 // Track it so it can be displayed in the queue even though we can't determine which series it is for
                 if (trackedDownload.RemoteEpisode == null)
                 {
-                    _logger.Trace("No Episode found for download '{0}'", trackedDownload.DownloadItem.Title);
+                    _logger.Trace("No Episode found for download '{DownloadTitle}'", trackedDownload.DownloadItem.Title);
                 }
             }
             catch (MultipleSeriesFoundException e)
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 existingItem.CanBeRemoved != downloadItem.CanBeRemoved ||
                 existingItem.CanMoveFiles != downloadItem.CanMoveFiles)
             {
-                _logger.Debug("Tracking '{0}:{1}': ClientState={2}{3} SonarrStage={4} Episode='{5}' OutputPath={6}.",
+                _logger.Debug("Tracking '{ClientName}:{DownloadTitle}': ClientState={ClientState}{Busy} SonarrStage={SonarrStage} Episode='{Episode}' OutputPath={OutputPath}.",
                     downloadItem.DownloadClientInfo.Name,
                     downloadItem.Title,
                     downloadItem.Status,

--- a/src/NzbDrone.Core/Download/UsenetClientBase.cs
+++ b/src/NzbDrone.Core/Download/UsenetClientBase.cs
@@ -56,37 +56,37 @@ namespace NzbDrone.Core.Download
 
                 nzbData = response.ResponseData;
 
-                _logger.Debug("Downloaded nzb for episode '{0}' finished ({1} bytes from {2})", remoteEpisode.Release.Title, nzbData.Length, url);
+                _logger.Debug("Downloaded nzb for episode '{EpisodeTitle}' finished ({Bytes} bytes from {Url})", remoteEpisode.Release.Title, nzbData.Length, url);
             }
             catch (HttpException ex)
             {
                 if (ex.Response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone)
                 {
-                    _logger.Error(ex, "Downloading nzb file for episode '{0}' failed since it no longer exists ({1})", remoteEpisode.Release.Title, url);
+                    _logger.Error(ex, "Downloading nzb file for episode '{EpisodeTitle}' failed since it no longer exists ({Url})", remoteEpisode.Release.Title, url);
                     throw new ReleaseUnavailableException(remoteEpisode.Release, "Downloading nzb failed", ex);
                 }
 
                 if ((int)ex.Response.StatusCode == 429)
                 {
-                    _logger.Error("API Grab Limit reached for {0}", url);
+                    _logger.Error("API Grab Limit reached for {Url}", url);
                 }
                 else
                 {
-                    _logger.Error(ex, "Downloading nzb for episode '{0}' failed ({1})", remoteEpisode.Release.Title, url);
+                    _logger.Error(ex, "Downloading nzb for episode '{EpisodeTitle}' failed ({Url})", remoteEpisode.Release.Title, url);
                 }
 
                 throw new ReleaseDownloadException(remoteEpisode.Release, "Downloading nzb failed", ex);
             }
             catch (WebException ex)
             {
-                _logger.Error(ex, "Downloading nzb for episode '{0}' failed ({1})", remoteEpisode.Release.Title, url);
+                _logger.Error(ex, "Downloading nzb for episode '{EpisodeTitle}' failed ({Url})", remoteEpisode.Release.Title, url);
 
                 throw new ReleaseDownloadException(remoteEpisode.Release, "Downloading nzb failed", ex);
             }
 
             _nzbValidationService.Validate(filename, nzbData);
 
-            _logger.Info("Adding report [{0}] to the queue.", remoteEpisode.Release.Title);
+            _logger.Info("Adding report [{DownloadTitle}] to the queue.", remoteEpisode.Release.Title);
             return AddFromNzbFile(remoteEpisode, filename, nzbData);
         }
     }

--- a/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Extras
 
         public List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles, string fileNameBeforeRename)
         {
-            _logger.Debug("Looking for existing extra files in {0}", series.Path);
+            _logger.Debug("Looking for existing extra files in {SeriesPath}", series.Path);
 
             var importedFiles = new List<string>();
 
@@ -47,7 +47,7 @@ namespace NzbDrone.Core.Extras
             var possibleExtraFiles = message.PossibleExtraFiles;
             var importedFiles = ImportExtraFiles(series, possibleExtraFiles, null);
 
-            _logger.Info("Found {0} possible extra files, imported {1} files.", possibleExtraFiles.Count, importedFiles.Count);
+            _logger.Info("Found {PossibleExtraFilesCount} possible extra files, imported {ImportedFilesCount} files.", possibleExtraFiles.Count, importedFiles.Count);
         }
     }
 }

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileManager.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Extras.Files
 
         protected TExtraFile MoveFile(Series series, EpisodeFile episodeFile, TExtraFile extraFile, string fileNameSuffix = null)
         {
-            _logger.Trace("Renaming extra file: {0}", extraFile);
+            _logger.Trace("Renaming extra file: {ExtraFile}", extraFile);
 
             var newFolder = Path.GetDirectoryName(Path.Combine(series.Path, episodeFile.RelativePath));
             var filenameBuilder = new StringBuilder(Path.GetFileNameWithoutExtension(episodeFile.RelativePath));
@@ -107,18 +107,18 @@ namespace NzbDrone.Core.Extras.Files
             {
                 try
                 {
-                    _logger.Trace("Renaming extra file: {0} to {1}", extraFile, newFileName);
+                    _logger.Trace("Renaming extra file: {ExtraFile} to {NewFileName}", extraFile, newFileName);
 
                     _diskProvider.MoveFile(existingFileName, newFileName);
                     extraFile.RelativePath = series.Path.GetRelativePath(newFileName);
 
-                    _logger.Trace("Renamed extra file from: {0}", extraFile);
+                    _logger.Trace("Renamed extra file from: {ExtraFile}", extraFile);
 
                     return extraFile;
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Unable to move file after rename: {0}", existingFileName);
+                    _logger.Warn(ex, "Unable to move file after rename: {ExistingFileName}", existingFileName);
                 }
             }
 

--- a/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/Files/ExtraFileService.cs
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.Extras.Files
 
         public void HandleAsync(SeriesDeletedEvent message)
         {
-            _logger.Debug("Deleting Extra from database for series: {0}", string.Join(',', message.Series));
+            _logger.Debug("Deleting Extra from database for series: {SeriesTitles}", string.Join(',', message.Series));
             _repository.DeleteForSeriesIds(message.Series.Select(m => m.Id).ToList());
         }
 
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Extras.Files
                 }
             }
 
-            _logger.Debug("Deleting Extra from database for episode file: {0}", episodeFile);
+            _logger.Debug("Deleting Extra from database for episode file: {EpisodeFile}", episodeFile);
             _repository.DeleteForEpisodeFile(episodeFile.Id);
         }
     }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Roksbox/RoksboxMetadata.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 return GetEpisodeMetadataFilename(episodeFilePath);
             }
 
-            _logger.Debug("Unknown episode file metadata: {0}", metadataFile.RelativePath);
+            _logger.Debug("Unknown episode file metadata: {RelativePath}", metadataFile.RelativePath);
             return Path.Combine(series.Path, metadataFile.RelativePath);
         }
 
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                 return null;
             }
 
-            _logger.Debug("Generating Episode Metadata for: {0}", episodeFile.RelativePath);
+            _logger.Debug("Generating Episode Metadata for: {RelativePath}", episodeFile.RelativePath);
 
             var xmlResult = string.Empty;
             foreach (var episode in episodeFile.Episodes.Value)
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
             var image = series.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? series.Images.FirstOrDefault();
             if (image == null)
             {
-                _logger.Trace("Failed to find suitable Series image for series {0}.", series.Title);
+                _logger.Trace("Failed to find suitable Series image for series {SeriesTitle}.", series.Title);
                 return new List<ImageFileResult>();
             }
 
@@ -212,7 +212,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
 
             if (!seasonFolders.TryGetValue(season.SeasonNumber, out var seasonFolder))
             {
-                _logger.Trace("Failed to find season folder for series {0}, season {1}.", series.Title, season.SeasonNumber);
+                _logger.Trace("Failed to find season folder for series {SeriesTitle}, season {SeasonNumber}.", series.Title, season.SeasonNumber);
                 return new List<ImageFileResult>();
             }
 
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
             var image = season.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? season.Images.FirstOrDefault();
             if (image == null)
             {
-                _logger.Trace("Failed to find suitable season image for series {0}, season {1}.", series.Title, season.SeasonNumber);
+                _logger.Trace("Failed to find suitable season image for series {SeriesTitle}, season {SeasonNumber}.", series.Title, season.SeasonNumber);
                 return new List<ImageFileResult>();
             }
 
@@ -283,13 +283,13 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Roksbox
                         }
                         else
                         {
-                            _logger.Debug("Failed to parse season number from {0} for series {1}.", folder, series.Title);
+                            _logger.Debug("Failed to parse season number from {FolderPath} for series {SeriesTitle}.", folder, series.Title);
                         }
                     }
                 }
                 else
                 {
-                    _logger.Debug("Rejecting folder {0} for series {1}.", Path.GetDirectoryName(folder), series.Title);
+                    _logger.Debug("Rejecting folder {FolderPath} for series {SeriesTitle}.", Path.GetDirectoryName(folder), series.Title);
                 }
             }
 

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Wdtv/WdtvMetadata.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                 return GetEpisodeMetadataFilename(episodeFilePath);
             }
 
-            _logger.Debug("Unknown episode file metadata: {0}", metadataFile.RelativePath);
+            _logger.Debug("Unknown episode file metadata: {RelativePath}", metadataFile.RelativePath);
             return Path.Combine(series.Path, metadataFile.RelativePath);
         }
 
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                 return null;
             }
 
-            _logger.Debug("Generating Episode Metadata for: {0}", Path.Combine(series.Path, episodeFile.RelativePath));
+            _logger.Debug("Generating Episode Metadata for: {EpisodeFilePath}", Path.Combine(series.Path, episodeFile.RelativePath));
 
             var xmlResult = string.Empty;
             foreach (var episode in episodeFile.Episodes.Value)
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             var image = series.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? series.Images.FirstOrDefault();
             if (image == null)
             {
-                _logger.Trace("Failed to find suitable Series image for series {0}.", series.Title);
+                _logger.Trace("Failed to find suitable Series image for series {SeriesTitle}.", series.Title);
                 return new List<ImageFileResult>();
             }
 
@@ -205,7 +205,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             // Work out the path to this season - if we don't have a matching path then skip this season.
             if (!seasonFolders.TryGetValue(season.SeasonNumber, out var seasonFolder))
             {
-                _logger.Trace("Failed to find season folder for series {0}, season {1}.", series.Title, season.SeasonNumber);
+                _logger.Trace("Failed to find season folder for series {SeriesTitle}, season {SeasonNumber}.", series.Title, season.SeasonNumber);
                 return new List<ImageFileResult>();
             }
 
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
             var image = season.Images.SingleOrDefault(c => c.CoverType == MediaCoverTypes.Poster) ?? season.Images.FirstOrDefault();
             if (image == null)
             {
-                _logger.Trace("Failed to find suitable season image for series {0}, season {1}.", series.Title, season.SeasonNumber);
+                _logger.Trace("Failed to find suitable season image for series {SeriesTitle}, season {SeasonNumber}.", series.Title, season.SeasonNumber);
                 return new List<ImageFileResult>();
             }
 
@@ -275,13 +275,13 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Wdtv
                         }
                         else
                         {
-                            _logger.Debug("Failed to parse season number from {0} for series {1}.", folder, series.Title);
+                            _logger.Debug("Failed to parse season number from {FolderPath} for series {SeriesTitle}.", folder, series.Title);
                         }
                     }
                 }
                 else
                 {
-                    _logger.Debug("Rejecting folder {0} for series {1}.", Path.GetDirectoryName(folder), series.Title);
+                    _logger.Debug("Rejecting folder {FolderPath} for series {SeriesTitle}.", Path.GetDirectoryName(folder), series.Title);
                 }
             }
 

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 return GetEpisodeMetadataFilename(episodeFilePath);
             }
 
-            _logger.Debug("Unknown episode file metadata: {0}", metadataFile.RelativePath);
+            _logger.Debug("Unknown episode file metadata: {RelativePath}", metadataFile.RelativePath);
             return Path.Combine(series.Path, metadataFile.RelativePath);
         }
 
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
 
             if (Settings.SeriesMetadata)
             {
-                _logger.Debug("Generating Series Metadata for: {0}", series.Title);
+                _logger.Debug("Generating Series Metadata for: {SeriesTitle}", series.Title);
 
                 var tvShow = new XElement("tvshow");
 
@@ -282,7 +282,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                 return null;
             }
 
-            _logger.Debug("Generating Episode Metadata for: {0}", Path.Combine(series.Path, episodeFile.RelativePath));
+            _logger.Debug("Generating Episode Metadata for: {EpisodeFilePath}", Path.Combine(series.Path, episodeFile.RelativePath));
 
             var watched = GetExistingWatchedStatus(series, episodeFile.RelativePath);
 
@@ -474,7 +474,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Unable to process episode image for file: {0}", Path.Combine(series.Path, episodeFile.RelativePath));
+                _logger.Error(ex, "Unable to process episode image for file: {EpisodeFilePath}", Path.Combine(series.Path, episodeFile.RelativePath));
 
                 return new List<ImageFileResult>();
             }

--- a/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
         public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, string fileNameBeforeRename)
         {
-            _logger.Debug("Looking for existing metadata in {0}", series.Path);
+            _logger.Debug("Looking for existing metadata in {SeriesPath}", series.Path);
 
             var metadataFiles = new List<MetadataFile>();
             var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, fileNameBeforeRename is not null);
@@ -74,19 +74,19 @@ namespace NzbDrone.Core.Extras.Metadata
                         }
                         catch (AugmentingFailedException)
                         {
-                            _logger.Debug("Unable to parse extra file: {0}", possibleMetadataFile);
+                            _logger.Debug("Unable to parse extra file: {FilePath}", possibleMetadataFile);
                             continue;
                         }
 
                         if (localEpisode.Episodes.Empty())
                         {
-                            _logger.Debug("Cannot find related episodes for: {0}", possibleMetadataFile);
+                            _logger.Debug("Cannot find related episodes for: {FilePath}", possibleMetadataFile);
                             continue;
                         }
 
                         if (localEpisode.Episodes.DistinctBy(e => e.EpisodeFileId).Count() > 1)
                         {
-                            _logger.Debug("Extra file: {0} does not match existing files.", possibleMetadataFile);
+                            _logger.Debug("Extra file: {FilePath} does not match existing files.", possibleMetadataFile);
                             continue;
                         }
 
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.Extras.Metadata
                 }
             }
 
-            _logger.Info("Found {0} existing metadata files", metadataFiles.Count);
+            _logger.Info("Found {MetadataFilesCount} existing metadata files", metadataFiles.Count);
             _metadataFileService.Upsert(metadataFiles);
 
             // Return files that were just imported along with files that were

--- a/src/NzbDrone.Core/Extras/Metadata/Files/CleanMetadataFileService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Files/CleanMetadataFileService.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Extras.Metadata.Files
 
         public void Clean(Series series)
         {
-            _logger.Debug("Cleaning missing metadata files for series: {0}", series.Title);
+            _logger.Debug("Cleaning missing metadata files for series: {SeriesTitle}", series.Title);
 
             var metadataFiles = _metadataFileService.GetFilesBySeries(series.Id);
 
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Extras.Metadata.Files
             {
                 if (!_diskProvider.FileExists(Path.Combine(series.Path, metadataFile.RelativePath)))
                 {
-                    _logger.Debug("Deleting metadata file from database: {0}", metadataFile.RelativePath);
+                    _logger.Debug("Deleting metadata file from database: {RelativePath}", metadataFile.RelativePath);
                     _metadataFileService.Delete(metadataFile.Id);
                 }
             }

--- a/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/MetadataService.cs
@@ -216,7 +216,7 @@ namespace NzbDrone.Core.Extras.Metadata
                             }
                             catch (Exception ex)
                             {
-                                _logger.Warn(ex, "Unable to move metadata file after rename: {0}", existingFileName);
+                                _logger.Warn(ex, "Unable to move metadata file after rename: {ExistingFileName}", existingFileName);
                             }
                         }
                     }
@@ -276,7 +276,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
             var fullPath = Path.Combine(series.Path, seriesMetadata.RelativePath);
 
-            _logger.Debug("Writing Series Metadata to: {0}", fullPath);
+            _logger.Debug("Writing Series Metadata to: {FullPath}", fullPath);
             SaveMetadataFile(fullPath, seriesMetadata.Contents);
 
             metadata.Hash = hash;
@@ -331,7 +331,7 @@ namespace NzbDrone.Core.Extras.Metadata
                 return null;
             }
 
-            _logger.Debug("Writing Episode Metadata to: {0}", fullPath);
+            _logger.Debug("Writing Episode Metadata to: {FullPath}", fullPath);
             SaveMetadataFile(fullPath, episodeMetadata.Contents);
 
             metadata.Hash = hash;
@@ -349,7 +349,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
                 if (_diskProvider.FileExists(fullPath))
                 {
-                    _logger.Debug("Series image already exists: {0}", fullPath);
+                    _logger.Debug("Series image already exists: {FullPath}", fullPath);
                     continue;
                 }
 
@@ -386,7 +386,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
                     if (_diskProvider.FileExists(fullPath))
                     {
-                        _logger.Debug("Season image already exists: {0}", fullPath);
+                        _logger.Debug("Season image already exists: {FullPath}", fullPath);
                         continue;
                     }
 
@@ -424,7 +424,7 @@ namespace NzbDrone.Core.Extras.Metadata
 
                 if (_diskProvider.FileExists(fullPath))
                 {
-                    _logger.Debug("Episode image already exists: {0}", fullPath);
+                    _logger.Debug("Episode image already exists: {FullPath}", fullPath);
                     continue;
                 }
 
@@ -492,15 +492,15 @@ namespace NzbDrone.Core.Extras.Metadata
             }
             catch (HttpException ex)
             {
-                _logger.Warn(ex, "Couldn't download image {0} for {1}. {2}", image.Url, series, ex.Message);
+                _logger.Warn(ex, "Couldn't download image {ImageUrl} for {SeriesTitle}. {ErrorMessage}", image.Url, series, ex.Message);
             }
             catch (WebException ex)
             {
-                _logger.Warn(ex, "Couldn't download image {0} for {1}. {2}", image.Url, series, ex.Message);
+                _logger.Warn(ex, "Couldn't download image {ImageUrl} for {SeriesTitle}. {ErrorMessage}", image.Url, series, ex.Message);
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Couldn't download image {0} for {1}. {2}", image.Url, series, ex.Message);
+                _logger.Error(ex, "Couldn't download image {ImageUrl} for {SeriesTitle}. {ErrorMessage}", image.Url, series, ex.Message);
             }
         }
 
@@ -524,7 +524,7 @@ namespace NzbDrone.Core.Extras.Metadata
             {
                 var path = Path.Combine(series.Path, file.RelativePath);
 
-                _logger.Debug("Removing duplicate Metadata file: {0}", path);
+                _logger.Debug("Removing duplicate Metadata file: {FilePath}", path);
 
                 var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(path));
                 _recycleBinProvider.DeleteFile(path, subfolder);

--- a/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
+++ b/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Extras.Others
 
         public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, string fileNameBeforeRename)
         {
-            _logger.Debug("Looking for existing extra files in {0}", series.Path);
+            _logger.Debug("Looking for existing extra files in {SeriesPath}", series.Path);
 
             var extraFiles = new List<OtherExtraFile>();
             var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, fileNameBeforeRename is not null);
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Extras.Others
 
                 if (extension.IsNullOrWhiteSpace())
                 {
-                    _logger.Debug("No extension for file: {0}", possibleExtraFile);
+                    _logger.Debug("No extension for file: {FilePath}", possibleExtraFile);
                     continue;
                 }
 
@@ -58,19 +58,19 @@ namespace NzbDrone.Core.Extras.Others
                 }
                 catch (AugmentingFailedException)
                 {
-                    _logger.Debug("Unable to parse extra file: {0}", possibleExtraFile);
+                    _logger.Debug("Unable to parse extra file: {FilePath}", possibleExtraFile);
                     continue;
                 }
 
                 if (localEpisode.Episodes.Empty())
                 {
-                    _logger.Debug("Cannot find related episodes for: {0}", possibleExtraFile);
+                    _logger.Debug("Cannot find related episodes for: {FilePath}", possibleExtraFile);
                     continue;
                 }
 
                 if (localEpisode.Episodes.DistinctBy(e => e.EpisodeFileId).Count() > 1)
                 {
-                    _logger.Debug("Extra file: {0} does not match existing files.", possibleExtraFile);
+                    _logger.Debug("Extra file: {FilePath} does not match existing files.", possibleExtraFile);
                     continue;
                 }
 
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.Extras.Others
                 extraFiles.Add(extraFile);
             }
 
-            _logger.Info("Found {0} existing other extra files", extraFiles.Count);
+            _logger.Info("Found {ExtraFilesCount} existing other extra files", extraFiles.Count);
             _otherExtraFileService.Upsert(extraFiles);
 
             // Return files that were just imported along with files that were

--- a/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
+++ b/src/NzbDrone.Core/Extras/Others/OtherExtraService.cs
@@ -134,7 +134,7 @@ namespace NzbDrone.Core.Extras.Others
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Failed to import extra file: {0}", file);
+                    _logger.Warn(ex, "Failed to import extra file: {FilePath}", file);
                 }
             }
 
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Extras.Others
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Failed to import extra file: {0}", file);
+                    _logger.Warn(ex, "Failed to import extra file: {FilePath}", file);
                 }
             }
 

--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Extras.Subtitles
 
         public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, string fileNameBeforeRename)
         {
-            _logger.Debug("Looking for existing subtitle files in {0}", series.Path);
+            _logger.Debug("Looking for existing subtitle files in {SeriesPath}", series.Path);
 
             var subtitleFiles = new List<SubtitleFile>();
             var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, fileNameBeforeRename is not null);
@@ -56,19 +56,19 @@ namespace NzbDrone.Core.Extras.Subtitles
                     }
                     catch (AugmentingFailedException)
                     {
-                        _logger.Debug("Unable to parse extra file: {0}", possibleSubtitleFile);
+                        _logger.Debug("Unable to parse extra file: {FilePath}", possibleSubtitleFile);
                         continue;
                     }
 
                     if (localEpisode.Episodes.Empty())
                     {
-                        _logger.Debug("Cannot find related episodes for: {0}", possibleSubtitleFile);
+                        _logger.Debug("Cannot find related episodes for: {FilePath}", possibleSubtitleFile);
                         continue;
                     }
 
                     if (localEpisode.Episodes.DistinctBy(e => e.EpisodeFileId).Count() > 1)
                     {
-                        _logger.Debug("Subtitle file: {0} does not match existing files.", possibleSubtitleFile);
+                        _logger.Debug("Subtitle file: {FilePath} does not match existing files.", possibleSubtitleFile);
                         continue;
                     }
 
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                 }
             }
 
-            _logger.Info("Found {0} existing subtitle files", subtitleFiles.Count);
+            _logger.Info("Found {SubtitleFilesCount} existing subtitle files", subtitleFiles.Count);
             _subtitleFileService.Upsert(subtitleFiles);
 
             // Return files that were just imported along with files that were

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -148,7 +148,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Failed to import subtitle file: {0}", file);
+                    _logger.Warn(ex, "Failed to import subtitle file: {FilePath}", file);
                 }
             }
 
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                 {
                     matchingFiles.AddRange(filteredFiles);
 
-                    _logger.Warn("Imported any available subtitle file for episode: {0}", localEpisode);
+                    _logger.Warn("Imported any available subtitle file for episode: {EpisodeTitle}", localEpisode);
                 }
             }
 
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to import subtitle file: {0}", path);
+                        _logger.Warn(ex, "Failed to import subtitle file: {FilePath}", path);
                     }
                 }
             }

--- a/src/NzbDrone.Core/HealthCheck/Checks/ApiKeyValidationCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ApiKeyValidationCheck.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
         {
             if (_configFileProvider.ApiKey.Length < MinimumLength)
             {
-                _logger.Warn("Please update your API key to be at least {0} characters long. You can do this via settings or the config file", MinimumLength);
+                _logger.Warn("Please update your API key to be at least {MinimumLength} characters long. You can do this via settings or the config file", MinimumLength);
 
                 return new HealthCheck(GetType(),
                     HealthCheckResult.Warning,

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientCheck.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (Exception ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", downloadClient.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", downloadClient.Definition.Name);
 
                     return new HealthCheck(GetType(),
                         HealthCheckResult.Error,

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (Exception ex)
                 {

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRootFolderCheck.cs
@@ -65,11 +65,11 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (HttpRequestException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (Exception ex)
                 {

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientSortingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientSortingCheck.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (Exception ex)
                 {

--- a/src/NzbDrone.Core/HealthCheck/Checks/ProxyCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ProxyCheck.cs
@@ -62,7 +62,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 // We only care about 400 responses, other error codes can be ignored
                 if (response.StatusCode == HttpStatusCode.BadRequest)
                 {
-                    _logger.Error("Proxy Health Check failed: {0}", response.StatusCode);
+                    _logger.Error("Proxy Health Check failed: {StatusCode}", response.StatusCode);
 
                     return new HealthCheck(GetType(),
                         HealthCheckResult.Error,

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -166,11 +166,11 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (HttpRequestException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (Exception ex)
                 {
@@ -367,11 +367,11 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 }
                 catch (DownloadClientException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (HttpRequestException ex)
                 {
-                    _logger.Debug(ex, "Unable to communicate with {0}", client.Definition.Name);
+                    _logger.Debug(ex, "Unable to communicate with {DownloadClientName}", client.Definition.Name);
                 }
                 catch (Exception ex)
                 {

--- a/src/NzbDrone.Core/HealthCheck/Checks/SystemTimeCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/SystemTimeCheck.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                 // +/- more than 1 day
                 if (Math.Abs(result.DateTimeUtc.Subtract(systemTime).TotalDays) >= 1)
                 {
-                    _logger.Error("System time mismatch. SystemTime: {0} Expected Time: {1}. Update system time", systemTime, result.DateTimeUtc);
+                    _logger.Error("System time mismatch. SystemTime: {SystemTime} Expected Time: {ExpectedTime}. Update system time", systemTime, result.DateTimeUtc);
                     return new HealthCheck(GetType(),
                         HealthCheckResult.Error,
                         HealthCheckReason.SystemTime,

--- a/src/NzbDrone.Core/HealthCheck/HealthCheckService.cs
+++ b/src/NzbDrone.Core/HealthCheck/HealthCheckService.cs
@@ -94,9 +94,9 @@ namespace NzbDrone.Core.HealthCheck
             {
                 var results = healthChecks.Select(c =>
                     {
-                        _logger.Trace("Check health -> {0}", c.GetType().Name);
+                        _logger.Trace("Check health -> {HealthCheckType}", c.GetType().Name);
                         var result = c.Check();
-                        _logger.Trace("Check health <- {0}", c.GetType().Name);
+                        _logger.Trace("Check health <- {HealthCheckType}", c.GetType().Name);
 
                         return result;
                     })

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -100,7 +100,7 @@ namespace NzbDrone.Core.History
 
         public string FindDownloadId(EpisodeImportedEvent trackedDownload)
         {
-            _logger.Debug("Trying to find downloadId for {0} from history", trackedDownload.ImportedEpisode.Path);
+            _logger.Debug("Trying to find downloadId for {FilePath} from history", trackedDownload.ImportedEpisode.Path);
 
             var episodeIds = trackedDownload.EpisodeInfo.Episodes.Select(c => c.Id).ToList();
             var allHistory = _historyRepository.FindDownloadHistory(trackedDownload.EpisodeInfo.Series.Id, trackedDownload.ImportedEpisode.Quality);

--- a/src/NzbDrone.Core/Housekeeping/Housekeepers/DeleteBadMediaCovers.cs
+++ b/src/NzbDrone.Core/Housekeeping/Housekeepers/DeleteBadMediaCovers.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.Housekeeping.Housekeepers
                     }
                     catch (Exception e)
                     {
-                        _logger.Error(e, "Couldn't validate image {0}", image.RelativePath);
+                        _logger.Error(e, "Couldn't validate image {RelativePath}", image.RelativePath);
                     }
                 }
             }

--- a/src/NzbDrone.Core/Housekeeping/HousekeepingService.cs
+++ b/src/NzbDrone.Core/Housekeeping/HousekeepingService.cs
@@ -27,13 +27,13 @@ namespace NzbDrone.Core.Housekeeping
             {
                 try
                 {
-                    _logger.Debug("Starting {0}", housekeeper.GetType().Name);
+                    _logger.Debug("Starting {HousekeeperType}", housekeeper.GetType().Name);
                     housekeeper.Clean();
-                    _logger.Debug("Completed {0}", housekeeper.GetType().Name);
+                    _logger.Debug("Completed {HousekeeperType}", housekeeper.GetType().Name);
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Error running housekeeping task: {0}", housekeeper.GetType().Name);
+                    _logger.Error(ex, "Error running housekeeping task: {HousekeeperType}", housekeeper.GetType().Name);
                 }
             }
 

--- a/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
+++ b/src/NzbDrone.Core/Http/CloudFlare/CloudFlareHttpInterceptor.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Http.CloudFlare
         {
             if (response.StatusCode == HttpStatusCode.Forbidden && response.Content.Contains(_cloudFlareChallengeScript))
             {
-                _logger.Debug("CloudFlare CAPTCHA block on {0}", response.Request.Url);
+                _logger.Debug("CloudFlare CAPTCHA block on {Url}", response.Request.Url);
                 throw new CloudFlareCaptchaException(response, CreateCaptchaRequest(response));
             }
 

--- a/src/NzbDrone.Core/ImportLists/AniList/AniListImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/AniList/AniListImportBase.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.ImportLists.AniList
         protected void CheckToken()
         {
             Settings.Validate().Filter("AccessToken", "RefreshToken").ThrowOnError();
-            _logger.Trace("Access token expires at {0}", Settings.Expires);
+            _logger.Trace("Access token expires at {Expires}", Settings.Expires);
 
             if (Settings.Expires < DateTime.UtcNow.AddMinutes(5))
             {

--- a/src/NzbDrone.Core/ImportLists/AniList/List/AniListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/AniList/List/AniListImport.cs
@@ -97,11 +97,11 @@ namespace NzbDrone.Core.ImportLists.AniList.List
                 if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
                     webException.Message.Contains("timed out"))
                 {
-                    _logger.Warn("{0} server is currently unavailable. {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{ImportList} server is currently unavailable. {Url} {Message}", this, url, webException.Message);
                 }
                 else
                 {
-                    _logger.Warn("{0} {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{ImportList} {Url} {Message}", this, url, webException.Message);
                 }
             }
             catch (TooManyRequestsException ex)
@@ -115,17 +115,17 @@ namespace NzbDrone.Core.ImportLists.AniList.List
                     _importListStatusService.RecordFailure(Definition.Id, TimeSpan.FromHours(1));
                 }
 
-                _logger.Warn("API Request Limit reached for {0}", this);
+                _logger.Warn("API Request Limit reached for {ImportList}", this);
             }
             catch (HttpException ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
-                _logger.Warn("{0} {1}", this, ex.Message);
+                _logger.Warn("{ImportList} {Message}", this, ex.Message);
             }
             catch (RequestLimitReachedException)
             {
                 _importListStatusService.RecordFailure(Definition.Id, TimeSpan.FromHours(1));
-                _logger.Warn("API Request Limit reached for {0}", this);
+                _logger.Warn("API Request Limit reached for {ImportList}", this);
             }
             catch (CloudFlareCaptchaException ex)
             {
@@ -134,23 +134,23 @@ namespace NzbDrone.Core.ImportLists.AniList.List
 
                 if (ex.IsExpired)
                 {
-                    _logger.Error(ex, "Expired CAPTCHA token for {0}, please refresh in import list settings.", this);
+                    _logger.Error(ex, "Expired CAPTCHA token for {ImportList}, please refresh in import list settings.", this);
                 }
                 else
                 {
-                    _logger.Error(ex, "CAPTCHA token required for {0}, check import list settings.", this);
+                    _logger.Error(ex, "CAPTCHA token required for {ImportList}, check import list settings.", this);
                 }
             }
             catch (ImportListException ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
-                _logger.Warn(ex, "{0}", url);
+                _logger.Warn(ex, "{Url}", url);
             }
             catch (Exception ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
                 ex.WithData("FeedUrl", url);
-                _logger.Error(ex, "An error occurred while processing feed. {0}", url);
+                _logger.Error(ex, "An error occurred while processing feed. {Url}", url);
             }
 
             return new ImportListFetchResult(CleanupListItems(releases), anyFailure);

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomImport.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.ImportLists.Custom
             catch (Exception ex)
             {
                 anyFailure = true;
-                _logger.Debug(ex, "Failed to fetch data for list {0} ({1})", Definition.Name, Name);
+                _logger.Debug(ex, "Failed to fetch data for list {DefinitionName} ({ImportListName})", Definition.Name, Name);
 
                 _importListStatusService.RecordFailure(Definition.Id);
             }

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.ImportLists
                 return result;
             }
 
-            _logger.Debug("Available import lists {0}", importLists.Count);
+            _logger.Debug("Available import lists {Count}", importLists.Count);
 
             var taskList = new List<Task>();
             var taskFactory = new TaskFactory(TaskCreationOptions.LongRunning, TaskContinuationOptions.None);
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.ImportLists
 
                     if (DateTime.UtcNow < importListNextSync)
                     {
-                        _logger.Trace("Skipping refresh of Import List {0} ({1}) due to minimum refresh interval. Next sync after {2}", importList.Name, importListLocal.Definition.Name, importListNextSync);
+                        _logger.Trace("Skipping refresh of Import List {ImportListName} ({DefinitionName}) due to minimum refresh interval. Next sync after {NextSync}", importList.Name, importListLocal.Definition.Name, importListNextSync);
                         continue;
                     }
                 }
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.ImportLists
 
                              lock (result)
                              {
-                                 _logger.Debug("Found {0} reports from {1} ({2})", importListReports.Count, importList.Name, importListLocal.Definition.Name);
+                                 _logger.Debug("Found {ReportCount} reports from {ImportListName} ({DefinitionName})", importListReports.Count, importList.Name, importListLocal.Definition.Name);
 
                                  if (!fetchResult.AnyFailure)
                                  {
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.ImportLists
                          }
                          catch (Exception e)
                          {
-                             _logger.Error(e, "Error during Import List Sync of {0} ({1})", importList.Name, importListLocal.Definition.Name);
+                             _logger.Error(e, "Error during Import List Sync of {ImportListName} ({DefinitionName})", importList.Name, importListLocal.Definition.Name);
                          }
                      }).LogExceptions();
 
@@ -97,7 +97,7 @@ namespace NzbDrone.Core.ImportLists
 
             result.Series = result.Series.DistinctBy(r => new { r.TvdbId, r.ImdbId, r.Title }).ToList();
 
-            _logger.Debug("Found {0} total reports from {1} lists", result.Series.Count, importLists.Count);
+            _logger.Debug("Found {ReportCount} total reports from {ListCount} lists", result.Series.Count, importLists.Count);
 
             return result;
         }
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.ImportLists
 
             if (importList == null || !definition.EnableAutomaticAdd)
             {
-                _logger.Debug("Import List {0} ({1}) is not enabled, skipping.", importList.Name, importList.Definition.Name);
+                _logger.Debug("Import List {ImportListName} ({DefinitionName}) is not enabled, skipping.", importList.Name, importList.Definition.Name);
                 return result;
             }
 
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.ImportLists
 
                     lock (result)
                     {
-                        _logger.Debug("Found {0} reports from {1} ({2})", importListReports.Count, importList.Name, importListLocal.Definition.Name);
+                        _logger.Debug("Found {ReportCount} reports from {ImportListName} ({DefinitionName})", importListReports.Count, importList.Name, importListLocal.Definition.Name);
 
                         if (!fetchResult.AnyFailure)
                         {
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.ImportLists
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Error during Import List Sync of {0} ({1})", importList.Name, importListLocal.Definition.Name);
+                    _logger.Error(e, "Error during Import List Sync of {ImportListName} ({DefinitionName})", importList.Name, importListLocal.Definition.Name);
                 }
             }).LogExceptions();
 

--- a/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
+++ b/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs
@@ -110,11 +110,11 @@ namespace NzbDrone.Core.ImportLists
                 if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
                     webException.Message.Contains("timed out"))
                 {
-                    _logger.Warn("{0} server is currently unavailable. {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{ImportList} server is currently unavailable. {Url} {Message}", this, url, webException.Message);
                 }
                 else
                 {
-                    _logger.Warn("{0} {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{ImportList} {Url} {Message}", this, url, webException.Message);
                 }
             }
             catch (TooManyRequestsException ex)
@@ -128,17 +128,17 @@ namespace NzbDrone.Core.ImportLists
                     _importListStatusService.RecordFailure(Definition.Id, TimeSpan.FromHours(1));
                 }
 
-                _logger.Warn("API Request Limit reached for {0}", this);
+                _logger.Warn("API Request Limit reached for {ImportList}", this);
             }
             catch (HttpException ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
-                _logger.Warn("{0} {1}", this, ex.Message);
+                _logger.Warn("{ImportList} {Message}", this, ex.Message);
             }
             catch (RequestLimitReachedException)
             {
                 _importListStatusService.RecordFailure(Definition.Id, TimeSpan.FromHours(1));
-                _logger.Warn("API Request Limit reached for {0}", this);
+                _logger.Warn("API Request Limit reached for {ImportList}", this);
             }
             catch (CloudFlareCaptchaException ex)
             {
@@ -146,23 +146,23 @@ namespace NzbDrone.Core.ImportLists
                 ex.WithData("FeedUrl", url);
                 if (ex.IsExpired)
                 {
-                    _logger.Error(ex, "Expired CAPTCHA token for {0}, please refresh in import list settings.", this);
+                    _logger.Error(ex, "Expired CAPTCHA token for {ImportList}, please refresh in import list settings.", this);
                 }
                 else
                 {
-                    _logger.Error(ex, "CAPTCHA token required for {0}, check import list settings.", this);
+                    _logger.Error(ex, "CAPTCHA token required for {ImportList}, check import list settings.", this);
                 }
             }
             catch (ImportListException ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
-                _logger.Warn(ex, "{0}", url);
+                _logger.Warn(ex, "{Url}", url);
             }
             catch (Exception ex)
             {
                 _importListStatusService.RecordFailure(Definition.Id);
                 ex.WithData("FeedUrl", url);
-                _logger.Error(ex, "An error occurred while processing feed. {0}", url);
+                _logger.Error(ex, "An error occurred while processing feed. {Url}", url);
             }
 
             return new ImportListFetchResult(CleanupListItems(releases), anyFailure);

--- a/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListFactory.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.ImportLists
             {
                 if (blockedImportLists.TryGetValue(importList.Definition.Id, out var blockedImportListStatus))
                 {
-                    _logger.Debug("Temporarily ignoring import list {0} till {1} due to recent failures.", importList.Definition.Name, blockedImportListStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring import list {ImportListName} till {DisabledTill} due to recent failures.", importList.Definition.Name, blockedImportListStatus.DisabledTill.Value.ToLocalTime());
                     continue;
                 }
 

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.ImportLists
 
         private void SyncList(ImportListDefinition definition)
         {
-            _logger.ProgressInfo("Starting Import List Refresh for List {0}", definition.Name);
+            _logger.ProgressInfo("Starting Import List Refresh for List {ImportListName}", definition.Name);
 
             var result = _listFetcherAndParser.FetchSingleList(definition);
 
@@ -126,7 +126,7 @@ namespace NzbDrone.Core.ImportLists
                 return;
             }
 
-            _logger.ProgressInfo("Processing {0} list items", items.Count);
+            _logger.ProgressInfo("Processing {Count} list items", items.Count);
 
             var reportNumber = 1;
 
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.ImportLists
 
             foreach (var item in items)
             {
-                _logger.ProgressTrace("Processing list item {0}/{1}", reportNumber, items.Count);
+                _logger.ProgressTrace("Processing list item {ReportNumber}/{Count}", reportNumber, items.Count);
 
                 reportNumber++;
 
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.ImportLists
 
                     if (mappedSeries == null)
                     {
-                        _logger.Debug("Rejected, unable to find matching TVDB ID for Anilist ID: {0} [{1}]", item.AniListId, item.Title);
+                        _logger.Debug("Rejected, unable to find matching TVDB ID for Anilist ID: {AniListId} [{Title}]", item.AniListId, item.Title);
 
                         continue;
                     }
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.ImportLists
 
                     if (mappedSeries == null)
                     {
-                        _logger.Debug("Rejected, unable to find matching TVDB ID for MAL ID: {0} [{1}]", item.MalId, item.Title);
+                        _logger.Debug("Rejected, unable to find matching TVDB ID for MAL ID: {MalId} [{Title}]", item.MalId, item.Title);
 
                         continue;
                     }
@@ -209,7 +209,7 @@ namespace NzbDrone.Core.ImportLists
 
                 if (item.TvdbId == 0)
                 {
-                    _logger.Debug("[{0}] Rejected, unable to find TVDB ID", item.Title);
+                    _logger.Debug("[{Title}] Rejected, unable to find TVDB ID", item.Title);
                     continue;
                 }
 
@@ -218,14 +218,14 @@ namespace NzbDrone.Core.ImportLists
 
                 if (excludedSeries != null)
                 {
-                    _logger.Debug("{0} [{1}] Rejected due to list exclusion", item.TvdbId, item.Title);
+                    _logger.Debug("{TvdbId} [{Title}] Rejected due to list exclusion", item.TvdbId, item.Title);
                     continue;
                 }
 
                 // Break if Series Exists in DB
                 if (existingTvdbIds.Any(x => x == item.TvdbId))
                 {
-                    _logger.Debug("{0} [{1}] Rejected, series exists in database", item.TvdbId, item.Title);
+                    _logger.Debug("{TvdbId} [{Title}] Rejected, series exists in database", item.TvdbId, item.Title);
                     continue;
                 }
 
@@ -260,7 +260,7 @@ namespace NzbDrone.Core.ImportLists
 
             _addSeriesService.AddSeries(seriesToAdd, true);
 
-            _logger.ProgressInfo("Import List Sync Completed. Items found: {0}, Series added: {1}", items.Count, seriesToAdd.Count);
+            _logger.ProgressInfo("Import List Sync Completed. Items found: {ItemCount}, Series added: {SeriesCount}", items.Count, seriesToAdd.Count);
         }
 
         public void Execute(ImportListSyncCommand message)
@@ -313,15 +313,15 @@ namespace NzbDrone.Core.ImportLists
                     switch (_configService.ListSyncLevel)
                     {
                         case ListSyncLevelType.LogOnly:
-                            _logger.Info("{0} was in your library, but not found in your lists --> You might want to unmonitor or remove it", series);
+                            _logger.Info("{Series} was in your library, but not found in your lists --> You might want to unmonitor or remove it", series);
                             break;
                         case ListSyncLevelType.KeepAndUnmonitor when series.Monitored:
-                            _logger.Info("{0} was in your library, but not found in your lists --> Keeping in library but unmonitoring it", series);
+                            _logger.Info("{Series} was in your library, but not found in your lists --> Keeping in library but unmonitoring it", series);
                             series.Monitored = false;
                             seriesToUpdate.Add(series);
                             break;
                         case ListSyncLevelType.KeepAndTag when !series.Tags.Contains(_configService.ListSyncTag):
-                            _logger.Info("{0} was in your library, but not found in your lists --> Keeping in library but tagging it", series);
+                            _logger.Info("{Series} was in your library, but not found in your lists --> Keeping in library but tagging it", series);
                             series.Tags.Add(_configService.ListSyncTag);
                             seriesToUpdate.Add(series);
                             break;

--- a/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportParser.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.ImportLists.Rss.Plex
 
             if (info.ImdbId.IsNullOrWhiteSpace() && info.TvdbId == 0 && info.TmdbId == 0)
             {
-                _logger.Warn("Each item in the RSS feed must have a guid element with a IMDB ID, TVDB ID or TMDB ID: '{0}'", info.Title);
+                _logger.Warn("Each item in the RSS feed must have a guid element with a IMDB ID, TVDB ID or TMDB ID: '{Title}'", info.Title);
 
                 return null;
             }

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseParser.cs
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.ImportLists.Rss
                 {
                     itemEx.WithData("FeedUrl", importResponse.Request.Url);
                     itemEx.WithData("ItemTitle", item.Title());
-                    _logger.Error(itemEx, "An error occurred while processing feed item from {0}", importResponse.Request.Url);
+                    _logger.Error(itemEx, "An error occurred while processing feed item from {Url}", importResponse.Request.Url);
                 }
             }
 
@@ -90,7 +90,7 @@ namespace NzbDrone.Core.ImportLists.Rss
             catch (XmlException ex)
             {
                 var contentSample = importListResponse.Content.Substring(0, Math.Min(importListResponse.Content.Length, 512));
-                _logger.Debug("Truncated response content (originally {0} characters): {1}", importListResponse.Content.Length, contentSample);
+                _logger.Debug("Truncated response content (originally {ContentLength} characters): {ContentSample}", importListResponse.Content.Length, contentSample);
 
                 ex.WithData(importListResponse.HttpResponse);
 

--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.ImportLists.Sonarr
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, "Failed to fetch data for list {0} ({1})", Definition.Name, Name);
+                _logger.Debug(ex, "Failed to fetch data for list {DefinitionName} ({ImportListName})", Definition.Name, Name);
 
                 _importListStatusService.RecordFailure(Definition.Id);
                 anyFailure = true;

--- a/src/NzbDrone.Core/IndexerSearch/EpisodeSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/EpisodeSearchService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.IndexerSearch
 
         private async Task SearchForBulkEpisodes(List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch)
         {
-            _logger.ProgressInfo("Performing search for {0} episodes", episodes.Count);
+            _logger.ProgressInfo("Performing search for {EpisodeCount} episodes", episodes.Count);
             var downloadedCount = 0;
             var groups = new List<EpisodeSearchGroup>();
 
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.IndexerSearch
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error(ex, "Unable to search for episodes in season {0} of [{1}]", seasonNumber, seriesId);
+                        _logger.Error(ex, "Unable to search for episodes in season {SeasonNumber} of [{SeriesId}]", seasonNumber, seriesId);
                         continue;
                     }
                 }
@@ -89,7 +89,7 @@ namespace NzbDrone.Core.IndexerSearch
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error(ex, "Unable to search for episode: [{0}]", episode);
+                        _logger.Error(ex, "Unable to search for episode: [{EpisodeTitle}]", episode);
                         continue;
                     }
                 }
@@ -99,7 +99,7 @@ namespace NzbDrone.Core.IndexerSearch
                 downloadedCount += processed.Grabbed.Count;
             }
 
-            _logger.ProgressInfo("Completed search for {0} episodes. {1} reports downloaded.", episodes.Count, downloadedCount);
+            _logger.ProgressInfo("Completed search for {EpisodeCount} episodes. {DownloadedCount} reports downloaded.", episodes.Count, downloadedCount);
         }
 
         private bool IsMonitored(bool episodeMonitored, bool seriesMonitored)
@@ -114,7 +114,7 @@ namespace NzbDrone.Core.IndexerSearch
                 var decisions = _releaseSearchService.EpisodeSearch(episodeId, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
                 var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 
-                _logger.ProgressInfo("Episode search completed. {0} reports downloaded.", processed.Grabbed.Count);
+                _logger.ProgressInfo("Episode search completed. {DownloadedCount} reports downloaded.", processed.Grabbed.Count);
             }
         }
 

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             if (episodes.Count == 0)
             {
-                _logger.Debug("No wanted episodes found for season {0}", seasonNumber);
+                _logger.Debug("No wanted episodes found for season {SeasonNumber}", seasonNumber);
                 return new List<DownloadDecision>();
             }
 
@@ -526,7 +526,7 @@ namespace NzbDrone.Core.IndexerSearch
             // Filter indexers to untagged indexers and indexers with intersecting tags
             indexers = indexers.Where(i => i.Definition.Tags.Empty() || i.Definition.Tags.Intersect(criteriaBase.Series.Tags).Any()).ToList();
 
-            _logger.ProgressInfo("Searching indexers for {0}. {1} active indexers", criteriaBase, indexers.Count);
+            _logger.ProgressInfo("Searching indexers for {SearchCriteria}. {IndexerCount} active indexers", criteriaBase, indexers.Count);
 
             var tasks = indexers.Select(indexer => DispatchIndexer(searchAction, indexer, criteriaBase));
 
@@ -534,13 +534,13 @@ namespace NzbDrone.Core.IndexerSearch
 
             var reports = batch.SelectMany(x => x).ToList();
 
-            _logger.ProgressDebug("Total of {0} reports were found for {1} from {2} indexers", reports.Count, criteriaBase, indexers.Count);
+            _logger.ProgressDebug("Total of {ReportCount} reports were found for {SearchCriteria} from {IndexerCount} indexers", reports.Count, criteriaBase, indexers.Count);
 
             // Update the last search time for all episodes if at least 1 indexer was searched.
             if (indexers.Any())
             {
                 var lastSearchTime = DateTime.UtcNow;
-                _logger.Debug("Setting last search time to: {0}", lastSearchTime);
+                _logger.Debug("Setting last search time to: {LastSearchTime}", lastSearchTime);
 
                 criteriaBase.Episodes.ForEach(e => e.LastSearchTime = lastSearchTime);
                 _episodeService.UpdateLastSearchTime(criteriaBase.Episodes);
@@ -557,7 +557,7 @@ namespace NzbDrone.Core.IndexerSearch
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Error while searching for {0}", criteriaBase);
+                _logger.Error(ex, "Error while searching for {SearchCriteria}", criteriaBase);
             }
 
             return Array.Empty<ReleaseInfo>();

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.IndexerSearch
             var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, false, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
             var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 
-            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
+            _logger.ProgressInfo("Season search completed. {DownloadedCount} reports downloaded.", processed.Grabbed.Count);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.IndexerSearch
 
             if (series.Seasons.None(s => s.Monitored))
             {
-                _logger.Debug("No seasons of {0} are monitored, searching for all monitored episodes", series.Title);
+                _logger.Debug("No seasons of {SeriesTitle} are monitored, searching for all monitored episodes", series.Title);
 
                 var episodes = _episodeService.GetEpisodeBySeries(series.Id)
                     .Where(e => e.Monitored &&
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.IndexerSearch
                 {
                     if (!season.Monitored)
                     {
-                        _logger.Debug("Season {0} of {1} is not monitored, skipping search", season.SeasonNumber, series.Title);
+                        _logger.Debug("Season {SeasonNumber} of {SeriesTitle} is not monitored, skipping search", season.SeasonNumber, series.Title);
                         continue;
                     }
 
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.IndexerSearch
                 }
             }
 
-            _logger.ProgressInfo("Series search completed. {0} reports downloaded.", downloadedCount);
+            _logger.ProgressInfo("Series search completed. {DownloadedCount} reports downloaded.", downloadedCount);
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/CachedIndexerSettingsProvider.cs
+++ b/src/NzbDrone.Core/Indexers/CachedIndexerSettingsProvider.cs
@@ -43,7 +43,7 @@ public class CachedIndexerSettingsProvider : ICachedIndexerSettingsProvider, IHa
 
         if (indexer?.Settings is not IIndexerSettings indexerSettings)
         {
-            Logger.Trace("Could not load settings for indexer ID: {0}", indexerId);
+            Logger.Trace("Could not load settings for indexer ID: {IndexerId}", indexerId);
 
             return null;
         }

--- a/src/NzbDrone.Core/Indexers/FetchAndParseRssService.cs
+++ b/src/NzbDrone.Core/Indexers/FetchAndParseRssService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Indexers
                 return new List<ReleaseInfo>();
             }
 
-            _logger.Debug("Available indexers {0}", indexers.Count);
+            _logger.Debug("Available indexers {IndexerCount}", indexers.Count);
 
             var tasks = indexers.Select(FetchIndexer);
 
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Indexers
 
             var result = batch.SelectMany(x => x).ToList();
 
-            _logger.Debug("Found {0} reports", result.Count);
+            _logger.Debug("Found {ReportCount} reports", result.Count);
 
             return result;
         }

--- a/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
+++ b/src/NzbDrone.Core/Indexers/HttpIndexerBase.cs
@@ -212,7 +212,7 @@ namespace NzbDrone.Core.Indexers
                     {
                         var gapStart = lastReleaseInfo.PublishDate;
                         var gapEnd = ordered.Last().PublishDate;
-                        _logger.Warn("Indexer {0} rss sync didn't cover the period between {1} and {2} UTC. Search may be required.", Definition.Name, gapStart, gapEnd);
+                        _logger.Warn("Indexer {IndexerName} rss sync didn't cover the period between {GapStart} and {GapEnd} UTC. Search may be required.", Definition.Name, gapStart, gapEnd);
                     }
 
                     lastReleaseInfo = ordered.First();
@@ -235,11 +235,11 @@ namespace NzbDrone.Core.Indexers
                 if (webException.Message.Contains("502") || webException.Message.Contains("503") ||
                     webException.Message.Contains("504") || webException.Message.Contains("timed out"))
                 {
-                    _logger.Warn("{0} server is currently unavailable. {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{Indexer} server is currently unavailable. {Url} {ExceptionMessage}", this, url, webException.Message);
                 }
                 else
                 {
-                    _logger.Warn("{0} {1} {2}", this, url, webException.Message);
+                    _logger.Warn("{Indexer} {Url} {ExceptionMessage}", this, url, webException.Message);
                 }
             }
             catch (TooManyRequestsException ex)
@@ -247,18 +247,18 @@ namespace NzbDrone.Core.Indexers
                 var retryTime = ex.RetryAfter != TimeSpan.Zero ? ex.RetryAfter : minimumBackoff;
                 _indexerStatusService.RecordFailure(Definition.Id, retryTime);
 
-                _logger.Warn("API Request Limit reached for {0}. Disabled for {1}", this, retryTime);
+                _logger.Warn("API Request Limit reached for {Indexer}. Disabled for {RetryTime}", this, retryTime);
             }
             catch (HttpException ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
                 if (ex.Response.HasHttpServerError)
                 {
-                    _logger.Warn("Unable to connect to {0} at [{1}]. Indexer's server is unavailable. Try again later. {2}", this, url, ex.Message);
+                    _logger.Warn("Unable to connect to {Indexer} at [{Url}]. Indexer's server is unavailable. Try again later. {ExceptionMessage}", this, url, ex.Message);
                 }
                 else
                 {
-                    _logger.Warn("{0} {1}", this, ex.Message);
+                    _logger.Warn("{Indexer} {ExceptionMessage}", this, ex.Message);
                 }
             }
             catch (RequestLimitReachedException ex)
@@ -266,12 +266,12 @@ namespace NzbDrone.Core.Indexers
                 var retryTime = ex.RetryAfter != TimeSpan.Zero ? ex.RetryAfter : minimumBackoff;
                 _indexerStatusService.RecordFailure(Definition.Id, retryTime);
 
-                _logger.Warn("API Request Limit reached for {0}. Disabled for {1}", this, retryTime);
+                _logger.Warn("API Request Limit reached for {Indexer}. Disabled for {RetryTime}", this, retryTime);
             }
             catch (ApiKeyException)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
-                _logger.Warn("Invalid API Key for {0} {1}", this, url);
+                _logger.Warn("Invalid API Key for {Indexer} {Url}", this, url);
             }
             catch (CloudFlareCaptchaException ex)
             {
@@ -279,28 +279,28 @@ namespace NzbDrone.Core.Indexers
                 ex.WithData("FeedUrl", url);
                 if (ex.IsExpired)
                 {
-                    _logger.Error(ex, "Expired CAPTCHA token for {0}, please refresh in indexer settings.", this);
+                    _logger.Error(ex, "Expired CAPTCHA token for {Indexer}, please refresh in indexer settings.", this);
                 }
                 else
                 {
-                    _logger.Error(ex, "CAPTCHA token required for {0}, check indexer settings.", this);
+                    _logger.Error(ex, "CAPTCHA token required for {Indexer}, check indexer settings.", this);
                 }
             }
             catch (TaskCanceledException ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
-                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout. {0}", url);
+                _logger.Warn(ex, "Unable to connect to indexer, possibly due to a timeout. {Url}", url);
             }
             catch (IndexerException ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
-                _logger.Warn(ex, "{0}", url);
+                _logger.Warn(ex, "{Url}", url);
             }
             catch (Exception ex)
             {
                 _indexerStatusService.RecordFailure(Definition.Id);
                 ex.WithData("FeedUrl", url);
-                _logger.Error(ex, "An error occurred while processing feed. {0}", url);
+                _logger.Error(ex, "An error occurred while processing feed. {Url}", url);
             }
 
             return CleanupReleases(releases);
@@ -310,14 +310,14 @@ namespace NzbDrone.Core.Indexers
         {
             if (release.Title.IsNullOrWhiteSpace())
             {
-                _logger.Trace("Invalid Release: '{0}' from indexer: {1}. No title provided.", release.InfoUrl, Definition.Name);
+                _logger.Trace("Invalid Release: '{InfoUrl}' from indexer: {IndexerName}. No title provided.", release.InfoUrl, Definition.Name);
 
                 return false;
             }
 
             if (release.DownloadUrl.IsNullOrWhiteSpace())
             {
-                _logger.Trace("Invalid Release: '{0}' from indexer: {1}. No Download URL provided.", release.Title, Definition.Name);
+                _logger.Trace("Invalid Release: '{ReleaseTitle}' from indexer: {IndexerName}. No Download URL provided.", release.Title, Definition.Name);
 
                 return false;
             }
@@ -341,7 +341,7 @@ namespace NzbDrone.Core.Indexers
             catch (Exception ex)
             {
                 ex.WithData(response.HttpResponse, 128 * 1024);
-                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.HttpResponse.ResponseData.Length, response.HttpResponse.Content);
+                _logger.Trace("Unexpected Response content ({ResponseSize} bytes): {ResponseContent}", response.HttpResponse.ResponseData.Length, response.HttpResponse.Content);
                 throw;
             }
         }

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Indexers
             {
                 if (blockedIndexers.TryGetValue(indexer.Definition.Id, out var blockedIndexerStatus))
                 {
-                    _logger.Debug("Temporarily ignoring indexer {0} till {1} due to recent failures.", indexer.Definition.Name, blockedIndexerStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring indexer {IndexerName} till {DisabledTill} due to recent failures.", indexer.Definition.Name, blockedIndexerStatus.DisabledTill.Value.ToLocalTime());
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabCapabilitiesProvider.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, "Failed to get newznab api capabilities from {0}", indexerSettings.BaseUrl);
+                _logger.Debug(ex, "Failed to get newznab api capabilities from {IndexerUrl}", indexerSettings.BaseUrl);
                 throw;
             }
 
@@ -70,22 +70,22 @@ namespace NzbDrone.Core.Indexers.Newznab
             catch (XmlException ex)
             {
                 ex.WithData(response, 128 * 1024);
-                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
-                _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}", indexerSettings.BaseUrl);
+                _logger.Trace("Unexpected Response content ({ResponseSize} bytes): {ResponseContent}", response.ResponseData.Length, response.Content);
+                _logger.Debug(ex, "Failed to parse newznab api capabilities for {IndexerUrl}", indexerSettings.BaseUrl);
                 throw;
             }
             catch (ApiKeyException ex)
             {
                 ex.WithData(response, 128 * 1024);
-                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
-                _logger.Debug(ex, "Failed to parse newznab api capabilities for {0}, invalid API key", indexerSettings.BaseUrl);
+                _logger.Trace("Unexpected Response content ({ResponseSize} bytes): {ResponseContent}", response.ResponseData.Length, response.Content);
+                _logger.Debug(ex, "Failed to parse newznab api capabilities for {IndexerUrl}, invalid API key", indexerSettings.BaseUrl);
                 throw;
             }
             catch (Exception ex)
             {
                 ex.WithData(response, 128 * 1024);
-                _logger.Trace("Unexpected Response content ({0} bytes): {1}", response.ResponseData.Length, response.Content);
-                _logger.Error(ex, "Failed to determine newznab api capabilities for {0}, using the defaults instead till Sonarr restarts", indexerSettings.BaseUrl);
+                _logger.Trace("Unexpected Response content ({ResponseSize} bytes): {ResponseContent}", response.ResponseData.Length, response.Content);
+                _logger.Error(ex, "Failed to determine newznab api capabilities for {IndexerUrl}, using the defaults instead till Sonarr restarts", indexerSettings.BaseUrl);
             }
 
             return capabilities;

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -217,14 +217,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (!SupportsEpisodeSearch)
             {
-                _logger.Debug("Indexer capabilities lacking season & ep query parameters, no Standard series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking season & ep query parameters, no Standard series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
 
             if (!SupportsTvTextSearches && !SupportsTvIdSearches)
             {
-                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Standard series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Standard series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
@@ -266,14 +266,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (!SupportsSeasonSearch)
             {
-                _logger.Debug("Indexer capabilities lacking season query parameter, no Standard series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking season query parameter, no Standard series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
 
             if (!SupportsTvTextSearches && !SupportsTvIdSearches)
             {
-                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Standard series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Standard series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
@@ -313,14 +313,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (!SupportsEpisodeSearch)
             {
-                _logger.Debug("Indexer capabilities lacking season & ep query parameters, no Daily series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking season & ep query parameters, no Daily series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
 
             if (!SupportsTvTextSearches && !SupportsTvIdSearches)
             {
-                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Daily series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Daily series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
@@ -360,14 +360,14 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             if (!SupportsEpisodeSearch)
             {
-                _logger.Debug("Indexer capabilities lacking season query parameter, no Daily series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking season query parameter, no Daily series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }
 
             if (!SupportsTvTextSearches && !SupportsTvIdSearches)
             {
-                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Daily series search possible: {0}", Definition.Name);
+                _logger.Debug("Indexer capabilities lacking q, title, tvdbid, imdbid, rid and tvmazeid parameters, no Daily series search possible: {IndexerName}", Definition.Name);
 
                 return pageableRequests;
             }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRssParser.cs
@@ -73,12 +73,12 @@ namespace NzbDrone.Core.Indexers.Newznab
             {
                 if (enclosureTypes.Intersect(TorrentEnclosureMimeTypes).Any())
                 {
-                    _logger.Warn("{0} does not contain {1}, found {2}, did you intend to add a Torznab indexer?", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
+                    _logger.Warn("{FeedUrl} does not contain {ExpectedMimeType}, found {ActualMimeType}, did you intend to add a Torznab indexer?", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
 
                     return false;
                 }
 
-                _logger.Warn("{0} does not contain {1}, found {2}.", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
+                _logger.Warn("{FeedUrl} does not contain {ExpectedMimeType}, found {ActualMimeType}.", indexerResponse.Request.Url, NzbEnclosureMimeType, enclosureTypes[0]);
             }
 
             return true;

--- a/src/NzbDrone.Core/Indexers/RssParser.cs
+++ b/src/NzbDrone.Core/Indexers/RssParser.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Indexers
                 {
                     itemEx.WithData("FeedUrl", indexerResponse.Request.Url);
                     itemEx.WithData("ItemTitle", item.Title());
-                    _logger.Error(itemEx, "An error occurred while processing feed item from {0}", indexerResponse.Request.Url);
+                    _logger.Error(itemEx, "An error occurred while processing feed item from {FeedUrl}", indexerResponse.Request.Url);
                 }
             }
 
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Indexers
             catch (XmlException ex)
             {
                 var contentSample = indexerResponse.Content.Substring(0, Math.Min(indexerResponse.Content.Length, 512));
-                _logger.Debug("Truncated response content (originally {0} characters): {1}", indexerResponse.Content.Length, contentSample);
+                _logger.Debug("Truncated response content (originally {ContentLength} characters): {ContentSample}", indexerResponse.Content.Length, contentSample);
 
                 ex.WithData(indexerResponse.HttpResponse);
 
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.Indexers
 
             releaseInfo = ProcessItem(item, releaseInfo);
 
-            _logger.Trace("Parsed: {0}", releaseInfo.Title);
+            _logger.Trace("Parsed: {ReleaseTitle}", releaseInfo.Title);
 
             return PostProcessItem(item, releaseInfo);
         }
@@ -277,7 +277,7 @@ namespace NzbDrone.Core.Indexers
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Failed to get enclosure for: {0}", item.Title());
+                        _logger.Warn(ex, "Failed to get enclosure for: {ItemTitle}", item.Title());
                     }
 
                     return null;
@@ -357,7 +357,7 @@ namespace NzbDrone.Core.Indexers
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, string.Format("Failed to parse Url {0}, ignoring.", value));
+                _logger.Debug(ex, "Failed to parse Url {Url}, ignoring.", value);
                 return null;
             }
         }

--- a/src/NzbDrone.Core/Indexers/RssSyncService.cs
+++ b/src/NzbDrone.Core/Indexers/RssSyncService.cs
@@ -47,11 +47,11 @@ namespace NzbDrone.Core.Indexers
 
             if (processed.Pending.Any())
             {
-                _logger.ProgressInfo("RSS Sync Completed. Reports found: {0}, Reports grabbed: {1}, Reports pending: {2}", reports.Count, processed.Grabbed.Count, processed.Pending.Count);
+                _logger.ProgressInfo("RSS Sync Completed. Reports found: {ReportCount}, Reports grabbed: {GrabbedCount}, Reports pending: {PendingCount}", reports.Count, processed.Grabbed.Count, processed.Pending.Count);
             }
             else
             {
-                _logger.ProgressInfo("RSS Sync Completed. Reports found: {0}, Reports grabbed: {1}", reports.Count, processed.Grabbed.Count);
+                _logger.ProgressInfo("RSS Sync Completed. Reports found: {ReportCount}, Reports grabbed: {GrabbedCount}", reports.Count, processed.Grabbed.Count);
             }
 
             return processed;

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssSettingsDetector.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         /// <returns>Parsed Settings or <c>null</c></returns>
         public TorrentRssIndexerParserSettings Detect(TorrentRssIndexerSettings settings)
         {
-            _logger.Debug("Evaluating TorrentRss feed '{0}'", settings.BaseUrl);
+            _logger.Debug("Evaluating TorrentRss feed '{FeedUrl}'", settings.BaseUrl);
 
             try
             {
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, string.Format("Unable to connect to indexer {0}: {1}", request.Url, ex.Message));
+                    _logger.Warn(ex, "Unable to connect to indexer {Url}: {Message}", request.Url, ex.Message);
                     return null;
                 }
 
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
             {
                 if (releases.Any(r => r.Size < ValidSizeThreshold))
                 {
-                    _logger.Debug("Feed {0} contains very small releases.", response.Request.Url);
+                    _logger.Debug("Feed {FeedUrl} contains very small releases.", response.Request.Url);
                 }
 
                 _logger.Trace("Feed has valid size in description.");
@@ -261,7 +261,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
 
             var torrentInfo = releases.First();
 
-            _logger.Trace("TorrentInfo: \n{0}", torrentInfo.ToString("L"));
+            _logger.Trace("TorrentInfo: \n{TorrentInfo}", torrentInfo.ToString("L"));
 
             if (releases.Any(r => r.Title.IsNullOrWhiteSpace()))
             {

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabRssParser.cs
@@ -64,12 +64,12 @@ namespace NzbDrone.Core.Indexers.Torznab
             {
                 if (enclosureTypes.Intersect(UsenetEnclosureMimeTypes).Any())
                 {
-                    _logger.Warn("{0} does not contain {1}, found {2}, did you intend to add a Newznab indexer?", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
+                    _logger.Warn("{FeedUrl} does not contain {ExpectedMimeType}, found {ActualMimeType}, did you intend to add a Newznab indexer?", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
 
                     return false;
                 }
 
-                _logger.Warn("{0} does not contain {1}, found {2}.", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
+                _logger.Warn("{FeedUrl} does not contain {ExpectedMimeType}, found {ActualMimeType}.", indexerResponse.Request.Url, TorrentEnclosureMimeType, enclosureTypes[0]);
             }
 
             return true;

--- a/src/NzbDrone.Core/Instrumentation/DeleteLogFilesService.cs
+++ b/src/NzbDrone.Core/Instrumentation/DeleteLogFilesService.cs
@@ -26,13 +26,13 @@ namespace NzbDrone.Core.Instrumentation
 
         public void Execute(DeleteLogFilesCommand message)
         {
-            _logger.Debug("Deleting all files in: {0}", _appFolderInfo.GetLogFolder());
+            _logger.Debug("Deleting all files in: {FolderPath}", _appFolderInfo.GetLogFolder());
             _diskProvider.EmptyFolder(_appFolderInfo.GetLogFolder());
         }
 
         public void Execute(DeleteUpdateLogFilesCommand message)
         {
-            _logger.Debug("Deleting all files in: {0}", _appFolderInfo.GetUpdateLogFolder());
+            _logger.Debug("Deleting all files in: {FolderPath}", _appFolderInfo.GetUpdateLogFolder());
             _diskProvider.EmptyFolder(_appFolderInfo.GetUpdateLogFolder());
         }
     }

--- a/src/NzbDrone.Core/Jobs/Scheduler.cs
+++ b/src/NzbDrone.Core/Jobs/Scheduler.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Jobs
 
                 var tasks = _taskManager.GetPending().ToList();
 
-                _logger.Trace("Pending Tasks: {0}", tasks.Count);
+                _logger.Trace("Pending Tasks: {PendingTaskCount}", tasks.Count);
 
                 foreach (var task in tasks)
                 {

--- a/src/NzbDrone.Core/Jobs/TaskManager.cs
+++ b/src/NzbDrone.Core/Jobs/TaskManager.cs
@@ -136,13 +136,13 @@ namespace NzbDrone.Core.Jobs
 
             var currentTasks = _scheduledTaskRepository.All().ToList();
 
-            _logger.Trace("Initializing jobs. Available: {0} Existing: {1}", defaultTasks.Count, currentTasks.Count);
+            _logger.Trace("Initializing jobs. Available: {AvailableCount} Existing: {ExistingCount}", defaultTasks.Count, currentTasks.Count);
 
             foreach (var job in currentTasks)
             {
                 if (!defaultTasks.Any(c => c.TypeName == job.TypeName))
                 {
-                    _logger.Trace("Removing job from database '{0}'", job.TypeName);
+                    _logger.Trace("Removing job from database '{JobTypeName}'", job.TypeName);
                     _scheduledTaskRepository.Delete(job.Id);
                 }
             }
@@ -205,7 +205,7 @@ namespace NzbDrone.Core.Jobs
 
             if (scheduledTask != null && message.Command.Body.UpdateScheduledTask)
             {
-                _logger.Trace("Updating last run time for: {0}", scheduledTask.TypeName);
+                _logger.Trace("Updating last run time for: {JobTypeName}", scheduledTask.TypeName);
 
                 var lastExecution = DateTime.UtcNow;
                 var startTime = message.Command.StartedAt.Value;

--- a/src/NzbDrone.Core/Localization/LocalizationService.cs
+++ b/src/NzbDrone.Core/Localization/LocalizationService.cs
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Localization
         {
             if (!File.Exists(resourcePath))
             {
-                _logger.Error("Missing translation/culture resource: {0}", resourcePath);
+                _logger.Error("Missing translation/culture resource: {ResourcePath}", resourcePath);
                 return;
             }
 

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -134,15 +134,15 @@ namespace NzbDrone.Core.MediaCover
                 }
                 catch (HttpException e)
                 {
-                    _logger.Warn("Couldn't download media cover for {0}. {1}", series, e.Message);
+                    _logger.Warn("Couldn't download media cover for {SeriesTitle}. {ErrorMessage}", series, e.Message);
                 }
                 catch (WebException e)
                 {
-                    _logger.Warn("Couldn't download media cover for {0}. {1}", series, e.Message);
+                    _logger.Warn("Couldn't download media cover for {SeriesTitle}. {ErrorMessage}", series, e.Message);
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Couldn't download media cover for {0}", series);
+                    _logger.Error(e, "Couldn't download media cover for {SeriesTitle}", series);
                 }
 
                 toResize.Add(Tuple.Create(cover, alreadyExists));
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.MediaCover
         {
             var fileName = GetCoverPath(series.Id, cover.CoverType);
 
-            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, series, cover.RemoteUrl);
+            _logger.Info("Downloading {CoverType} for {SeriesTitle} {RemoteUrl}", cover.CoverType, series, cover.RemoteUrl);
             _httpClient.DownloadFile(cover.RemoteUrl, fileName);
         }
 
@@ -204,7 +204,7 @@ namespace NzbDrone.Core.MediaCover
 
                 if (forceResize || !_diskProvider.FileExists(resizeFileName) || _diskProvider.GetFileSize(resizeFileName) == 0)
                 {
-                    _logger.Debug("Resizing {0}-{1} for {2}", cover.CoverType, height, series);
+                    _logger.Debug("Resizing {CoverType}-{Height} for {SeriesTitle}", cover.CoverType, height, series);
 
                     try
                     {
@@ -212,7 +212,7 @@ namespace NzbDrone.Core.MediaCover
                     }
                     catch
                     {
-                        _logger.Debug("Couldn't resize media cover {0}-{1} for {2}, using full size image instead.", cover.CoverType, height, series);
+                        _logger.Debug("Couldn't resize media cover {CoverType}-{Height} for {SeriesTitle}, using full size image instead.", cover.CoverType, height, series);
                     }
                 }
             }

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -84,20 +84,20 @@ namespace NzbDrone.Core.MediaFiles
             {
                 if (!_diskProvider.FolderExists(rootFolder))
                 {
-                    _logger.Warn("Series' root folder ({0}) doesn't exist.", rootFolder);
+                    _logger.Warn("Series' root folder ({RootFolderPath}) doesn't exist.", rootFolder);
                     _eventAggregator.PublishEvent(new SeriesScanSkippedEvent(series, SeriesScanSkippedReason.RootFolderDoesNotExist));
                     return;
                 }
 
                 if (_diskProvider.FolderEmpty(rootFolder))
                 {
-                    _logger.Warn("Series' root folder ({0}) is empty.", rootFolder);
+                    _logger.Warn("Series' root folder ({RootFolderPath}) is empty.", rootFolder);
                     _eventAggregator.PublishEvent(new SeriesScanSkippedEvent(series, SeriesScanSkippedReason.RootFolderIsEmpty));
                     return;
                 }
             }
 
-            _logger.ProgressInfo("Scanning {0}", series.Title);
+            _logger.ProgressInfo("Scanning {SeriesTitle}", series.Title);
 
             if (!seriesFolderExists)
             {
@@ -105,11 +105,11 @@ namespace NzbDrone.Core.MediaFiles
                 {
                     if (_configService.DeleteEmptyFolders)
                     {
-                        _logger.Debug("Not creating missing series folder: {0} because delete empty series folders is enabled", series.Path);
+                        _logger.Debug("Not creating missing series folder: {SeriesPath} because delete empty series folders is enabled", series.Path);
                     }
                     else
                     {
-                        _logger.Debug("Creating missing series folder: {0}", series.Path);
+                        _logger.Debug("Creating missing series folder: {SeriesPath}", series.Path);
 
                         _diskProvider.CreateFolder(series.Path);
                         SetPermissions(series.Path);
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
                 else
                 {
-                    _logger.Debug("Series folder doesn't exist: {0}", series.Path);
+                    _logger.Debug("Series folder doesn't exist: {SeriesPath}", series.Path);
                 }
 
                 CleanMediaFiles(series, new List<string>());
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.MediaFiles
             var videoFilesStopwatch = Stopwatch.StartNew();
             var mediaFileList = FilterPaths(series.Path, GetVideoFiles(series.Path)).ToList();
             videoFilesStopwatch.Stop();
-            _logger.Trace("Finished getting episode files for: {0} [{1}]", series, videoFilesStopwatch.Elapsed);
+            _logger.Trace("Finished getting episode files for: {SeriesTitle} [{Elapsed}]", series, videoFilesStopwatch.Elapsed);
 
             CleanMediaFiles(series, mediaFileList);
 
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.MediaFiles
             var decisionsStopwatch = Stopwatch.StartNew();
             var decisions = _importDecisionMaker.GetImportDecisions(unmappedFiles, series, false);
             decisionsStopwatch.Stop();
-            _logger.Trace("Import decisions complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
+            _logger.Trace("Import decisions complete for: {SeriesTitle} [{Elapsed}]", series, decisionsStopwatch.Elapsed);
             _importApprovedEpisodes.Import(decisions, false);
 
             // Update existing files that have a different file size
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             fileInfoStopwatch.Stop();
-            _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
+            _logger.Trace("Reprocessing existing files complete for: {SeriesTitle} [{Elapsed}]", series, decisionsStopwatch.Elapsed);
 
             RemoveEmptySeriesFolder(series.Path);
 
@@ -189,42 +189,42 @@ namespace NzbDrone.Core.MediaFiles
 
         private void CleanMediaFiles(Series series, List<string> mediaFileList)
         {
-            _logger.Debug("{0} Cleaning up media files in DB", series);
+            _logger.Debug("{SeriesTitle} Cleaning up media files in DB", series);
             _mediaFileTableCleanupService.Clean(series, mediaFileList);
         }
 
         private void CompletedScanning(Series series, List<string> possibleExtraFiles)
         {
-            _logger.Info("Completed scanning disk for {0}", series.Title);
+            _logger.Info("Completed scanning disk for {SeriesTitle}", series.Title);
             _eventAggregator.PublishEvent(new SeriesScannedEvent(series, possibleExtraFiles));
         }
 
         public string[] GetVideoFiles(string path, bool allDirectories = true)
         {
-            _logger.Debug("Scanning '{0}' for video files", path);
+            _logger.Debug("Scanning '{FolderPath}' for video files", path);
 
             var filesOnDisk = _diskProvider.GetFiles(path, allDirectories).ToList();
 
             var mediaFileList = filesOnDisk.Where(file => MediaFileExtensions.Extensions.Contains(Path.GetExtension(file)))
                                            .ToList();
 
-            _logger.Trace("{0} files were found in {1}", filesOnDisk.Count, path);
-            _logger.Debug("{0} video files were found in {1}", mediaFileList.Count, path);
+            _logger.Trace("{FileCount} files were found in {FolderPath}", filesOnDisk.Count, path);
+            _logger.Debug("{VideoFileCount} video files were found in {FolderPath}", mediaFileList.Count, path);
 
             return mediaFileList.ToArray();
         }
 
         public string[] GetNonVideoFiles(string path, bool allDirectories = true)
         {
-            _logger.Debug("Scanning '{0}' for non-video files", path);
+            _logger.Debug("Scanning '{FolderPath}' for non-video files", path);
 
             var filesOnDisk = _diskProvider.GetFiles(path, allDirectories).ToList();
 
             var mediaFileList = filesOnDisk.Where(file => !MediaFileExtensions.Extensions.Contains(Path.GetExtension(file)))
                                            .ToList();
 
-            _logger.Trace("{0} files were found in {1}", filesOnDisk.Count, path);
-            _logger.Debug("{0} non-video files were found in {1}", mediaFileList.Count, path);
+            _logger.Trace("{FileCount} files were found in {FolderPath}", filesOnDisk.Count, path);
+            _logger.Debug("{NonVideoFileCount} non-video files were found in {FolderPath}", mediaFileList.Count, path);
 
             return mediaFileList.ToArray();
         }

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesCommandService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesCommandService.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.MediaFiles
         {
             if (!_diskProvider.FolderExists(message.Path) && !_diskProvider.FileExists(message.Path))
             {
-                _logger.Warn("Folder/File specified for import scan [{0}] doesn't exist.", message.Path);
+                _logger.Warn("Folder/File specified for import scan [{FilePath}] doesn't exist.", message.Path);
                 return new List<ImportResult>();
             }
 
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.MediaFiles
 
                 if (trackedDownload != null)
                 {
-                    _logger.Debug("External directory scan request for known download {0}. [{1}]", message.DownloadClientId, message.Path);
+                    _logger.Debug("External directory scan request for known download {DownloadClientId}. [{FilePath}]", message.DownloadClientId, message.Path);
 
                     var importResults = _downloadedEpisodesImportService.ProcessPath(message.Path, message.ImportMode, trackedDownload.RemoteEpisode.Series, trackedDownload.DownloadItem);
 
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.MediaFiles
                     return importResults;
                 }
 
-                _logger.Warn("External directory scan request for unknown download {0}, attempting normal import. [{1}]", message.DownloadClientId, message.Path);
+                _logger.Warn("External directory scan request for unknown download {DownloadClientId}, attempting normal import. [{FilePath}]", message.DownloadClientId, message.Path);
             }
 
             return _downloadedEpisodesImportService.ProcessPath(message.Path, message.ImportMode);

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public List<ImportResult> ProcessPath(string path, ImportMode importMode = ImportMode.Auto, Series series = null, DownloadClientItem downloadClientItem = null)
         {
-            _logger.Debug("Processing path: {0}", path);
+            _logger.Debug("Processing path: {FilePath}", path);
 
             if (_diskProvider.FolderExists(path))
             {
@@ -124,14 +124,14 @@ namespace NzbDrone.Core.MediaFiles
 
                     if (episodeParseResult == null)
                     {
-                        _logger.Warn("Unable to parse file on import: [{0}]", videoFile);
+                        _logger.Warn("Unable to parse file on import: [{FilePath}]", videoFile);
                         return false;
                     }
 
                     if (_detectSample.IsSample(series, videoFile, episodeParseResult.IsPossibleSpecialEpisode) !=
                         DetectSampleResult.Sample)
                     {
-                        _logger.Warn("Non-sample file detected: [{0}]", videoFile);
+                        _logger.Warn("Non-sample file detected: [{FilePath}]", videoFile);
                         return false;
                     }
                 }
@@ -146,12 +146,12 @@ namespace NzbDrone.Core.MediaFiles
             }
             catch (DirectoryNotFoundException e)
             {
-                _logger.Debug(e, "Folder {0} has already been removed", directoryInfo.FullName);
+                _logger.Debug(e, "Folder {FolderPath} has already been removed", directoryInfo.FullName);
                 return false;
             }
             catch (Exception e)
             {
-                _logger.Debug(e, "Unable to determine whether folder {0} should be removed", directoryInfo.FullName);
+                _logger.Debug(e, "Unable to determine whether folder {FolderPath} should be removed", directoryInfo.FullName);
                 return false;
             }
         }
@@ -163,7 +163,7 @@ namespace NzbDrone.Core.MediaFiles
 
             if (series == null)
             {
-                _logger.Debug("Unknown Series {0}", cleanedUpName);
+                _logger.Debug("Unknown Series {SeriesTitle}", cleanedUpName);
 
                 return new List<ImportResult>
                        {
@@ -233,7 +233,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
                 catch (IOException e)
                 {
-                    _logger.Debug(e, "Unable to delete folder after importing: {0}", e.Message);
+                    _logger.Debug(e, "Unable to delete folder after importing: {Message}", e.Message);
                 }
             }
             else if (importResults.Empty())
@@ -250,7 +250,7 @@ namespace NzbDrone.Core.MediaFiles
 
             if (series == null)
             {
-                _logger.Debug("Unknown Series for file: {0}", fileInfo.Name);
+                _logger.Debug("Unknown Series for file: {FileName}", fileInfo.Name);
 
                 return new List<ImportResult>
                        {
@@ -265,7 +265,7 @@ namespace NzbDrone.Core.MediaFiles
         {
             if (Path.GetFileNameWithoutExtension(fileInfo.Name).StartsWith("._"))
             {
-                _logger.Debug("[{0}] starts with '._', skipping", fileInfo.FullName);
+                _logger.Debug("[{FilePath}] starts with '._', skipping", fileInfo.FullName);
 
                 return new List<ImportResult>
                        {
@@ -318,7 +318,7 @@ namespace NzbDrone.Core.MediaFiles
 
             if (extension.IsNullOrWhiteSpace() || !MediaFileExtensions.Extensions.Contains(extension))
             {
-                _logger.Debug("[{0}] has an unsupported extension: '{1}'", fileInfo.FullName, extension);
+                _logger.Debug("[{FilePath}] has an unsupported extension: '{Extension}'", fileInfo.FullName, extension);
 
                 return new List<ImportResult>
                        {
@@ -355,7 +355,7 @@ namespace NzbDrone.Core.MediaFiles
 
         private ImportResult FileIsLockedResult(string videoFile)
         {
-            _logger.Debug("[{0}] is currently locked by another process, skipping", videoFile);
+            _logger.Debug("[{FilePath}] is currently locked by another process, skipping", videoFile);
             return new ImportResult(new ImportDecision(new LocalEpisode { Path = videoFile }, new ImportRejection(ImportRejectionReason.FileLocked, "Locked file, try again later")), "Locked file, try again later");
         }
 
@@ -402,13 +402,13 @@ namespace NzbDrone.Core.MediaFiles
 
                 if (mount == null)
                 {
-                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {0}. Unable to find a volume mounted for the path. If you're using a mapped network drive see the FAQ for more info", path);
+                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {FilePath}. Unable to find a volume mounted for the path. If you're using a mapped network drive see the FAQ for more info", path);
                     return;
                 }
 
                 if (mount.DriveType == DriveType.Network)
                 {
-                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {0}. It's recommended to avoid mapped network drives when running as a Windows service. See the FAQ for more info", path);
+                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {FilePath}. It's recommended to avoid mapped network drives when running as a Windows service. See the FAQ for more info", path);
                     return;
                 }
             }
@@ -417,12 +417,12 @@ namespace NzbDrone.Core.MediaFiles
             {
                 if (path.StartsWith(@"\\"))
                 {
-                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {0}. Ensure the user running Sonarr has access to the network share", path);
+                    _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {FilePath}. Ensure the user running Sonarr has access to the network share", path);
                     return;
                 }
             }
 
-            _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {0}. Ensure the path exists and the user running Sonarr has the correct permissions to access this file/folder", path);
+            _logger.Error("Import failed, path does not exist or is not accessible by Sonarr: {FilePath}. Ensure the path exists and the user running Sonarr has the correct permissions to access this file/folder", path);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.MediaFiles
 
             EnsureEpisodeFolder(episodeFile, series, episodes.Select(v => v.SeasonNumber).First(), filePath);
 
-            _logger.Debug("Renaming episode file: {0} to {1}", episodeFile, filePath);
+            _logger.Debug("Renaming episode file: {SourcePath} to {DestinationPath}", episodeFile, filePath);
 
             return TransferFile(episodeFile, series, episodes, filePath, TransferMode.Move);
         }
@@ -86,7 +86,7 @@ namespace NzbDrone.Core.MediaFiles
 
             EnsureEpisodeFolder(episodeFile, localEpisode, filePath);
 
-            _logger.Debug("Moving episode file: {0} to {1}", episodeFile.Path, filePath);
+            _logger.Debug("Moving episode file: {SourcePath} to {DestinationPath}", episodeFile.Path, filePath);
 
             return TransferFile(episodeFile, localEpisode.Series, localEpisode.Episodes, filePath, TransferMode.Move, localEpisode);
         }
@@ -99,11 +99,11 @@ namespace NzbDrone.Core.MediaFiles
 
             if (_configService.CopyUsingHardlinks)
             {
-                _logger.Debug("Attempting to hardlink episode file: {0} to {1}", episodeFile.Path, filePath);
+                _logger.Debug("Attempting to hardlink episode file: {SourcePath} to {DestinationPath}", episodeFile.Path, filePath);
                 return TransferFile(episodeFile, localEpisode.Series, localEpisode.Episodes, filePath, TransferMode.HardLinkOrCopy, localEpisode);
             }
 
-            _logger.Debug("Copying episode file: {0} to {1}", episodeFile.Path, filePath);
+            _logger.Debug("Copying episode file: {SourcePath} to {DestinationPath}", episodeFile.Path, filePath);
             return TransferFile(episodeFile, localEpisode.Series, localEpisode.Episodes, filePath, TransferMode.Copy, localEpisode);
         }
 
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.MediaFiles
             }
             catch (IOException ex)
             {
-                _logger.Error(ex, "Unable to create directory: {0}", directoryName);
+                _logger.Error(ex, "Unable to create directory: {DirectoryPath}", directoryName);
             }
 
             _mediaFileAttributeService.SetFolderPermissions(directoryName);

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguage.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateLanguage.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                     continue;
                 }
 
-                _logger.Trace("Considering Languages {0} ({1}) from {2}", string.Join(", ", augmentedLanguage.Languages ?? new List<Language>()), augmentedLanguage.Confidence, augmentLanguage.Name);
+                _logger.Trace("Considering Languages {Languages} ({Confidence}) from {AugmenterName}", string.Join(", ", augmentedLanguage.Languages ?? new List<Language>()), augmentedLanguage.Confidence, augmentLanguage.Name);
 
                 if (augmentedLanguage?.Languages != null &&
                     augmentedLanguage.Languages.Count > 0 &&
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                 }
             }
 
-            _logger.Debug("Selected languages: {0}", string.Join(", ", languages.ToList()));
+            _logger.Debug("Selected languages: {Languages}", string.Join(", ", languages.ToList()));
 
             localEpisode.Languages = languages;
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateQuality.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateQuality.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                     continue;
                 }
 
-                _logger.Trace("Considering Source {0} ({1}) Resolution {2} ({3}) Revision {4} from {5}", augmentedQuality.Source, augmentedQuality.SourceConfidence, augmentedQuality.Resolution, augmentedQuality.ResolutionConfidence, augmentedQuality.Revision, augmentQuality.Name);
+                _logger.Trace("Considering Source {Source} ({SourceConfidence}) Resolution {Resolution} ({ResolutionConfidence}) Revision {Revision} from {AugmenterName}", augmentedQuality.Source, augmentedQuality.SourceConfidence, augmentedQuality.Resolution, augmentedQuality.ResolutionConfidence, augmentedQuality.Revision, augmentQuality.Name);
 
                 if (source == QualitySource.Unknown ||
                     (augmentedQuality.SourceConfidence > sourceConfidence && augmentedQuality.Source != QualitySource.Unknown))
@@ -76,7 +76,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                 }
             }
 
-            _logger.Trace("Selected Source {0} ({1}) Resolution {2} ({3}) Revision {4}", source, sourceConfidence, resolution, resolutionConfidence, revision);
+            _logger.Trace("Selected Source {Source} ({SourceConfidence}) Resolution {Resolution} ({ResolutionConfidence}) Revision {Revision}", source, sourceConfidence, resolution, resolutionConfidence, revision);
 
             var quality = new QualityModel(QualityFinder.FindBySourceAndResolution(source, resolution), revision);
 
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
             quality.RevisionDetectionSource = revisionConfidence == Confidence.Tag ? QualityDetectionSource.Name : QualityDetectionSource.Unknown;
 
-            _logger.Debug("Using quality: {0}", quality);
+            _logger.Debug("Using quality: {Quality}", quality);
 
             localEpisode.Quality = quality;
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateSubtitleInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateSubtitleInfo.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
             if (subtitleTitleInfo.TitleFirst && (episodeFileTitle.Contains(subtitleTitleInfo.RawTitle, StringComparison.OrdinalIgnoreCase) || originalEpisodeFileTitle.Contains(subtitleTitleInfo.RawTitle, StringComparison.OrdinalIgnoreCase)))
             {
-                _logger.Debug("Subtitle title '{0}' is in episode file title '{1}'. Removing from subtitle title.", subtitleTitleInfo.RawTitle, episodeFileTitle);
+                _logger.Debug("Subtitle title '{SubtitleTitle}' is in episode file title '{EpisodeFileTitle}'. Removing from subtitle title.", subtitleTitleInfo.RawTitle, episodeFileTitle);
 
                 subtitleTitleInfo = LanguageParser.ParseBasicSubtitle(path);
             }
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
             if (cleanedTags.Count != subtitleTitleInfo.LanguageTags.Count)
             {
-                _logger.Debug("Removed language tags '{0}' from subtitle title '{1}'.", string.Join(", ", subtitleTitleInfo.LanguageTags.Except(cleanedTags)), subtitleTitleInfo.RawTitle);
+                _logger.Debug("Removed language tags '{LanguageTags}' from subtitle title '{SubtitleTitle}'.", string.Join(", ", subtitleTitleInfo.LanguageTags.Except(cleanedTags)), subtitleTitleInfo.RawTitle);
                 subtitleTitleInfo.LanguageTags = cleanedTags;
             }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -47,35 +47,35 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators.Augment
 
             if (width >= 3200 || height >= 2100)
             {
-                _logger.Trace("Resolution {0}x{1} considered 2160p", width, height);
+                _logger.Trace("Resolution {Width}x{Height} considered 2160p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, 2160, Confidence.MediaInfo);
             }
 
             if (width >= 1800 || height >= 1000)
             {
-                _logger.Trace("Resolution {0}x{1} considered 1080p", width, height);
+                _logger.Trace("Resolution {Width}x{Height} considered 1080p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, 1080, Confidence.MediaInfo);
             }
 
             if (width >= 1200 || height >= 700)
             {
-                _logger.Trace("Resolution {0}x{1} considered 720p", width, height);
+                _logger.Trace("Resolution {Width}x{Height} considered 720p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, 720, Confidence.MediaInfo);
             }
 
             if (width >= 1000 || height >= 560)
             {
-                _logger.Trace("Resolution {0}x{1} considered 576p", width, height);
+                _logger.Trace("Resolution {Width}x{Height} considered 576p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, 576, Confidence.MediaInfo);
             }
 
             if (width > 0 && height > 0)
             {
-                _logger.Trace("Resolution {0}x{1} considered 480p", width, height);
+                _logger.Trace("Resolution {Width}x{Height} considered 480p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, 480, Confidence.MediaInfo);
             }
 
-            _logger.Trace("Resolution {0}x{1}", width, height);
+            _logger.Trace("Resolution {Width}x{Height}", width, height);
 
             return null;
         }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/DetectSample.cs
@@ -106,17 +106,17 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
             if (fileRuntime.TotalMinutes.Equals(0))
             {
-                _logger.Error("[{0}] has a runtime of 0, is it a valid video file?", path);
+                _logger.Error("[{FilePath}] has a runtime of 0, is it a valid video file?", path);
                 return DetectSampleResult.Sample;
             }
 
             if (fileRuntime.TotalSeconds < minimumRuntime)
             {
-                _logger.Debug("[{0}] appears to be a sample. Runtime: {1} seconds. Expected at least: {2} seconds", path, fileRuntime, minimumRuntime);
+                _logger.Debug("[{FilePath}] appears to be a sample. Runtime: {Runtime} seconds. Expected at least: {MinimumRuntime} seconds", path, fileRuntime, minimumRuntime);
                 return DetectSampleResult.Sample;
             }
 
-            _logger.Debug("[{0}] does not appear to be a sample. Runtime {1} seconds is more than minimum of {2} seconds", path, fileRuntime, minimumRuntime);
+            _logger.Debug("[{FilePath}] does not appear to be a sample. Runtime {Runtime} seconds is more than minimum of {MinimumRuntime} seconds", path, fileRuntime, minimumRuntime);
             return DetectSampleResult.NotSample;
         }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportDecisionMaker.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
         {
             var newFiles = filterExistingFiles ? _mediaFileService.FilterExistingFiles(videoFiles.ToList(), series) : videoFiles.ToList();
 
-            _logger.Debug("Analyzing {0}/{1} files.", newFiles.Count, videoFiles.Count);
+            _logger.Debug("Analyzing {NewFileCount}/{TotalFileCount} files.", newFiles.Count, videoFiles.Count);
 
             // If not importing from a scene source (series folder for example), then assume all files are not samples
             // to avoid using media info on every file needlessly (especially if Analyse Media Files is disabled).
@@ -161,18 +161,18 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Couldn't import file. {0}", localEpisode.Path);
+                _logger.Error(ex, "Couldn't import file. {FilePath}", localEpisode.Path);
 
                 decision = new ImportDecision(localEpisode, new ImportRejection(ImportRejectionReason.Error, "Unexpected error processing file"));
             }
 
             if (decision == null)
             {
-                _logger.Error("Unable to make a decision on {0}", localEpisode.Path);
+                _logger.Error("Unable to make a decision on {FilePath}", localEpisode.Path);
             }
             else if (decision.Rejections.Any())
             {
-                _logger.Debug("File rejected for the following reasons: {0}", string.Join(", ", decision.Rejections));
+                _logger.Debug("File rejected for the following reasons: {Rejections}", string.Join(", ", decision.Rejections));
             }
             else
             {
@@ -197,7 +197,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             {
                 // e.Data.Add("report", remoteEpisode.Report.ToJson());
                 // e.Data.Add("parsed", remoteEpisode.ParsedEpisodeInfo.ToJson());
-                _logger.Error(e, "Couldn't evaluate decision on {0}", localEpisode.Path);
+                _logger.Error(e, "Couldn't evaluate decision on {FilePath}", localEpisode.Path);
                 return new ImportRejection(ImportRejectionReason.DecisionError, $"{spec.GetType().Name}: {e.Message}");
             }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             if (languageParse.Count <= 1 && languageParse.First() == Language.Unknown && series != null)
             {
                 languageParse = new List<Language> { series.OriginalLanguage };
-                _logger.Debug("Language couldn't be parsed from release, falling back to series original language: {0}", series.OriginalLanguage.Name);
+                _logger.Debug("Language couldn't be parsed from release, falling back to series original language: {OriginalLanguage}", series.OriginalLanguage.Name);
             }
 
             if (episodeIds.Any())
@@ -362,7 +362,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             }
             catch (Exception ex)
             {
-                _logger.Warn(ex, "Failed to process file: {0}", file);
+                _logger.Warn(ex, "Failed to process file: {FilePath}", file);
             }
 
             return new ManualImportItem
@@ -427,11 +427,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (seasons.Empty())
                 {
-                    _logger.Warn("Expected one season, but found none for: {0}", decision.LocalEpisode.Path);
+                    _logger.Warn("Expected one season, but found none for: {FilePath}", decision.LocalEpisode.Path);
                 }
                 else if (seasons.Count > 1)
                 {
-                    _logger.Warn("Expected one season, but found {0} ({1}) for: {2}", seasons.Count, string.Join(", ", seasons), decision.LocalEpisode.Path);
+                    _logger.Warn("Expected one season, but found {SeasonCount} ({Seasons}) for: {FilePath}", seasons.Count, string.Join(", ", seasons), decision.LocalEpisode.Path);
                 }
                 else
                 {
@@ -484,7 +484,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
         public void Execute(ManualImportCommand message)
         {
-            _logger.ProgressTrace("Manually importing {0} files using mode {1}", message.Files.Count, message.ImportMode);
+            _logger.ProgressTrace("Manually importing {FileCount} files using mode {ImportMode}", message.Files.Count, message.ImportMode);
 
             var imported = new List<ImportResult>();
             var importedTrackedDownload = new List<ManuallyImportedFile>();
@@ -492,7 +492,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
             for (var i = 0; i < message.Files.Count; i++)
             {
-                _logger.ProgressTrace("Processing file {0} of {1}", i + 1, message.Files.Count);
+                _logger.ProgressTrace("Processing file {CurrentFile} of {TotalFiles}", i + 1, message.Files.Count);
 
                 var file = message.Files[i];
                 var series = _seriesService.GetSeries(file.SeriesId);
@@ -571,7 +571,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
             if (imported.Any())
             {
-                _logger.ProgressTrace("Manually imported {0} files", imported.Count);
+                _logger.ProgressTrace("Manually imported {FileCount} files", imported.Count);
             }
 
             var untrackedImports = importedUntrackedDownload.Where(i => i.Result == ImportResultType.Imported).ToList();

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/AlreadyImportedSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/AlreadyImportedSpecification.cs
@@ -63,13 +63,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                     // If the release was imported after the last grab reject it
                     if (lastImported.Date.After(lastGrabbed.Date))
                     {
-                        _logger.Debug("Episode file previously imported at {0}", lastImported.Date);
+                        _logger.Debug("Episode file previously imported at {ImportDate}", lastImported.Date);
                         return ImportSpecDecision.Reject(ImportRejectionReason.EpisodeAlreadyImported, "Episode file already imported at {0}", lastImported.Date.ToLocalTime());
                     }
                 }
                 else
                 {
-                    _logger.Debug("Episode file previously imported at {0}", lastImported.Date);
+                    _logger.Debug("Episode file previously imported at {ImportDate}", lastImported.Date);
                     return ImportSpecDecision.Reject(ImportRejectionReason.EpisodeAlreadyImported, "Episode file already imported at {0}", lastImported.Date.ToLocalTime());
                 }
             }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/EpisodeTitleSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/EpisodeTitleSpecification.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
         {
             if (localEpisode.ExistingFile)
             {
-                _logger.Debug("{0} is in series folder, skipping check", localEpisode.Path);
+                _logger.Debug("{FilePath} is in series folder, skipping check", localEpisode.Path);
                 return ImportSpecDecision.Accept();
             }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/FreeSpaceSpecification.cs
@@ -43,13 +43,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (!freeSpace.HasValue)
                 {
-                    _logger.Debug("Free space check returned an invalid result for: {0}", path);
+                    _logger.Debug("Free space check returned an invalid result for: {FolderPath}", path);
                     return ImportSpecDecision.Accept();
                 }
 
                 if (freeSpace < localEpisode.Size + _configService.MinimumFreeSpaceWhenImporting.Megabytes())
                 {
-                    _logger.Warn("Not enough free space ({0}) to import: {1} ({2})", freeSpace, localEpisode, localEpisode.Size);
+                    _logger.Warn("Not enough free space ({FreeSpace}) to import: {FilePath} ({FileSize})", freeSpace, localEpisode, localEpisode.Size);
                     return ImportSpecDecision.Reject(ImportRejectionReason.MinimumFreeSpace, "Not enough free space");
                 }
             }
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Unable to check free disk space while importing. {0}", localEpisode.Path);
+                _logger.Error(ex, "Unable to check free disk space while importing. {FilePath}", localEpisode.Path);
             }
 
             return ImportSpecDecision.Accept();

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecification.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
             if (unexpected.Any())
             {
-                _logger.Debug("Unexpected episode(s) in file: {0}", FormatEpisode(unexpected));
+                _logger.Debug("Unexpected episode(s) in file: {Episodes}", FormatEpisode(unexpected));
 
                 if (unexpected.Count == 1)
                 {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesGrabSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/MatchesGrabSpecification.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
             if (unexpected.Any())
             {
-                _logger.Debug("Unexpected episode(s) in file: {0}", FormatEpisode(unexpected));
+                _logger.Debug("Unexpected episode(s) in file: {Episodes}", FormatEpisode(unexpected));
 
                 if (unexpected.Count == 1)
                 {

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotUnpackingSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/NotUnpackingSpecification.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
         {
             if (localEpisode.ExistingFile)
             {
-                _logger.Debug("{0} is in series folder, skipping unpacking check", localEpisode.Path);
+                _logger.Debug("{FilePath} is in series folder, skipping unpacking check", localEpisode.Path);
                 return ImportSpecDecision.Accept();
             }
 
@@ -39,13 +39,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                     {
                         if (OsInfo.IsNotWindows)
                         {
-                            _logger.Debug("{0} is still being unpacked", localEpisode.Path);
+                            _logger.Debug("{FilePath} is still being unpacked", localEpisode.Path);
                             return ImportSpecDecision.Reject(ImportRejectionReason.Unpacking, "File is still being unpacked");
                         }
 
                         if (_diskProvider.FileGetLastWrite(localEpisode.Path) > DateTime.UtcNow.AddMinutes(-5))
                         {
-                            _logger.Debug("{0} appears to be unpacking still", localEpisode.Path);
+                            _logger.Debug("{FilePath} appears to be unpacking still", localEpisode.Path);
                             return ImportSpecDecision.Reject(ImportRejectionReason.Unpacking, "File is still being unpacked");
                         }
                     }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UnverifiedSceneNumberingSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UnverifiedSceneNumberingSpecification.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
             if (localEpisode.Episodes.Any(v => v.UnverifiedSceneNumbering))
             {
-                _logger.Debug("This file uses unverified scene numbers, will not auto-import until numbering is confirmed on TheXEM. Skipping {0}", localEpisode.Path);
+                _logger.Debug("This file uses unverified scene numbers, will not auto-import until numbering is confirmed on TheXEM. Skipping {FilePath}", localEpisode.Path);
                 return ImportSpecDecision.Reject(ImportRejectionReason.UnverifiedSceneMapping, "This show has individual episode mappings on TheXEM but the mapping for this episode has not been confirmed yet by their administrators. TheXEM needs manual input.");
             }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Specifications/UpgradeSpecification.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (episodeFile == null)
                 {
-                    _logger.Trace("Unable to get episode file details from the DB. EpisodeId: {0} EpisodeFileId: {1}", episode.Id, episode.EpisodeFileId);
+                    _logger.Trace("Unable to get episode file details from the DB. EpisodeId: {EpisodeId} EpisodeFileId: {EpisodeFileId}", episode.Id, episode.EpisodeFileId);
                     continue;
                 }
 
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (qualityCompare < 0)
                 {
-                    _logger.Debug("This file isn't a quality upgrade for all episodes. Existing quality: {0}. New Quality {1}. Skipping {2}", episodeFile.Quality.Quality, localEpisode.Quality.Quality, localEpisode.Path);
+                    _logger.Debug("This file isn't a quality upgrade for all episodes. Existing quality: {ExistingQuality}. New Quality {NewQuality}. Skipping {FilePath}", episodeFile.Quality.Quality, localEpisode.Quality.Quality, localEpisode.Path);
                     return ImportSpecDecision.Reject(ImportRejectionReason.NotQualityUpgrade, "Not an upgrade for existing episode file(s). Existing quality: {0}. New Quality {1}.", episodeFile.Quality.Quality, localEpisode.Quality.Quality);
                 }
 
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                     downloadPropersAndRepacks != ProperDownloadTypes.DoNotPrefer &&
                     localEpisode.Quality.Revision.CompareTo(episodeFile.Quality.Revision) < 0)
                 {
-                    _logger.Debug("This file isn't a quality revision upgrade for all episodes. Skipping {0}", localEpisode.Path);
+                    _logger.Debug("This file isn't a quality revision upgrade for all episodes. Skipping {FilePath}", localEpisode.Path);
                     return ImportSpecDecision.Reject(ImportRejectionReason.NotRevisionUpgrade, "Not a quality revision upgrade for existing episode file(s)");
                 }
 
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
 
                 if (qualityCompare == 0 && newFormatScore < currentFormatScore)
                 {
-                    _logger.Debug("New item's custom formats [{0}] ({1}) do not improve on [{2}] ({3}), skipping",
+                    _logger.Debug("New item's custom formats [{NewFormats}] ({NewFormatScore}) do not improve on [{CurrentFormats}] ({CurrentFormatScore}), skipping",
                         newFormats != null ? newFormats.ConcatToString() : "",
                         newFormatScore,
                         currentFormats != null ? currentFormats.ConcatToString() : "",
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Specifications
                         currentFormatScore);
                 }
 
-                _logger.Debug("New item's custom formats [{0}] ({1}) improve on [{2}] ({3}), accepting",
+                _logger.Debug("New item's custom formats [{NewFormats}] ({NewFormatScore}) improve on [{CurrentFormats}] ({CurrentFormatScore}), accepting",
                     newFormats != null ? newFormats.ConcatToString() : "",
                     newFormatScore,
                     currentFormats != null ? currentFormats.ConcatToString() : "",

--- a/src/NzbDrone.Core/MediaFiles/MediaFileAttributeService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileAttributeService.cs
@@ -42,12 +42,12 @@ namespace NzbDrone.Core.MediaFiles
                 {
                     if (ex is UnauthorizedAccessException || ex is InvalidOperationException || ex is FileNotFoundException)
                     {
-                        _logger.Debug("Unable to apply folder permissions to {0}", path);
+                        _logger.Debug("Unable to apply folder permissions to {FolderPath}", path);
                         _logger.Debug(ex, ex.Message);
                     }
                     else
                     {
-                        _logger.Warn("Unable to apply folder permissions to: {0}", path);
+                        _logger.Warn("Unable to apply folder permissions to: {FolderPath}", path);
                         _logger.Warn(ex, ex.Message);
                     }
                 }
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.MediaFiles
         {
             if (OsInfo.IsWindows)
             {
-                _logger.Debug("Setting last write time on series folder: {0}", path);
+                _logger.Debug("Setting last write time on series folder: {FolderPath}", path);
                 _diskProvider.FolderSetLastWriteTime(path, time);
             }
         }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -66,19 +66,19 @@ namespace NzbDrone.Core.MediaFiles
 
             if (!_diskProvider.FolderExists(rootFolder))
             {
-                _logger.Warn("Series' root folder ({0}) doesn't exist.", rootFolder);
+                _logger.Warn("Series' root folder ({RootFolderPath}) doesn't exist.", rootFolder);
                 throw new NzbDroneClientException(HttpStatusCode.Conflict, "Series' root folder ({0}) doesn't exist.", rootFolder);
             }
 
             if (_diskProvider.GetDirectories(rootFolder).Empty())
             {
-                _logger.Warn("Series' root folder ({0}) is empty.", rootFolder);
+                _logger.Warn("Series' root folder ({RootFolderPath}) is empty.", rootFolder);
                 throw new NzbDroneClientException(HttpStatusCode.Conflict, "Series' root folder ({0}) is empty.", rootFolder);
             }
 
             if (_diskProvider.FolderExists(series.Path) && _diskProvider.FileExists(fullPath))
             {
-                _logger.Info("Deleting episode file: {0}", fullPath);
+                _logger.Info("Deleting episode file: {FilePath}", fullPath);
 
                 var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
 
@@ -108,11 +108,11 @@ namespace NzbDrone.Core.MediaFiles
                     var series = _seriesService.GetSeries(seriesId);
                     var mediaFiles = _mediaFileService.GetFilesBySeries(seriesId);
 
-                    _logger.ProgressDebug("{0}: Deleting episode files}", series.Title);
+                    _logger.ProgressDebug("{SeriesTitle}: Deleting episode files", series.Title);
 
                     if (mediaFiles.Count == 0)
                     {
-                        _logger.Debug("No files found for series: {0}", series.Title);
+                        _logger.Debug("No files found for series: {SeriesTitle}", series.Title);
                         continue;
                     }
 
@@ -120,21 +120,21 @@ namespace NzbDrone.Core.MediaFiles
 
                     if (!_diskProvider.FolderExists(rootFolder))
                     {
-                        _logger.Warn("Series' root folder ({0}) doesn't exist.", rootFolder);
+                        _logger.Warn("Series' root folder ({RootFolderPath}) doesn't exist.", rootFolder);
                         _commandResultReporter.Report(CommandResult.Indeterminate);
                         continue;
                     }
 
                     if (_diskProvider.GetDirectories(rootFolder).Empty())
                     {
-                        _logger.Warn("Series' root folder ({0}) is empty.", rootFolder);
+                        _logger.Warn("Series' root folder ({RootFolderPath}) is empty.", rootFolder);
                         _commandResultReporter.Report(CommandResult.Indeterminate);
                         continue;
                     }
 
                     if (!_diskProvider.FolderExists(series.Path))
                     {
-                        _logger.Warn("Series' folder ({0}) does not exist.", series.Path);
+                        _logger.Warn("Series' folder ({SeriesPath}) does not exist.", series.Path);
                         _commandResultReporter.Report(CommandResult.Indeterminate);
                         continue;
                     }
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.MediaFiles
 
                         if (_diskProvider.FileExists(fullPath))
                         {
-                            _logger.Info("Deleting episode file: {0}", fullPath);
+                            _logger.Info("Deleting episode file: {FilePath}", fullPath);
 
                             var subfolder = _diskProvider.GetParentFolder(series.Path).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
 
@@ -164,11 +164,11 @@ namespace NzbDrone.Core.MediaFiles
                         }
                     }
 
-                    _logger.ProgressDebug("{0}: Deleted episode files", series.Title);
+                    _logger.ProgressDebug("{SeriesTitle}: Deleted episode files", series.Title);
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, "Unable to delete files for series with ID: {0}", seriesId);
+                    _logger.Warn(ex, "Unable to delete files for series with ID: {SeriesId}", seriesId);
                     _commandResultReporter.Report(CommandResult.Indeterminate);
                 }
             }
@@ -191,13 +191,13 @@ namespace NzbDrone.Core.MediaFiles
 
                         if (series.Path.IsParentPath(s.Value))
                         {
-                            _logger.Error("Series path: '{0}' is a parent of another series, not deleting files.", series.Path);
+                            _logger.Error("Series path: '{SeriesPath}' is a parent of another series, not deleting files.", series.Path);
                             return;
                         }
 
                         if (series.Path.PathEquals(s.Value))
                         {
-                            _logger.Error("Series path: '{0}' is the same as another series, not deleting files.", series.Path);
+                            _logger.Error("Series path: '{SeriesPath}' is the same as another series, not deleting files.", series.Path);
                             return;
                         }
                     }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileTableCleanupService.cs
@@ -44,14 +44,14 @@ namespace NzbDrone.Core.MediaFiles
                 {
                     if (!filesOnDiskKeys.Contains(episodeFilePath))
                     {
-                        _logger.Debug("File [{0}] no longer exists on disk, removing from db", episodeFilePath);
+                        _logger.Debug("File [{FilePath}] no longer exists on disk, removing from db", episodeFilePath);
                         _mediaFileService.Delete(seriesFile, DeleteMediaFileReason.MissingFromDisk);
                         continue;
                     }
 
                     if (episodes.None(e => e.EpisodeFileId == episodeFile.Id))
                     {
-                        _logger.Debug("File [{0}] is not assigned to any episodes, removing from db", episodeFilePath);
+                        _logger.Debug("File [{FilePath}] is not assigned to any episodes, removing from db", episodeFilePath);
                         _mediaFileService.Delete(episodeFile, DeleteMediaFileReason.NoLinkedEpisodes);
                         continue;
                     }
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Unable to cleanup EpisodeFile in DB: {0}", episodeFile.Id);
+                    _logger.Error(ex, "Unable to cleanup EpisodeFile in DB: {EpisodeFileId}", episodeFile.Id);
                 }
             }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (!_diskProvider.FileExists(path))
             {
-                _logger.Debug("Can't update MediaInfo because '{0}' does not exist", path);
+                _logger.Debug("Can't update MediaInfo because '{FilePath}' does not exist", path);
                 return false;
             }
 
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 _mediaFileService.Update(episodeFile);
             }
 
-            _logger.Debug("Updated MediaInfo for '{0}'", path);
+            _logger.Debug("Updated MediaInfo for '{FilePath}'", path);
 
             return true;
         }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             try
             {
-                _logger.Debug("Getting media info from {0}", filename);
+                _logger.Debug("Getting media info from {FilePath}", filename);
 
                 var analysis = FFProbe.Analyse(filename, customArguments: "-probesize 50000000");
                 var primaryVideoStream = GetPrimaryVideoStream(analysis);
@@ -165,7 +165,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Unable to parse media info from file: {0}", filename);
+                _logger.Error(ex, "Unable to parse media info from file: {FilePath}", filename);
             }
 
             return null;

--- a/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
+++ b/src/NzbDrone.Core/MediaFiles/RecycleBinProvider.cs
@@ -40,41 +40,41 @@ namespace NzbDrone.Core.MediaFiles
 
         public void DeleteFolder(string path)
         {
-            _logger.Info("Attempting to send '{0}' to recycling bin", path);
+            _logger.Info("Attempting to send '{FolderPath}' to recycling bin", path);
             var recyclingBin = _configService.RecycleBin;
 
             if (string.IsNullOrWhiteSpace(recyclingBin))
             {
-                _logger.Info("Recycling Bin has not been configured, deleting permanently. {0}", path);
+                _logger.Info("Recycling Bin has not been configured, deleting permanently. {FolderPath}", path);
                 _diskProvider.DeleteFolder(path, true);
-                _logger.Debug("Folder has been permanently deleted: {0}", path);
+                _logger.Debug("Folder has been permanently deleted: {FolderPath}", path);
             }
             else
             {
                 var destination = Path.Combine(recyclingBin, new DirectoryInfo(path).Name);
 
-                _logger.Debug("Moving '{0}' to '{1}'", path, destination);
+                _logger.Debug("Moving '{SourcePath}' to '{DestinationPath}'", path, destination);
                 _diskTransferService.TransferFolder(path, destination, TransferMode.Move);
 
-                _logger.Debug("Setting last accessed: {0}", path);
+                _logger.Debug("Setting last accessed: {FolderPath}", path);
                 _diskProvider.FolderSetLastWriteTime(destination, DateTime.UtcNow);
                 foreach (var file in _diskProvider.GetFiles(destination, true))
                 {
                     SetLastWriteTime(file, DateTime.UtcNow);
                 }
 
-                _logger.Debug("Folder has been moved to the recycling bin: {0}", destination);
+                _logger.Debug("Folder has been moved to the recycling bin: {DestinationPath}", destination);
             }
         }
 
         public string DeleteFile(string path, string subfolder = "")
         {
-            _logger.Debug("Attempting to send '{0}' to recycling bin", path);
+            _logger.Debug("Attempting to send '{FilePath}' to recycling bin", path);
             var recyclingBin = _configService.RecycleBin;
 
             if (string.IsNullOrWhiteSpace(recyclingBin))
             {
-                _logger.Info("Recycling Bin has not been configured, deleting permanently. {0}", path);
+                _logger.Info("Recycling Bin has not been configured, deleting permanently. {FilePath}", path);
 
                 if (OsInfo.IsWindows)
                 {
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.MediaFiles
                 }
 
                 _diskProvider.DeleteFile(path);
-                _logger.Debug("File has been permanently deleted: {0}", path);
+                _logger.Debug("File has been permanently deleted: {FilePath}", path);
 
                 return null;
             }
@@ -94,12 +94,12 @@ namespace NzbDrone.Core.MediaFiles
 
                 try
                 {
-                    _logger.Debug("Creating folder {0}", destinationFolder);
+                    _logger.Debug("Creating folder {FolderPath}", destinationFolder);
                     _diskProvider.CreateFolder(destinationFolder);
                 }
                 catch (IOException e)
                 {
-                    _logger.Error(e, "Unable to create the folder '{0}' in the recycling bin for the file '{1}'", destinationFolder, fileInfo.Name);
+                    _logger.Error(e, "Unable to create the folder '{FolderPath}' in the recycling bin for the file '{FileName}'", destinationFolder, fileInfo.Name);
                     throw new RecycleBinException($"Unable to create the folder '{destinationFolder}' in the recycling bin for the file '{fileInfo.Name}'", e);
                 }
 
@@ -119,18 +119,18 @@ namespace NzbDrone.Core.MediaFiles
 
                 try
                 {
-                    _logger.Debug("Moving '{0}' to '{1}'", path, destination);
+                    _logger.Debug("Moving '{SourcePath}' to '{DestinationPath}'", path, destination);
                     _diskTransferService.TransferFile(path, destination, TransferMode.Move);
                 }
                 catch (IOException e)
                 {
-                    _logger.Error(e, "Unable to move '{0}' to the recycling bin: '{1}'", path, destination);
+                    _logger.Error(e, "Unable to move '{SourcePath}' to the recycling bin: '{DestinationPath}'", path, destination);
                     throw new RecycleBinException($"Unable to move '{path}' to the recycling bin: '{destination}'", e);
                 }
 
                 SetLastWriteTime(destination, DateTime.UtcNow);
 
-                _logger.Debug("File has been moved to the recycling bin: {0}", destination);
+                _logger.Debug("File has been moved to the recycling bin: {DestinationPath}", destination);
 
                 return destination;
             }
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.MediaFiles
                 return;
             }
 
-            _logger.Info("Removing items older than {0} days from the recycling bin", cleanupDays);
+            _logger.Info("Removing items older than {CleanupDays} days from the recycling bin", cleanupDays);
 
             var removedFiles = new List<string>();
             var skippedFiles = new List<string>();
@@ -184,19 +184,19 @@ namespace NzbDrone.Core.MediaFiles
             {
                 if (_diskProvider.FileGetLastWrite(file).AddDays(cleanupDays) > DateTime.UtcNow)
                 {
-                    _logger.Debug("File hasn't expired yet, skipping: {0}", file);
+                    _logger.Debug("File hasn't expired yet, skipping: {FilePath}", file);
                     skippedFiles.Add(file);
                     continue;
                 }
 
                 removedFiles.Add(file);
-                _logger.Debug("File expired, deleting: {0}", file);
+                _logger.Debug("File expired, deleting: {FilePath}", file);
                 _diskProvider.DeleteFile(file);
             }
 
             _diskProvider.RemoveEmptySubfolders(_configService.RecycleBin);
 
-            _logger.Debug("Recycling Bin has been cleaned up. Removed: {0}. Skipped: {1}", removedFiles.Count, skippedFiles.Count);
+            _logger.Debug("Recycling Bin has been cleaned up. Removed: {RemovedCount}. Skipped: {SkippedCount}", removedFiles.Count, skippedFiles.Count);
         }
 
         private void SetLastWriteTime(string file, DateTime dateTime)
@@ -204,16 +204,16 @@ namespace NzbDrone.Core.MediaFiles
             // Swallow any IOException that may be thrown due to "Invalid parameter"
             try
             {
-                _logger.Trace("Setting last write time for file: {0}", file);
+                _logger.Trace("Setting last write time for file: {FilePath}", file);
                 _diskProvider.FileSetLastWriteTime(file, dateTime);
             }
             catch (IOException ex)
             {
-                _logger.Warn(ex, "Failed to set last write time for file: {0}", file);
+                _logger.Warn(ex, "Failed to set last write time for file: {FilePath}", file);
             }
             catch (UnauthorizedAccessException ex)
             {
-                _logger.Warn(ex, "Failed to set last write time for file: {0}", file);
+                _logger.Warn(ex, "Failed to set last write time for file: {FilePath}", file);
             }
         }
 

--- a/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.MediaFiles
 
                 if (!episodesInFile.Any())
                 {
-                    _logger.Warn("File ({0}) is not linked to any episodes", episodeFilePath);
+                    _logger.Warn("File ({FilePath}) is not linked to any episodes", episodeFilePath);
                     continue;
                 }
 
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.MediaFiles
 
                 try
                 {
-                    _logger.Debug("Renaming episode file: {0}", episodeFile);
+                    _logger.Debug("Renaming episode file: {FileName}", episodeFile);
                     _episodeFileMover.MoveEpisodeFile(episodeFile, series);
 
                     _mediaFileService.Update(episodeFile);
@@ -150,21 +150,21 @@ namespace NzbDrone.Core.MediaFiles
                                     PreviousPath = previousPath
                                 });
 
-                    _logger.Debug("Renamed episode file: {0}", episodeFile);
+                    _logger.Debug("Renamed episode file: {FileName}", episodeFile);
 
                     _eventAggregator.PublishEvent(new EpisodeFileRenamedEvent(series, episodeFile, previousPath));
                 }
                 catch (FileAlreadyExistsException ex)
                 {
-                    _logger.Warn("File not renamed, there is already a file at the destination: {0}", ex.Filename);
+                    _logger.Warn("File not renamed, there is already a file at the destination: {DestinationPath}", ex.Filename);
                 }
                 catch (SameFilenameException ex)
                 {
-                    _logger.Debug("File not renamed, source and destination are the same: {0}", ex.Filename);
+                    _logger.Debug("File not renamed, source and destination are the same: {FilePath}", ex.Filename);
                 }
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Failed to rename file {0}", previousPath);
+                    _logger.Error(ex, "Failed to rename file {FilePath}", previousPath);
                 }
             }
 
@@ -183,9 +183,9 @@ namespace NzbDrone.Core.MediaFiles
             var series = _seriesService.GetSeries(message.SeriesId);
             var episodeFiles = _mediaFileService.Get(message.Files);
 
-            _logger.ProgressInfo("Renaming {0} files for {1}", episodeFiles.Count, series.Title);
+            _logger.ProgressInfo("Renaming {FileCount} files for {SeriesTitle}", episodeFiles.Count, series.Title);
             var renamedFiles = RenameFiles(episodeFiles, series);
-            _logger.ProgressInfo("{0} selected episode files renamed for {1}", renamedFiles.Count, series.Title);
+            _logger.ProgressInfo("{RenamedCount} selected episode files renamed for {SeriesTitle}", renamedFiles.Count, series.Title);
 
             _eventAggregator.PublishEvent(new RenameCompletedEvent());
         }
@@ -198,9 +198,9 @@ namespace NzbDrone.Core.MediaFiles
             foreach (var series in seriesToRename)
             {
                 var episodeFiles = _mediaFileService.GetFilesBySeries(series.Id);
-                _logger.ProgressInfo("Renaming all files in series: {0}", series.Title);
+                _logger.ProgressInfo("Renaming all files in series: {SeriesTitle}", series.Title);
                 var renamedFiles = RenameFiles(episodeFiles, series);
-                _logger.ProgressInfo("{0} episode files renamed for {1}", renamedFiles.Count, series.Title);
+                _logger.ProgressInfo("{RenamedCount} episode files renamed for {SeriesTitle}", renamedFiles.Count, series.Title);
             }
 
             _eventAggregator.PublishEvent(new RenameCompletedEvent());

--- a/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.MediaFiles
 
                     if (!_diskProvider.FileExists(fileName))
                     {
-                        _logger.Warn("Script output contains non-existent possible extra file: {0}", fileName);
+                        _logger.Warn("Script output contains non-existent possible extra file: {FilePath}", fileName);
                     }
 
                     possibleExtraFiles.Add(fileName);
@@ -197,11 +197,11 @@ namespace NzbDrone.Core.MediaFiles
                 environmentVariables.Add("Sonarr_DeletedRecycleBinPaths", string.Join("|", oldFiles.Select(e => e.RecycleBinPath ?? string.Empty)));
             }
 
-            _logger.Debug("Executing external script: {0}", _configService.ScriptImportPath);
+            _logger.Debug("Executing external script: {ScriptPath}", _configService.ScriptImportPath);
 
             var processOutput = _processProvider.StartAndCapture(_configService.ScriptImportPath, $"\"{sourcePath}\" \"{destinationFilePath}\"", environmentVariables);
 
-            _logger.Debug("Script Output: \r\n{0}", string.Join("\r\n", processOutput.Lines));
+            _logger.Debug("Script Output: \r\n{ScriptOutput}", string.Join("\r\n", processOutput.Lines));
 
             if (processOutput.ExitCode != 0)
             {

--- a/src/NzbDrone.Core/MediaFiles/TorrentInfo/TorrentFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/TorrentInfo/TorrentFileInfoReader.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.MediaFiles.TorrentInfo
             }
             catch
             {
-                _logger.Trace("Invalid torrent file contents: {0}", Encoding.ASCII.GetString(fileContents));
+                _logger.Trace("Invalid torrent file contents: {FileContents}", Encoding.ASCII.GetString(fileContents));
                 throw;
             }
         }

--- a/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.MediaFiles
                     var mtime = localDate.WithTicksFrom(oldLastWrite);
 
                     _diskProvider.FileSetLastWriteTime(filePath, mtime);
-                    _logger.Debug("Date of file [{0}] changed from '{1}' to '{2}'", filePath, oldLastWrite, mtime);
+                    _logger.Debug("Date of file [{FilePath}] changed from '{OldDate}' to '{NewDate}'", filePath, oldLastWrite, mtime);
 
                     return true;
                 }
@@ -127,11 +127,11 @@ namespace NzbDrone.Core.MediaFiles
 
             if (updated.Any())
             {
-                _logger.ProgressDebug("Changed file date for {0} files of {1} in {2}", updated.Count, episodeFiles.Count, message.Series.Title);
+                _logger.ProgressDebug("Changed file date for {UpdatedCount} files of {TotalCount} in {SeriesTitle}", updated.Count, episodeFiles.Count, message.Series.Title);
             }
             else
             {
-                _logger.ProgressDebug("No file dates changed for {0}", message.Series.Title);
+                _logger.ProgressDebug("No file dates changed for {SeriesTitle}", message.Series.Title);
             }
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -61,12 +61,12 @@ namespace NzbDrone.Core.MediaFiles
 
                 if (_diskProvider.FileExists(episodeFilePath))
                 {
-                    _logger.Debug("Removing existing episode file: {0}", file);
+                    _logger.Debug("Removing existing episode file: {FileName}", file);
                     recycleBinPath = _recycleBinProvider.DeleteFile(episodeFilePath, subfolder);
                 }
                 else
                 {
-                    _logger.Warn("Existing episode file missing from disk: {0}", episodeFilePath);
+                    _logger.Warn("Existing episode file missing from disk: {FilePath}", episodeFilePath);
                 }
 
                 moveFileResult.OldFiles.Add(new DeletedEpisodeFile(file, recycleBinPath));

--- a/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Messaging.Commands
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error(ex, "Error occurred while executing task {0}", command.Name);
+                        _logger.Error(ex, "Error occurred while executing task {CommandName}", command.Name);
                     }
                 }
             }
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Messaging.Commands
             {
                 handler = (IExecute<TCommand>)_serviceFactory.Build(typeof(IExecute<TCommand>));
 
-                _logger.Trace("{0} -> {1}", command.GetType().Name, handler.GetType().Name);
+                _logger.Trace("{CommandType} -> {HandlerType}", command.GetType().Name, handler.GetType().Name);
 
                 _commandQueueManager.Start(commandModel);
                 BroadcastCommandUpdate(commandModel);
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Messaging.Commands
 
                 if (handler != null)
                 {
-                    _logger.Trace("{0} <- {1} [{2}]", command.GetType().Name, handler.GetType().Name, commandModel.Duration.ToString());
+                    _logger.Trace("{CommandType} <- {HandlerType} [{Duration}]", command.GetType().Name, handler.GetType().Name, commandModel.Duration.ToString());
                 }
             }
         }

--- a/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Messaging.Commands
         public List<CommandModel> PushMany<TCommand>(List<TCommand> commands)
             where TCommand : Command
         {
-            _logger.Trace("Publishing {0} commands", commands.Count);
+            _logger.Trace("Publishing {CommandCount} commands", commands.Count);
 
             lock (_commandQueue)
             {
@@ -103,8 +103,8 @@ namespace NzbDrone.Core.Messaging.Commands
         {
             Ensure.That(command, () => command).IsNotNull();
 
-            _logger.Trace("Publishing {0}", command.Name);
-            _logger.Trace("Checking if command is queued or started: {0}", command.Name);
+            _logger.Trace("Publishing {CommandName}", command.Name);
+            _logger.Trace("Checking if command is queued or started: {CommandName}", command.Name);
 
             command.Trigger = trigger;
 
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Messaging.Commands
 
                 if (existing != null)
                 {
-                    _logger.Trace("Command is already in progress: {0}", command.Name);
+                    _logger.Trace("Command is already in progress: {CommandName}", command.Name);
 
                     return existing;
                 }
@@ -130,7 +130,7 @@ namespace NzbDrone.Core.Messaging.Commands
                     Status = CommandStatus.Queued
                 };
 
-                _logger.Trace("Inserting new command: {0}", commandModel.Name);
+                _logger.Trace("Inserting new command: {CommandName}", commandModel.Name);
 
                 _repo.Insert(commandModel);
                 _commandQueue.Add(commandModel);
@@ -190,7 +190,7 @@ namespace NzbDrone.Core.Messaging.Commands
         public void Start(CommandModel command)
         {
             // Marks the command as started in the DB, the queue takes care of marking it as started on it's own
-            _logger.Trace("Marking command as started: {0}", command.Name);
+            _logger.Trace("Marking command as started: {CommandName}", command.Name);
             _repo.Start(command);
         }
 

--- a/src/NzbDrone.Core/Messaging/Commands/TestCommandExecutor.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/TestCommandExecutor.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Messaging.Commands
 
         public void Execute(TestCommand message)
         {
-            _logger.ProgressInfo("Starting Test command. duration {0}", message.Duration);
+            _logger.ProgressInfo("Starting Test command. duration {Duration}", message.Duration);
             Thread.Sleep(message.Duration);
             _logger.ProgressInfo("Completed Test command");
         }

--- a/src/NzbDrone.Core/Messaging/Commands/UnknownCommandExecutor.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/UnknownCommandExecutor.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Messaging.Commands
 
         public void Execute(UnknownCommand message)
         {
-            _logger.Debug("Ignoring unknown command {0}", message.ContractName);
+            _logger.Debug("Ignoring unknown command {CommandName}", message.ContractName);
         }
     }
 }

--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -59,7 +59,7 @@ namespace NzbDrone.Core.Messaging.Events
 
             if (_runtimeInfo.IsExiting && @event.GetType().HasAttribute<LifecycleEventAttribute>())
             {
-                _logger.Warn("Event {0} blocked due to application shutdown", eventName);
+                _logger.Warn("Event {EventName} blocked due to application shutdown", eventName);
                 return;
             }
 
@@ -80,7 +80,7 @@ namespace NzbDrone.Core.Messaging.Events
                         _logger.Warn("Thread pool state WT:{0} PT:{1}  MAXWT:{2} MAXPT:{3} MINWT:{4} MINPT:{5}", workerThreads, completionPortThreads, maxWorkerThreads, maxCompletionPortThreads, minWorkerThreads, minCompletionPortThreads);
             */
 
-            _logger.Trace("Publishing {0}", eventName);
+            _logger.Trace("Publishing {EventName}", eventName);
 
             EventSubscribers<TEvent> subscribers;
             lock (_eventSubscribers)
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Messaging.Events
                     }
                     catch (Exception ex)
                     {
-                        _logger.Warn(ex, "Unable to resolve event subscribers for {0}, container may be disposed", eventName);
+                        _logger.Warn(ex, "Unable to resolve event subscribers for {EventName}, container may be disposed", eventName);
                         return;
                     }
                 }
@@ -107,13 +107,13 @@ namespace NzbDrone.Core.Messaging.Events
             {
                 try
                 {
-                    _logger.Trace("{0} -> {1}", eventName, handler.GetType().Name);
+                    _logger.Trace("{EventName} -> {HandlerType}", eventName, handler.GetType().Name);
                     handler.Handle(@event);
-                    _logger.Trace("{0} <- {1}", eventName, handler.GetType().Name);
+                    _logger.Trace("{EventName} <- {HandlerType}", eventName, handler.GetType().Name);
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "{0} failed while processing [{1}]", handler.GetType().Name, eventName);
+                    _logger.Error(e, "{HandlerType} failed while processing [{EventName}]", handler.GetType().Name, eventName);
                 }
             }
 
@@ -135,9 +135,9 @@ namespace NzbDrone.Core.Messaging.Events
 
                 _taskFactory.StartNew(() =>
                 {
-                    _logger.Trace("{0} ~> {1}", eventName, handlerLocal.GetType().Name);
+                    _logger.Trace("{EventName} ~> {HandlerType}", eventName, handlerLocal.GetType().Name);
                     handlerLocal.HandleAsync(@event);
-                    _logger.Trace("{0} <~ {1}", eventName, handlerLocal.GetType().Name);
+                    _logger.Trace("{EventName} <~ {HandlerType}", eventName, handlerLocal.GetType().Name);
                 },
                         TaskCreationOptions.PreferFairness)
                 .LogExceptions();

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseProxy.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Core.Notifications.Apprise
             {
                 if (httpException.Response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    _logger.Error(ex, "HTTP Auth credentials are invalid: {0}", ex.Message);
+                    _logger.Error(ex, "HTTP Auth credentials are invalid: {Message}", ex.Message);
                     return new ValidationFailure("AuthUsername", _localizationService.GetLocalizedString("NotificationsValidationInvalidHttpCredentials", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
                 }
 
@@ -109,16 +109,16 @@ namespace NzbDrone.Core.Notifications.Apprise
                 {
                     var error = Json.Deserialize<AppriseError>(httpException.Response.Content);
 
-                    _logger.Error(ex, "Unable to send test message. Response from API: {0}", error.Error);
+                    _logger.Error(ex, "Unable to send test message. Response from API: {ApiError}", error.Error);
                     return new ValidationFailure(string.Empty, _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessageApiResponse", new Dictionary<string, object> { { "error", error.Error } }));
                 }
 
-                _logger.Error(ex, "Unable to send test message. Server connection failed: ({0}) {1}", httpException.Response.StatusCode, ex.Message);
+                _logger.Error(ex, "Unable to send test message. Server connection failed: ({StatusCode}) {Message}", httpException.Response.StatusCode, ex.Message);
                 return new ValidationFailure("Url", _localizationService.GetLocalizedString("NotificationsValidationUnableToConnectToApi", new Dictionary<string, object> { { "service", "Apprise" }, { "responseCode", httpException.Response.StatusCode }, { "exceptionMessage", ex.Message } }));
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Unable to send test message: {0}", ex.Message);
+                _logger.Error(ex, "Unable to send test message: {Message}", ex.Message);
                 return new ValidationFailure("Url", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessage", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
             }
 

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -358,12 +358,12 @@ namespace NzbDrone.Core.Notifications.CustomScript
 
         private ProcessOutput ExecuteScript(StringDictionary environmentVariables)
         {
-            _logger.Debug("Executing external script: {0}", Settings.Path);
+            _logger.Debug("Executing external script: {FilePath}", Settings.Path);
 
             var processOutput = _processProvider.StartAndCapture(Settings.Path, Settings.Arguments, environmentVariables);
 
-            _logger.Debug("Executed external script: {0} - Status: {1}", Settings.Path, processOutput.ExitCode);
-            _logger.Debug("Script Output: \r\n{0}", string.Join("\r\n", processOutput.Lines));
+            _logger.Debug("Executed external script: {FilePath} - Status: {ExitCode}", Settings.Path, processOutput.ExitCode);
+            _logger.Debug("Script Output: \r\n{ScriptOutput}", string.Join("\r\n", processOutput.Lines));
 
             return processOutput;
         }

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordProxy.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Notifications.Discord
             }
             catch (HttpException ex)
             {
-                _logger.Error(ex, "Unable to post payload {0}", payload);
+                _logger.Error(ex, "Unable to post payload {Payload}", payload);
                 throw new DiscordException("Unable to post payload", ex);
             }
         }

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -119,21 +119,21 @@ namespace NzbDrone.Core.Notifications.Email
                 Text = body
             };
 
-            _logger.Debug("Sending email Subject: {0}", subject);
+            _logger.Debug("Sending email Subject: {Subject}", subject);
 
             try
             {
                 Send(email, settings);
-                _logger.Debug("Email sent. Subject: {0}", subject);
+                _logger.Debug("Email sent. Subject: {Subject}", subject);
             }
             catch (Exception ex)
             {
-                _logger.Error("Error sending email. Subject: {0}", email.Subject);
+                _logger.Error("Error sending email. Subject: {Subject}", email.Subject);
                 _logger.Debug(ex, ex.Message);
                 throw;
             }
 
-            _logger.Debug("Finished sending email. Subject: {0}", subject);
+            _logger.Debug("Finished sending email. Subject: {Subject}", subject);
         }
 
         private void Send(MimeMessage email, EmailSettings settings)
@@ -201,7 +201,7 @@ namespace NzbDrone.Core.Notifications.Email
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "{0} email address '{1}' invalid", type, address);
+                _logger.Error(ex, "{AddressType} email address '{EmailAddress}' invalid", type, address);
                 throw;
             }
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Notifications.Emby
             {
                 if (Settings.UpdateLibrary)
                 {
-                    _logger.Debug("Performing library update for {0} series", items.Count);
+                    _logger.Debug("Performing library update for {Count} series", items.Count);
 
                     items.ForEach(item =>
                     {
@@ -139,7 +139,7 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             if (Settings.UpdateLibrary)
             {
-                _logger.Debug("Scheduling library update for series {0} {1}", series.Id, series.Title);
+                _logger.Debug("Scheduling library update for series {SeriesId} {SeriesTitle}", series.Id, series.Title);
                 _updateQueue.Add(Settings.Host, series, updateType);
             }
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Emby
             request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
 
             var response = _httpClient.Get(request);
-            _logger.Trace("Response: {0}", response.Content);
+            _logger.Trace("Response: {ResponseContent}", response.Content);
         }
 
         public void Notify(MediaBrowserSettings settings, string title, string message)
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Notifications.Emby
                     return new HashSet<string>();
                 }
 
-                _logger.Trace("Found series by name/id: {0}", string.Join(" ", paths));
+                _logger.Trace("Found series by name/id: {Paths}", string.Join(" ", paths));
 
                 return paths.ToHashSet();
             }
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Notifications.Emby
             request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
 
             var response = _httpClient.Get<T>(request);
-            _logger.Trace("Response: {0}", response.Content);
+            _logger.Trace("Response: {ResponseContent}", response.Content);
 
             CheckForError(response);
 
@@ -156,7 +156,7 @@ namespace NzbDrone.Core.Notifications.Emby
             request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
 
             var response = _httpClient.Post(request);
-            _logger.Trace("Response: {0}", response.Content);
+            _logger.Trace("Response: {ResponseContent}", response.Content);
 
             CheckForError(response);
 
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
         private void CheckForError(HttpResponse response)
         {
-            _logger.Debug("Looking for error in response: {0}", response);
+            _logger.Debug("Looking for error in response: {Response}", response);
 
             // TODO: actually check for the error
         }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserService.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Notifications.Emby
         {
             try
             {
-                _logger.Debug("Testing connection to Emby/Jellyfin : {0}", settings.Address);
+                _logger.Debug("Testing connection to Emby/Jellyfin : {Address}", settings.Address);
                 _proxy.TestConnection(settings);
             }
             catch (HttpException ex)

--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Notifications
             {
                 if (blockedNotifications.TryGetValue(notification.Definition.Id, out var notificationStatus))
                 {
-                    _logger.Debug("Temporarily ignoring notification {0} till {1} due to recent failures.", notification.Definition.Name, notificationStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring notification {NotificationName} till {DisabledTill} due to recent failures.", notification.Definition.Name, notificationStatus.DisabledTill.Value.ToLocalTime());
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -108,7 +108,7 @@ namespace NzbDrone.Core.Notifications
                 return true;
             }
 
-            _logger.Debug("{0} does not have any intersecting tags with {1}. Notification will not be sent.", definition.Name, series.Title);
+            _logger.Debug("{NotificationName} does not have any intersecting tags with {SeriesTitle}. Notification will not be sent.", definition.Name, series.Title);
             return false;
         }
 
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.Notifications
                 catch (Exception ex)
                 {
                     _notificationStatusService.RecordFailure(notification.Definition.Id);
-                    _logger.Error(ex, "Unable to send OnGrab notification to {0}", notification.Definition.Name);
+                    _logger.Error(ex, "Unable to send OnGrab notification to {NotificationName}", notification.Definition.Name);
                 }
             }
         }
@@ -376,7 +376,7 @@ namespace NzbDrone.Core.Notifications
                 catch (Exception ex)
                 {
                     _notificationStatusService.RecordFailure(notification.Definition.Id);
-                    _logger.Error(ex, "Unable to send OnManualInteractionRequired notification to {0}", notification.Definition.Name);
+                    _logger.Error(ex, "Unable to send OnManualInteractionRequired notification to {NotificationName}", notification.Definition.Name);
                 }
             }
         }

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Notifications.Ntfy
                 }
                 catch (NtfyException ex)
                 {
-                    _logger.Error(ex, "Unable to send test message to {0}", topic);
+                    _logger.Error(ex, "Unable to send test message to {Topic}", topic);
                     error = true;
                 }
             }

--- a/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/PlexTv/PlexTvProxy.cs
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Notifications.Plex.PlexTv
 
             HttpResponse response;
 
-            _logger.Debug("Url: {0}", httpRequest.Url);
+            _logger.Debug("Url: {Url}", httpRequest.Url);
 
             try
             {

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServer.cs
@@ -71,7 +71,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
             if (Settings.UpdateLibrary)
             {
-                _logger.Debug("Scheduling library update for series {0} {1}", series.Id, series.Title);
+                _logger.Debug("Scheduling library update for series {SeriesId} {SeriesTitle}", series.Id, series.Title);
                 _updateQueue.Add(Settings.Host, series, false);
             }
         }
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             {
                 if (Settings.UpdateLibrary)
                 {
-                    _logger.Debug("Performing library update for {0} series", items.Count);
+                    _logger.Debug("Performing library update for {Count} series", items.Count);
                     _plexServerService.UpdateLibrary(items.Select(i => i.Series), Settings);
                 }
             });

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerProxy.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
             HttpResponse response;
 
-            _logger.Debug("Url: {0}", httpRequest.Url);
+            _logger.Debug("Url: {Url}", httpRequest.Url);
 
             try
             {

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerService.cs
@@ -61,7 +61,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
                     UpdateSections(series, sections, settings);
                 }
 
-                _logger.Debug("Finished sending Update Request to Plex Server (took {0} ms)", watch.ElapsedMilliseconds);
+                _logger.Debug("Finished sending Update Request to Plex Server (took {ElapsedMs} ms)", watch.ElapsedMilliseconds);
             }
             catch (Exception ex)
             {
@@ -72,7 +72,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         private List<PlexSection> GetSections(PlexServerSettings settings)
         {
-            _logger.Debug("Getting sections from Plex host: {0}", settings.Host);
+            _logger.Debug("Getting sections from Plex host: {Host}", settings.Host);
 
             return _plexServerProxy.GetTvSections(settings).ToList();
         }
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         private Version GetVersion(PlexServerSettings settings)
         {
-            _logger.Debug("Getting version from Plex host: {0}", settings.Host);
+            _logger.Debug("Getting version from Plex host: {Host}", settings.Host);
 
             var rawVersion = _plexServerProxy.Version(settings);
             var version = new Version(Regex.Match(rawVersion, @"^(\d+[.-]){4}").Value.Trim('.', '-'));
@@ -112,12 +112,12 @@ namespace NzbDrone.Core.Notifications.Plex.Server
                     {
                         mappedPath = new OsPath(settings.MapTo) + (rootFolder - new OsPath(settings.MapFrom));
 
-                        _logger.Trace("Mapping Path from {0} to {1} for partial scan", rootFolder, mappedPath);
+                        _logger.Trace("Mapping Path from {RootFolder} to {MappedPath} for partial scan", rootFolder, mappedPath);
                     }
 
                     if (location.Path.PathEquals(mappedPath.FullPath))
                     {
-                        _logger.Debug("Updating matching section location, {0}", location.Path);
+                        _logger.Debug("Updating matching section location, {LocationPath}", location.Path);
                         UpdateSectionPath(seriesRelativePath, section, location, settings);
 
                         return;
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
             // unless it's a Windows drive letter (S:\) that needs to be trimmed.
             var pathToUpdate = $"{location.Path.TrimEnd(separator)}{separator}{locationRelativePath}";
 
-            _logger.Debug("Updating section location, {0}", location.Path);
+            _logger.Debug("Updating section location, {LocationPath}", location.Path);
             _plexServerProxy.Update(section.Id, pathToUpdate, settings);
         }
 

--- a/src/NzbDrone.Core/Notifications/Prowl/ProwlProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/ProwlProxy.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Notifications.Prowl
             {
                 if (ex.Response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    _logger.Error(ex, "Apikey is invalid: {0}", settings.ApiKey);
+                    _logger.Error(ex, "Apikey is invalid: {ApiKey}", settings.ApiKey);
                     throw new ProwlException("Apikey is invalid", ex);
                 }
 

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletProxy.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletProxy.cs
@@ -50,7 +50,7 @@ namespace NzbDrone.Core.Notifications.PushBullet
                     }
                     catch (PushBulletException ex)
                     {
-                        _logger.Error(ex, "Unable to send test message to {0}", channelTag);
+                        _logger.Error(ex, "Unable to send test message to {ChannelTag}", channelTag);
                         error = true;
                     }
                 }
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Notifications.PushBullet
                         }
                         catch (PushBulletException ex)
                         {
-                            _logger.Error(ex, "Unable to send test message to {0}", deviceId);
+                            _logger.Error(ex, "Unable to send test message to {DeviceId}", deviceId);
                             error = true;
                         }
                     }

--- a/src/NzbDrone.Core/Notifications/Pushcut/PushcutProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/PushcutProxy.cs
@@ -70,7 +70,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
             }
             catch (HttpException exception)
             {
-                _logger.Error(exception, "Unable to send Pushcut notification: {0}", exception.Message);
+                _logger.Error(exception, "Unable to send Pushcut notification: {Message}", exception.Message);
                 throw new PushcutException("Unable to send Pushcut notification: {0}", exception.Message, exception);
             }
         }
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
             {
                 if (httpException.Response.StatusCode == HttpStatusCode.Forbidden)
                 {
-                    _logger.Error(pushcutException, "API Key is invalid: {0}", pushcutException.Message);
+                    _logger.Error(pushcutException, "API Key is invalid: {Message}", pushcutException.Message);
                     return new ValidationFailure("API Key", _localizationService.GetLocalizedString("NotificationsValidationInvalidApiKeyExceptionMessage", new Dictionary<string, object> { { "exceptionMessage", pushcutException.Message } }));
                 }
 
@@ -95,11 +95,11 @@ namespace NzbDrone.Core.Notifications.Pushcut
                 {
                     var response = Json.Deserialize<PushcutResponse>(httpException.Response.Content);
 
-                    _logger.Error(pushcutException, "Unable to send test notification. Response from Pushcut: {0}", response.Error);
+                    _logger.Error(pushcutException, "Unable to send test notification. Response from Pushcut: {ApiError}", response.Error);
                     return new ValidationFailure("Url", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessageApiResponse", new Dictionary<string, object> { { "error", response.Error } }));
                 }
 
-                _logger.Error(pushcutException, "Unable to connect to Pushcut API. Server connection failed: ({0}) {1}", httpException.Response.StatusCode, pushcutException.Message);
+                _logger.Error(pushcutException, "Unable to connect to Pushcut API. Server connection failed: ({StatusCode}) {Message}", httpException.Response.StatusCode, pushcutException.Message);
                 return new ValidationFailure("Host", _localizationService.GetLocalizedString("NotificationsValidationUnableToConnectToApi", new Dictionary<string, object> { { "responseCode", httpException.Response.StatusCode }, { "exceptionMessage", pushcutException.Message } }));
             }
 

--- a/src/NzbDrone.Core/Notifications/Signal/SignalProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalProxy.cs
@@ -74,12 +74,12 @@ namespace NzbDrone.Core.Notifications.Signal
             }
             catch (WebException ex)
             {
-                _logger.Error(ex, "Unable to send test message: {0}", ex.Message);
+                _logger.Error(ex, "Unable to send test message: {Message}", ex.Message);
                 return new ValidationFailure("Host", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessage", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
             }
             catch (HttpException ex)
             {
-                _logger.Error(ex, "Unable to send test message: {0}", ex.Message);
+                _logger.Error(ex, "Unable to send test message: {Message}", ex.Message);
 
                 if (ex.Response.StatusCode == HttpStatusCode.BadRequest)
                 {
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Notifications.Signal
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Unable to send test message: {0}", ex.Message);
+                _logger.Error(ex, "Unable to send test message: {Message}", ex.Message);
                 return new ValidationFailure("Host", _localizationService.GetLocalizedString("NotificationsValidationUnableToSendTestMessage", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
             }
 

--- a/src/NzbDrone.Core/Notifications/Slack/SlackProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackProxy.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Notifications.Slack
             }
             catch (HttpException ex)
             {
-                _logger.Error(ex, "Unable to post payload {0}", payload);
+                _logger.Error(ex, "Unable to post payload {Payload}", payload);
                 throw new SlackExeption("Unable to post payload", ex);
             }
         }

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterService.cs
@@ -74,14 +74,14 @@ namespace NzbDrone.Core.Notifications.Twitter
                     {
                         if (responseStream == null)
                         {
-                            _logger.Trace("Status Code: {0}", httpResponse.StatusCode);
+                            _logger.Trace("Status Code: {StatusCode}", httpResponse.StatusCode);
                             throw new TwitterException("Error received from Twitter: " + httpResponse.StatusCode, ex);
                         }
 
                         using (var reader = new StreamReader(responseStream))
                         {
                             var responseBody = reader.ReadToEnd();
-                            _logger.Trace("Response: {0} Status Code: {1}", responseBody, httpResponse.StatusCode);
+                            _logger.Trace("Response: {ResponseBody} Status Code: {StatusCode}", responseBody, httpResponse.StatusCode);
                             throw new TwitterException("Error received from Twitter: " + responseBody, ex);
                         }
                     }

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
         {
             _updateQueue.ProcessQueue(Settings.Host, (items) =>
             {
-                _logger.Debug("Performing library update for {0} series", items.Count);
+                _logger.Debug("Performing library update for {Count} series", items.Count);
 
                 items.ForEach(item =>
                 {
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
         {
             if (Settings.UpdateLibrary || Settings.CleanLibrary)
             {
-                _logger.Debug("Scheduling library update for series {0} {1}", series.Id, series.Title);
+                _logger.Debug("Scheduling library update for series {SeriesId} {SeriesTitle}", series.Id, series.Title);
                 _updateQueue.Add(Settings.Host, series, clean);
             }
         }

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcJsonApiProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcJsonApiProxy.cs
@@ -88,7 +88,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
             }
 
             var response = _httpClient.Execute(request);
-            _logger.Trace("Response: {0}", response.Content);
+            _logger.Trace("Response: {ResponseContent}", response.Content);
 
             CheckForError(response);
 
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
                 throw new XbmcJsonException("Invalid response from XBMC, the response is not valid JSON");
             }
 
-            _logger.Trace("Looking for error in response, {0}", response.Content);
+            _logger.Trace("Looking for error in response, {ResponseContent}", response.Content);
 
             if (response.Content.StartsWith("{\"error\""))
             {

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcService.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcService.cs
@@ -91,18 +91,18 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
                 if (seriesPath != null)
                 {
-                    _logger.Debug("Updating series {0} (Kodi path: {1}) on Kodi host: {2}", series, seriesPath, settings.Address);
+                    _logger.Debug("Updating series {Series} (Kodi path: {KodiPath}) on Kodi host: {Address}", series, seriesPath, settings.Address);
                 }
                 else
                 {
-                    _logger.Debug("Series {0} doesn't exist on Kodi host: {1}, Updating Entire Library", series, settings.Address);
+                    _logger.Debug("Series {Series} doesn't exist on Kodi host: {Address}, Updating Entire Library", series, settings.Address);
                 }
 
                 var response = _proxy.UpdateLibrary(settings, seriesPath);
 
                 if (!response.Equals("OK", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    _logger.Debug("Failed to update library for: {0}", settings.Address);
+                    _logger.Debug("Failed to update library for: {Address}", settings.Address);
                 }
             }
             catch (Exception ex)
@@ -118,7 +118,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
                 return false;
             }
 
-            _logger.Debug("Determining if there are any active players on Kodi host: {0}", settings.Address);
+            _logger.Debug("Determining if there are any active players on Kodi host: {Address}", settings.Address);
             var activePlayers = _proxy.GetActivePlayers(settings);
 
             return activePlayers.Any(a => a.Type.Equals("video"));

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -652,7 +652,7 @@ namespace NzbDrone.Core.Organizer
         {
             if (episodeFile.MediaInfo == null)
             {
-                _logger.Trace("Media info is unavailable for {0}", episodeFile);
+                _logger.Trace("Media info is unavailable for {EpisodeFile}", episodeFile);
 
                 return;
             }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -108,13 +108,13 @@ namespace NzbDrone.Core.Parser
 
                 if (!tvdbId.HasValue)
                 {
-                    _logger.Trace("Title {0} not matching any series.", title);
+                    _logger.Trace("Title {SeriesTitle} not matching any series.", title);
                     continue;
                 }
 
                 if (foundTvdbId.HasValue && tvdbId != foundTvdbId)
                 {
-                    _logger.Trace("Title {0} both matches tvdbid {1} and {2}, no series selected.", parsedEpisodeInfo.SeriesTitle, foundTvdbId, tvdbId);
+                    _logger.Trace("Title {SeriesTitle} both matches tvdbid {FoundTvdbId} and {TvdbId}, no series selected.", parsedEpisodeInfo.SeriesTitle, foundTvdbId, tvdbId);
                     return null;
                 }
 
@@ -354,7 +354,7 @@ namespace NzbDrone.Core.Parser
 
             if (series == null)
             {
-                _logger.Debug("No matching series {0}", releaseTitle);
+                _logger.Debug("No matching series {ReleaseTitle}", releaseTitle);
                 return null;
             }
 
@@ -395,7 +395,7 @@ namespace NzbDrone.Core.Parser
                     Special = true
                 };
 
-                _logger.Debug("Found special episode {0} for title '{1}'", info, releaseTitle);
+                _logger.Debug("Found special episode {EpisodeInfo} for title '{ReleaseTitle}'", info, releaseTitle);
                 return info;
             }
 
@@ -417,7 +417,7 @@ namespace NzbDrone.Core.Parser
 
                 if (series == null)
                 {
-                    _logger.Debug("No matching series {0}", parsedEpisodeInfo.SeriesTitle);
+                    _logger.Debug("No matching series {SeriesTitle}", parsedEpisodeInfo.SeriesTitle);
                     return null;
                 }
 
@@ -547,7 +547,7 @@ namespace NzbDrone.Core.Parser
 
             if (series == null)
             {
-                _logger.Debug("No matching series {0}", parsedEpisodeInfo.SeriesTitle);
+                _logger.Debug("No matching series {SeriesTitle}", parsedEpisodeInfo.SeriesTitle);
                 return null;
             }
 
@@ -632,7 +632,7 @@ namespace NzbDrone.Core.Parser
 
                 foreach (var episode in episodes)
                 {
-                    _logger.Debug("Using absolute episode number {0} for: {1} - TVDB: {2}x{3:00}",
+                    _logger.Debug("Using absolute episode number {AbsoluteEpisodeNumber} for: {SeriesTitle} - TVDB: {SeasonNumber}x{EpisodeNumber:00}",
                                 absoluteEpisodeNumber,
                                 series.Title,
                                 episode.SeasonNumber,
@@ -673,7 +673,7 @@ namespace NzbDrone.Core.Parser
 
                     if (episodes != null && episodes.Any())
                     {
-                        _logger.Debug("Using Scene to TVDB Mapping for: {0} - Scene: {1}x{2:00} - TVDB: {3}",
+                        _logger.Debug("Using Scene to TVDB Mapping for: {SeriesTitle} - Scene: {SceneSeasonNumber}x{SceneEpisodeNumber:00} - TVDB: {TvdbMapping}",
                                     series.Title,
                                     episodes.First().SceneSeasonNumber,
                                     episodes.First().SceneEpisodeNumber,
@@ -702,7 +702,7 @@ namespace NzbDrone.Core.Parser
                 }
                 else
                 {
-                    _logger.Debug("Unable to find {0}", parsedEpisodeInfo);
+                    _logger.Debug("Unable to find {ParsedEpisodeInfo}", parsedEpisodeInfo);
                 }
             }
 

--- a/src/NzbDrone.Core/RemotePathMappings/RemotePathMappingService.cs
+++ b/src/NzbDrone.Core/RemotePathMappings/RemotePathMappingService.cs
@@ -139,15 +139,15 @@ namespace NzbDrone.Core.RemotePathMappings
                 return remotePath;
             }
 
-            _logger.Trace("Evaluating remote path remote mappings for match to host [{0}] and remote path [{1}]", host, remotePath.FullPath);
+            _logger.Trace("Evaluating remote path remote mappings for match to host [{Host}] and remote path [{RemotePath}]", host, remotePath.FullPath);
 
             foreach (var mapping in mappings)
             {
-                _logger.Trace("Checking configured remote path mapping: {0} - {1}", mapping.Host, mapping.RemotePath);
+                _logger.Trace("Checking configured remote path mapping: {Host} - {RemotePath}", mapping.Host, mapping.RemotePath);
                 if (host.Equals(mapping.Host, StringComparison.InvariantCultureIgnoreCase) && new OsPath(mapping.RemotePath).Contains(remotePath))
                 {
                     var localPath = new OsPath(mapping.LocalPath) + (remotePath - new OsPath(mapping.RemotePath));
-                    _logger.Debug("Remapped remote path [{0}] to local path [{1}] for host [{2}]", remotePath, localPath, host);
+                    _logger.Debug("Remapped remote path [{RemotePath}] to local path [{LocalPath}] for host [{Host}]", remotePath, localPath, host);
 
                     return localPath;
                 }
@@ -170,15 +170,15 @@ namespace NzbDrone.Core.RemotePathMappings
                 return localPath;
             }
 
-            _logger.Trace("Evaluating remote path local mappings for match to host [{0}] and local path [{1}]", host, localPath.FullPath);
+            _logger.Trace("Evaluating remote path local mappings for match to host [{Host}] and local path [{LocalPath}]", host, localPath.FullPath);
 
             foreach (var mapping in mappings)
             {
-                _logger.Trace("Checking configured remote path mapping {0} - {1}", mapping.Host, mapping.RemotePath);
+                _logger.Trace("Checking configured remote path mapping {Host} - {RemotePath}", mapping.Host, mapping.RemotePath);
                 if (host.Equals(mapping.Host, StringComparison.InvariantCultureIgnoreCase) && new OsPath(mapping.LocalPath).Contains(localPath))
                 {
                     var remotePath = new OsPath(mapping.RemotePath) + (localPath - new OsPath(mapping.LocalPath));
-                    _logger.Debug("Remapped local path [{0}] to remote path [{1}] for host [{2}]", localPath, remotePath, host);
+                    _logger.Debug("Remapped local path [{LocalPath}] to remote path [{RemotePath}] for host [{Host}]", localPath, remotePath, host);
 
                     return remotePath;
                 }

--- a/src/NzbDrone.Core/RootFolders/RootFolderService.cs
+++ b/src/NzbDrone.Core/RootFolders/RootFolderService.cs
@@ -87,7 +87,7 @@ namespace NzbDrone.Core.RootFolders
                 // We don't want an exception to prevent the root folders from loading in the UI, so they can still be deleted
                 catch (Exception ex)
                 {
-                    _logger.Error(ex, "Unable to get free space and unmapped folders for root folder {0}", folder.Path);
+                    _logger.Error(ex, "Unable to get free space and unmapped folders for root folder {FolderPath}", folder.Path);
                     folder.UnmappedFolders = new List<UnmappedFolder>();
                 }
             });
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.RootFolders
 
             if (!_diskProvider.FolderExists(path))
             {
-                _logger.Debug("Path supplied does not exist: {0}", path);
+                _logger.Debug("Path supplied does not exist: {Path}", path);
                 return results;
             }
 
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.RootFolders
             var setToRemove = SpecialFolders;
             results.RemoveAll(x => setToRemove.Contains(new DirectoryInfo(x.Path.ToLowerInvariant()).Name));
 
-            _logger.Debug("{0} unmapped folders detected.", results.Count);
+            _logger.Debug("{UnmappedFolderCount} unmapped folders detected.", results.Count);
             return results.OrderBy(u => u.Name, StringComparer.InvariantCultureIgnoreCase).ToList();
         }
 

--- a/src/NzbDrone.Core/Security/X509CertificateValidationService.cs
+++ b/src/NzbDrone.Core/Security/X509CertificateValidationService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Security
 
             if (certificate is X509Certificate2 cert2 && cert2.SignatureAlgorithm.FriendlyName == "md5RSA")
             {
-                _logger.Error("https://{0} uses the obsolete md5 hash in it's https certificate, if that is your certificate, please (re)create certificate with better algorithm as soon as possible.", targetHostName);
+                _logger.Error("https://{TargetHostName} uses the obsolete md5 hash in it's https certificate, if that is your certificate, please (re)create certificate with better algorithm as soon as possible.", targetHostName);
             }
 
             if (sslPolicyErrors == SslPolicyErrors.None)
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Security
                 return true;
             }
 
-            _logger.Error("Certificate validation for {0} failed. {1}", targetHostName, sslPolicyErrors);
+            _logger.Error("Certificate validation for {TargetHostName} failed. {SslPolicyErrors}", targetHostName, sslPolicyErrors);
 
             return false;
         }

--- a/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderFactory.cs
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.ThingiProvider
 
         public void Handle(ApplicationStartedEvent message)
         {
-            _logger.Debug("Initializing Providers. Count {0}", _providers.Count);
+            _logger.Debug("Initializing Providers. Count {ProviderCount}", _providers.Count);
 
             RemoveMissingImplementations();
 
@@ -202,7 +202,7 @@ namespace NzbDrone.Core.ThingiProvider
 
             foreach (var invalidDefinition in storedProvider.Where(def => GetImplementation(def) == null))
             {
-                _logger.Warn("Removing {0}", invalidDefinition.Name);
+                _logger.Warn("Removing {ProviderName}", invalidDefinition.Name);
                 _providerRepository.Delete(invalidDefinition);
             }
         }

--- a/src/NzbDrone.Core/Tv/AddSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/AddSeriesService.cs
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Tv
             newSeries = AddSkyhookData(newSeries);
             newSeries = SetPropertiesAndValidate(newSeries);
 
-            _logger.Info("Adding Series {0} Path: [{1}]", newSeries, newSeries.Path);
+            _logger.Info("Adding Series {SeriesTitle} Path: [{Path}]", newSeries, newSeries.Path);
             _seriesService.AddSeries(newSeries);
 
             return newSeries;
@@ -64,11 +64,11 @@ namespace NzbDrone.Core.Tv
             {
                 if (s.Path.IsNullOrWhiteSpace())
                 {
-                    _logger.Info("Adding Series {0} Root Folder Path: [{1}]", s, s.RootFolderPath);
+                    _logger.Info("Adding Series {SeriesTitle} Root Folder Path: [{RootFolderPath}]", s, s.RootFolderPath);
                 }
                 else
                 {
-                    _logger.Info("Adding Series {0} Path: [{1}]", s, s.Path);
+                    _logger.Info("Adding Series {SeriesTitle} Path: [{Path}]", s, s.Path);
                 }
 
                 try
@@ -78,20 +78,20 @@ namespace NzbDrone.Core.Tv
                     series.Added = added;
                     if (existingSeriesTvdbIds.Any(f => f == series.TvdbId))
                     {
-                        _logger.Debug("TVDB ID {0} was not added due to validation failure: Series {1} already exists in database", s.TvdbId, s);
+                        _logger.Debug("TVDB ID {TvdbId} was not added due to validation failure: Series {SeriesTitle} already exists in database", s.TvdbId, s);
                         continue;
                     }
 
                     if (seriesToAdd.Any(f => f.TvdbId == series.TvdbId))
                     {
-                        _logger.Trace("TVDB ID {0} was already added from another import list, not adding series {1} again", s.TvdbId, s);
+                        _logger.Trace("TVDB ID {TvdbId} was already added from another import list, not adding series {SeriesTitle} again", s.TvdbId, s);
                         continue;
                     }
 
                     var duplicateSlug = seriesToAdd.FirstOrDefault(f => f.TitleSlug == series.TitleSlug);
                     if (duplicateSlug != null)
                     {
-                        _logger.Debug("TVDB ID {0} was not added due to validation failure: Duplicate Slug {1} used by series {2}", s.TvdbId, s.TitleSlug, duplicateSlug.TvdbId);
+                        _logger.Debug("TVDB ID {TvdbId} was not added due to validation failure: Duplicate Slug {TitleSlug} used by series {DuplicateTvdbId}", s.TvdbId, s.TitleSlug, duplicateSlug.TvdbId);
                         continue;
                     }
 
@@ -104,7 +104,7 @@ namespace NzbDrone.Core.Tv
                         throw;
                     }
 
-                    _logger.Debug("Series {0} with TVDB ID {1} was not added due to validation failures. {2}", s, s.TvdbId, ex.Message);
+                    _logger.Debug("Series {SeriesTitle} with TVDB ID {TvdbId} was not added due to validation failures. {Message}", s, s.TvdbId, ex.Message);
                 }
             }
 
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.Tv
             }
             catch (SeriesNotFoundException)
             {
-                _logger.Error("Series {0} with TVDB ID {1} was not found, it may have been removed from TheTVDB. Path: {2}", newSeries, newSeries.TvdbId, newSeries.Path);
+                _logger.Error("Series {SeriesTitle} with TVDB ID {TvdbId} was not found, it may have been removed from TheTVDB. Path: {Path}", newSeries, newSeries.TvdbId, newSeries.Path);
 
                 throw new ValidationException(new List<ValidationFailure>
                                               {

--- a/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
@@ -53,38 +53,38 @@ namespace NzbDrone.Core.Tv
             switch (monitoringOptions.Monitor)
             {
                 case MonitorTypes.All:
-                    _logger.Debug("[{0}] Monitoring all episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring all episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0);
 
                     break;
 
                 case MonitorTypes.Future:
-                    _logger.Debug("[{0}] Monitoring future episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring future episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && (!e.AirDateUtc.HasValue || e.AirDateUtc >= DateTime.UtcNow));
 
                     break;
 
                 case MonitorTypes.Missing:
-                    _logger.Debug("[{0}] Monitoring missing episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring missing episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && !e.HasFile);
 
                     break;
 
                 case MonitorTypes.Existing:
-                    _logger.Debug("[{0}] Monitoring existing episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring existing episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.HasFile);
 
                     break;
 
                 case MonitorTypes.Pilot:
-                    _logger.Debug("[{0}] Monitoring first episode episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring first episode episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes,
                         e => e.SeasonNumber > 0 && e.SeasonNumber == firstSeason && e.EpisodeNumber == 1);
 
                     break;
 
                 case MonitorTypes.FirstSeason:
-                    _logger.Debug("[{0}] Monitoring first season episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring first season episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.SeasonNumber == firstSeason);
 
                     break;
@@ -93,14 +93,14 @@ namespace NzbDrone.Core.Tv
                 #pragma warning disable CS0612
                 case MonitorTypes.LatestSeason:
                 #pragma warning restore CS0612
-                    _logger.Debug("[{0}] Monitoring latest season episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring latest season episodes", series.Title);
 
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.SeasonNumber == lastSeason);
 
                     break;
 
                 case MonitorTypes.Recent:
-                    _logger.Debug("[{0}] Monitoring recent and future episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring recent and future episodes", series.Title);
 
                     ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 &&
                                                                 (!e.AirDateUtc.HasValue || (
@@ -111,19 +111,19 @@ namespace NzbDrone.Core.Tv
                     break;
 
                 case MonitorTypes.MonitorSpecials:
-                    _logger.Debug("[{0}] Monitoring special episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Monitoring special episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes.Where(e => e.SeasonNumber == 0), true);
 
                     break;
 
                 case MonitorTypes.UnmonitorSpecials:
-                    _logger.Debug("[{0}] Unmonitoring special episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Unmonitoring special episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes.Where(e => e.SeasonNumber == 0), false);
 
                     break;
 
                 case MonitorTypes.None:
-                    _logger.Debug("[{0}] Unmonitoring all episodes", series.Title);
+                    _logger.Debug("[{SeriesTitle}] Unmonitoring all episodes", series.Title);
                     ToggleEpisodesMonitoredState(episodes, e => false);
 
                     break;
@@ -174,7 +174,7 @@ namespace NzbDrone.Core.Tv
 
         private void LegacySetEpisodeMonitoredStatus(Series series, MonitoringOptions monitoringOptions)
         {
-            _logger.Debug("[{0}] Setting episode monitored status.", series.Title);
+            _logger.Debug("[{SeriesTitle}] Setting episode monitored status.", series.Title);
 
             var episodes = _episodeService.GetEpisodeBySeries(series.Id);
 
@@ -210,7 +210,7 @@ namespace NzbDrone.Core.Tv
 
                 if (!season.Monitored)
                 {
-                    _logger.Debug("Unmonitoring all episodes in season {0}", season.SeasonNumber);
+                    _logger.Debug("Unmonitoring all episodes in season {SeasonNumber}", season.SeasonNumber);
                     ToggleEpisodesMonitoredState(episodes.Where(e => e.SeasonNumber == season.SeasonNumber), false);
                 }
 
@@ -220,7 +220,7 @@ namespace NzbDrone.Core.Tv
                 {
                     if (episodes.Where(e => e.SeasonNumber == season.SeasonNumber).All(e => !e.Monitored))
                     {
-                        _logger.Debug("Unmonitoring season {0} because all episodes are not monitored", season.SeasonNumber);
+                        _logger.Debug("Unmonitoring season {SeasonNumber} because all episodes are not monitored", season.SeasonNumber);
                         season.Monitored = false;
                     }
                 }

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -180,7 +180,7 @@ namespace NzbDrone.Core.Tv
             var episode = _episodeRepository.Get(episodeId);
             _episodeRepository.SetMonitoredFlat(episode, monitored);
 
-            _logger.Debug("Monitored flag for Episode:{0} was set to {1}", episodeId, monitored);
+            _logger.Debug("Monitored flag for Episode:{EpisodeId} was set to {Monitored}", episodeId, monitored);
         }
 
         public void SetMonitored(IEnumerable<int> ids, bool monitored)
@@ -264,7 +264,7 @@ namespace NzbDrone.Core.Tv
         {
             foreach (var episode in GetEpisodesByFileId(message.EpisodeFile.Id))
             {
-                _logger.Debug("Detaching episode {0} from file.", episode.Id);
+                _logger.Debug("Detaching episode {EpisodeId} from file.", episode.Id);
 
                 var unmonitorEpisodes = _configService.AutoUnmonitorPreviouslyDownloadedEpisodes;
 
@@ -303,7 +303,7 @@ namespace NzbDrone.Core.Tv
                     }
                 }
 
-                _logger.Debug("Linking [{0}] > [{1}]", message.EpisodeFile.RelativePath, episode);
+                _logger.Debug("Linking [{RelativePath}] > [{EpisodeTitle}]", message.EpisodeFile.RelativePath, episode);
             }
         }
 

--- a/src/NzbDrone.Core/Tv/MoveSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/MoveSeriesService.cs
@@ -39,28 +39,28 @@ namespace NzbDrone.Core.Tv
         {
             if (!sourcePath.IsPathValid(PathValidationType.CurrentOs))
             {
-                _logger.Warn("Folder '{0}' for '{1}' is invalid, unable to move series. Try moving files manually", sourcePath, series.Title);
+                _logger.Warn("Folder '{FolderPath}' for '{SeriesTitle}' is invalid, unable to move series. Try moving files manually", sourcePath, series.Title);
                 return;
             }
 
             if (!_diskProvider.FolderExists(sourcePath))
             {
-                _logger.Debug("Folder '{0}' for '{1}' does not exist, not moving.", sourcePath, series.Title);
+                _logger.Debug("Folder '{FolderPath}' for '{SeriesTitle}' does not exist, not moving.", sourcePath, series.Title);
                 return;
             }
 
             if (index != null && total != null)
             {
-                _logger.ProgressInfo("Moving {0} from '{1}' to '{2}' ({3}/{4})", series.Title, sourcePath, destinationPath, index + 1, total);
+                _logger.ProgressInfo("Moving {SeriesTitle} from '{SourcePath}' to '{DestinationPath}' ({Index}/{Total})", series.Title, sourcePath, destinationPath, index + 1, total);
             }
             else
             {
-                _logger.ProgressInfo("Moving {0} from '{1}' to '{2}'", series.Title, sourcePath, destinationPath);
+                _logger.ProgressInfo("Moving {SeriesTitle} from '{SourcePath}' to '{DestinationPath}'", series.Title, sourcePath, destinationPath);
             }
 
             if (sourcePath.PathEquals(destinationPath))
             {
-                _logger.ProgressInfo("{0} is already in the specified location '{1}'.", series, destinationPath);
+                _logger.ProgressInfo("{SeriesTitle} is already in the specified location '{DestinationPath}'.", series, destinationPath);
                 return;
             }
 
@@ -71,13 +71,13 @@ namespace NzbDrone.Core.Tv
                 _diskProvider.CreateFolder(new DirectoryInfo(destinationPath).Parent.FullName);
                 _diskTransferService.TransferFolder(sourcePath, destinationPath, TransferMode.Move);
 
-                _logger.ProgressInfo("{0} moved successfully to {1}", series.Title, destinationPath);
+                _logger.ProgressInfo("{SeriesTitle} moved successfully to {DestinationPath}", series.Title, destinationPath);
 
                 _eventAggregator.PublishEvent(new SeriesMovedEvent(series, sourcePath, destinationPath));
             }
             catch (IOException ex)
             {
-                _logger.Error(ex, "Unable to move series from '{0}' to '{1}'. Try moving files manually", sourcePath, destinationPath);
+                _logger.Error(ex, "Unable to move series from '{SourcePath}' to '{DestinationPath}'. Try moving files manually", sourcePath, destinationPath);
 
                 RevertPath(series.Id, sourcePath);
             }
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.Tv
             var seriesToMove = message.Series;
             var destinationRootFolder = message.DestinationRootFolder;
 
-            _logger.ProgressInfo("Moving {0} series to '{1}'", seriesToMove.Count, destinationRootFolder);
+            _logger.ProgressInfo("Moving {Count} series to '{DestinationRootFolder}'", seriesToMove.Count, destinationRootFolder);
 
             for (var index = 0; index < seriesToMove.Count; index++)
             {
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Tv
                 MoveSingleSeries(series, s.SourcePath, destinationPath, index, seriesToMove.Count);
             }
 
-            _logger.ProgressInfo("Finished moving {0} series to '{1}'", seriesToMove.Count, destinationRootFolder);
+            _logger.ProgressInfo("Finished moving {Count} series to '{DestinationRootFolder}'", seriesToMove.Count, destinationRootFolder);
         }
     }
 }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Tv
 
         public void RefreshEpisodeInfo(Series series, IEnumerable<Episode> remoteEpisodes)
         {
-            _logger.Info("Starting episode info refresh for: {0}", series);
+            _logger.Info("Starting episode info refresh for: {SeriesTitle}", series);
             var successCount = 0;
             var failCount = 0;
 
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Tv
                 }
                 catch (Exception e)
                 {
-                    _logger.Fatal(e, "An error has occurred while updating episode info for series {0}. {1}", series, episode);
+                    _logger.Fatal(e, "An error has occurred while updating episode info for series {SeriesTitle}. {EpisodeTitle}", series, episode);
                     failCount++;
                 }
             }
@@ -132,14 +132,14 @@ namespace NzbDrone.Core.Tv
 
             if (failCount != 0)
             {
-                _logger.Info("Finished episode refresh for series: {0}. Successful: {1} - Failed: {2} ",
+                _logger.Info("Finished episode refresh for series: {SeriesTitle}. Successful: {SuccessCount} - Failed: {FailCount} ",
                     series.Title,
                     successCount,
                     failCount);
             }
             else
             {
-                _logger.Info("Finished episode refresh for series: {0}.", series);
+                _logger.Info("Finished episode refresh for series: {SeriesTitle}.", series);
             }
         }
 
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.Tv
             {
                 if (hasExisting)
                 {
-                    _logger.Warn("Show {0} ({1}) had {2} old episodes appear, please check monitored status.", series.TvdbId, series.Title, oldEpisodes.Count);
+                    _logger.Warn("Show {TvdbId} ({SeriesTitle}) had {Count} old episodes appear, please check monitored status.", series.TvdbId, series.Title, oldEpisodes.Count);
                 }
                 else
                 {
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.Tv
                         }
                     }
 
-                    _logger.Warn("Show {0} ({1}) had {2} old episodes appear, unmonitored aired episodes to prevent unexpected downloads.", series.TvdbId, series.Title, oldEpisodes.Count);
+                    _logger.Warn("Show {TvdbId} ({SeriesTitle}) had {Count} old episodes appear, unmonitored aired episodes to prevent unexpected downloads.", series.TvdbId, series.Title, oldEpisodes.Count);
                 }
             }
         }
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Tv
             {
                 if (group.Key.SeasonNumber != 0 && group.Count() > 3)
                 {
-                    _logger.Debug("Not adjusting multi-episode air times for series {0} season {1} since more than 3 episodes 'aired' on the same day", series.Title, group.Key.SeasonNumber);
+                    _logger.Debug("Not adjusting multi-episode air times for series {SeriesTitle} season {SeasonNumber} since more than 3 episodes 'aired' on the same day", series.Title, group.Key.SeasonNumber);
                     continue;
                 }
 

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Tv
             // but before this series was refreshed won't be lost.
             var series = _seriesService.GetSeries(seriesId);
 
-            _logger.ProgressInfo("Updating {0}", series.Title);
+            _logger.ProgressInfo("Updating {SeriesTitle}", series.Title);
 
             Series seriesInfo;
             List<Episode> episodes;
@@ -73,7 +73,7 @@ namespace NzbDrone.Core.Tv
                 {
                     series.Status = SeriesStatusType.Deleted;
                     _seriesService.UpdateSeries(series, publishUpdatedEvent: false);
-                    _logger.Debug("Series marked as deleted on tvdb for {0}", series.Title);
+                    _logger.Debug("Series marked as deleted on tvdb for {SeriesTitle}", series.Title);
                     _eventAggregator.PublishEvent(new SeriesUpdatedEvent(series));
                 }
 
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Tv
 
             if (series.TvdbId != seriesInfo.TvdbId)
             {
-                _logger.Warn("Series '{0}' (tvdbid {1}) was replaced with '{2}' (tvdbid {3}), because the original was a duplicate.", series.Title, series.TvdbId, seriesInfo.Title, seriesInfo.TvdbId);
+                _logger.Warn("Series '{SeriesTitle}' (tvdbid {TvdbId}) was replaced with '{NewSeriesTitle}' (tvdbid {NewTvdbId}), because the original was a duplicate.", series.Title, series.TvdbId, seriesInfo.Title, seriesInfo.TvdbId);
                 series.TvdbId = seriesInfo.TvdbId;
             }
 
@@ -128,7 +128,7 @@ namespace NzbDrone.Core.Tv
             _seriesService.UpdateSeries(series, publishUpdatedEvent: false);
             _refreshEpisodeService.RefreshEpisodeInfo(series, episodes);
 
-            _logger.Debug("Finished series refresh for {0}", series.Title);
+            _logger.Debug("Finished series refresh for {SeriesTitle}", series.Title);
             _eventAggregator.PublishEvent(new SeriesUpdatedEvent(series));
 
             return series;
@@ -146,14 +146,14 @@ namespace NzbDrone.Core.Tv
                 {
                     if (season.SeasonNumber == 0)
                     {
-                        _logger.Debug("Ignoring season 0 for series [{0}] {1} by default", series.TvdbId, series.Title);
+                        _logger.Debug("Ignoring season 0 for series [{TvdbId}] {SeriesTitle} by default", series.TvdbId, series.Title);
                         season.Monitored = false;
                         continue;
                     }
 
                     var monitorNewSeasons = series.MonitorNewItems == NewItemMonitorTypes.All;
 
-                    _logger.Debug("New season ({0}) for series: [{1}] {2}, setting monitored to {3}", season.SeasonNumber, series.TvdbId, series.Title, monitorNewSeasons.ToString().ToLowerInvariant());
+                    _logger.Debug("New season ({SeasonNumber}) for series: [{TvdbId}] {SeriesTitle}, setting monitored to {Monitored}", season.SeasonNumber, series.TvdbId, series.Title, monitorNewSeasons.ToString().ToLowerInvariant());
                     season.Monitored = monitorNewSeasons;
                 }
                 else
@@ -171,18 +171,18 @@ namespace NzbDrone.Core.Tv
 
             if (isNew)
             {
-                _logger.Trace("Forcing rescan of {0}. Reason: New series", series);
+                _logger.Trace("Forcing rescan of {SeriesTitle}. Reason: New series", series);
             }
             else if (rescanAfterRefresh == RescanAfterRefreshType.Never)
             {
-                _logger.Trace("Skipping rescan of {0}. Reason: never rescan after refresh", series);
+                _logger.Trace("Skipping rescan of {SeriesTitle}. Reason: never rescan after refresh", series);
                 _eventAggregator.PublishEvent(new SeriesScanSkippedEvent(series, SeriesScanSkippedReason.NeverRescanAfterRefresh));
 
                 return;
             }
             else if (rescanAfterRefresh == RescanAfterRefreshType.AfterManual && trigger != CommandTrigger.Manual)
             {
-                _logger.Trace("Skipping rescan of {0}. Reason: not after automatic scans", series);
+                _logger.Trace("Skipping rescan of {SeriesTitle}. Reason: not after automatic scans", series);
                 _eventAggregator.PublishEvent(new SeriesScanSkippedEvent(series, SeriesScanSkippedReason.RescanAfterManualRefreshOnly));
 
                 return;
@@ -194,7 +194,7 @@ namespace NzbDrone.Core.Tv
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Couldn't rescan series {0}", series);
+                _logger.Error(e, "Couldn't rescan series {SeriesTitle}", series);
             }
         }
 
@@ -228,7 +228,7 @@ namespace NzbDrone.Core.Tv
                     }
                     catch (SeriesNotFoundException)
                     {
-                        _logger.Error("Series '{0}' (tvdbid {1}) was not found, it may have been removed from TheTVDB.", series.Title, series.TvdbId);
+                        _logger.Error("Series '{SeriesTitle}' (tvdbid {TvdbId}) was not found, it may have been removed from TheTVDB.", series.Title, series.TvdbId);
 
                         // Mark the result as indeterminate so it's not marked as a full success,
                         // but we can still process other series if needed.
@@ -236,7 +236,7 @@ namespace NzbDrone.Core.Tv
                     }
                     catch (Exception e)
                     {
-                        _logger.Error(e, "Couldn't refresh info for {0}", series);
+                        _logger.Error(e, "Couldn't refresh info for {SeriesTitle}", series);
                         UpdateTags(series);
                         RescanSeries(series, isNew, trigger);
 
@@ -261,12 +261,12 @@ namespace NzbDrone.Core.Tv
                         }
                         catch (SeriesNotFoundException)
                         {
-                            _logger.Error("Series '{0}' (tvdbid {1}) was not found, it may have been removed from TheTVDB.", seriesLocal.Title, seriesLocal.TvdbId);
+                            _logger.Error("Series '{SeriesTitle}' (tvdbid {TvdbId}) was not found, it may have been removed from TheTVDB.", seriesLocal.Title, seriesLocal.TvdbId);
                             continue;
                         }
                         catch (Exception e)
                         {
-                            _logger.Error(e, "Couldn't refresh info for {0}", seriesLocal);
+                            _logger.Error(e, "Couldn't refresh info for {SeriesTitle}", seriesLocal);
                         }
 
                         UpdateTags(series);
@@ -274,7 +274,7 @@ namespace NzbDrone.Core.Tv
                     }
                     else
                     {
-                        _logger.Info("Skipping refresh of series: {0}", seriesLocal.Title);
+                        _logger.Info("Skipping refresh of series: {SeriesTitle}", seriesLocal.Title);
                         UpdateTags(series);
                         RescanSeries(seriesLocal, false, trigger);
                     }

--- a/src/NzbDrone.Core/Tv/SeriesPathBuilder.cs
+++ b/src/NzbDrone.Core/Tv/SeriesPathBuilder.cs
@@ -52,7 +52,7 @@ namespace NzbDrone.Core.Tv
 
             var directoryName = series.Path.GetDirectoryName();
 
-            _logger.Warn("Unable to get relative path for series path {0}, using series folder name {1}", series.Path, directoryName);
+            _logger.Warn("Unable to get relative path for series path {SeriesPath}, using series folder name {DirectoryName}", series.Path, directoryName);
 
             return directoryName;
         }

--- a/src/NzbDrone.Core/Tv/SeriesScannedHandler.cs
+++ b/src/NzbDrone.Core/Tv/SeriesScannedHandler.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Tv
                 return;
             }
 
-            _logger.Info("[{0}] was recently added, performing post-add actions", series.Title);
+            _logger.Info("[{SeriesTitle}] was recently added, performing post-add actions", series.Title);
             _episodeMonitoredService.SetEpisodeMonitoredStatus(series, addOptions);
 
             _eventAggregator.PublishEvent(new SeriesAddCompletedEvent(series));

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -140,10 +140,10 @@ namespace NzbDrone.Core.Tv
             // series are usually the first thing in release title, so we select the leftmost and longest match
             var match = query.First().series;
 
-            _logger.Debug("Multiple series matched {0} from title {1}", match.Title, title);
+            _logger.Debug("Multiple series matched {MatchTitle} from title {Title}", match.Title, title);
             foreach (var entry in list)
             {
-                _logger.Debug("Multiple series match candidate: {0} cleantitle: {1}", entry.Title, entry.CleanTitle);
+                _logger.Debug("Multiple series match candidate: {SeriesTitle} cleantitle: {CleanTitle}", entry.Title, entry.CleanTitle);
             }
 
             return match;
@@ -229,28 +229,28 @@ namespace NzbDrone.Core.Tv
 
         public List<Series> UpdateSeries(List<Series> series, bool useExistingRelativeFolder)
         {
-            _logger.Debug("Updating {0} series", series.Count);
+            _logger.Debug("Updating {Count} series", series.Count);
 
             foreach (var s in series)
             {
-                _logger.Trace("Updating: {0}", s.Title);
+                _logger.Trace("Updating: {SeriesTitle}", s.Title);
 
                 if (!s.RootFolderPath.IsNullOrWhiteSpace())
                 {
                     s.Path = _seriesPathBuilder.BuildPath(s, useExistingRelativeFolder);
 
-                    _logger.Trace("Changing path for {0} to {1}", s.Title, s.Path);
+                    _logger.Trace("Changing path for {SeriesTitle} to {Path}", s.Title, s.Path);
                 }
                 else
                 {
-                    _logger.Trace("Not changing path for: {0}", s.Title);
+                    _logger.Trace("Not changing path for: {SeriesTitle}", s.Title);
                 }
 
                 UpdateTags(s);
             }
 
             _seriesRepository.UpdateMany(series);
-            _logger.Debug("{0} series updated", series.Count);
+            _logger.Debug("{Count} series updated", series.Count);
             _eventAggregator.PublishEvent(new SeriesBulkEditedEvent(series));
 
             return series;
@@ -268,7 +268,7 @@ namespace NzbDrone.Core.Tv
 
         public bool UpdateTags(Series series)
         {
-            _logger.Trace("Updating tags for {0}", series);
+            _logger.Trace("Updating tags for {SeriesTitle}", series);
 
             var tagsAdded = new HashSet<int>();
             var tagsRemoved = new HashSet<int>();
@@ -294,12 +294,12 @@ namespace NzbDrone.Core.Tv
 
             if (tagsAdded.Any() || tagsRemoved.Any())
             {
-                _logger.Debug("Updated tags for '{0}'. Added: {1}, Removed: {2}", series.Title, tagsAdded.Count, tagsRemoved.Count);
+                _logger.Debug("Updated tags for '{SeriesTitle}'. Added: {TagsAdded}, Removed: {TagsRemoved}", series.Title, tagsAdded.Count, tagsRemoved.Count);
 
                 return true;
             }
 
-            _logger.Debug("Tags not updated for '{0}'", series.Title);
+            _logger.Debug("Tags not updated for '{SeriesTitle}'", series.Title);
 
             return false;
         }

--- a/src/NzbDrone.Core/Tv/ShouldRefreshSeries.cs
+++ b/src/NzbDrone.Core/Tv/ShouldRefreshSeries.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Tv
             {
                 if (series.LastInfoSync < DateTime.UtcNow.AddDays(-30))
                 {
-                    _logger.Trace("Series {0} last updated more than 30 days ago, should refresh.", series.Title);
+                    _logger.Trace("Series {SeriesTitle} last updated more than 30 days ago, should refresh.", series.Title);
                     return true;
                 }
 
@@ -40,21 +40,21 @@ namespace NzbDrone.Core.Tv
 
                 if (atLeastOneAiredEpisodeWithoutTitle)
                 {
-                    _logger.Trace("Series {0} with at least one aired episode with TBA title, should refresh.",
+                    _logger.Trace("Series {SeriesTitle} with at least one aired episode with TBA title, should refresh.",
                         series.Title);
                     return true;
                 }
 
                 if (series.LastInfoSync >= DateTime.UtcNow.AddHours(-6))
                 {
-                    _logger.Trace("Series {0} last updated less than 6 hours ago, should not be refreshed.",
+                    _logger.Trace("Series {SeriesTitle} last updated less than 6 hours ago, should not be refreshed.",
                         series.Title);
                     return false;
                 }
 
                 if (series.Status != SeriesStatusType.Ended)
                 {
-                    _logger.Trace("Series {0} is not ended, should refresh.", series.Title);
+                    _logger.Trace("Series {SeriesTitle} is not ended, should refresh.", series.Title);
                     return true;
                 }
 
@@ -62,11 +62,11 @@ namespace NzbDrone.Core.Tv
 
                 if (lastEpisode != null && lastEpisode.AirDateUtc > DateTime.UtcNow.AddDays(-30))
                 {
-                    _logger.Trace("Last episode in {0} aired less than 30 days ago, should refresh.", series.Title);
+                    _logger.Trace("Last episode in {SeriesTitle} aired less than 30 days ago, should refresh.", series.Title);
                     return true;
                 }
 
-                _logger.Trace("Series {0} ended long ago, should not be refreshed.", series.Title);
+                _logger.Trace("Series {SeriesTitle} ended long ago, should not be refreshed.", series.Title);
                 return false;
             }
             catch (Exception e)

--- a/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
+++ b/src/NzbDrone.Core/Update/ConfigureUpdateMechanism.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Update
                 if ((packageUpdateMechanism != externalMechanism && updateMechanism == externalMechanism) ||
                     (packageUpdateMechanism == externalMechanism && updateMechanism == UpdateMechanism.BuiltIn))
                 {
-                    _logger.Info("Update mechanism {0} not supported in the current configuration, changing to {1}.", updateMechanism, packageUpdateMechanism);
+                    _logger.Info("Update mechanism {UpdateMechanism} not supported in the current configuration, changing to {PackageUpdateMechanism}.", updateMechanism, packageUpdateMechanism);
                     ChangeUpdateMechanism(packageUpdateMechanism);
                     break;
                 }
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Update
                 var packageBranch = _deploymentInfoProvider.PackageBranch;
                 if (packageBranch.IsNotNullOrWhiteSpace() && packageBranch != currentBranch)
                 {
-                    _logger.Info("External updater uses branch {0} instead of the currently selected {1}, changing to {0}.", packageBranch, currentBranch);
+                    _logger.Info("External updater uses branch {PackageBranch} instead of the currently selected {CurrentBranch}, changing to {PackageBranch}.", packageBranch, currentBranch);
                     ChangeBranch(packageBranch);
                 }
             }

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -110,7 +110,7 @@ namespace NzbDrone.Core.Update
 
             if (_diskProvider.GetTotalSize(tempFolder) < 1.Gigabytes())
             {
-                _logger.Warn("Temporary location '{0}' has less than 1 GB free space, Sonarr may not be able to update itself.", tempFolder);
+                _logger.Warn("Temporary location '{TempFolder}' has less than 1 GB free space, Sonarr may not be able to update itself.", tempFolder);
             }
 
             var packageDestination = Path.Combine(updateSandboxFolder, updatePackage.FileName);
@@ -121,8 +121,8 @@ namespace NzbDrone.Core.Update
                 _diskProvider.DeleteFolder(updateSandboxFolder, true);
             }
 
-            _logger.ProgressInfo("Downloading update {0}", updatePackage.Version);
-            _logger.Debug("Downloading update package from [{0}] to [{1}]", updatePackage.Url, packageDestination);
+            _logger.ProgressInfo("Downloading update {Version}", updatePackage.Version);
+            _logger.Debug("Downloading update package from [{Url}] to [{Destination}]", updatePackage.Url, packageDestination);
             _httpClient.DownloadFile(updatePackage.Url, packageDestination);
 
             _logger.ProgressInfo("Verifying update package");
@@ -156,7 +156,7 @@ namespace NzbDrone.Core.Update
 
             if (!_diskProvider.FileExists(updateClientExePath))
             {
-                _logger.Warn("Update client {0} does not exist, aborting update.", updateClientExePath);
+                _logger.Warn("Update client {UpdateClientPath} does not exist, aborting update.", updateClientExePath);
                 return false;
             }
 
@@ -166,7 +166,7 @@ namespace NzbDrone.Core.Update
                 _diskProvider.SetFilePermissions(updateClientExePath, "755", null);
             }
 
-            _logger.Info("Starting update client {0}", updateClientExePath);
+            _logger.Info("Starting update client {UpdateClientPath}", updateClientExePath);
             _logger.ProgressInfo("Sonarr will restart shortly.");
 
             _processProvider.Start(updateClientExePath, GetUpdaterArgs(updateSandboxFolder));
@@ -181,14 +181,14 @@ namespace NzbDrone.Core.Update
             {
                 try
                 {
-                    _logger.Info("Branch [{0}] is being redirected to [{1}]]", currentBranch, package.Branch);
+                    _logger.Info("Branch [{CurrentBranch}] is being redirected to [{NewBranch}]]", currentBranch, package.Branch);
                     var config = new Dictionary<string, object>();
                     config["Branch"] = package.Branch;
                     _configFileProvider.SaveConfigDictionary(config);
                 }
                 catch (Exception e)
                 {
-                    _logger.Error(e, "Couldn't change the branch from [{0}] to [{1}].", currentBranch, package.Branch);
+                    _logger.Error(e, "Couldn't change the branch from [{CurrentBranch}] to [{NewBranch}].", currentBranch, package.Branch);
                 }
             }
         }
@@ -210,7 +210,7 @@ namespace NzbDrone.Core.Update
             _logger.Info("Removing Sonarr.Update");
             _diskProvider.DeleteFolder(_appFolderInfo.GetUpdateClientFolder(), true);
 
-            _logger.ProgressInfo("Starting update script: {0}", _configFileProvider.UpdateScriptPath);
+            _logger.ProgressInfo("Starting update script: {UpdateScriptPath}", _configFileProvider.UpdateScriptPath);
             _processProvider.Start(scriptPath, GetUpdaterArgs(updateSandboxFolder));
         }
 
@@ -264,12 +264,12 @@ namespace NzbDrone.Core.Update
             // Safety net, ConfigureUpdateMechanism should take care of invalid settings
             if (_configFileProvider.UpdateMechanism == UpdateMechanism.BuiltIn && _deploymentInfoProvider.IsExternalUpdateMechanism)
             {
-                _logger.ProgressDebug("Built-In updater disabled, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
+                _logger.ProgressDebug("Built-In updater disabled, please use {PackageUpdateMechanism} to install", _deploymentInfoProvider.PackageUpdateMechanism);
                 return null;
             }
             else if (_configFileProvider.UpdateMechanism != UpdateMechanism.Script && _deploymentInfoProvider.IsExternalUpdateMechanism)
             {
-                _logger.ProgressDebug("Update available, please use {0} to install", _deploymentInfoProvider.PackageUpdateMechanism);
+                _logger.ProgressDebug("Update available, please use {PackageUpdateMechanism} to install", _deploymentInfoProvider.PackageUpdateMechanism);
                 return null;
             }
 
@@ -344,7 +344,7 @@ namespace NzbDrone.Core.Update
                     return;
                 }
 
-                _logger.Info("Installing post-install update from {0} to {1}", BuildInfo.Version, latestAvailable.Version);
+                _logger.Info("Installing post-install update from {CurrentVersion} to {NewVersion}", BuildInfo.Version, latestAvailable.Version);
                 _diskProvider.DeleteFile(updateMarker);
 
                 var installing = InstallUpdate(latestAvailable);

--- a/src/NzbDrone.Host/AccessControl/FirewallAdapter.cs
+++ b/src/NzbDrone.Host/AccessControl/FirewallAdapter.cs
@@ -31,13 +31,13 @@ namespace NzbDrone.Host.AccessControl
             {
                 if (!IsNzbDronePortOpen(_configFileProvider.Port))
                 {
-                    _logger.Debug("Opening Port for NzbDrone: {0}", _configFileProvider.Port);
+                    _logger.Debug("Opening Port for NzbDrone: {Port}", _configFileProvider.Port);
                     OpenFirewallPort(_configFileProvider.Port);
                 }
 
                 if (_configFileProvider.EnableSsl && !IsNzbDronePortOpen(_configFileProvider.SslPort))
                 {
-                    _logger.Debug("Opening SSL Port for NzbDrone: {0}", _configFileProvider.SslPort);
+                    _logger.Debug("Opening SSL Port for NzbDrone: {SslPort}", _configFileProvider.SslPort);
                     OpenFirewallPort(_configFileProvider.SslPort);
                 }
             }

--- a/src/NzbDrone.Host/BrowserService.cs
+++ b/src/NzbDrone.Host/BrowserService.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Host
             {
                 if (_runtimeInfo.IsUserInteractive)
                 {
-                    _logger.Info("Starting default browser. {0}", url);
+                    _logger.Info("Starting default browser. {Url}", url);
                     _processProvider.OpenDefaultBrowser(url);
                 }
                 else
@@ -43,7 +43,7 @@ namespace NzbDrone.Host
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Couldn't open default browser to {0}", url);
+                _logger.Error(e, "Couldn't open default browser to {Url}", url);
             }
         }
     }

--- a/src/NzbDrone.Host/SingleInstancePolicy.cs
+++ b/src/NzbDrone.Host/SingleInstancePolicy.cs
@@ -73,7 +73,7 @@ namespace NzbDrone.Host
 
                 if (otherProcesses.Any())
                 {
-                    _logger.Info("{0} instance(s) of Sonarr are running", otherProcesses.Count);
+                    _logger.Info("{InstanceCount} instance(s) of Sonarr are running", otherProcesses.Count);
                 }
 
                 return otherProcesses;

--- a/src/NzbDrone.Host/UtilityModeRouter.cs
+++ b/src/NzbDrone.Host/UtilityModeRouter.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Host
 
         public void Route(ApplicationModes applicationModes)
         {
-            _logger.Info("Application mode: {0}", applicationModes);
+            _logger.Info("Application mode: {ApplicationMode}", applicationModes);
 
             switch (applicationModes)
             {

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Mono.Disk
 
             if (mount == null)
             {
-                _logger.Debug("Unable to get free space for '{0}', unable to find suitable drive", path);
+                _logger.Debug("Unable to get free space for '{Path}', unable to find suitable drive", path);
                 return null;
             }
 
@@ -80,7 +80,7 @@ namespace NzbDrone.Mono.Disk
 
         protected void SetPermissions(string path, string mask, string group, FilePermissions permissions)
         {
-            _logger.Debug("Setting permissions: {0} on {1}", mask, path);
+            _logger.Debug("Setting permissions: {Mask} on {Path}", mask, path);
 
             // Preserve non-access permissions
             if (Syscall.stat(path, out var curStat) < 0)
@@ -160,7 +160,7 @@ namespace NzbDrone.Mono.Disk
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, "Failed to copy permissions from {0} to {1}", sourcePath, targetPath);
+                _logger.Debug(ex, "Failed to copy permissions from {SourcePath} to {TargetPath}", sourcePath, targetPath);
             }
         }
 
@@ -188,7 +188,7 @@ namespace NzbDrone.Mono.Disk
                         }
                         catch (Exception ex)
                         {
-                            _logger.Debug(ex, "Failed to fetch drive info for mount point: {0}", d.Name);
+                            _logger.Debug(ex, "Failed to fetch drive info for mount point: {MountPoint}", d.Name);
 
                             return null;
                         }
@@ -325,7 +325,7 @@ namespace NzbDrone.Mono.Disk
                     Syscall.lstat(destination, out var deststat) != 0 &&
                     Syscall.rename(source, destination) == 0)
                 {
-                    _logger.Trace("Moved '{0}' -> '{1}' using Syscall.rename", source, destination);
+                    _logger.Trace("Moved '{Source}' -> '{Destination}' using Syscall.rename", source, destination);
                     return;
                 }
             }
@@ -350,7 +350,7 @@ namespace NzbDrone.Mono.Disk
                 if (exists && dstInfo.Length == srcInfo.Length)
                 {
                     // mono 6.0, mono 6.4 and netcore 3.1 bug: full length file since utime and chmod happens at the end
-                    _logger.Debug("{3} failed to {2} file likely due to known {3} bug, attempting to {2} directly. '{0}' -> '{1}'", source, destination, move ? "move" : "copy", PlatformInfo.PlatformName);
+                    _logger.Debug("{PlatformName} failed to {Operation} file likely due to known platform bug, attempting to {Operation2} directly. '{Source}' -> '{Destination}'", PlatformInfo.PlatformName, move ? "move" : "copy", move ? "move" : "copy", source, destination);
 
                     // Check at least part of the file since UnauthorizedAccess can happen due to legitimate reasons too
                     var checkLength = (int)Math.Min(64 * 1024, dstInfo.Length);
@@ -359,7 +359,7 @@ namespace NzbDrone.Mono.Disk
                         var srcData = new byte[checkLength];
                         var dstData = new byte[checkLength];
 
-                        _logger.Trace("Check last {0} bytes from {1}", checkLength, destination);
+                        _logger.Trace("Check last {CheckLength} bytes from {Destination}", checkLength, destination);
 
                         using (var srcStream = new FileStream(source, FileMode.Open, FileAccess.Read))
                         using (var dstStream = new FileStream(destination, FileMode.Open, FileAccess.Read))
@@ -381,7 +381,7 @@ namespace NzbDrone.Mono.Disk
                             }
                         }
 
-                        _logger.Trace("Copy was complete, finishing {0} operation", move ? "move" : "copy");
+                        _logger.Trace("Copy was complete, finishing {Operation} operation", move ? "move" : "copy");
                     }
                 }
                 else
@@ -398,12 +398,12 @@ namespace NzbDrone.Mono.Disk
                     }
                     catch
                     {
-                        _logger.Debug("Unable to change last modified date for {0}, skipping.", destination);
+                        _logger.Debug("Unable to change last modified date for {Destination}, skipping.", destination);
                     }
 
                     if (move)
                     {
-                        _logger.Trace("Removing source file {0}", source);
+                        _logger.Trace("Removing source file {Source}", source);
                         File.Delete(source);
                     }
                 }
@@ -433,18 +433,18 @@ namespace NzbDrone.Mono.Disk
             {
                 if (ex.ErrorCode == Errno.EXDEV)
                 {
-                    _logger.Trace("Hardlink '{0}' to '{1}' failed due to cross-device access.", source, destination);
+                    _logger.Trace("Hardlink '{Source}' to '{Destination}' failed due to cross-device access.", source, destination);
                 }
                 else
                 {
-                    _logger.Debug(ex, "Hardlink '{0}' to '{1}' failed.", source, destination);
+                    _logger.Debug(ex, "Hardlink '{Source}' to '{Destination}' failed.", source, destination);
                 }
 
                 return false;
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, "Hardlink '{0}' to '{1}' failed.", source, destination);
+                _logger.Debug(ex, "Hardlink '{Source}' to '{Destination}' failed.", source, destination);
                 return false;
             }
         }

--- a/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
+++ b/src/NzbDrone.Mono/Disk/ProcMountProvider.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Mono.Disk
             {
                 if (!_hasLoggedProcMountFailure)
                 {
-                    _logger.Debug(ex, "Failed to retrieve mounts from {0}", PROC_MOUNTS_FILENAME);
+                    _logger.Debug(ex, "Failed to retrieve mounts from {FileName}", PROC_MOUNTS_FILENAME);
                     _hasLoggedProcMountFailure = true;
                 }
             }
@@ -78,7 +78,7 @@ namespace NzbDrone.Mono.Disk
                 }
                 catch (Exception ex)
                 {
-                    _logger.Debug(ex, "Failed to get filesystem types from {0}, using default set.", PROC_FILESYSTEMS_FILENAME);
+                    _logger.Debug(ex, "Failed to get filesystem types from {FileName}, using default set.", PROC_FILESYSTEMS_FILENAME);
                 }
 
                 if (result.Empty())
@@ -101,7 +101,7 @@ namespace NzbDrone.Mono.Disk
 
             if (split.Length != 6)
             {
-                _logger.Debug("Unable to parse {0} line: {1}", PROC_MOUNTS_FILENAME, line);
+                _logger.Debug("Unable to parse {FileName} line: {Line}", PROC_MOUNTS_FILENAME, line);
                 return null;
             }
 

--- a/src/NzbDrone.Mono/Disk/SymbolicLinkResolver.cs
+++ b/src/NzbDrone.Mono/Disk/SymbolicLinkResolver.cs
@@ -39,12 +39,12 @@ namespace NzbDrone.Mono.Disk
                 }
 
                 var ex = new UnixIOException(Errno.ELOOP);
-                _logger.Warn("Failed to check for symlinks in the path {0}: {1}", path, ex.Message);
+                _logger.Warn("Failed to check for symlinks in the path {Path}: {Message}", path, ex.Message);
                 return path;
             }
             catch (Exception ex)
             {
-                _logger.Debug(ex, "Failed to check for symlinks in the path {0}", path);
+                _logger.Debug(ex, "Failed to check for symlinks in the path {Path}", path);
                 return path;
             }
         }
@@ -143,7 +143,7 @@ namespace NzbDrone.Mono.Disk
                 var errno = Stdlib.GetLastError();
                 if (errno != Errno.EINVAL)
                 {
-                    _logger.Trace("Checking path {0} for symlink returned error {1}, assuming it's not a symlink.", path, errno);
+                    _logger.Trace("Checking path {Path} for symlink returned error {Errno}, assuming it's not a symlink.", path, errno);
                 }
 
                 wasSymLink = true;

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
 
             if (!_diskProvider.FolderExists(PLIST_DIR))
             {
-                _logger.Debug("Directory {0} doesn't exist", PLIST_DIR);
+                _logger.Debug("Directory {Directory} doesn't exist", PLIST_DIR);
                 return null;
             }
 
@@ -40,7 +40,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
 
             if (string.IsNullOrWhiteSpace(versionFile))
             {
-                _logger.Debug("Couldn't find version plist file in {0}", PLIST_DIR);
+                _logger.Debug("Couldn't find version plist file in {Directory}", PLIST_DIR);
                 return null;
             }
 

--- a/src/NzbDrone.Update/UpdateEngine/BackupAndRestore.cs
+++ b/src/NzbDrone.Update/UpdateEngine/BackupAndRestore.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Update.UpdateEngine
         {
             _logger.Info("Attempting to rollback upgrade");
             var count = _diskTransferService.MirrorFolder(_appFolderInfo.GetUpdateBackUpFolder(), target);
-            _logger.Info("Rolled back {0} files", count);
+            _logger.Info("Rolled back {FileCount} files", count);
         }
     }
 }

--- a/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
+++ b/src/NzbDrone.Update/UpdateEngine/DetectExistingVersion.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Update.UpdateEngine
             }
             catch (Exception ex)
             {
-                _logger.Warn(ex, "Failed to get existing version from {0}", targetFolder);
+                _logger.Warn(ex, "Failed to get existing version from {TargetFolder}", targetFolder);
             }
 
             return "(unknown)";

--- a/src/NzbDrone.Update/UpdateEngine/InstallUpdateService.cs
+++ b/src/NzbDrone.Update/UpdateEngine/InstallUpdateService.cs
@@ -85,15 +85,15 @@ namespace NzbDrone.Update.UpdateEngine
 
         public void Start(string installationFolder, int processId)
         {
-            _logger.Info("Installation Folder: {0}", installationFolder);
-            _logger.Info("Updating Sonarr from version {0} to version {1}", _detectExistingVersion.GetExistingVersion(installationFolder), BuildInfo.Version);
+            _logger.Info("Installation Folder: {InstallationFolder}", installationFolder);
+            _logger.Info("Updating Sonarr from version {ExistingVersion} to version {NewVersion}", _detectExistingVersion.GetExistingVersion(installationFolder), BuildInfo.Version);
 
             Verify(installationFolder, processId);
 
             if (installationFolder.EndsWith(@"\bin\Sonarr") || installationFolder.EndsWith(@"/bin/Sonarr"))
             {
                 installationFolder = installationFolder.GetParentPath();
-                _logger.Info("Fixed Installation Folder: {0}", installationFolder);
+                _logger.Info("Fixed Installation Folder: {InstallationFolder}", installationFolder);
             }
 
             var appType = _detectApplicationType.GetAppType();

--- a/src/NzbDrone.Update/UpdateEngine/StartNzbDrone.cs
+++ b/src/NzbDrone.Update/UpdateEngine/StartNzbDrone.cs
@@ -72,7 +72,7 @@ namespace NzbDrone.Update.UpdateEngine
 
         private void Start(string installationFolder, string fileName)
         {
-            _logger.Info("Starting {0}", fileName);
+            _logger.Info("Starting {FileName}", fileName);
             var path = Path.Combine(installationFolder, fileName);
 
             if (!_startupContext.Flags.Contains(StartupContext.NO_BROWSER))

--- a/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleasePushController.cs
@@ -50,7 +50,7 @@ namespace Sonarr.Api.V3.Indexers
         [Consumes("application/json")]
         public ActionResult<List<ReleaseResource>> Create([FromBody] ReleaseResource release)
         {
-            _logger.Info("Release pushed: {0} - {1}", release.Title, release.DownloadUrl ?? release.MagnetUrl);
+            _logger.Info("Release pushed: {Title} - {DownloadUrl}", release.Title, release.DownloadUrl ?? release.MagnetUrl);
 
             ValidateResource(release);
 
@@ -87,11 +87,11 @@ namespace Sonarr.Api.V3.Indexers
 
             if (indexer == null)
             {
-                _logger.Debug("Push Release {0} not associated with an indexer.", release.Title);
+                _logger.Debug("Push Release {Title} not associated with an indexer.", release.Title);
             }
             else
             {
-                _logger.Debug("Push Release {0} associated with indexer '{1} ({2})", release.Title, indexer.Name, indexer.Id);
+                _logger.Debug("Push Release {Title} associated with indexer '{IndexerName} ({IndexerId})", release.Title, indexer.Name, indexer.Id);
 
                 release.IndexerId = indexer.Id;
                 release.Indexer = indexer.Name;
@@ -104,11 +104,11 @@ namespace Sonarr.Api.V3.Indexers
 
             if (downloadClient == null)
             {
-                _logger.Debug("Push Release {0} not associated with a download client.", release.Title);
+                _logger.Debug("Push Release {Title} not associated with a download client.", release.Title);
             }
             else
             {
-                _logger.Debug("Push Release {0} associated with download client '{1} ({2})", release.Title, downloadClient.Name, downloadClient.Id);
+                _logger.Debug("Push Release {Title} associated with download client '{DownloadClientName} ({DownloadClientId})", release.Title, downloadClient.Name, downloadClient.Id);
             }
 
             return downloadClient?.Id;

--- a/src/Sonarr.Api.V5/Release/ReleasePushController.cs
+++ b/src/Sonarr.Api.V5/Release/ReleasePushController.cs
@@ -52,7 +52,7 @@ public class ReleasePushController : RestController<ReleasePushResource>
     [Consumes("application/json")]
     public ActionResult<ReleaseResource> Create([FromBody] ReleasePushResource release)
     {
-        _logger.Info("Release pushed: {0} - {1}", release.Title, release.DownloadUrl ?? release.MagnetUrl);
+        _logger.Info("Release pushed: {ReleaseTitle} - {DownloadUrl}", release.Title, release.DownloadUrl ?? release.MagnetUrl);
 
         ValidateResource(release);
 
@@ -89,11 +89,11 @@ public class ReleasePushController : RestController<ReleasePushResource>
 
         if (indexer == null)
         {
-            _logger.Debug("Push Release {0} not associated with an indexer.", release.Title);
+            _logger.Debug("Push Release {ReleaseTitle} not associated with an indexer.", release.Title);
         }
         else
         {
-            _logger.Debug("Push Release {0} associated with indexer '{1} ({2})", release.Title, indexer.Name, indexer.Id);
+            _logger.Debug("Push Release {ReleaseTitle} associated with indexer '{IndexerName} ({IndexerId})", release.Title, indexer.Name, indexer.Id);
 
             release.IndexerId = indexer.Id;
             release.Indexer = indexer.Name;
@@ -106,11 +106,11 @@ public class ReleasePushController : RestController<ReleasePushResource>
 
         if (downloadClient == null)
         {
-            _logger.Debug("Push Release {0} not associated with a download client.", release.Title);
+            _logger.Debug("Push Release {ReleaseTitle} not associated with a download client.", release.Title);
         }
         else
         {
-            _logger.Debug("Push Release {0} associated with download client '{1} ({2})", release.Title, downloadClient.Name, downloadClient.Id);
+            _logger.Debug("Push Release {ReleaseTitle} associated with download client '{DownloadClientName} ({DownloadClientId})", release.Title, downloadClient.Name, downloadClient.Id);
         }
 
         return downloadClient?.Id;

--- a/src/Sonarr.Http/Authentication/AuthenticationController.cs
+++ b/src/Sonarr.Http/Authentication/AuthenticationController.cs
@@ -62,11 +62,11 @@ namespace Sonarr.Http.Authentication
             {
                 if (e.InnerException is XmlException)
                 {
-                    _logger.Error(e, "Failed to authenticate user due to corrupt XML. Please remove all XML files from {0} and restart Sonarr", Path.Combine(_appFolderInfo.AppDataFolder, "asp"));
+                    _logger.Error(e, "Failed to authenticate user due to corrupt XML. Please remove all XML files from {FilePath} and restart Sonarr", Path.Combine(_appFolderInfo.AppDataFolder, "asp"));
                 }
                 else
                 {
-                    _logger.Error(e, "Failed to authenticate user. {0}", e.Message);
+                    _logger.Error(e, "Failed to authenticate user. {Message}", e.Message);
                 }
 
                 return Unauthorized();

--- a/src/Sonarr.Http/ErrorManagement/SonarrErrorPipeline.cs
+++ b/src/Sonarr.Http/ErrorManagement/SonarrErrorPipeline.cs
@@ -38,14 +38,14 @@ namespace Sonarr.Http.ErrorManagement
 
             if (exception is ApiException apiException)
             {
-                _logger.Warn(apiException, "API Error:\n{0}", apiException.Message);
+                _logger.Warn(apiException, "API Error:\n{Message}", apiException.Message);
 
                 errorModel = new ErrorModel(apiException);
                 statusCode = apiException.StatusCode;
             }
             else if (exception is ValidationException validationException)
             {
-                _logger.Warn("Invalid request {0}", validationException.Message);
+                _logger.Warn("Invalid request {Message}", validationException.Message);
 
                 response.StatusCode = (int)HttpStatusCode.BadRequest;
                 response.ContentType = "application/json";
@@ -74,11 +74,11 @@ namespace Sonarr.Http.ErrorManagement
                     }
                 }
 
-                _logger.Error(sqLiteException, "[{0} {1}]", context.Request.Method, context.Request.Path);
+                _logger.Error(sqLiteException, "[{Method} {Path}]", context.Request.Method, context.Request.Path);
             }
             else
             {
-                _logger.Fatal(exception, "Request Failed. {0} {1}", context.Request.Method, context.Request.Path);
+                _logger.Fatal(exception, "Request Failed. {Method} {Path}", context.Request.Method, context.Request.Path);
             }
 
             await errorModel.WriteToResponse(response, statusCode);

--- a/src/Sonarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
+++ b/src/Sonarr.Http/Frontend/Mappers/StaticResourceMapperBase.cs
@@ -49,7 +49,7 @@ namespace Sonarr.Http.Frontend.Mappers
                 }));
             }
 
-            _logger.Warn("File {0} not found", filePath);
+            _logger.Warn("File {FilePath} not found", filePath);
 
             return Task.FromResult<IActionResult>(null);
         }

--- a/src/Sonarr.Http/Frontend/StaticResourceController.cs
+++ b/src/Sonarr.Http/Frontend/StaticResourceController.cs
@@ -69,7 +69,7 @@ namespace Sonarr.Http.Frontend
                 return NotFound();
             }
 
-            _logger.Warn("Couldn't find handler for {0}", path);
+            _logger.Warn("Couldn't find handler for {Path}", path);
 
             return NotFound();
         }

--- a/src/Sonarr.Http/Middleware/LoggingMiddleware.cs
+++ b/src/Sonarr.Http/Middleware/LoggingMiddleware.cs
@@ -44,7 +44,7 @@ namespace Sonarr.Http.Middleware
 
             var reqPath = GetRequestPathAndQuery(context.Request);
 
-            _loggerHttp.Trace("Req: {0} [{1}] {2} (from {3})", id, context.Request.Method, reqPath, GetOrigin(context));
+            _loggerHttp.Trace("Req: {RequestId} [{Method}] {Path} (from {RemoteIp})", id, context.Request.Method, reqPath, GetOrigin(context));
         }
 
         private void LogEnd(HttpContext context)
@@ -57,11 +57,11 @@ namespace Sonarr.Http.Middleware
 
             var reqPath = GetRequestPathAndQuery(context.Request);
 
-            _loggerHttp.Trace("Res: {0} [{1}] {2}: {3}.{4} ({5} ms)", id, context.Request.Method, reqPath, context.Response.StatusCode, (HttpStatusCode)context.Response.StatusCode, (int)duration.TotalMilliseconds);
+            _loggerHttp.Trace("Res: {RequestId} [{Method}] {Path}: {StatusCode}.{StatusCodeName} ({Elapsed} ms)", id, context.Request.Method, reqPath, context.Response.StatusCode, (HttpStatusCode)context.Response.StatusCode, (int)duration.TotalMilliseconds);
 
             if (context.Request.IsApiRequest())
             {
-                _loggerApi.Debug("[{0}] {1}: {2}.{3} ({4} ms)", context.Request.Method, reqPath, context.Response.StatusCode, (HttpStatusCode)context.Response.StatusCode, (int)duration.TotalMilliseconds);
+                _loggerApi.Debug("[{Method}] {Path}: {StatusCode}.{StatusCodeName} ({Elapsed} ms)", context.Request.Method, reqPath, context.Response.StatusCode, (HttpStatusCode)context.Response.StatusCode, (int)duration.TotalMilliseconds);
             }
         }
 

--- a/src/Sonarr.Http/REST/RestController.cs
+++ b/src/Sonarr.Http/REST/RestController.cs
@@ -115,7 +115,7 @@ namespace Sonarr.Http.REST
             var controllerAttributes = descriptor.ControllerTypeInfo.CustomAttributes;
             if (controllerAttributes.Any(x => x.AttributeType == DEPRECATED_ATTRIBUTE) || attributes.Any(x => x.AttributeType == DEPRECATED_ATTRIBUTE))
             {
-                _logger.Warn("API call made to deprecated endpoint from {0}", Request.Headers.UserAgent.ToString());
+                _logger.Warn("API call made to deprecated endpoint from {UserAgent}", Request.Headers.UserAgent.ToString());
                 Response.Headers["Deprecation"] = "true";
             }
 


### PR DESCRIPTION
## Summary

- Replace positional `{0}` placeholders with named properties (e.g. `{SeriesTitle}`, `{FilePath}`, `{Elapsed}`) in all NLog log calls across the codebase (~900 statements, ~240 files)
- Convert the handful of `$"..."` string interpolation log calls to template style
- Inline the two `string.Format(...)` cases that were used as log message arguments

## Motivation

The infrastructure for structured logging was already in place:
- `NLog.Layouts.ClefJsonLayout` is referenced and wired up for console/CLEF output
- `[MessageTemplateFormatMethod]` is already used on the `ProgressInfo`/`ProgressDebug`/`ProgressTrace` extension methods
- One migration file (`225_mediainfo_multiple_streams.cs`) already used named properties as the target pattern

With named properties, log consumers that support structured logging (Seq, Elastic, Grafana Loki, etc.) can index and filter on individual values — e.g. filter by `SeriesTitle`, group by `StatusCode`, alert on `EpisodeId`. Previously all values were rendered into a flat string with no queryable fields.

## What was NOT changed

- The logging infrastructure itself (`Instrumentation/` folder) — no changes needed there
- Log levels, sinks, or configuration
- Commented-out log statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)