### PR TITLE
Default to `und` for audio streams with no language tag

### DIFF
--- a/frontend/src/Episode/Summary/MediaInfo.tsx
+++ b/frontend/src/Episode/Summary/MediaInfo.tsx
@@ -61,39 +61,50 @@ function MediaInfo(props: MediaInfoProps) {
             <DescriptionListItem
               key={key}
               title={translate('MediaInfoSubtitlesHeader')}
-              data={value.reduce(
-                (acc: React.ReactNode[] | null, subtitleStream, index) => {
-                  const language = getLanguageName(subtitleStream.language);
+              data={
+                value.length > 0
+                  ? value.reduce(
+                      (
+                        acc: React.ReactNode[] | null,
+                        subtitleStream,
+                        index
+                      ) => {
+                        const language = getLanguageName(
+                          subtitleStream.language
+                        );
 
-                  let line = `${
-                    subtitleStream.format?.toUpperCase() || translate('Unknown')
-                  }`;
+                        let line = `${
+                          subtitleStream.format?.toUpperCase() ||
+                          translate('Unknown')
+                        }`;
 
-                  if (
-                    subtitleStream.title !== undefined &&
-                    subtitleStream.title !== language
-                  ) {
-                    line += ` | ${subtitleStream.title}`;
-                  }
+                        if (
+                          subtitleStream.title !== undefined &&
+                          subtitleStream.title !== language
+                        ) {
+                          line += ` | ${subtitleStream.title}`;
+                        }
 
-                  if (subtitleStream.forced) {
-                    line += ` | ${translate('MediaInfoForced')}`;
-                  }
+                        if (subtitleStream.forced) {
+                          line += ` | ${translate('MediaInfoForced')}`;
+                        }
 
-                  if (subtitleStream.hearingImpaired) {
-                    line += ` | ${translate('MediaInfoHearingImpaired')}`;
-                  }
+                        if (subtitleStream.hearingImpaired) {
+                          line += ` | ${translate('MediaInfoHearingImpaired')}`;
+                        }
 
-                  const curr = (
-                    <span key={index} title={line}>
-                      {language}
-                    </span>
-                  );
+                        const curr = (
+                          <span key={index} title={line}>
+                            {language}
+                          </span>
+                        );
 
-                  return acc === null ? [curr] : [acc, ' / ', curr];
-                },
-                null
-              )}
+                        return acc === null ? [curr] : [acc, ' / ', curr];
+                      },
+                      null
+                    )
+                  : translate('None')
+              }
             />
           );
         }

