### PR TITLE
Fix all filter for calendar page

### DIFF
--- a/frontend/src/Calendar/useCalendar.ts
+++ b/frontend/src/Calendar/useCalendar.ts
@@ -118,7 +118,7 @@ const useCalendar = () => {
         return acc;
       },
       {
-        includeUnmonitored: false,
+        includeUnmonitored: true,
         includeSpecials: true,
       }
     );


### PR DESCRIPTION
#### Description
`All` filter means no filters leading to not being possible to display the unmonitored without defaulting to true, or adding `{ key: 'unmonitored', value: [true], type: 'equal' }` to filters.

https://github.com/Sonarr/Sonarr/blob/1449b8152545171a6f628a0e2ce6292e4c420da8/frontend/src/Calendar/useCalendar.ts#L19-L21

