### PR TITLE
Allow "is not" on activity queue custom filters

### DIFF
--- a/frontend/src/Helpers/Props/filterBuilderTypes.ts
+++ b/frontend/src/Helpers/Props/filterBuilderTypes.ts
@@ -79,6 +79,10 @@ export const possibleFilterTypes: Record<
       key: 'equal',
       value: () => translate('FilterIs'),
     },
+    {
+      key: 'notEqual',
+      value: () => translate('FilterIsNot'),
+    },
   ],
 
   exact: [


### PR DESCRIPTION
#### Description
Allow to use "is not" filter for queue custom filters. [FILTER_BUILDER](https://github.com/Sonarr/Sonarr/blob/5bde9242393b988d8b5f154b0b935f6289af9f6d/frontend/src/Activity/Queue/useQueue.ts#L38)

Now is possible to make a filter that says "status is completed & series is "my favorite one" but is not possible to create one that says "status is completed & series **is not** "my favorite one".

This should allow for that.
I did a very shallow codebase exploration so if i'm issing something important please let me know.


#### Screenshots for UI Changes

<img width="871" height="338" alt="imagen" src="https://github.com/user-attachments/assets/6292116a-6130-4089-a1d9-87dd0d1141dd" />


#### Issues Fixed or Closed by this PR
Couldn't find any existing related to this.

