### PR TITLE
Fixed: Refresh Trakt token 24 hours before expiry instead of 5 minutes

### DIFF
--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
@@ -40,7 +40,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
             Settings.Validate().Filter("AccessToken", "RefreshToken").ThrowOnError();
             _logger.Trace($"Access token expires at {Settings.Expires}");
 
-            if (Settings.Expires < DateTime.UtcNow.AddMinutes(5))
+            if (Settings.Expires < DateTime.UtcNow.AddHours(24))
             {
                 RefreshToken();
             }


### PR DESCRIPTION
#### Description
Trakt advises apps to refresh tokens proactively rather than waiting for expiry (#7874). With import lists syncing every 12 hours, a 5-minute window gives only one attempt right at expiry. Widening to 24 hours allows a couple of retries while the token is still valid.

#### Issues Fixed or Closed by this PR
* Related to #7874