--- a/frontend/src/Episode/Summary/MediaInfo.tsx
+++ b/frontend/src/Episode/Summary/MediaInfo.tsx
@@ -23,7 +23,10 @@ function MediaInfo(props: MediaInfoProps) {
 
         if (key === 'audioStreams') {
           return value.map((audioStream, index) => {
-            const language = getLanguageName(audioStream.language);
+            const language =
+              audioStream.language === 'und'
+                ? translate('Unknown')
+                : getLanguageName(audioStream.language);
 
             let line = `${language}`;
 

--- a/src/NzbDrone.Core.Test/Datastore/Migration/225_mediainfo_multiple_streamsFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/225_mediainfo_multiple_streamsFixture.cs
@@ -98,6 +98,63 @@ public class mediainfo_multiple_streamsFixture : MigrationTest<mediainfo_multipl
     }
 
     [Test]
+    public void should_convert_non_empty_media_info_with_empty_audio_languages()
+    {
+        var db = WithMigrationTestDb(c =>
+        {
+            c.Insert.IntoTable("EpisodeFiles").Row(new
+            {
+                SeriesId = 1,
+                SeasonNumber = 1,
+                RelativePath = "Season 01/S01E05.mkv",
+                Size = 125.Megabytes(),
+                DateAdded = DateTime.UtcNow,
+                OriginalFilePath = "Series.Title.S01E05.720p.HDTV.x265-Sonarr.mkv",
+                ReleaseGroup = "Sonarr",
+                Quality = new QualityModel(Quality.HDTV720p).ToJson(),
+                Languages = "[1]",
+                MediaInfo = new
+                {
+                    AudioFormat = "truehd",
+                    AudioCodecID = "[0][0][0][0]",
+                    AudioProfile = "Dolby TrueHD + Dolby Atmos",
+                    AudioBitrate = 224000,
+                    AudioChannels = 2,
+                    AudioChannelPositions = "stereo",
+                    AudioLanguages = new List<string>(),
+                    Subtitles = new List<string> { "ger", "eng", "rum" },
+                    ScanType = "Progressive",
+                    SchemaRevision = 13
+                }.ToJson()
+            });
+        });
+
+        var items = db.Query<EpisodeFile225>("SELECT \"Id\", \"RelativePath\", \"MediaInfo\" FROM \"EpisodeFiles\"");
+
+        items.Should().HaveCount(1);
+
+        var mediainfo = items.First().MediaInfo;
+
+        mediainfo.AudioFormat.Should().BeNull();
+        mediainfo.AudioCodecID.Should().BeNull();
+        mediainfo.AudioProfile.Should().BeNull();
+        mediainfo.AudioBitrate.Should().BeNull();
+        mediainfo.AudioChannels.Should().BeNull();
+        mediainfo.AudioChannelPositions.Should().BeNull();
+
+        mediainfo.AudioStreams.First().Format.Should().Be("truehd");
+        mediainfo.AudioStreams.First().CodecId.Should().Be("[0][0][0][0]");
+        mediainfo.AudioStreams.First().Profile.Should().Be("Dolby TrueHD + Dolby Atmos");
+        mediainfo.AudioStreams.First().Bitrate.Should().Be(224000);
+        mediainfo.AudioStreams.First().Channels.Should().Be(2);
+        mediainfo.AudioStreams.First().ChannelPositions.Should().Be("stereo");
+        mediainfo.AudioStreams.First().Language.Should().Be("und");
+
+        mediainfo.AudioStreams.Select(s => s.Language).Should().BeEquivalentTo("und");
+        mediainfo.SubtitleStreams.Select(s => s.Language).Should().BeEquivalentTo("eng", "ger", "rum");
+    }
+
+    [Test]
     public void should_convert_to_null_on_invalid_media_info()
     {
         var db = WithMigrationTestDb(c =>

--- a/src/NzbDrone.Core/Datastore/Migration/225_mediainfo_multiple_streams.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/225_mediainfo_multiple_streams.cs
@@ -128,13 +128,19 @@ public class mediainfo_multiple_streams : NzbDroneMigrationBase
             {
                 Language = language,
             })
-            .ToList();
-        audioStreams?.FirstOrDefault()?.Format = old.AudioFormat;
-        audioStreams?.FirstOrDefault()?.CodecId = old.AudioCodecID;
-        audioStreams?.FirstOrDefault()?.Profile = old.AudioProfile;
-        audioStreams?.FirstOrDefault()?.Bitrate = old.AudioBitrate;
-        audioStreams?.FirstOrDefault()?.Channels = old.AudioChannels;
-        audioStreams?.FirstOrDefault()?.ChannelPositions = old.AudioChannelPositions;
+            .ToList() ?? [];
+
+        if (audioStreams.Count == 0)
+        {
+            audioStreams.Add(new MediaInfoAudioStream225 { Language = "und" });
+        }
+
+        audioStreams.FirstOrDefault()?.Format = old.AudioFormat;
+        audioStreams.FirstOrDefault()?.CodecId = old.AudioCodecID;
+        audioStreams.FirstOrDefault()?.Profile = old.AudioProfile;
+        audioStreams.FirstOrDefault()?.Bitrate = old.AudioBitrate;
+        audioStreams.FirstOrDefault()?.Channels = old.AudioChannels;
+        audioStreams.FirstOrDefault()?.ChannelPositions = old.AudioChannelPositions;
 
         return audioStreams;
     }
@@ -146,7 +152,7 @@ public class mediainfo_multiple_streams : NzbDroneMigrationBase
             {
                 Language = language,
             })
-            .ToList();
+            .ToList() ?? [];
 
         return subtitleStreams;
     }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         public static string FormatAudioCodec(MediaInfoAudioStreamModel audioStream, string sceneName)
         {
-            if (audioStream.Format == null)
+            if (audioStream?.Format == null)
             {
                 return null;
             }
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         public static string FormatVideoCodec(MediaInfoModel mediaInfo, string sceneName)
         {
-            if (mediaInfo.VideoFormat == null)
+            if (mediaInfo?.VideoFormat == null)
             {
                 return null;
             }
@@ -270,7 +270,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         private static decimal? FormatAudioChannelsFromAudioChannelPositions(MediaInfoAudioStreamModel audioStream)
         {
-            if (audioStream.ChannelPositions == null)
+            if (audioStream?.ChannelPositions == null)
             {
                 return 0;
             }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -85,13 +85,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.RawStreamData = string.Concat(analysis.OutputData);
 
                 mediaInfoModel.AudioStreams = analysis.AudioStreams?
-                    .Where(stream => stream.Language.IsNotNullOrWhiteSpace())
                     .OrderBy(stream => stream.Index)
                     .Select(stream =>
                     {
                         var model = new MediaInfoAudioStreamModel
                         {
-                            Language = stream.Language,
+                            Language = stream.Language.IsNotNullOrWhiteSpace() ? stream.Language : "und",
                             Format = stream.CodecName,
                             CodecId = stream.CodecTagString,
                             Profile = stream.Profile,


### PR DESCRIPTION
#### Description
Defaulting to `und` (shown as `Unknown` in UI) for cases where the audio streams have the language tag missing.

#### Screenshots for UI Changes
<img height="500" alt="Screenshot" src="https://github.com/user-attachments/assets/6ce5b60e-707c-436d-b95f-377c64da59c7" />

