### PR TITLE
fix: Stop tracking downloads after they're removed from the download client

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
@@ -81,8 +81,8 @@ namespace NzbDrone.Core.Download.Clients.Aria2
             {
                 var firstFile = torrent.Files?.FirstOrDefault();
 
-                // skip metadata download
-                if (firstFile?.Path?.Contains("[METADATA]") == true)
+                // skip metadata download or if the torrent is already removed
+                if (firstFile?.Path?.Contains("[METADATA]") == true || torrent.Status == "removed")
                 {
                     continue;
                 }
@@ -120,9 +120,6 @@ namespace NzbDrone.Core.Download.Clients.Aria2
                     case "complete":
                         status = DownloadItemStatus.Completed;
                         break;
-                    case "removed":
-                        status = DownloadItemStatus.Failed;
-                        break;
                 }
 
                 _logger.Trace($"- aria2 getstatus hash:'{torrent.InfoHash}' gid:'{torrent.Gid}' status:'{status}' total:{totalLength} completed:'{completedLength}'");
@@ -139,7 +136,6 @@ namespace NzbDrone.Core.Download.Clients.Aria2
                     OutputPath = outputPath,
                     RemainingSize = totalLength - completedLength,
                     RemainingTime = downloadSpeed == 0 ? (TimeSpan?)null : new TimeSpan(0, 0, (int)((totalLength - completedLength) / downloadSpeed)),
-                    Removed = torrent.Status == "removed",
                     SeedRatio = totalLength > 0 ? (double)uploadedLength / totalLength : 0,
                     Status = status,
                     Title = title,

--- a/src/NzbDrone.Core/Download/DownloadClientItem.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItem.cs
@@ -23,7 +23,6 @@ namespace NzbDrone.Core.Download
         public bool IsEncrypted { get; set; }
         public bool CanMoveFiles { get; set; }
         public bool CanBeRemoved { get; set; }
-        public bool Removed { get; set; }
 
         public DownloadClientItem Clone()
         {

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -31,7 +31,6 @@ namespace NzbDrone.Core.Download
             var trackedDownload = message.TrackedDownload;
 
             if (trackedDownload == null ||
-                message.TrackedDownload.DownloadItem.Removed ||
                 !trackedDownload.DownloadItem.CanBeRemoved)
             {
                 return;
@@ -56,8 +55,7 @@ namespace NzbDrone.Core.Download
 
             MarkItemAsImported(trackedDownload, downloadClient);
 
-            if (trackedDownload.DownloadItem.Removed ||
-                !trackedDownload.DownloadItem.CanBeRemoved ||
+            if (!trackedDownload.DownloadItem.CanBeRemoved ||
                 trackedDownload.DownloadItem.Status == DownloadItemStatus.Downloading)
             {
                 return;
@@ -77,8 +75,7 @@ namespace NzbDrone.Core.Download
             var downloadClient = _downloadClientProvider.Get(trackedDownload.DownloadClient);
             var definition = downloadClient.Definition as DownloadClientDefinition;
 
-            if (trackedDownload.DownloadItem.Removed ||
-                !trackedDownload.DownloadItem.CanBeRemoved ||
+            if (!trackedDownload.DownloadItem.CanBeRemoved ||
                 !definition.RemoveCompletedDownloads)
             {
                 return;

--- a/src/NzbDrone.Core/Download/DownloadEventHub.cs
+++ b/src/NzbDrone.Core/Download/DownloadEventHub.cs
@@ -12,14 +12,17 @@ namespace NzbDrone.Core.Download
     {
         private readonly IConfigService _configService;
         private readonly IProvideDownloadClient _downloadClientProvider;
+        private readonly ITrackedDownloadService _trackedDownloadService;
         private readonly Logger _logger;
 
         public DownloadEventHub(IConfigService configService,
             IProvideDownloadClient downloadClientProvider,
+            ITrackedDownloadService trackedDownloadService,
             Logger logger)
         {
             _configService = configService;
             _downloadClientProvider = downloadClientProvider;
+            _trackedDownloadService = trackedDownloadService;
             _logger = logger;
         }
 
@@ -90,7 +93,7 @@ namespace NzbDrone.Core.Download
             {
                 _logger.Debug("[{0}] Removing download from {1} history", trackedDownload.DownloadItem.Title, trackedDownload.DownloadItem.DownloadClientInfo.Name);
                 downloadClient.RemoveItem(trackedDownload.DownloadItem, true);
-                trackedDownload.DownloadItem.Removed = true;
+                _trackedDownloadService.StopTracking(trackedDownload.DownloadItem.DownloadId);
             }
             catch (NotSupportedException)
             {

--- a/src/NzbDrone.Core/Download/DownloadProcessingService.cs
+++ b/src/NzbDrone.Core/Download/DownloadProcessingService.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Download
         private void RemoveCompletedDownloads()
         {
             var trackedDownloads = _trackedDownloadService.GetTrackedDownloads()
-                                                          .Where(t => !t.DownloadItem.Removed && t.DownloadItem.CanBeRemoved && t.State == TrackedDownloadState.Imported)
+                                                          .Where(t => t.DownloadItem.CanBeRemoved && t.State == TrackedDownloadState.Imported)
                                                           .ToList();
 
             foreach (var trackedDownload in trackedDownloads)


### PR DESCRIPTION
#### Description
Stop tracking downloads after they're removed from the download client. We already do these when manually removing items in the QueueController but is missed in the import workflow.

Steps to reproduce:
1. Grab and import a download
2. Delete the episode files
3. Grab the same hash again. Sonarr ignores this and removes it from the download client without importing.

If you do step 3 after sonarr is restarted, it would correctly import the download since the trackedDownloads cache is cleared out.

#### Issues Fixed or Closed by this PR
* Closes #2393

