### PR TITLE
Fix listing media files for specific series with Manage Episodes

### DIFF
--- a/src/Sonarr.Api.V5/ManualImport/ManualImportController.cs
+++ b/src/Sonarr.Api.V5/ManualImport/ManualImportController.cs
@@ -22,7 +22,7 @@ public class ManualImportController : Controller
 
     [HttpGet]
     [Produces("application/json")]
-    public Ok<List<ManualImportResource>> GetMediaFiles(string? folder, [FromQuery] string[]? downloadIds, int? seriesId, int? seasonNumber, bool filterExistingFiles = true)
+    public Ok<List<ManualImportResource>> GetMediaFiles(string? folder, int? seriesId, int? seasonNumber, [FromQuery] string[]? downloadIds = null, bool filterExistingFiles = true)
     {
         if (seriesId.HasValue && downloadIds == null)
         {


### PR DESCRIPTION
#### Description
Regression after ce8a5d8a6bed6bfbbab0047e799b60b4326cc9d8 where `downloadIds` is an empty list by default, not a null.