### PR TITLE
Add configurable TMDb metadata source support

### DIFF
--- a/TMDB_METADATA_SOURCE_PLAN.md
+++ b/TMDB_METADATA_SOURCE_PLAN.md
@@ -1,0 +1,51 @@
+## TMDb Metadata Source Plan
+
+### Goal
+
+Add TMDb as a selectable metadata source in Sonarr so users can switch between TVDB and TMDb from `/settings/metadatasource`.
+
+### Scope
+
+- Add a persisted metadata source setting with TMDb credentials.
+- Add a runtime selector so existing callers use the configured metadata provider.
+- Implement a TMDb metadata provider for series search and details.
+- Update series lookup/add/refresh flows to work with the selected source.
+- Update the metadata source settings UI.
+- Add backend and integration tests.
+
+### Implementation Checklist
+
+- [ ] Add config model values:
+  - [ ] `MetadataSource`
+  - [ ] `TmdbApiKey` or bearer token storage
+- [ ] Add V5 settings endpoint/resource for metadata source settings.
+- [ ] Add frontend settings model and page for `/settings/metadatasource`.
+- [ ] Introduce a metadata source selector/facade implementing:
+  - [ ] `ISearchForNewSeries`
+  - [ ] `IProvideSeriesInfo`
+- [ ] Keep TVDB flow through `SkyHookProxy`.
+- [ ] Add TMDb provider:
+  - [ ] search TV series
+  - [ ] lookup by TMDb ID
+  - [ ] map via IMDb/TVDB external IDs
+  - [ ] get show details
+  - [ ] get season details
+  - [ ] map series/episodes/images/ratings/external IDs
+- [ ] Update add/refresh code paths for provider-selected lookups.
+- [ ] Preserve TVDB compatibility where required for existing Sonarr flows.
+- [ ] Add tests:
+  - [ ] settings controller/resource coverage
+  - [ ] selector/facade unit tests
+  - [ ] TMDb proxy mapping/HTTP tests
+  - [ ] series lookup/add/refresh integration coverage
+- [ ] Verify with:
+  - [ ] targeted backend tests
+  - [ ] integration tests
+  - [ ] `yarn lint`
+  - [ ] `yarn build`
+- [ ] Create branch, commit, and open PR when complete.
+
+### Notes
+
+- First implementation target: fully selectable source in UI and runtime, while preserving existing TVDB-based behavior where Sonarr still depends on a TVDB identifier.
+- If TMDb content lacks a usable TVDB mapping, the code should fail clearly rather than silently producing partially-supported series records.

--- a/frontend/src/Settings/MetadataSource/MetadataSourceSettings.tsx
+++ b/frontend/src/Settings/MetadataSource/MetadataSourceSettings.tsx
@@ -1,17 +1,123 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import Alert from 'Components/Alert';
+import FieldSet from 'Components/FieldSet';
+import Form from 'Components/Form/Form';
+import FormGroup from 'Components/Form/FormGroup';
+import FormInputGroup from 'Components/Form/FormInputGroup';
+import FormLabel from 'Components/Form/FormLabel';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
 import PageContent from 'Components/Page/PageContent';
 import PageContentBody from 'Components/Page/PageContentBody';
+import { inputTypes, kinds } from 'Helpers/Props';
 import SettingsToolbar from 'Settings/SettingsToolbar';
