### PR TITLE
Fixed: Wrap bulk UpdateMany/SetFields in a transaction

### DIFF
--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -266,8 +266,10 @@ namespace NzbDrone.Core.Datastore
             }
 
             using (var conn = _database.OpenConnection())
+            using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
             {
-                UpdateFields(conn, null, models, _properties);
+                UpdateFields(conn, tran, models, _properties);
+                tran.Commit();
             }
         }
 
@@ -371,8 +373,10 @@ namespace NzbDrone.Core.Datastore
             var propertiesToUpdate = properties.Select(x => x.GetMemberName()).ToList();
 
             using (var conn = _database.OpenConnection())
+            using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
             {
-                UpdateFields(conn, null, models, propertiesToUpdate);
+                UpdateFields(conn, tran, models, propertiesToUpdate);
+                tran.Commit();
             }
 
             foreach (var model in models)


### PR DESCRIPTION
#### Description

`BasicRepository.UpdateMany` and the bulk overload of `SetFields(IList<T>, ...)` call `UpdateFields` with a null transaction. Dapper handles an `IList` parameter by looping and executing the SQL once per item, so without an explicit transaction each row gets auto-committed on its own. On SQLite (WAL mode + default `synchronous=FULL`, see `ConnectionStringFactory.cs`) that's one `fsync` per row.

This patch wraps both bulk paths in a `BeginTransaction`/`Commit` block, the same way `InsertMany` already does it.

I ran into this on a 113-series library with `/config` on a spinning disk. Scheduled Refresh Series was taking about 30 minutes, and most of that time was spent inside `RefreshEpisodeService.RefreshEpisodeInfo`, which calls `UpdateMany(updateList)` to rewrite the full episode set for each series. For long-running shows like *The Daily Show* (~3000 episodes) that's a lot of fsyncs. After the patch the same refresh runs in about 59 seconds, and *The Daily Show* alone went from ~6.5 min to a couple of seconds.

A few notes on safety:

- Behaviour for valid inputs is unchanged. Same rows, same values.
- Atomicity is tighter now: partial failures roll back, which matches what `InsertMany` already does. `InsertMany` doesn't have a dedicated atomicity test, so I haven't added one here for parity.
- Same semantics under SQLite and PostgreSQL. Both `System.Data.SQLite` and Npgsql support `BeginTransaction(IsolationLevel.ReadCommitted)`.
- The `foreach (var model in models) { ModelUpdated(model); }` loop at the end of `SetFields(IList<T>, ...)` stays outside the transaction, so event publication order isn't affected.
- Existing `BasicRepositoryFixture` tests still pass, including `should_be_able_to_update_many`, `should_be_able_to_update_many_single_field`, and the `throw_if_id_zero` cases.

#### Related Issues

#7056 and #2373 look like the same underlying problem (slow Refresh Series on HDD-backed AppData). This should help in those scenarios.

#### Issues Fixed or Closed by this PR
