### PR TITLE
Fix nullref when getting series by alias title and year

### DIFF
--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -144,7 +144,7 @@ namespace NzbDrone.Core.Parser
             {
                 var series = _seriesService.FindByTvdbId(tvdbId.Value);
 
-                if (series.Year == year)
+                if (series != null && series.Year == year)
                 {
                     return series;
                 }


### PR DESCRIPTION
#### Description
Fix to prevent nullref on parsing with year in the titles.