### PR TITLE
Add OnDownloadComplete notification event

### DIFF
--- a/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.tsx
+++ b/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.tsx
@@ -33,6 +33,7 @@ function NotificationEventItems({
     onHealthRestored,
     onApplicationUpdate,
     onManualInteractionRequired,
+    onDownloadComplete,
     supportsOnGrab,
     supportsOnDownload,
     supportsOnUpgrade,
@@ -44,6 +45,7 @@ function NotificationEventItems({
     supportsOnEpisodeFileDeleteForUpgrade,
     supportsOnApplicationUpdate,
     supportsOnManualInteractionRequired,
+    supportsOnDownloadComplete,
     supportsOnHealthIssue,
     supportsOnHealthRestored,
     includeHealthWarnings,
@@ -65,6 +67,17 @@ function NotificationEventItems({
               helpText={translate('OnGrab')}
               isDisabled={!supportsOnGrab.value}
               {...onGrab}
+              onChange={onInputChange}
+            />
+          </div>
+
+          <div>
+            <FormInputGroup
+              type={inputTypes.CHECK}
+              name="onDownloadComplete"
+              helpText={translate('OnDownloadComplete')}
+              isDisabled={!supportsOnDownloadComplete.value}
+              {...onDownloadComplete}
               onChange={onInputChange}
             />
           </div>

--- a/frontend/src/Settings/Notifications/useConnections.ts
+++ b/frontend/src/Settings/Notifications/useConnections.ts
@@ -28,6 +28,7 @@ export interface NotificationModel extends Provider {
   onHealthRestored: boolean;
   onApplicationUpdate: boolean;
   onManualInteractionRequired: boolean;
+  onDownloadComplete: boolean;
   supportsOnGrab: boolean;
   supportsOnDownload: boolean;
   supportsOnUpgrade: boolean;
@@ -41,6 +42,7 @@ export interface NotificationModel extends Provider {
   supportsOnHealthRestored: boolean;
   supportsOnApplicationUpdate: boolean;
   supportsOnManualInteractionRequired: boolean;
+  supportsOnDownloadComplete: boolean;
   tags: number[];
 }
 
@@ -111,6 +113,7 @@ export const useManageConnection = (
           onApplicationUpdate: schema.supportsOnApplicationUpdate || false,
           onManualInteractionRequired:
             schema.supportsOnManualInteractionRequired || false,
+          onDownloadComplete: schema.supportsOnDownloadComplete || false,
         }
       : ({} as NotificationModel),
     PATH

--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -92,6 +92,11 @@ namespace NzbDrone.Core.Test.NotificationTests
             {
                 TestLogger.Info("OnManualInteractionRequired was called");
             }
+
+            public override void OnDownloadComplete(DownloadCompleteMessage message)
+            {
+                TestLogger.Info("OnDownloadComplete was called");
+            }
         }
 
         private class TestNotificationWithNoEvents : NotificationBase<TestSetting>
@@ -133,6 +138,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnHealthRestored.Should().BeTrue();
             notification.SupportsOnApplicationUpdate.Should().BeTrue();
             notification.SupportsOnManualInteractionRequired.Should().BeTrue();
+            notification.SupportsOnDownloadComplete.Should().BeTrue();
         }
 
         [Test]
@@ -151,6 +157,7 @@ namespace NzbDrone.Core.Test.NotificationTests
             notification.SupportsOnHealthRestored.Should().BeFalse();
             notification.SupportsOnApplicationUpdate.Should().BeFalse();
             notification.SupportsOnManualInteractionRequired.Should().BeFalse();
+            notification.SupportsOnDownloadComplete.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/231_add_on_download_complete_to_notifications.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/231_add_on_download_complete_to_notifications.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(231)]
+    public class add_on_download_complete_to_notifications : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Notifications")
+                 .AddColumn("OnDownloadComplete").AsBoolean().WithDefaultValue(false);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -123,6 +123,8 @@ namespace NzbDrone.Core.Download
             }
 
             trackedDownload.State = TrackedDownloadState.ImportPending;
+
+            _eventAggregator.PublishEvent(new DownloadClientItemCompletedEvent(trackedDownload));
         }
 
         public void Import(TrackedDownload trackedDownload)

--- a/src/NzbDrone.Core/Download/DownloadClientItemCompletedEvent.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientItemCompletedEvent.cs
@@ -1,0 +1,15 @@
+using NzbDrone.Common.Messaging;
+using NzbDrone.Core.Download.TrackedDownloads;
+
+namespace NzbDrone.Core.Download
+{
+    public class DownloadClientItemCompletedEvent : IEvent
+    {
+        public TrackedDownload TrackedDownload { get; private set; }
+
+        public DownloadClientItemCompletedEvent(TrackedDownload trackedDownload)
+        {
+            TrackedDownload = trackedDownload;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1591,6 +1591,7 @@
   "NzbgetHistoryItemMessage": "PAR Status: {parStatus} - Unpack Status: {unpackStatus} - Move Status: {moveStatus} - Script Status: {scriptStatus} - Delete Status: {deleteStatus} - Mark Status: {markStatus}",
   "Ok": "Ok",
   "OnApplicationUpdate": "On Application Update",
+  "OnDownloadComplete": "On Download Complete",
   "OnEpisodeFileDelete": "On Episode File Delete",
   "OnEpisodeFileDeleteForUpgrade": "On Episode File Delete For Upgrade",
   "OnFileImport": "On File Import",

--- a/src/NzbDrone.Core/Notifications/Apprise/Apprise.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/Apprise.cs
@@ -70,6 +70,11 @@ namespace NzbDrone.Core.Notifications.Apprise
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, GetPosterUrl(message.Series), Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, GetPosterUrl(message.Series), Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScript.cs
@@ -321,6 +321,22 @@ namespace NzbDrone.Core.Notifications.CustomScript
             ExecuteScript(environmentVariables);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            var series = message.Series;
+            var environmentVariables = new StringDictionary();
+
+            AddInstanceVariables(environmentVariables, "DownloadComplete");
+            AddSeriesVariables(environmentVariables, series);
+
+            environmentVariables.Add("Sonarr_Download_Client", message.DownloadClientInfo?.Name ?? string.Empty);
+            environmentVariables.Add("Sonarr_Download_Client_Type", message.DownloadClientInfo?.Type ?? string.Empty);
+            environmentVariables.Add("Sonarr_Download_Id", message.DownloadId ?? string.Empty);
+            environmentVariables.Add("Sonarr_Download_SourcePath", message.SourcePath ?? string.Empty);
+
+            ExecuteScript(environmentVariables);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -623,6 +623,41 @@ namespace NzbDrone.Core.Notifications.Discord
             _proxy.SendPayload(payload, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            var embed = new Embed
+            {
+                Author = new DiscordAuthor
+                {
+                    Name = Settings.Author.IsNullOrWhiteSpace() ? _configFileProvider.InstanceName : Settings.Author,
+                    IconUrl = "https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/256.png"
+                },
+                Title = message.Series?.Title ?? message.Message,
+                Description = "Download Complete",
+                Timestamp = DateTime.UtcNow.ToString("O"),
+                Color = (int)DiscordColors.Standard,
+                Fields = new List<DiscordField>()
+                {
+                    new()
+                    {
+                        Name = "Download Client",
+                        Value = message.DownloadClientInfo?.Name ?? string.Empty,
+                        Inline = true
+                    },
+                    new()
+                    {
+                        Name = "Source Path",
+                        Value = message.SourcePath ?? string.Empty,
+                        Inline = true
+                    }
+                },
+            };
+
+            var payload = CreatePayload(null, new List<Embed> { embed });
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/DownloadCompleteMessage.cs
+++ b/src/NzbDrone.Core/Notifications/DownloadCompleteMessage.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Notifications
+{
+    public class DownloadCompleteMessage
+    {
+        public string Message { get; set; }
+        public Series Series { get; set; }
+        public List<Episode> Episodes { get; set; }
+        public QualityModel Quality { get; set; }
+        public DownloadClientItemClientInfo DownloadClientInfo { get; set; }
+        public string DownloadId { get; set; }
+        public string SourcePath { get; set; }
+        public GrabbedReleaseInfo Release { get; set; }
+
+        public override string ToString()
+        {
+            return Message;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Email/Email.cs
+++ b/src/NzbDrone.Core/Notifications/Email/Email.cs
@@ -95,6 +95,13 @@ namespace NzbDrone.Core.Notifications.Email
             SendEmail(Settings, MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, body);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            var body = $"{message.Message}";
+
+            SendEmail(Settings, DOWNLOAD_COMPLETE_TITLE_BRANDED, body);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/Gotify.cs
@@ -79,6 +79,11 @@ namespace NzbDrone.Core.Notifications.Gotify
             SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, message.Series);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, message.Series);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.Notifications
         void OnHealthRestored(HealthCheck.HealthCheck previousCheck);
         void OnApplicationUpdate(ApplicationUpdateMessage updateMessage);
         void OnManualInteractionRequired(ManualInteractionRequiredMessage message);
+        void OnDownloadComplete(DownloadCompleteMessage message);
         void ProcessQueue();
         bool SupportsOnGrab { get; }
         bool SupportsOnDownload { get; }
@@ -34,5 +35,6 @@ namespace NzbDrone.Core.Notifications
         bool SupportsOnHealthRestored { get; }
         bool SupportsOnApplicationUpdate { get; }
         bool SupportsOnManualInteractionRequired { get; }
+        bool SupportsOnDownloadComplete { get; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Join/Join.cs
+++ b/src/NzbDrone.Core/Notifications/Join/Join.cs
@@ -67,6 +67,11 @@ namespace NzbDrone.Core.Notifications.Join
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Mailgun/Mailgun.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/Mailgun.cs
@@ -78,6 +78,11 @@ namespace NzbDrone.Core.Notifications.Mailgun
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowser.cs
@@ -116,6 +116,14 @@ namespace NzbDrone.Core.Notifications.Emby
             }
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            if (Settings.Notify)
+            {
+                _mediaBrowserService.Notify(Settings, DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message);
+            }
+        }
+
         public override void ProcessQueue()
         {
             _updateQueue.ProcessQueue(Settings.Host, (items) =>

--- a/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/Notifiarr.cs
@@ -80,6 +80,11 @@ namespace NzbDrone.Core.Notifications.Notifiarr
             _proxy.SendNotification(BuildManualInteractionRequiredPayload(message), Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(BuildOnDownloadCompletePayload(message), Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.Notifications
         protected const string HEALTH_RESTORED_TITLE = "Health Check Restored";
         protected const string APPLICATION_UPDATE_TITLE = "Application Updated";
         protected const string MANUAL_INTERACTION_REQUIRED_TITLE = "Manual Interaction";
+        protected const string DOWNLOAD_COMPLETE_TITLE = "Download Complete";
 
         protected const string EPISODE_GRABBED_TITLE_BRANDED = "Sonarr - " + EPISODE_GRABBED_TITLE;
         protected const string EPISODE_DOWNLOADED_TITLE_BRANDED = "Sonarr - " + EPISODE_DOWNLOADED_TITLE;
@@ -31,6 +32,7 @@ namespace NzbDrone.Core.Notifications
         protected const string HEALTH_RESTORED_TITLE_BRANDED = "Sonarr - " + HEALTH_RESTORED_TITLE;
         protected const string APPLICATION_UPDATE_TITLE_BRANDED = "Sonarr - " + APPLICATION_UPDATE_TITLE;
         protected const string MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED = "Sonarr - " + MANUAL_INTERACTION_REQUIRED_TITLE;
+        protected const string DOWNLOAD_COMPLETE_TITLE_BRANDED = "Sonarr - " + DOWNLOAD_COMPLETE_TITLE;
 
         public abstract string Name { get; }
 
@@ -89,6 +91,10 @@ namespace NzbDrone.Core.Notifications
         {
         }
 
+        public virtual void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+        }
+
         public virtual void ProcessQueue()
         {
         }
@@ -106,6 +112,7 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnHealthRestored => HasConcreteImplementation("OnHealthRestored");
         public bool SupportsOnApplicationUpdate => HasConcreteImplementation("OnApplicationUpdate");
         public bool SupportsOnManualInteractionRequired => HasConcreteImplementation("OnManualInteractionRequired");
+        public bool SupportsOnDownloadComplete => HasConcreteImplementation("OnDownloadComplete");
 
         protected TSettings Settings => (TSettings)Definition.Settings;
 

--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Notifications
         public bool OnHealthRestored { get; set; }
         public bool OnApplicationUpdate { get; set; }
         public bool OnManualInteractionRequired { get; set; }
+        public bool OnDownloadComplete { get; set; }
 
         [MemberwiseEqualityIgnore]
         public bool SupportsOnGrab { get; set; }
@@ -63,7 +64,10 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnManualInteractionRequired { get; set; }
 
         [MemberwiseEqualityIgnore]
-        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnImportComplete || OnRename || OnSeriesAdd || OnSeriesDelete || OnEpisodeFileDelete || (OnEpisodeFileDelete && OnEpisodeFileDeleteForUpgrade) || OnHealthIssue || OnHealthRestored || OnApplicationUpdate || OnManualInteractionRequired;
+        public bool SupportsOnDownloadComplete { get; set; }
+
+        [MemberwiseEqualityIgnore]
+        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnImportComplete || OnRename || OnSeriesAdd || OnSeriesDelete || OnEpisodeFileDelete || (OnEpisodeFileDelete && OnEpisodeFileDeleteForUpgrade) || OnHealthIssue || OnHealthRestored || OnApplicationUpdate || OnManualInteractionRequired || OnDownloadComplete;
 
         public bool Equals(NotificationDefinition other)
         {

--- a/src/NzbDrone.Core/Notifications/NotificationFactory.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationFactory.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Notifications
         List<INotification> OnHealthRestoredEnabled(bool filterBlockedNotifications = true);
         List<INotification> OnApplicationUpdateEnabled(bool filterBlockedNotifications = true);
         List<INotification> OnManualInteractionEnabled(bool filterBlockedNotifications = true);
+        List<INotification> OnDownloadCompleteEnabled(bool filterBlockedNotifications = true);
     }
 
     public class NotificationFactory : ProviderFactory<INotification, NotificationDefinition>, INotificationFactory
@@ -172,6 +173,16 @@ namespace NzbDrone.Core.Notifications
             return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnManualInteractionRequired).ToList();
         }
 
+        public List<INotification> OnDownloadCompleteEnabled(bool filterBlockedNotifications = true)
+        {
+            if (filterBlockedNotifications)
+            {
+                return FilterBlockedNotifications(GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnDownloadComplete)).ToList();
+            }
+
+            return GetAvailableProviders().Where(n => ((NotificationDefinition)n.Definition).OnDownloadComplete).ToList();
+        }
+
         private IEnumerable<INotification> FilterBlockedNotifications(IEnumerable<INotification> notifications)
         {
             var blockedNotifications = _notificationStatusService.GetBlockedProviders().ToDictionary(v => v.ProviderId, v => v);
@@ -205,6 +216,7 @@ namespace NzbDrone.Core.Notifications
             definition.SupportsOnHealthRestored = provider.SupportsOnHealthRestored;
             definition.SupportsOnApplicationUpdate = provider.SupportsOnApplicationUpdate;
             definition.SupportsOnManualInteractionRequired = provider.SupportsOnManualInteractionRequired;
+            definition.SupportsOnDownloadComplete = provider.SupportsOnDownloadComplete;
         }
 
         public override ValidationResult Test(NotificationDefinition definition)

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Notifications
           IHandle<EpisodeImportedEvent>,
           IHandle<DownloadCompletedEvent>,
           IHandle<UntrackedDownloadCompletedEvent>,
+          IHandle<DownloadClientItemCompletedEvent>,
           IHandle<SeriesRenamedEvent>,
           IHandle<SeriesAddCompletedEvent>,
           IHandle<SeriesDeletedEvent>,
@@ -377,6 +378,51 @@ namespace NzbDrone.Core.Notifications
                 {
                     _notificationStatusService.RecordFailure(notification.Definition.Id);
                     _logger.Error(ex, "Unable to send OnManualInteractionRequired notification to {0}", notification.Definition.Name);
+                }
+            }
+        }
+
+        public void Handle(DownloadClientItemCompletedEvent message)
+        {
+            var trackedDownload = message.TrackedDownload;
+            var series = trackedDownload.RemoteEpisode?.Series;
+            var episodes = trackedDownload.RemoteEpisode?.Episodes;
+            var quality = trackedDownload.RemoteEpisode?.ParsedEpisodeInfo?.Quality;
+
+            var mess = series != null && episodes != null && quality != null
+                ? GetMessage(series, episodes, quality)
+                : trackedDownload.DownloadItem.Title;
+
+            if (mess.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var downloadCompleteMessage = new DownloadCompleteMessage
+            {
+                Message = mess,
+                Series = series,
+                Episodes = episodes,
+                Quality = quality,
+                DownloadClientInfo = trackedDownload.DownloadItem.DownloadClientInfo,
+                DownloadId = trackedDownload.DownloadItem.DownloadId,
+                SourcePath = trackedDownload.DownloadItem.OutputPath.FullPath
+            };
+
+            foreach (var notification in _notificationFactory.OnDownloadCompleteEnabled())
+            {
+                try
+                {
+                    if (series == null || ShouldHandleSeries(notification.Definition, series))
+                    {
+                        notification.OnDownloadComplete(downloadCompleteMessage);
+                        _notificationStatusService.RecordSuccess(notification.Definition.Id);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _notificationStatusService.RecordFailure(notification.Definition.Id);
+                    _logger.Warn(ex, "Unable to send OnDownloadComplete notification to: " + notification.Definition.Name);
                 }
             }
         }

--- a/src/NzbDrone.Core/Notifications/Ntfy/Ntfy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/Ntfy.cs
@@ -68,6 +68,11 @@ namespace NzbDrone.Core.Notifications.Ntfy
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/Prowl.cs
@@ -66,6 +66,11 @@ namespace NzbDrone.Core.Notifications.Prowl
             _prowlProxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _prowlProxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBullet.cs
@@ -69,6 +69,11 @@ namespace NzbDrone.Core.Notifications.PushBullet
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Pushcut/Pushcut.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/Pushcut.cs
@@ -79,6 +79,11 @@ namespace NzbDrone.Core.Notifications.Pushcut
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE_BRANDED, manualInteractionRequiredMessage.Message, null, [], Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message, null, [], Settings);
+        }
+
         private string GetPosterUrl(Series series)
         {
             return series.Images.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Poster)?.RemoteUrl;

--- a/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/Pushover.cs
@@ -66,6 +66,11 @@ namespace NzbDrone.Core.Notifications.Pushover
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/SendGrid/SendGrid.cs
+++ b/src/NzbDrone.Core/Notifications/SendGrid/SendGrid.cs
@@ -72,6 +72,11 @@ namespace NzbDrone.Core.Notifications.SendGrid
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Signal/Signal.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/Signal.cs
@@ -66,6 +66,11 @@ namespace NzbDrone.Core.Notifications.Signal
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Simplepush/Simplepush.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/Simplepush.cs
@@ -66,6 +66,11 @@ namespace NzbDrone.Core.Notifications.Simplepush
             _proxy.SendNotification(MANUAL_INTERACTION_REQUIRED_TITLE, message.Message, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendNotification(DOWNLOAD_COMPLETE_TITLE, message.Message, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -205,6 +205,23 @@ namespace NzbDrone.Core.Notifications.Slack
             _proxy.SendPayload(payload, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            var attachments = new List<Attachment>
+            {
+                new()
+                {
+                    Title = message.Series?.Title ?? message.Message,
+                    Text = message.Message,
+                    Color = "good"
+                }
+            };
+
+            var payload = CreatePayload("Download Complete", attachments);
+
+            _proxy.SendPayload(payload, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/Telegram.cs
@@ -109,6 +109,15 @@ namespace NzbDrone.Core.Notifications.Telegram
             _proxy.SendNotification(title, message.Message, links, Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            var title = Settings.IncludeAppNameInTitle ? DOWNLOAD_COMPLETE_TITLE_BRANDED : DOWNLOAD_COMPLETE_TITLE;
+            title = Settings.IncludeInstanceNameInTitle ? $"{title} - {InstanceName}" : title;
+            var links = GetLinks(message.Series);
+
+            _proxy.SendNotification(title, message.Message, links, Settings);
+        }
+
         public override ValidationResult Test()
         {
             var failures = new List<ValidationFailure>();

--- a/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/Twitter.cs
@@ -68,6 +68,11 @@ namespace NzbDrone.Core.Notifications.Twitter
             _twitterService.SendNotification($"Manual Interaction Required: {message.Message}", Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _twitterService.SendNotification($"Download Complete: {message.Message}", Settings);
+        }
+
         public override object RequestAction(string action, IDictionary<string, string> query)
         {
             if (action == "startOAuth")

--- a/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/Webhook.cs
@@ -78,6 +78,11 @@ namespace NzbDrone.Core.Notifications.Webhook
             _proxy.SendWebhook(BuildManualInteractionRequiredPayload(message), Settings);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            _proxy.SendWebhook(BuildOnDownloadCompletePayload(message), Settings);
+        }
+
         public override string Name => "Webhook";
 
         public override ValidationResult Test()

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -217,6 +217,22 @@ namespace NzbDrone.Core.Notifications.Webhook
             };
         }
 
+        protected WebhookDownloadCompletePayload BuildOnDownloadCompletePayload(DownloadCompleteMessage message)
+        {
+            return new WebhookDownloadCompletePayload
+            {
+                EventType = WebhookEventType.DownloadComplete,
+                InstanceName = _configFileProvider.InstanceName,
+                ApplicationUrl = _configService.ApplicationUrl,
+                Series = GetSeries(message.Series),
+                Episodes = message.Episodes?.ConvertAll(x => new WebhookEpisode(x)),
+                DownloadClient = message.DownloadClientInfo?.Name,
+                DownloadClientType = message.DownloadClientInfo?.Type,
+                DownloadId = message.DownloadId,
+                SourcePath = message.SourcePath
+            };
+        }
+
         protected WebhookPayload BuildTestPayload()
         {
             return new WebhookGrabPayload

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookDownloadCompletePayload.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookDownloadCompletePayload.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Core.Notifications.Webhook
+{
+    public class WebhookDownloadCompletePayload : WebhookPayload
+    {
+        public WebhookSeries Series { get; set; }
+        public List<WebhookEpisode> Episodes { get; set; }
+        public WebhookGrabbedRelease Release { get; set; }
+        public string DownloadClient { get; set; }
+        public string DownloadClientType { get; set; }
+        public string DownloadId { get; set; }
+        public string SourcePath { get; set; }
+        public WebhookCustomFormatInfo CustomFormatInfo { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookEventType.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookEventType.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Notifications.Webhook
         Health,
         ApplicationUpdate,
         HealthRestored,
-        ManualInteractionRequired
+        ManualInteractionRequired,
+        DownloadComplete
     }
 }

--- a/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/Xbmc.cs
@@ -100,6 +100,11 @@ namespace NzbDrone.Core.Notifications.Xbmc
             Notify(Settings, MANUAL_INTERACTION_REQUIRED_TITLE, message.Message);
         }
 
+        public override void OnDownloadComplete(DownloadCompleteMessage message)
+        {
+            Notify(Settings, DOWNLOAD_COMPLETE_TITLE_BRANDED, message.Message);
+        }
+
         public override string Name => "Kodi";
 
         public override void ProcessQueue()

--- a/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
+++ b/src/Sonarr.Api.V3/Notifications/NotificationResource.cs
@@ -19,6 +19,7 @@ namespace Sonarr.Api.V3.Notifications
         public bool OnHealthRestored { get; set; }
         public bool OnApplicationUpdate { get; set; }
         public bool OnManualInteractionRequired { get; set; }
+        public bool OnDownloadComplete { get; set; }
         public bool SupportsOnGrab { get; set; }
         public bool SupportsOnDownload { get; set; }
         public bool SupportsOnUpgrade { get; set; }
@@ -32,6 +33,7 @@ namespace Sonarr.Api.V3.Notifications
         public bool SupportsOnHealthRestored { get; set; }
         public bool SupportsOnApplicationUpdate { get; set; }
         public bool SupportsOnManualInteractionRequired { get; set; }
+        public bool SupportsOnDownloadComplete { get; set; }
         public string TestCommand { get; set; }
     }
 
@@ -60,6 +62,7 @@ namespace Sonarr.Api.V3.Notifications
             resource.OnHealthRestored = definition.OnHealthRestored;
             resource.OnApplicationUpdate = definition.OnApplicationUpdate;
             resource.OnManualInteractionRequired = definition.OnManualInteractionRequired;
+            resource.OnDownloadComplete = definition.OnDownloadComplete;
             resource.SupportsOnGrab = definition.SupportsOnGrab;
             resource.SupportsOnDownload = definition.SupportsOnDownload;
             resource.SupportsOnUpgrade = definition.SupportsOnUpgrade;
@@ -73,6 +76,7 @@ namespace Sonarr.Api.V3.Notifications
             resource.SupportsOnHealthRestored = definition.SupportsOnHealthRestored;
             resource.SupportsOnApplicationUpdate = definition.SupportsOnApplicationUpdate;
             resource.SupportsOnManualInteractionRequired = definition.SupportsOnManualInteractionRequired;
+            resource.SupportsOnDownloadComplete = definition.SupportsOnDownloadComplete;
 
             return resource;
         }
@@ -100,6 +104,7 @@ namespace Sonarr.Api.V3.Notifications
             definition.OnHealthRestored = resource.OnHealthRestored;
             definition.OnApplicationUpdate = resource.OnApplicationUpdate;
             definition.OnManualInteractionRequired = resource.OnManualInteractionRequired;
+            definition.OnDownloadComplete = resource.OnDownloadComplete;
             definition.SupportsOnGrab = resource.SupportsOnGrab;
             definition.SupportsOnDownload = resource.SupportsOnDownload;
             definition.SupportsOnUpgrade = resource.SupportsOnUpgrade;
@@ -113,6 +118,7 @@ namespace Sonarr.Api.V3.Notifications
             definition.SupportsOnHealthRestored = resource.SupportsOnHealthRestored;
             definition.SupportsOnApplicationUpdate = resource.SupportsOnApplicationUpdate;
             definition.SupportsOnManualInteractionRequired = resource.SupportsOnManualInteractionRequired;
+            definition.SupportsOnDownloadComplete = resource.SupportsOnDownloadComplete;
 
             return definition;
         }


### PR DESCRIPTION
#### Description
Adds a new `OnDownloadComplete` notification event that fires when the download client reports a download as complete, before Sonarr begins importing. This fills the gap between `OnGrab` and `OnDownload` (import) in the notification timeline:

`OnGrab` → **`OnDownloadComplete`** (new) → `OnDownload` (per-file import) → `OnImportComplete` (batch)

The event is published in `CompletedDownloadService.Check()` when a tracked download transitions to `ImportPending` state. All 22 applicable notification providers implement the event (Plex, Trakt, SynologyIndexer excluded — they only handle library-level events). Test fixture updated.

Apologies for the large PR — to support this new event across all notification providers, I had to touch a lot of files. Most of the provider changes are small (5-line overrides following existing patterns). Happy to split this up into smaller PRs if preferred, but I didn't want to add this in a piecemeal way that would leave providers in an inconsistent state.

#### Database Migration
YES - 231

#### Issues Fixed or Closed by this PR
* Closes #8560