### PR TITLE
Fixed queue details counter

### DIFF
--- a/frontend/src/Activity/Queue/Details/QueueDetailsProvider.tsx
+++ b/frontend/src/Activity/Queue/Details/QueueDetailsProvider.tsx
@@ -89,15 +89,15 @@ export function useQueueDetailsForSeries(
           return acc;
         }
 
-        if (seasonNumber != null && item.seasonNumber !== seasonNumber) {
+        if (
+          seasonNumber != null &&
+          !item.seasonNumbers?.includes(seasonNumber)
+        ) {
           return acc;
         }
 
-        acc.count++;
-
-        if (item.episodeHasFile) {
-          acc.episodesWithFiles++;
-        }
+        acc.count += item.episodeIds.length;
+        acc.episodesWithFiles += item.episodesWithFilesCount;
 
         return acc;
       },

--- a/frontend/src/Activity/Queue/Queue.tsx
+++ b/frontend/src/Activity/Queue/Queue.tsx
@@ -365,7 +365,7 @@ function QueueContent() {
           selectedIds.every((id: number) => {
             const item = records.find((i) => i.id === id);
 
-            return !!(item && item.seriesId && item.episodeId);
+            return !!(item && item.seriesId && item.episodeIds.length);
           })
         }
         isPending={

--- a/frontend/src/Activity/Queue/QueueRow.tsx
+++ b/frontend/src/Activity/Queue/QueueRow.tsx
@@ -29,6 +29,8 @@ import Queue, {
   QueueTrackedDownloadStatus,
   StatusMessage,
 } from 'typings/Queue';
+import formatDateTime from 'Utilities/Date/formatDateTime';
+import getRelativeDate from 'Utilities/Date/getRelativeDate';
 import formatBytes from 'Utilities/Number/formatBytes';
 import formatCustomFormatScore from 'Utilities/Number/formatCustomFormatScore';
 import translate from 'Utilities/String/translate';
@@ -106,7 +108,7 @@ function QueueRow(props: QueueRowProps) {
 
   const series = useSingleSeries(seriesId);
   const episodes = useEpisodesWithIds(episodeIds);
-  const { showRelativeDates, shortDateFormat, timeFormat } =
+  const { showRelativeDates, shortDateFormat, longDateFormat, timeFormat } =
     useUiSettingsValues();
   const { removeQueueItem, isRemoving } = useRemoveQueueItem(id);
   const { grabQueueItem, isGrabbing, grabError } = useGrabQueueItem(id);
@@ -248,17 +250,39 @@ function QueueRow(props: QueueRowProps) {
 
           return (
             <TableRowCell key={name}>
-              <RelativeDateCell
-                key={name}
-                component="span"
-                date={episodes[0].airDateUtc}
-              />
-              {' - '}
-              <RelativeDateCell
-                key={name}
-                component="span"
-                date={episodes[episodes.length - 1].airDateUtc}
-              />
+              <span
+                title={`${formatDateTime(
+                  episodes[0].airDateUtc,
+                  longDateFormat,
+                  timeFormat,
+                  {
+                    includeRelativeDay: !showRelativeDates,
+                  }
+                )} - ${formatDateTime(
+                  episodes[episodes.length - 1].airDateUtc,
+                  longDateFormat,
+                  timeFormat,
+                  {
+                    includeRelativeDay: !showRelativeDates,
+                  }
+                )}`}
+              >
+                {getRelativeDate({
+                  date: episodes[0].airDateUtc,
+                  shortDateFormat,
+                  showRelativeDates,
+                  timeFormat,
+                  timeForToday: true,
+                })}
+                {' - '}
+                {getRelativeDate({
+                  date: episodes[episodes.length - 1].airDateUtc,
+                  shortDateFormat,
+                  showRelativeDates,
+                  timeFormat,
+                  timeForToday: true,
+                })}
+              </span>
             </TableRowCell>
           );
         }

--- a/frontend/src/Calendar/Agenda/AgendaEvent.tsx
+++ b/frontend/src/Calendar/Agenda/AgendaEvent.tsx
@@ -154,10 +154,7 @@ function AgendaEvent(props: AgendaEventProps) {
 
           {queueItem ? (
             <span className={styles.statusIcon}>
-              <CalendarEventQueueDetails
-                seasonNumber={seasonNumber}
-                {...queueItem}
-              />
+              <CalendarEventQueueDetails {...queueItem} />
             </span>
           ) : null}
 

--- a/frontend/src/Calendar/CalendarMissingEpisodeSearchButton.tsx
+++ b/frontend/src/Calendar/CalendarMissingEpisodeSearchButton.tsx
@@ -39,9 +39,7 @@ const useMissingEpisodeIdsSelector = () => {
       moment(airDateUtc).isAfter(start) &&
       moment(airDateUtc).isBefore(end) &&
       isBefore(episode.airDateUtc) &&
-      !queueDetails.some(
-        (details) => !!details.episode && details.episode.id === episode.id
-      )
+      !queueDetails.some((details) => details.episodeIds?.includes(episode.id))
     ) {
       acc.push(episode.id);
     }

--- a/frontend/src/typings/Queue.ts
+++ b/frontend/src/typings/Queue.ts
@@ -42,15 +42,13 @@ interface Queue extends ModelBase {
   protocol: DownloadProtocol;
   downloadClient: string;
   outputPath: string;
-  episodeHasFile: boolean;
+  episodesWithFilesCount: number;
   seriesId?: number;
-  episodeId?: number;
   episodeIds: number[];
-  seasonNumber?: number;
   seasonNumbers: number[];
   downloadClientHasPostImportCategory: boolean;
   isFullSeason: boolean;
-  episode?: Episode;
+  episodes?: Episode[];
 }
 
 export default Queue;


### PR DESCRIPTION
#### Description
Updating `Queue` interface to match the v5 API.

<!-- Remove any of the following sections if they are not used -->

#### Screenshots for UI Changes
queue changes
<img width="500" alt="before" src="https://github.com/user-attachments/assets/48c8d3cb-0d5e-43fe-b47d-56790610deaf" />
<img width="500" alt="after" src="https://github.com/user-attachments/assets/82c0fdea-0029-467d-87f0-07ac90249dfa" />

queue details on series page
<img width="500" alt="Screenshot" src="https://github.com/user-attachments/assets/3d81c833-01e1-4e29-ad3a-9170eece8988" />

