### PR TITLE
Fix nullref when filtering series endpoint by tvdbid

### DIFF
--- a/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/IEnumerableExtensions.cs
@@ -78,7 +78,8 @@ namespace NzbDrone.Common.Extensions
             return result;
         }
 
-        public static void AddIfNotNull<TSource>(this List<TSource> source, TSource item)
+        #nullable enable
+        public static void AddIfNotNull<TSource>(this List<TSource> source, TSource? item)
         {
             if (item == null)
             {
@@ -87,6 +88,7 @@ namespace NzbDrone.Common.Extensions
 
             source.Add(item);
         }
+        #nullable disable
 
         public static bool Empty<TSource>(this IEnumerable<TSource> source)
         {

--- a/src/Sonarr.Api.V5/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesController.cs
@@ -115,7 +115,7 @@ public class SeriesController : RestControllerWithSignalR<SeriesResource, NzbDro
 
         if (tvdbId.HasValue)
         {
-            seriesResources.AddIfNotNull(_seriesService.FindByTvdbId(tvdbId.Value).ToResource(includeSeasonImages));
+            seriesResources.AddIfNotNull(_seriesService.FindByTvdbId(tvdbId.Value)?.ToResource(includeSeasonImages));
         }
         else
         {


### PR DESCRIPTION
#### Description
Fix for when calling the series endpoint with a non-existing tvdbid.

```
[Fatal] SonarrErrorPipeline: Request Failed. GET /api/v5/series 

[v10.0.0.42363] System.NullReferenceException: Object reference not set to an instance of an object.
   at Sonarr.Api.V5.Series.SeriesResourceMapper.ToResource(Series model, Boolean includeSeasonImages) in ./Sonarr.Api.V5/Series/SeriesResource.cs:line 68
   at Sonarr.Api.V5.Series.SeriesController.AllSeries(Nullable`1 tvdbId, SeriesSubresource[] includeSubresources) in ./Sonarr.Api.V5/Series/SeriesController.cs:line 118
   at lambda_method26(Closure, Object, Object[])
```

If `#nullable` is not wanted, we could switch to old attribute way with `[AllowNull] TSource item`.