+import { InputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
-import TheTvdb from './TheTvdb';
+import {
+  MetadataSourceType,
+  useManageMetadataSourceSettings,
+} from './useMetadataSourceSettings';
+
+const metadataSourceOptions = [
+  {
+    key: MetadataSourceType.Tvdb,
+    value: 'TheTVDB',
+  },
+  {
+    key: MetadataSourceType.Tmdb,
+    value: 'TMDb',
+  },
+];
 
 function MetadataSourceSettings() {
+  const {
+    isFetching,
+    isFetched,
+    error,
+    hasPendingChanges,
+    hasSettings,
+    settings,
+    isSaving,
+    validationErrors,
+    validationWarnings,
+    saveSettings,
+    updateSetting,
+  } = useManageMetadataSourceSettings();
+
+  const handleInputChange = useCallback(
+    (change: InputChanged) => {
+      updateSetting(
+        change.name as 'metadataSource' | 'tmdbApiKey',
+        change.value as MetadataSourceType | string
+      );
+    },
+    [updateSetting]
+  );
+
+  const handleSavePress = useCallback(() => {
+    saveSettings();
+  }, [saveSettings]);
+
+  const selectedMetadataSource = settings.metadataSource?.value;
+
   return (
     <PageContent title={translate('MetadataSourceSettings')}>
-      <SettingsToolbar showSave={false} />
+      <SettingsToolbar
+        hasPendingChanges={hasPendingChanges}
+        isSaving={isSaving}
+        onSavePress={handleSavePress}
+      />
 
       <PageContentBody>
-        <TheTvdb />
+        {isFetching && isFetched ? <LoadingIndicator /> : null}
+
+        {!isFetching && error ? (
+          <Alert kind={kinds.DANGER}>
+            Failed to load metadata source settings.
+          </Alert>
+        ) : null}
+
+        {hasSettings && isFetched && !error ? (
+          <Form
+            id="metadataSourceSettings"
+            validationErrors={validationErrors}
+            validationWarnings={validationWarnings}
+          >
+            <FieldSet legend={translate('MetadataSource')}>
+              <FormGroup>
+                <FormLabel>Provider</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.SELECT}
+                  name="metadataSource"
+                  values={metadataSourceOptions}
+                  helpText="Choose which provider Sonarr uses for series lookup and refresh metadata."
+                  onChange={handleInputChange}
+                  {...settings.metadataSource}
+                />
+              </FormGroup>
+
+              {selectedMetadataSource === MetadataSourceType.Tmdb ? (
+                <FormGroup>
+                  <FormLabel>TMDb API Key</FormLabel>
+
+                  <FormInputGroup
+                    type={inputTypes.PASSWORD}
+                    name="tmdbApiKey"
+                    helpText="Required for direct TMDb access. Sonarr currently still expects TMDb results to resolve to a TVDB ID for full compatibility."
+                    onChange={handleInputChange}
+                    {...settings.tmdbApiKey}
+                  />
+                </FormGroup>
+              ) : null}
+            </FieldSet>
+
+            <FieldSet legend="Attribution">
+              <Alert kind={kinds.INFO}>TheTVDB: https://thetvdb.com</Alert>
+
+              <Alert kind={kinds.INFO}>TMDb: https://www.themoviedb.org</Alert>
+            </FieldSet>
+          </Form>
+        ) : null}
       </PageContentBody>
     </PageContent>
   );

--- a/frontend/src/Settings/MetadataSource/useMetadataSourceSettings.ts
+++ b/frontend/src/Settings/MetadataSource/useMetadataSourceSettings.ts
@@ -1,0 +1,21 @@
+import { useManageSettings, useSettings } from 'Settings/useSettings';
+
+export enum MetadataSourceType {
+  Tvdb = 0,
+  Tmdb = 1,
+}
+
+export interface MetadataSourceSettingsModel {
+  metadataSource: MetadataSourceType;
+  tmdbApiKey: string;
+}
+
+const PATH = '/settings/metadatasource';
+
+export const useMetadataSourceSettings = () => {
+  return useSettings<MetadataSourceSettingsModel>(PATH);
+};
+
+export const useManageMetadataSourceSettings = () => {
+  return useManageSettings<MetadataSourceSettingsModel>(PATH);
+};

--- a/src/NzbDrone.Core.Test/MetadataSource/MetadataSourceSelectorFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/MetadataSourceSelectorFixture.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.MetadataSource
+{
+    [TestFixture]
+    public class MetadataSourceSelectorFixture : CoreTest<MetadataSourceSelector>
+    {
+        [Test]
+        public void should_use_tvdb_provider_for_series_search_when_tvdb_selected()
+        {
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(c => c.MetadataSource)
+                  .Returns(MetadataSourceType.Tvdb);
+
+            var expected = new List<Series> { new Series { TvdbId = 1 } };
+
+            Mocker.GetMock<ITvdbMetadataSource>()
+                  .Setup(s => s.SearchForNewSeries("archer"))
+                  .Returns(expected);
+
+            Subject.SearchForNewSeries("archer").Should().BeSameAs(expected);
+
+            Mocker.GetMock<ITmdbMetadataSource>()
+                  .Verify(s => s.SearchForNewSeries(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_use_tmdb_provider_for_series_search_when_tmdb_selected()
+        {
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(c => c.MetadataSource)
+                  .Returns(MetadataSourceType.Tmdb);
+
+            var expected = new List<Series> { new Series { TmdbId = 2 } };
+
+            Mocker.GetMock<ITmdbMetadataSource>()
+                  .Setup(s => s.SearchForNewSeries("archer"))
+                  .Returns(expected);
+
+            Subject.SearchForNewSeries("archer").Should().BeSameAs(expected);
+
+            Mocker.GetMock<ITvdbMetadataSource>()
+                  .Verify(s => s.SearchForNewSeries(It.IsAny<string>()), Times.Never());
+        }
+
+        [Test]
+        public void should_always_use_tvdb_provider_for_anilist_search()
+        {
+            var expected = new List<Series> { new Series { TvdbId = 3 } };
+
+            Mocker.GetMock<ITvdbMetadataSource>()
+                  .Setup(s => s.SearchForNewSeriesByAniListId(123))
+                  .Returns(expected);
+
+            Subject.SearchForNewSeriesByAniListId(123).Should().BeSameAs(expected);
+
+            Mocker.GetMock<ITmdbMetadataSource>()
+                  .Verify(s => s.SearchForNewSeriesByAniListId(It.IsAny<int>()), Times.Never());
+        }
+
+        [Test]
+        public void should_use_tmdb_provider_for_series_info_when_tmdb_selected()
+        {
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(c => c.MetadataSource)
+                  .Returns(MetadataSourceType.Tmdb);
+
+            var expected = new Tuple<Series, List<Episode>>(new Series { TmdbId = 10 }, new List<Episode>());
+
+            Mocker.GetMock<ITmdbMetadataSource>()
+                  .Setup(s => s.GetSeriesInfo(20, 10))
+                  .Returns(expected);
+
+            Subject.GetSeriesInfo(20, 10).Should().BeSameAs(expected);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MetadataSource/Tmdb/TmdbProxyFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/Tmdb/TmdbProxyFixture.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource.Tmdb;
+using NzbDrone.Core.MetadataSource.Tmdb.Resource;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MetadataSource.Tmdb
+{
+    [TestFixture]
+    public class TmdbProxyFixture : CoreTest<TmdbProxy>
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            Mocker.GetMock<IConfigService>()
+                  .SetupGet(c => c.TmdbApiKey)
+                  .Returns("tmdb-api-key");
+        }
+
+        [Test]
+        public void should_map_search_results_with_tvdb_ids()
+        {
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(c => c.Get<TmdbTvSearchResponse>(It.Is<HttpRequest>(r => r.Url.FullUri.Contains("/search/tv"))))
+                  .Returns<HttpRequest>(r => CreateResponse(r, new TmdbTvSearchResponse
+                  {
+                      Results = new List<TmdbTvSearchResult>
+                      {
+                          new TmdbTvSearchResult
+                          {
+                              Id = 1399,
+                              Name = "Game of Thrones",
+                              Overview = "Winter is coming",
+                              FirstAirDate = "2011-04-17",
+                              PosterPath = "/poster.jpg",
+                              BackdropPath = "/backdrop.jpg",
+                              OriginalLanguage = "en",
+                              OriginCountry = new List<string> { "US" }
+                          }
+                      }
+                  }));
+
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(c => c.Get<TmdbExternalIdsResource>(It.Is<HttpRequest>(r => r.Url.FullUri.Contains("/tv/1399/external_ids"))))
+                  .Returns<HttpRequest>(r => CreateResponse(r, new TmdbExternalIdsResource
+                  {
+                      TvdbId = 121361,
+                      ImdbId = "tt0944947"
+                  }));
+
+            var result = Subject.SearchForNewSeries("Game of Thrones");
+
+            result.Should().ContainSingle();
+            result[0].Title.Should().Be("Game of Thrones");
+            result[0].TvdbId.Should().Be(121361);
+            result[0].TmdbId.Should().Be(1399);
+            result[0].ImdbId.Should().Be("tt0944947");
+        }
+
+        [Test]
+        public void should_map_series_details_and_episodes()
+        {
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(c => c.Get<TmdbTvDetailsResource>(It.Is<HttpRequest>(r => r.Url.FullUri.Contains("/tv/1399?"))))
+                  .Returns<HttpRequest>(r => CreateResponse(r, new TmdbTvDetailsResource
+                  {
+                      Id = 1399,
+                      Name = "Game of Thrones",
+                      Overview = "Winter is coming",
+                      FirstAirDate = "2011-04-17",
+                      LastAirDate = "2019-05-19",
+                      EpisodeRunTime = new List<int> { 55 },
+                      Status = "Ended",
+                      Networks = new List<TmdbNetworkResource> { new TmdbNetworkResource { Name = "HBO" } },
+                      OriginCountry = new List<string> { "US" },
+                      OriginalLanguage = "en",
+                      PosterPath = "/poster.jpg",
+                      BackdropPath = "/backdrop.jpg",
+                      VoteAverage = 8.4m,
+                      VoteCount = 100,
+                      ExternalIds = new TmdbExternalIdsResource { TvdbId = 121361, ImdbId = "tt0944947" },
+                      AggregateCredits = new TmdbAggregateCreditsResource
+                      {
+                          Cast = new List<TmdbCastResource>
+                          {
+                              new TmdbCastResource
+                              {
+                                  Name = "Kit Harington",
+                                  ProfilePath = "/kit.jpg",
+                                  Roles = new List<TmdbRoleResource> { new TmdbRoleResource { Character = "Jon Snow" } }
+                              }
+                          }
+                      },
+                      ContentRatings = new TmdbContentRatingsResource
+                      {
+                          Results = new List<TmdbContentRatingResource>
+                          {
+                              new TmdbContentRatingResource { CountryCode = "US", Rating = "TV-MA" }
+                          }
+                      },
+                      Images = new TmdbImagesResource
+                      {
+                          Posters = new List<TmdbImageResource> { new TmdbImageResource { FilePath = "/poster2.jpg" } },
+                          Backdrops = new List<TmdbImageResource> { new TmdbImageResource { FilePath = "/backdrop2.jpg" } },
+                          Logos = new List<TmdbImageResource> { new TmdbImageResource { FilePath = "/logo.png" } }
+                      },
+                      Seasons = new List<TmdbSeasonSummaryResource>
+                      {
+                          new TmdbSeasonSummaryResource { SeasonNumber = 1, PosterPath = "/season1.jpg" }
+                      }
+                  }));
+
+            Mocker.GetMock<IHttpClient>()
+                  .Setup(c => c.Get<TmdbSeasonDetailsResource>(It.Is<HttpRequest>(r => r.Url.FullUri.Contains("/tv/1399/season/1?"))))
+                  .Returns<HttpRequest>(r => CreateResponse(r, new TmdbSeasonDetailsResource
+                  {
+                      SeasonNumber = 1,
+                      PosterPath = "/season1.jpg",
+                      Episodes = new List<TmdbEpisodeResource>
+                      {
+                          new TmdbEpisodeResource
+                          {
+                              Name = "Winter Is Coming",
+                              Overview = "Ned visits King's Landing.",
+                              AirDate = "2011-04-17",
+                              EpisodeNumber = 1,
+                              SeasonNumber = 1,
+                              Runtime = 62,
+                              VoteAverage = 8.0m,
+                              VoteCount = 10,
+                              StillPath = "/still.jpg",
+                              EpisodeType = "finale"
+                          }
+                      }
+                  }));
+
+            var result = Subject.GetSeriesInfo(121361, 1399);
+
+            result.Item1.Title.Should().Be("Game of Thrones");
+            result.Item1.TvdbId.Should().Be(121361);
+            result.Item1.TmdbId.Should().Be(1399);
+            result.Item1.Network.Should().Be("HBO");
+            result.Item1.Certification.Should().Be("TV-MA");
+            result.Item1.Actors.Should().ContainSingle(a => a.Name == "Kit Harington" && a.Character == "Jon Snow");
+            result.Item2.Should().ContainSingle();
+            result.Item2[0].Title.Should().Be("Winter Is Coming");
+            result.Item2[0].Runtime.Should().Be(62);
+            result.Item2[0].Images.Should().NotBeEmpty();
+        }
+
+        private static HttpResponse<T> CreateResponse<T>(HttpRequest request, T resource)
+            where T : new()
+        {
+            var response = new HttpResponse(request, new HttpHeader { { "Content-Type", "application/json" } }, resource.ToJson());
+
+            return new HttpResponse<T>(response);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/TvTests/AddSeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/AddSeriesFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.TvTests
         private void GivenValidSeries(int tvdbId)
         {
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(tvdbId))
+                  .Setup(s => s.GetSeriesInfo(tvdbId, It.IsAny<int>()))
                   .Returns(new Tuple<Series, List<Episode>>(_fakeSeries, new List<Episode>()));
         }
 
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Test.TvTests
             };
 
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(newSeries.TvdbId))
+                  .Setup(s => s.GetSeriesInfo(newSeries.TvdbId, It.IsAny<int>()))
                   .Throws(new SeriesNotFoundException(newSeries.TvdbId));
 
             Mocker.GetMock<IAddSeriesValidator>()

--- a/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/RefreshSeriesServiceFixture.cs
@@ -42,8 +42,8 @@ namespace NzbDrone.Core.Test.TvTests
                   .Returns(_series);
 
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(It.IsAny<int>()))
-                  .Callback<int>(p => { throw new SeriesNotFoundException(p); });
+                  .Setup(s => s.GetSeriesInfo(It.IsAny<int>(), It.IsAny<int>()))
+                  .Callback<int, int>((p, _) => { throw new SeriesNotFoundException(p); });
 
             Mocker.GetMock<IAutoTaggingService>()
                 .Setup(s => s.GetTagChanges(_series))
@@ -53,7 +53,7 @@ namespace NzbDrone.Core.Test.TvTests
         private void GivenNewSeriesInfo(Series series)
         {
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(_series.TvdbId))
+                  .Setup(s => s.GetSeriesInfo(_series.TvdbId, _series.TmdbId))
                   .Returns(new Tuple<Series, List<Episode>>(series, new List<Episode>()));
         }
 
@@ -250,7 +250,7 @@ namespace NzbDrone.Core.Test.TvTests
         public void should_rescan_series_if_updating_fails()
         {
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(_series.Id))
+                  .Setup(s => s.GetSeriesInfo(_series.Id, It.IsAny<int>()))
                   .Throws(new IOException());
 
             Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));
@@ -265,7 +265,7 @@ namespace NzbDrone.Core.Test.TvTests
         public void should_not_rescan_series_if_updating_fails_with_series_not_found()
         {
             Mocker.GetMock<IProvideSeriesInfo>()
-                  .Setup(s => s.GetSeriesInfo(_series.Id))
+                  .Setup(s => s.GetSeriesInfo(_series.Id, It.IsAny<int>()))
                   .Throws(new SeriesNotFoundException(_series.Id));
 
             Subject.Execute(new RefreshSeriesCommand(new List<int> { _series.Id }));

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Security;
 
@@ -374,6 +375,20 @@ namespace NzbDrone.Core.Configuration
             get { return GetValueInt("UILanguage", (int)Language.English); }
 
             set { SetValue("UILanguage", value); }
+        }
+
+        public MetadataSourceType MetadataSource
+        {
+            get { return GetValueEnum("MetadataSource", MetadataSourceType.Tvdb); }
+
+            set { SetValue("MetadataSource", value); }
+        }
+
+        public string TmdbApiKey
+        {
+            get { return GetValue("TmdbApiKey", string.Empty); }
+
+            set { SetValue("TmdbApiKey", value); }
         }
 
         public bool CleanupMetadataImages

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -3,6 +3,7 @@ using NzbDrone.Common.Http.Proxy;
 using NzbDrone.Core.ImportLists;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
+using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Security;
 
@@ -72,6 +73,10 @@ namespace NzbDrone.Core.Configuration
         bool ShowRelativeDates { get; set; }
         bool EnableColorImpairedMode { get; set; }
         int UILanguage { get; set; }
+
+        // Metadata source
+        MetadataSourceType MetadataSource { get; set; }
+        string TmdbApiKey { get; set; }
 
         // Internal
         bool CleanupMetadataImages { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/IProvideSeriesInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideSeriesInfo.cs
@@ -6,6 +6,6 @@ namespace NzbDrone.Core.MetadataSource
 {
     public interface IProvideSeriesInfo
     {
-        Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId);
+        Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId, int tmdbSeriesId = 0);
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/ITmdbMetadataSource.cs
+++ b/src/NzbDrone.Core/MetadataSource/ITmdbMetadataSource.cs
@@ -1,0 +1,6 @@
+namespace NzbDrone.Core.MetadataSource
+{
+    public interface ITmdbMetadataSource : IProvideSeriesInfo, ISearchForNewSeries
+    {
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/ITvdbMetadataSource.cs
+++ b/src/NzbDrone.Core/MetadataSource/ITvdbMetadataSource.cs
@@ -1,0 +1,6 @@
+namespace NzbDrone.Core.MetadataSource
+{
+    public interface ITvdbMetadataSource : IProvideSeriesInfo, ISearchForNewSeries
+    {
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/MetadataSourceSelector.cs
+++ b/src/NzbDrone.Core/MetadataSource/MetadataSourceSelector.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.MetadataSource
+{
+    public class MetadataSourceSelector : IProvideSeriesInfo, ISearchForNewSeries
+    {
+        private readonly IConfigService _configService;
+        private readonly ITvdbMetadataSource _tvdbMetadataSource;
+        private readonly ITmdbMetadataSource _tmdbMetadataSource;
+
+        public MetadataSourceSelector(IConfigService configService,
+                                      ITvdbMetadataSource tvdbMetadataSource,
+                                      ITmdbMetadataSource tmdbMetadataSource)
+        {
+            _configService = configService;
+            _tvdbMetadataSource = tvdbMetadataSource;
+            _tmdbMetadataSource = tmdbMetadataSource;
+        }
+
+        public Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId, int tmdbSeriesId = 0)
+        {
+            if (_configService.MetadataSource == MetadataSourceType.Tmdb)
+            {
+                return _tmdbMetadataSource.GetSeriesInfo(tvdbSeriesId, tmdbSeriesId);
+            }
+
+            return _tvdbMetadataSource.GetSeriesInfo(tvdbSeriesId, tmdbSeriesId);
+        }
+
+        public List<Series> SearchForNewSeries(string title)
+        {
+            if (_configService.MetadataSource == MetadataSourceType.Tmdb)
+            {
+                return _tmdbMetadataSource.SearchForNewSeries(title);
+            }
+
+            return _tvdbMetadataSource.SearchForNewSeries(title);
+        }
+
+        public List<Series> SearchForNewSeriesByImdbId(string imdbId)
+        {
+            if (_configService.MetadataSource == MetadataSourceType.Tmdb)
+            {
+                return _tmdbMetadataSource.SearchForNewSeriesByImdbId(imdbId);
+            }
+
+            return _tvdbMetadataSource.SearchForNewSeriesByImdbId(imdbId);
+        }
+
+        public List<Series> SearchForNewSeriesByAniListId(int aniListId)
+        {
+            return _tvdbMetadataSource.SearchForNewSeriesByAniListId(aniListId);
+        }
+
+        public List<Series> SearchForNewSeriesByTmdbId(int tmdbId)
+        {
+            if (_configService.MetadataSource == MetadataSourceType.Tmdb)
+            {
+                return _tmdbMetadataSource.SearchForNewSeriesByTmdbId(tmdbId);
+            }
+
+            return _tvdbMetadataSource.SearchForNewSeriesByTmdbId(tmdbId);
+        }
+
+        public List<Series> SearchForNewSeriesByMyAnimeListId(int malId)
+        {
+            return _tvdbMetadataSource.SearchForNewSeriesByMyAnimeListId(malId);
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/MetadataSourceType.cs
+++ b/src/NzbDrone.Core/MetadataSource/MetadataSourceType.cs
@@ -1,0 +1,8 @@
+namespace NzbDrone.Core.MetadataSource
+{
+    public enum MetadataSourceType
+    {
+        Tvdb = 0,
+        Tmdb = 1
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -18,7 +18,7 @@ using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MetadataSource.SkyHook
 {
-    public class SkyHookProxy : IProvideSeriesInfo, ISearchForNewSeries
+    public class SkyHookProxy : ITvdbMetadataSource
     {
         private readonly IHttpClient _httpClient;
         private readonly Logger _logger;
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             _requestBuilder = requestBuilder.SkyHookTvdb;
         }
 
-        public Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId)
+        public Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId, int tmdbSeriesId = 0)
         {
             var httpRequest = _requestBuilder.Create()
                                              .SetSegment("route", "shows")

--- a/src/NzbDrone.Core/MetadataSource/Tmdb/Resource/TmdbResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/Tmdb/Resource/TmdbResource.cs
@@ -1,0 +1,245 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace NzbDrone.Core.MetadataSource.Tmdb.Resource
+{
+    public class TmdbTvSearchResponse
+    {
+        [JsonPropertyName("results")]
+        public List<TmdbTvSearchResult> Results { get; set; } = new List<TmdbTvSearchResult>();
+    }
+
+    public class TmdbFindResponse
+    {
+        [JsonPropertyName("tv_results")]
+        public List<TmdbFindTvResult> TvResults { get; set; } = new List<TmdbFindTvResult>();
+    }
+
+    public class TmdbFindTvResult
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+    }
+
+    public class TmdbTvSearchResult
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("overview")]
+        public string Overview { get; set; }
+
+        [JsonPropertyName("first_air_date")]
+        public string FirstAirDate { get; set; }
+
+        [JsonPropertyName("poster_path")]
+        public string PosterPath { get; set; }
+
+        [JsonPropertyName("backdrop_path")]
+        public string BackdropPath { get; set; }
+
+        [JsonPropertyName("original_language")]
+        public string OriginalLanguage { get; set; }
+
+        [JsonPropertyName("origin_country")]
+        public List<string> OriginCountry { get; set; } = new List<string>();
+    }
+
+    public class TmdbTvDetailsResource
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("overview")]
+        public string Overview { get; set; }
+
+        [JsonPropertyName("first_air_date")]
+        public string FirstAirDate { get; set; }
+
+        [JsonPropertyName("last_air_date")]
+        public string LastAirDate { get; set; }
+
+        [JsonPropertyName("episode_run_time")]
+        public List<int> EpisodeRunTime { get; set; } = new List<int>();
+
+        [JsonPropertyName("genres")]
+        public List<TmdbGenreResource> Genres { get; set; } = new List<TmdbGenreResource>();
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("networks")]
+        public List<TmdbNetworkResource> Networks { get; set; } = new List<TmdbNetworkResource>();
+
+        [JsonPropertyName("origin_country")]
+        public List<string> OriginCountry { get; set; } = new List<string>();
+
+        [JsonPropertyName("original_language")]
+        public string OriginalLanguage { get; set; }
+
+        [JsonPropertyName("poster_path")]
+        public string PosterPath { get; set; }
+
+        [JsonPropertyName("backdrop_path")]
+        public string BackdropPath { get; set; }
+
+        [JsonPropertyName("vote_average")]
+        public decimal VoteAverage { get; set; }
+
+        [JsonPropertyName("vote_count")]
+        public int VoteCount { get; set; }
+
+        [JsonPropertyName("external_ids")]
+        public TmdbExternalIdsResource ExternalIds { get; set; }
+
+        [JsonPropertyName("aggregate_credits")]
+        public TmdbAggregateCreditsResource AggregateCredits { get; set; }
+
+        [JsonPropertyName("content_ratings")]
+        public TmdbContentRatingsResource ContentRatings { get; set; }
+
+        [JsonPropertyName("images")]
+        public TmdbImagesResource Images { get; set; }
+
+        [JsonPropertyName("seasons")]
+        public List<TmdbSeasonSummaryResource> Seasons { get; set; } = new List<TmdbSeasonSummaryResource>();
+    }
+
+    public class TmdbSeasonDetailsResource
+    {
+        [JsonPropertyName("season_number")]
+        public int SeasonNumber { get; set; }
+
+        [JsonPropertyName("poster_path")]
+        public string PosterPath { get; set; }
+
+        [JsonPropertyName("episodes")]
+        public List<TmdbEpisodeResource> Episodes { get; set; } = new List<TmdbEpisodeResource>();
+    }
+
+    public class TmdbEpisodeResource
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("overview")]
+        public string Overview { get; set; }
+
+        [JsonPropertyName("air_date")]
+        public string AirDate { get; set; }
+
+        [JsonPropertyName("episode_number")]
+        public int EpisodeNumber { get; set; }
+
+        [JsonPropertyName("season_number")]
+        public int SeasonNumber { get; set; }
+
+        [JsonPropertyName("runtime")]
+        public int? Runtime { get; set; }
+
+        [JsonPropertyName("vote_average")]
+        public decimal VoteAverage { get; set; }
+
+        [JsonPropertyName("vote_count")]
+        public int VoteCount { get; set; }
+
+        [JsonPropertyName("still_path")]
+        public string StillPath { get; set; }
+
+        [JsonPropertyName("episode_type")]
+        public string EpisodeType { get; set; }
+    }
+
+    public class TmdbGenreResource
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+
+    public class TmdbNetworkResource
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+    }
+
+    public class TmdbExternalIdsResource
+    {
+        [JsonPropertyName("imdb_id")]
+        public string ImdbId { get; set; }
+
+        [JsonPropertyName("tvdb_id")]
+        public int? TvdbId { get; set; }
+    }
+
+    public class TmdbAggregateCreditsResource
+    {
+        [JsonPropertyName("cast")]
+        public List<TmdbCastResource> Cast { get; set; } = new List<TmdbCastResource>();
+    }
+
+    public class TmdbCastResource
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("profile_path")]
+        public string ProfilePath { get; set; }
+
+        [JsonPropertyName("roles")]
+        public List<TmdbRoleResource> Roles { get; set; } = new List<TmdbRoleResource>();
+    }
+
+    public class TmdbRoleResource
+    {
+        [JsonPropertyName("character")]
+        public string Character { get; set; }
+    }
+
+    public class TmdbContentRatingsResource
+    {
+        [JsonPropertyName("results")]
+        public List<TmdbContentRatingResource> Results { get; set; } = new List<TmdbContentRatingResource>();
+    }
+
+    public class TmdbContentRatingResource
+    {
+        [JsonPropertyName("iso_3166_1")]
+        public string CountryCode { get; set; }
+
+        [JsonPropertyName("rating")]
+        public string Rating { get; set; }
+    }
+
+    public class TmdbImagesResource
+    {
+        [JsonPropertyName("posters")]
+        public List<TmdbImageResource> Posters { get; set; } = new List<TmdbImageResource>();
+
+        [JsonPropertyName("backdrops")]
+        public List<TmdbImageResource> Backdrops { get; set; } = new List<TmdbImageResource>();
+
+        [JsonPropertyName("logos")]
+        public List<TmdbImageResource> Logos { get; set; } = new List<TmdbImageResource>();
+    }
+
+    public class TmdbImageResource
+    {
+        [JsonPropertyName("file_path")]
+        public string FilePath { get; set; }
+    }
+
+    public class TmdbSeasonSummaryResource
+    {
+        [JsonPropertyName("season_number")]
+        public int SeasonNumber { get; set; }
+
+        [JsonPropertyName("poster_path")]
+        public string PosterPath { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/Tmdb/TmdbProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/Tmdb/TmdbProxy.cs
@@ -1,0 +1,462 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using NLog;
+using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.DataAugmentation.DailySeries;
+using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MetadataSource.SkyHook;
+using NzbDrone.Core.MetadataSource.Tmdb.Resource;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.MetadataSource.Tmdb
+{
+    public class TmdbProxy : ITmdbMetadataSource
+    {
+        private const string ApiUrl = "https://api.themoviedb.org/3";
+        private const string ImageBaseUrl = "https://image.tmdb.org/t/p/original";
+
+        private readonly IHttpClient _httpClient;
+        private readonly ISeriesService _seriesService;
+        private readonly IDailySeriesService _dailySeriesService;
+        private readonly IConfigService _configService;
+        private readonly Logger _logger;
+
+        public TmdbProxy(IHttpClient httpClient,
+                         ISeriesService seriesService,
+                         IDailySeriesService dailySeriesService,
+                         IConfigService configService,
+                         Logger logger)
+        {
+            _httpClient = httpClient;
+            _seriesService = seriesService;
+            _dailySeriesService = dailySeriesService;
+            _configService = configService;
+            _logger = logger;
+        }
+
+        public Tuple<Series, List<Episode>> GetSeriesInfo(int tvdbSeriesId, int tmdbSeriesId = 0)
+        {
+            var resolvedTmdbId = tmdbSeriesId > 0 ? tmdbSeriesId : FindTmdbIdByTvdbId(tvdbSeriesId);
+
+            if (resolvedTmdbId <= 0)
+            {
+                throw new SeriesNotFoundException(tvdbSeriesId);
+            }
+
+            var details = Get<TmdbTvDetailsResource>($"tv/{resolvedTmdbId}", request =>
+            {
+                request.AddQueryParam("append_to_response", "external_ids,aggregate_credits,content_ratings,images");
+                request.AddQueryParam("include_image_language", "en,null");
+            });
+
+            if (details.ExternalIds?.TvdbId is not > 0 && tvdbSeriesId > 0)
+            {
+                details.ExternalIds ??= new TmdbExternalIdsResource();
+                details.ExternalIds.TvdbId = tvdbSeriesId;
+            }
+
+            var seasons = details.Seasons
+                                 .Where(s => s.SeasonNumber >= 0)
+                                 .Select(s => Get<TmdbSeasonDetailsResource>($"tv/{resolvedTmdbId}/season/{s.SeasonNumber}"))
+                                 .ToList();
+
+            var series = MapSeries(details);
+            var runtime = details.EpisodeRunTime.FirstOrDefault();
+            var episodes = seasons.SelectMany(s => s.Episodes.Select(e => MapEpisode(e, runtime))).ToList();
+
+            return new Tuple<Series, List<Episode>>(series, episodes);
+        }
+
+        public List<Series> SearchForNewSeriesByImdbId(string imdbId)
+        {
+            imdbId = Parser.Parser.NormalizeImdbId(imdbId);
+
+            if (imdbId == null)
+            {
+                return new List<Series>();
+            }
+
+            return FindByExternalId(imdbId, "imdb_id");
+        }
+
+        public List<Series> SearchForNewSeriesByAniListId(int aniListId)
+        {
+            return new List<Series>();
+        }
+
+        public List<Series> SearchForNewSeriesByTmdbId(int tmdbId)
+        {
+            if (tmdbId <= 0)
+            {
+                return new List<Series>();
+            }
+
+            try
+            {
+                return new List<Series> { GetSeriesInfo(0, tmdbId).Item1 }
+                    .Where(s => s.TvdbId > 0)
+                    .ToList();
+            }
+            catch (SeriesNotFoundException)
+            {
+                return new List<Series>();
+            }
+        }
+
+        public List<Series> SearchForNewSeriesByMyAnimeListId(int malId)
+        {
+            return new List<Series>();
+        }
+
+        public List<Series> SearchForNewSeries(string title)
+        {
+            if (title.IsPathValid(PathValidationType.AnyOs))
+            {
+                throw new InvalidSearchTermException("Invalid search term '{0}'", title);
+            }
+
+            var lowerTitle = title.ToLowerInvariant().Trim();
+
+            if (lowerTitle.StartsWith("tmdb:") || lowerTitle.StartsWith("tmdbid:"))
+            {
+                var slug = lowerTitle.Split(':')[1].Trim();
+
+                if (slug.IsNullOrWhiteSpace() || slug.Any(char.IsWhiteSpace) || !int.TryParse(slug, out var tmdbId) || tmdbId <= 0)
+                {
+                    return new List<Series>();
+                }
+
+                return SearchForNewSeriesByTmdbId(tmdbId);
+            }
+
+            if (lowerTitle.StartsWith("tvdb:") || lowerTitle.StartsWith("tvdbid:"))
+            {
+                var slug = lowerTitle.Split(':')[1].Trim();
+
+                if (slug.IsNullOrWhiteSpace() || slug.Any(char.IsWhiteSpace) || !int.TryParse(slug, out var tvdbId) || tvdbId <= 0)
+                {
+                    return new List<Series>();
+                }
+
+                return FindByExternalId(tvdbId.ToString(CultureInfo.InvariantCulture), "tvdb_id");
+            }
+
+            var response = Get<TmdbTvSearchResponse>("search/tv", request => request.AddQueryParam("query", title.Trim()));
+
+            return response.Results
+                           .Select(MapSearchResult)
+                           .Where(s => s.TvdbId > 0)
+                           .ToList();
+        }
+
+        private List<Series> FindByExternalId(string id, string externalSource)
+        {
+            var response = Get<TmdbFindResponse>($"find/{id}", request => request.AddQueryParam("external_source", externalSource));
+
+            return response.TvResults
+                           .Select(result => MapSearchResult(new TmdbTvSearchResult { Id = result.Id }))
+                           .Where(series => series.TvdbId > 0)
+                           .ToList();
+        }
+
+        private Series MapSearchResult(TmdbTvSearchResult searchResult)
+        {
+            var externalIds = Get<TmdbExternalIdsResource>($"tv/{searchResult.Id}/external_ids");
+            var tvdbId = externalIds.TvdbId.GetValueOrDefault();
+
+            if (tvdbId > 0)
+            {
+                var existingSeries = _seriesService.FindByTvdbId(tvdbId);
+
+                if (existingSeries != null)
+                {
+                    return existingSeries;
+                }
+            }
+
+            return MapSeries(searchResult, externalIds);
+        }
+
+        private Series MapSeries(TmdbTvSearchResult searchResult, TmdbExternalIdsResource externalIds)
+        {
+            var series = new Series
+            {
+                TvdbId = externalIds?.TvdbId ?? 0,
+                TmdbId = searchResult.Id,
+                ImdbId = externalIds?.ImdbId,
+                Title = searchResult.Name,
+                CleanTitle = Parser.Parser.CleanSeriesTitle(searchResult.Name),
+                Overview = searchResult.Overview,
+                Monitored = true,
+                OriginalCountry = searchResult.OriginCountry.FirstOrDefault(),
+                OriginalLanguage = searchResult.OriginalLanguage.IsNotNullOrWhiteSpace()
+                    ? IsoLanguages.Find(searchResult.OriginalLanguage.ToLowerInvariant())?.Language ?? Language.English
+                    : Language.English
+            };
+
+            series.SortTitle = SeriesTitleNormalizer.Normalize(series.Title, series.TvdbId > 0 ? series.TvdbId : series.TmdbId);
+            series.TitleSlug = series.Title.CleanSeriesTitle();
+
+            if (searchResult.FirstAirDate.IsNotNullOrWhiteSpace() && DateTime.TryParseExact(searchResult.FirstAirDate, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var firstAired))
+            {
+                series.FirstAired = firstAired;
+                series.Year = firstAired.Year;
+            }
+
+            AddImage(series.Images, MediaCoverTypes.Poster, searchResult.PosterPath);
+            AddImage(series.Images, MediaCoverTypes.Fanart, searchResult.BackdropPath);
+
+            return series;
+        }
+
+        private Series MapSeries(TmdbTvDetailsResource details)
+        {
+            var series = new Series
+            {
+                TvdbId = details.ExternalIds?.TvdbId ?? 0,
+                TmdbId = details.Id,
+                ImdbId = details.ExternalIds?.ImdbId,
+                Title = details.Name,
+                CleanTitle = Parser.Parser.CleanSeriesTitle(details.Name),
+                Overview = details.Overview,
+                Monitored = true,
+                Runtime = details.EpisodeRunTime.FirstOrDefault(),
+                Network = details.Networks.FirstOrDefault()?.Name,
+                Status = MapSeriesStatus(details.Status),
+                Ratings = new Ratings { Votes = details.VoteCount, Value = details.VoteAverage },
+                Genres = details.Genres.Select(g => g.Name).Where(g => g.IsNotNullOrWhiteSpace()).ToList(),
+                OriginalCountry = details.OriginCountry.FirstOrDefault(),
+                OriginalLanguage = details.OriginalLanguage.IsNotNullOrWhiteSpace()
+                    ? IsoLanguages.Find(details.OriginalLanguage.ToLowerInvariant())?.Language ?? Language.English
+                    : Language.English,
+                Actors = details.AggregateCredits?.Cast.Select(MapActor).Where(a => a != null).ToList() ?? new List<Actor>(),
+                Seasons = details.Seasons.Select(MapSeason).ToList(),
+                TitleSlug = details.Name.CleanSeriesTitle(),
+                Certification = MapCertification(details.ContentRatings)
+            };
+
+            series.SortTitle = SeriesTitleNormalizer.Normalize(series.Title, series.TvdbId > 0 ? series.TvdbId : series.TmdbId);
+
+            if (details.FirstAirDate.IsNotNullOrWhiteSpace() && DateTime.TryParseExact(details.FirstAirDate, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var firstAired))
+            {
+                series.FirstAired = firstAired;
+                series.Year = firstAired.Year;
+            }
+
+            if (details.LastAirDate.IsNotNullOrWhiteSpace() && DateTime.TryParseExact(details.LastAirDate, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var lastAired))
+            {
+                series.LastAired = lastAired;
+            }
+
+            AddImage(series.Images, MediaCoverTypes.Poster, details.PosterPath);
+            AddImage(series.Images, MediaCoverTypes.Fanart, details.BackdropPath);
+
+            foreach (var poster in details.Images?.Posters ?? new List<TmdbImageResource>())
+            {
+                AddImage(series.Images, MediaCoverTypes.Poster, poster.FilePath);
+            }
+
+            foreach (var backdrop in details.Images?.Backdrops ?? new List<TmdbImageResource>())
+            {
+                AddImage(series.Images, MediaCoverTypes.Fanart, backdrop.FilePath);
+            }
+
+            foreach (var logo in details.Images?.Logos ?? new List<TmdbImageResource>())
+            {
+                AddImage(series.Images, MediaCoverTypes.Clearlogo, logo.FilePath);
+            }
+
+            if (series.TvdbId > 0 && _dailySeriesService.IsDailySeries(series.TvdbId))
+            {
+                series.SeriesType = SeriesTypes.Daily;
+            }
+
+            return series;
+        }
+
+        private static Actor MapActor(TmdbCastResource cast)
+        {
+            if (cast?.Name.IsNullOrWhiteSpace() ?? true)
+            {
+                return null;
+            }
+
+            var actor = new Actor
+            {
+                Name = cast.Name,
+                Character = cast.Roles.FirstOrDefault()?.Character
+            };
+
+            if (cast.ProfilePath.IsNotNullOrWhiteSpace())
+            {
+                actor.Images.Add(new MediaCover.MediaCover(MediaCoverTypes.Headshot, BuildImageUrl(cast.ProfilePath)));
+            }
+
+            return actor;
+        }
+
+        private static Season MapSeason(TmdbSeasonSummaryResource season)
+        {
+            var mapped = new Season
+            {
+                SeasonNumber = season.SeasonNumber,
+                Monitored = season.SeasonNumber > 0
+            };
+
+            AddImage(mapped.Images, MediaCoverTypes.Poster, season.PosterPath);
+
+            return mapped;
+        }
+
+        private static Episode MapEpisode(TmdbEpisodeResource episode, int seriesRuntime)
+        {
+            var mapped = new Episode
+            {
+                Overview = episode.Overview,
+                SeasonNumber = episode.SeasonNumber,
+                EpisodeNumber = episode.EpisodeNumber,
+                Title = episode.Name,
+                AirDate = episode.AirDate,
+                Runtime = episode.Runtime ?? seriesRuntime,
+                FinaleType = episode.EpisodeType,
+                Ratings = new Ratings
+                {
+                    Votes = episode.VoteCount,
+                    Value = episode.VoteAverage
+                }
+            };
+
+            if (episode.AirDate.IsNotNullOrWhiteSpace() && DateTime.TryParseExact(episode.AirDate, "yyyy-MM-dd", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var airDateUtc))
+            {
+                mapped.AirDateUtc = airDateUtc;
+            }
+
+            AddImage(mapped.Images, MediaCoverTypes.Screenshot, episode.StillPath);
+
+            return mapped;
+        }
+
+        private static string MapCertification(TmdbContentRatingsResource contentRatings)
+        {
+            var rating = contentRatings?.Results?.FirstOrDefault(r => r.CountryCode == "US" && r.Rating.IsNotNullOrWhiteSpace())
+                         ?? contentRatings?.Results?.FirstOrDefault(r => r.CountryCode == "GB" && r.Rating.IsNotNullOrWhiteSpace())
+                         ?? contentRatings?.Results?.FirstOrDefault(r => r.Rating.IsNotNullOrWhiteSpace());
+
+            return rating?.Rating?.ToUpperInvariant();
+        }
+
+        private static SeriesStatusType MapSeriesStatus(string status)
+        {
+            if (status.IsNullOrWhiteSpace())
+            {
+                return SeriesStatusType.Continuing;
+            }
+
+            if (status.Equals("Ended", StringComparison.InvariantCultureIgnoreCase) ||
+                status.Equals("Canceled", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return SeriesStatusType.Ended;
+            }
+
+            if (status.Equals("Planned", StringComparison.InvariantCultureIgnoreCase) ||
+                status.Equals("Pilot", StringComparison.InvariantCultureIgnoreCase) ||
+                status.Equals("In Production", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return SeriesStatusType.Upcoming;
+            }
+
+            return SeriesStatusType.Continuing;
+        }
+
+        private int FindTmdbIdByTvdbId(int tvdbId)
+        {
+            if (tvdbId <= 0)
+            {
+                return 0;
+            }
+
+            var response = Get<TmdbFindResponse>($"find/{tvdbId}", request => request.AddQueryParam("external_source", "tvdb_id"));
+
+            return response.TvResults.FirstOrDefault()?.Id ?? 0;
+        }
+
+        private T Get<T>(string resource, Action<HttpRequestBuilder> builderAction = null)
+            where T : new()
+        {
+            EnsureApiKey();
+
+            var requestBuilder = new HttpRequestBuilder(ApiUrl)
+                .Resource(resource)
+                .AddQueryParam("api_key", _configService.TmdbApiKey);
+
+            builderAction?.Invoke(requestBuilder);
+
+            var request = requestBuilder.Build();
+            request.SuppressHttpError = true;
+
+            var response = _httpClient.Get<T>(request);
+
+            if (response.HasHttpError)
+            {
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new SeriesNotFoundException(0, $"TMDb resource '{resource}' was not found.");
+                }
+
+                _logger.Warn("TMDb request failed for resource {0} with status {1}", resource, response.StatusCode);
+                throw new HttpException(request, response);
+            }
+
+            return response.Resource;
+        }
+
+        private void EnsureApiKey()
+        {
+            if (_configService.TmdbApiKey.IsNullOrWhiteSpace())
+            {
+                throw new InvalidOperationException("TMDb API key is not configured.");
+            }
+        }
+
+        private static void AddImage(ICollection<MediaCover.MediaCover> images, MediaCoverTypes coverType, string path)
+        {
+            if (path.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var imageUrl = BuildImageUrl(path);
+
+            if (images.Any(i => i.CoverType == coverType && i.RemoteUrl == imageUrl))
+            {
+                return;
+            }
+
+            images.Add(new MediaCover.MediaCover(coverType, imageUrl));
+        }
+
+        private static string BuildImageUrl(string path)
+        {
+            if (path.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            if (path.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return path;
+            }
+
+            return $"{ImageBaseUrl}{path}";
+        }
+    }
+}

--- a/src/NzbDrone.Core/Tv/AddSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/AddSeriesService.cs
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Tv
 
             try
             {
-                tuple = _seriesInfo.GetSeriesInfo(newSeries.TvdbId);
+                tuple = _seriesInfo.GetSeriesInfo(newSeries.TvdbId, newSeries.TmdbId);
             }
             catch (SeriesNotFoundException)
             {

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.Tv
 
             try
             {
-                var tuple = _seriesInfo.GetSeriesInfo(series.TvdbId);
+                var tuple = _seriesInfo.GetSeriesInfo(series.TvdbId, series.TmdbId);
                 seriesInfo = tuple.Item1;
                 episodes = tuple.Item2;
             }

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -24,6 +24,7 @@ using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Common.Options;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore.Extensions;
+using NzbDrone.Core.MetadataSource;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 using PostgresOptions = NzbDrone.Core.Datastore.PostgresOptions;
@@ -90,8 +91,12 @@ namespace NzbDrone.Host
                     c.AutoAddServices(ASSEMBLIES)
                         .AddNzbDroneLogger()
                         .AddDatabase()
-                        .AddStartupContext(startupContext)
-                        .Resolve<UtilityModeRouter>()
+                        .AddStartupContext(startupContext);
+
+                    c.RegisterDelegate<IProvideSeriesInfo>(r => r.Resolve<MetadataSourceSelector>(), Reuse.Singleton, ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+                    c.RegisterDelegate<ISearchForNewSeries>(r => r.Resolve<MetadataSourceSelector>(), Reuse.Singleton, ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+
+                    c.Resolve<UtilityModeRouter>()
                         .Route(appMode);
 
                     if (config.GetValue(nameof(ConfigFileProvider.LogDbEnabled), true))
@@ -170,6 +175,9 @@ namespace NzbDrone.Host
                         .AddNzbDroneLogger()
                         .AddDatabase()
                         .AddStartupContext(context);
+
+                    c.RegisterDelegate<IProvideSeriesInfo>(r => r.Resolve<MetadataSourceSelector>(), Reuse.Singleton, ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+                    c.RegisterDelegate<ISearchForNewSeries>(r => r.Resolve<MetadataSourceSelector>(), Reuse.Singleton, ifAlreadyRegistered: IfAlreadyRegistered.Replace);
 
                     if (logDbEnabled)
                     {

--- a/src/NzbDrone.Integration.Test/ApiTests/MetadataSourceSettingsFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/MetadataSourceSettingsFixture.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Integration.Test.Client;
+using RestSharp;
+using Sonarr.Http.REST;
+
+namespace NzbDrone.Integration.Test.ApiTests
+{
+    [TestFixture]
+    public class MetadataSourceSettingsFixture : IntegrationTest
+    {
+        private ClientBase<TestMetadataSourceSettingsResource> _metadataSourceSettings;
+
+        [SetUp]
+        public void SetUpTest()
+        {
+            var v5Client = new RestClient(RootUrl + "api/v5/");
+            _metadataSourceSettings = new ClientBase<TestMetadataSourceSettingsResource>(v5Client, ApiKey, "settings/metadatasource");
+        }
+
+        [Test]
+        public void should_be_able_to_get_metadata_source_settings()
+        {
+            var settings = _metadataSourceSettings.GetSingle();
+
+            settings.Should().NotBeNull();
+            settings.MetadataSource.Should().Be(MetadataSourceType.Tvdb);
+        }
+
+        [Test]
+        public void should_be_able_to_update_metadata_source_settings()
+        {
+            var settings = _metadataSourceSettings.GetSingle();
+            settings.MetadataSource = MetadataSourceType.Tmdb;
+            settings.TmdbApiKey = "tmdb-test-key";
+
+            var result = _metadataSourceSettings.Put(settings);
+
+            result.MetadataSource.Should().Be(MetadataSourceType.Tmdb);
+            result.TmdbApiKey.Should().Be("tmdb-test-key");
+        }
+
+        [Test]
+        public void should_require_tmdb_api_key_when_tmdb_is_selected()
+        {
+            var settings = _metadataSourceSettings.GetSingle();
+            settings.MetadataSource = MetadataSourceType.Tmdb;
+            settings.TmdbApiKey = string.Empty;
+
+            var errors = _metadataSourceSettings.InvalidPut(settings);
+
+            errors.Should().NotBeNull();
+        }
+
+        public class TestMetadataSourceSettingsResource : RestResource
+        {
+            public MetadataSourceType MetadataSource { get; set; }
+            public string TmdbApiKey { get; set; }
+        }
+    }
+}

--- a/src/Sonarr.Api.V5/Settings/MetadataSourceSettingsController.cs
+++ b/src/Sonarr.Api.V5/Settings/MetadataSourceSettingsController.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
+using Sonarr.Http;
+
+namespace Sonarr.Api.V5.Settings;
+
+[V5ApiController("settings/metadatasource")]
+public class MetadataSourceSettingsController : SettingsController<MetadataSourceSettingsResource>
+{
+    public MetadataSourceSettingsController(IConfigFileProvider configFileProvider, IConfigService configService)
+        : base(configFileProvider, configService)
+    {
+        SharedValidator.RuleFor(c => c.MetadataSource)
+                       .IsInEnum();
+
+        SharedValidator.RuleFor(c => c.TmdbApiKey)
+                       .NotEmpty()
+                       .When(c => c.MetadataSource == MetadataSourceType.Tmdb)
+                       .WithMessage("TMDb API key is required when TMDb is selected");
+    }
+
+    protected override MetadataSourceSettingsResource ToResource(IConfigFileProvider configFile, IConfigService model)
+    {
+        return MetadataSourceSettingsResourceMapper.ToResource(model);
+    }
+}

--- a/src/Sonarr.Api.V5/Settings/MetadataSourceSettingsResource.cs
+++ b/src/Sonarr.Api.V5/Settings/MetadataSourceSettingsResource.cs
@@ -1,0 +1,23 @@
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
+using Sonarr.Http.REST;
+
+namespace Sonarr.Api.V5.Settings;
+
+public class MetadataSourceSettingsResource : RestResource
+{
+    public MetadataSourceType MetadataSource { get; set; }
+    public string? TmdbApiKey { get; set; }
+}
+
+public static class MetadataSourceSettingsResourceMapper
+{
+    public static MetadataSourceSettingsResource ToResource(IConfigService configService)
+    {
+        return new MetadataSourceSettingsResource
+        {
+            MetadataSource = configService.MetadataSource,
+            TmdbApiKey = configService.TmdbApiKey
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable `/settings/metadatasource` backend setting and WebUI form so users can switch between TVDB and TMDb and provide a TMDb API key
- route series lookup/add/refresh metadata calls through a selector service and add a TMDb provider that maps TMDb search/details data back into Sonarr's existing series and episode models
- cover the new selector, TMDb proxy mapping, and metadata source settings endpoint with focused core and integration tests

## Testing
- `/root/.dotnet/dotnet build src/Sonarr.sln -nologo`
- `/root/.dotnet/dotnet test src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj --no-build --filter "FullyQualifiedName~MetadataSourceSelectorFixture|FullyQualifiedName~TmdbProxyFixture|FullyQualifiedName~AddSeriesFixture|FullyQualifiedName~RefreshSeriesServiceFixture"`
- `/root/.dotnet/dotnet test src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj --no-build --filter "FullyQualifiedName~MetadataSourceSettingsFixture"`
- `corepack yarn lint`
- `corepack yarn build`