### PR TITLE
Migrate mediainfo per episode file one at the time to avoid OOM

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/225_mediainfo_multiple_streams.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/225_mediainfo_multiple_streams.cs
@@ -46,8 +46,6 @@ public class mediainfo_multiple_streams : NzbDroneMigrationBase
     {
         var existing = conn.Query<EpisodeFile224>("SELECT \"Id\", \"MediaInfo\" FROM \"EpisodeFiles\"");
 
-        var updated = new List<object>();
-
         foreach (var row in existing)
         {
             if (row.MediaInfo.IsNullOrWhiteSpace())
@@ -64,7 +62,7 @@ public class mediainfo_multiple_streams : NzbDroneMigrationBase
             {
                 _logger.Warn(ex, "Episode {EpisodeId} contains invalid JSON data, skipping.", row.Id);
 
-                updated.Add(new EpisodeFile225 { Id = row.Id, MediaInfo = null });
+                UpdateMediaInfoForEpisodeFile(conn, tran, new EpisodeFile225 { Id = row.Id, MediaInfo = null });
 
                 continue;
             }
@@ -83,17 +81,17 @@ public class mediainfo_multiple_streams : NzbDroneMigrationBase
                 continue;
             }
 
-            updated.Add(new EpisodeFile225
+            UpdateMediaInfoForEpisodeFile(conn, tran, new EpisodeFile225
             {
                 Id = row.Id,
                 MediaInfo = JsonSerializer.Serialize(newMediaInfo, _serializerSettings)
             });
         }
+    }
 
-        conn.Execute(
-            "UPDATE \"EpisodeFiles\" SET \"MediaInfo\" = @MediaInfo WHERE \"Id\" = @Id",
-            updated,
-            transaction: tran);
+    private static void UpdateMediaInfoForEpisodeFile(IDbConnection conn, IDbTransaction tran, EpisodeFile225 updated)
+    {
+        conn.Execute("UPDATE \"EpisodeFiles\" SET \"MediaInfo\" = @MediaInfo WHERE \"Id\" = @Id", updated, transaction: tran);
     }
 
     private static MediaInfo225 MigrateMediaInfo(MediaInfo224 old)


### PR DESCRIPTION
#### Description
Update media info for episode files one by one instead of saving a list with JSON objects for the whole library to avoid OOM exceptions.

