### PR TITLE
Fixed: Don't throw error on pushed released with empty indexer and download client ids

### DIFF
--- a/src/NzbDrone.Core/Download/DownloadClientFactory.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientFactory.cs
@@ -60,9 +60,9 @@ namespace NzbDrone.Core.Download
         {
             var all = All();
             var clientByName = name.IsNullOrWhiteSpace() ? null : all.FirstOrDefault(c => c.Name.EqualsIgnoreCase(name));
-            var clientById = id.HasValue ? all.FirstOrDefault(c => c.Id == id.Value) : null;
+            var clientById = id is > 0 ? all.FirstOrDefault(c => c.Id == id.Value) : null;
 
-            if (id.HasValue && clientById == null)
+            if (id is > 0 && clientById == null)
             {
                 throw new ResolveDownloadClientException("Download client with ID '{0}' could not be found", id.Value);
             }

--- a/src/NzbDrone.Core/Indexers/IndexerFactory.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerFactory.cs
@@ -96,9 +96,9 @@ namespace NzbDrone.Core.Indexers
         {
             var all = All();
             var clientByName = name.IsNullOrWhiteSpace() ? null : all.FirstOrDefault(c => c.Name.EqualsIgnoreCase(name));
-            var clientById = id.HasValue ? all.FirstOrDefault(c => c.Id == id.Value) : null;
+            var clientById = id is > 0 ? all.FirstOrDefault(c => c.Id == id.Value) : null;
 
-            if (id.HasValue && clientById == null)
+            if (id is > 0 && clientById == null)
             {
                 throw new ResolveIndexerException("Indexer with ID '{0}' could not be found", id.Value);
             }
@@ -115,7 +115,7 @@ namespace NzbDrone.Core.Indexers
 
             if (clientByName != null && clientById != null && clientByName.Id != clientById.Id)
             {
-                throw new ResolveIndexerException("Indexer with name '{0}' does not match Indexerwith ID '{1}'", name, id.Value);
+                throw new ResolveIndexerException("Indexer with name '{0}' does not match indexer with ID '{1}'", name, id.Value);
             }
 
             return clientById ?? clientByName;


### PR DESCRIPTION
#### Description
Regression after b2f2c21a61eea3eec213af045853b5a5d27a754f as IndexerId on ReleaseInfo is not nullable and the resolve methods treat 0 as a valid id.

Checking if id is greater than 0 in resolve method instead of switching to nullable int as there's too much existing code using `indexerId == 0` to require a refactoring at this time.

Side note, we should eventually catch ResolveIndexerException/ResolveDownloadClientException and return ValidationException instead?