### PR TITLE
Fix series ending year on details page

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -36,7 +36,7 @@ import DeleteSeriesModal from 'Series/Delete/DeleteSeriesModal';
 import EditSeriesModal from 'Series/Edit/EditSeriesModal';
 import SeriesHistoryModal from 'Series/History/SeriesHistoryModal';
 import MonitoringOptionsModal from 'Series/MonitoringOptions/MonitoringOptionsModal';
-import { Image, Statistics } from 'Series/Series';
+import { Image, SeriesStatus, Statistics } from 'Series/Series';
 import SeriesGenres from 'Series/SeriesGenres';
 import SeriesPoster from 'Series/SeriesPoster';
 import { getSeriesStatusDetails } from 'Series/SeriesStatus';
@@ -67,10 +67,22 @@ function getFanartUrl(images: Image[]) {
   return images.find((image) => image.coverType === 'fanart')?.url;
 }
 
-function getDateYear(date: string | undefined) {
-  const dateDate = moment.utc(date);
+function getDateYear(date: string) {
+  return moment.utc(date).format('YYYY');
+}
 
-  return dateDate.format('YYYY');
+function getRunningYears(
+  status: SeriesStatus,
+  year: number,
+  lastAired: string | undefined
+) {
+  if (year === 0) {
+    return null;
+  }
+
+  return status === 'ended' && lastAired
+    ? `${year}-${getDateYear(lastAired)}`
+    : `${year}-`;
 }
 
 interface ExpandedState {
@@ -394,18 +406,13 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
     genres,
     tags,
     year,
+    lastAired,
   } = series;
 
-  const {
-    episodeCount = 0,
-    episodeFileCount = 0,
-    sizeOnDisk = 0,
-    lastAired,
-  } = statistics;
+  const { episodeCount = 0, episodeFileCount = 0, sizeOnDisk = 0 } = statistics;
 
   const statusDetails = getSeriesStatusDetails(status);
-  const runningYears =
-    status === 'ended' ? `${year}-${getDateYear(lastAired)}` : `${year}-`;
+  const runningYears = getRunningYears(status, year, lastAired);
 
   let episodeFilesCountMessage = translate('SeriesDetailsNoEpisodeFiles');
 

--- a/frontend/src/Series/Series.ts
+++ b/frontend/src/Series/Series.ts
@@ -37,7 +37,6 @@ export interface Statistics {
   sizeOnDisk: number;
   totalEpisodeCount: number;
   monitoredEpisodeCount: number;
-  lastAired?: string;
 }
 
 export interface Season {
@@ -71,7 +70,8 @@ interface Series extends ModelBase {
   certification: string;
   cleanTitle: string;
   ended: boolean;
-  firstAired: string;
+  firstAired?: string;
+  lastAired?: string;
   genres: string[];
   images: Image[];
   imdbId?: string;


### PR DESCRIPTION
#### Description
Last aired is not part of `SeriesStatisticsResource`, but `SeriesResource`.

https://github.com/Sonarr/Sonarr/blob/1449b8152545171a6f628a0e2ce6292e4c420da8/src/Sonarr.Api.V5/Series/SeriesController.cs#L296-L297

