### PR TITLE
Fixed: Propagate Trakt token refresh failures instead of swallowing exceptions

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
@@ -109,7 +109,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
             }
             catch (HttpException)
             {
-                _logger.Warn($"Error refreshing trakt access token");
+                _logger.Warn("Error retrieving Trakt user settings");
             }
 
             return null;
@@ -125,26 +125,22 @@ namespace NzbDrone.Core.ImportLists.Trakt
                 .AddQueryParam("refresh_token", Settings.RefreshToken)
                 .Build();
 
-            try
+            var response = _httpClient.Get<RefreshRequestResponse>(request);
+
+            if (response?.Resource == null)
             {
-                var response = _httpClient.Get<RefreshRequestResponse>(request);
-
-                if (response != null && response.Resource != null)
-                {
-                    var token = response.Resource;
-                    Settings.AccessToken = token.AccessToken;
-                    Settings.Expires = DateTime.UtcNow.AddSeconds(token.ExpiresIn);
-                    Settings.RefreshToken = token.RefreshToken ?? Settings.RefreshToken;
-
-                    if (Definition.Id > 0)
-                    {
-                        _importListRepository.UpdateSettings((ImportListDefinition)Definition);
-                    }
-                }
+                _logger.Warn("Trakt token refresh returned an empty response");
+                return;
             }
-            catch (HttpException)
+
+            var token = response.Resource;
+            Settings.AccessToken = token.AccessToken;
+            Settings.Expires = DateTime.UtcNow.AddSeconds(token.ExpiresIn);
+            Settings.RefreshToken = token.RefreshToken ?? Settings.RefreshToken;
+
+            if (Definition.Id > 0)
             {
-                _logger.Warn($"Error refreshing trakt access token");
+                _importListRepository.UpdateSettings((ImportListDefinition)Definition);
             }
         }
     }


### PR DESCRIPTION
#### Description
When refreshing a Trakt access token fails, the exception was silently swallowed, leaving the import list with a stale token and no visible error. This removes the silent catch so failures surface through Sonarr's standard import list error handling.

Also corrects a misleading log message in `GetUserName` that referred to token refreshing rather than user settings retrieval.

#### Issues Fixed or Closed by this PR
* Related to #7874