### PR TITLE
Bump NUnit to 4.5.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,8 @@ dotnet_diagnostic.IDE0005.severity = error
 dotnet_diagnostic.IDE0007.severity = error
 # Inline variable declaration
 dotnet_diagnostic.IDE0018.severity = error
+# Call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = warning
 
 # Stylecop Rules
 dotnet_diagnostic.SA0001.severity = none

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -52,14 +52,14 @@ runs:
         echo "Sonarr__Postgres__Password=postgres" >> "$GITHUB_ENV"
 
     - name: Download Artifact
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact }}
         path: _tests
 
     - name: Download Binary Artifact
       if: ${{ inputs.integration_tests }}
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.binary_artifact }}
         path: _output

--- a/.github/workflows/build_v5.yml
+++ b/.github/workflows/build_v5.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Volta
-        uses: volta-cli/action@v4
+        uses: volta-cli/action@v5
 
       - name: Yarn Install
         run: yarn install

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -122,9 +122,9 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(SonarrProject)'=='true' and '$(EnableAnalyzers)'=='false'">

--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -981,7 +981,7 @@ namespace NzbDrone.Common.Test.DiskTests
             var sourceFiles = Directory.GetFileSystemEntries(source, "*", SearchOption.AllDirectories).Select(v => v.Substring(source.Length + 1)).ToArray();
             var destFiles = Directory.GetFileSystemEntries(destination, "*", SearchOption.AllDirectories).Select(v => v.Substring(destination.Length + 1)).ToArray();
 
-            CollectionAssert.AreEquivalent(sourceFiles, destFiles);
+            Assert.That(sourceFiles, Is.EquivalentTo(destFiles));
         }
 
         private void VerifyMoveFolder(string source, string from, string destination)
@@ -991,7 +991,7 @@ namespace NzbDrone.Common.Test.DiskTests
             var sourceFiles = Directory.GetFileSystemEntries(source, "*", SearchOption.AllDirectories).Select(v => v.Substring(source.Length + 1)).ToArray();
             var destFiles = Directory.GetFileSystemEntries(destination, "*", SearchOption.AllDirectories).Select(v => v.Substring(destination.Length + 1)).ToArray();
 
-            CollectionAssert.AreEquivalent(sourceFiles, destFiles);
+            Assert.That(sourceFiles, Is.EquivalentTo(destFiles));
         }
 
         private void VerifyDeletedFile(string filePath)

--- a/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
@@ -131,7 +131,9 @@ public class HappyEyeballs<TSocket>
                 await delayCts.CancelAsync().ConfigureAwait(false);
                 await timeoutTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
+#pragma warning disable CA1849
                 completedTask = whenAnyDone.Result;
+#pragma warning restore CA1849
             }
             else
             {
@@ -165,7 +167,9 @@ public class HappyEyeballs<TSocket>
         {
             if (task.IsCompletedSuccessfully)
             {
+#pragma warning disable CA1849
                 task.Result.Dispose();
+#pragma warning restore CA1849
             }
         }
 
@@ -176,6 +180,8 @@ public class HappyEyeballs<TSocket>
             throw new AggregateException(innerExceptions);
         }
 
+#pragma warning disable CA1849
         return successTask.Result;
+#pragma warning restore CA1849
     }
 }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DownloadClientFixtureBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using NLog;
@@ -39,7 +38,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests
 
             Mocker.GetMock<IHttpClient>()
                   .Setup(s => s.GetAsync(It.IsAny<HttpRequest>()))
-                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>())));
+                  .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>()));
 
             Mocker.GetMock<IRemotePathMappingService>()
                 .Setup(v => v.RemapRemoteToLocal(It.IsAny<string>(), It.IsAny<OsPath>()))

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/HadoukenTests/HadoukenFixture.cs
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.HadoukenTests
         {
             Mocker.GetMock<IHttpClient>()
                   .Setup(s => s.GetAsync(It.IsAny<HttpRequest>()))
-                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), new byte[1000])));
+                  .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), new byte[1000]));
 
             Mocker.GetMock<IHadoukenProxy>()
                 .Setup(s => s.AddTorrentUri(It.IsAny<HadoukenSettings>(), It.IsAny<string>()))

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -111,31 +111,31 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SingleEpisodeSearchCriteria>()))
                 .Callback<SingleEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SeasonSearchCriteria>()))
                 .Callback<SeasonSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<DailyEpisodeSearchCriteria>()))
                 .Callback<DailyEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<DailySeasonSearchCriteria>()))
                 .Callback<DailySeasonSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeEpisodeSearchCriteria>()))
                 .Callback<AnimeEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeSeasonSearchCriteria>()))
                 .Callback<AnimeSeasonSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             _mockIndexer.Setup(v => v.Fetch(It.IsAny<SpecialEpisodeSearchCriteria>()))
                 .Callback<SpecialEpisodeSearchCriteria>(s => result.Add(s))
-                .Returns(Task.FromResult<IList<Parser.Model.ReleaseInfo>>(new List<Parser.Model.ReleaseInfo>()));
+                .ReturnsAsync(new List<Parser.Model.ReleaseInfo>());
 
             return result;
         }

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using Moq;
@@ -38,11 +37,11 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             Mocker.GetMock<ISearchForReleases>()
                   .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, false, true, false))
-                  .Returns(Task.FromResult(new List<DownloadDecision>()));
+                  .ReturnsAsync(new List<DownloadDecision>());
 
             Mocker.GetMock<IProcessDownloadDecisions>()
                   .Setup(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
-                  .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>())));
+                  .ReturnsAsync(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>()));
         }
 
         [Test]
@@ -91,7 +90,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             Mocker.GetMock<ISearchForReleases>()
                   .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false))
-                  .Returns(Task.FromResult(new List<DownloadDecision>()))
+                  .ReturnsAsync(new List<DownloadDecision>())
                   .Callback<int, int, bool, bool, bool, bool>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch) => seasonOrder.Add(seasonNumber));
 
             Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });

--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetFixture.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Post)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -79,7 +79,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
         {
             Mocker.GetMock<IHttpClient>()
                 .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.BadRequest)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.BadRequest));
 
             var results = await Subject.FetchRecent();
 
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
         {
             Mocker.GetMock<IHttpClient>()
                 .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.Unauthorized)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.Unauthorized));
 
             var results = await Subject.FetchRecent();
 
@@ -111,7 +111,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
         {
             Mocker.GetMock<IHttpClient>()
                 .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.NotFound)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.NotFound));
 
             var results = await Subject.FetchRecent();
 
@@ -127,7 +127,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
         {
             Mocker.GetMock<IHttpClient>()
                 .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.ServiceUnavailable)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Array.Empty<byte>(), System.Net.HttpStatusCode.ServiceUnavailable));
 
             var results = await Subject.FetchRecent();
 
@@ -149,7 +149,7 @@ namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Post)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FanzubTests/FanzubFixture.cs
@@ -32,7 +32,7 @@ namespace NzbDrone.Core.Test.IndexerTests.FanzubTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader { { "Content-Type", "application/json" } }, recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader { { "Content-Type", "application/json" } }, recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/HDBitsTests/HDBitsFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/HDBitsTests/HDBitsFixture.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Test.IndexerTests.HDBitsTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Post)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), responseJson)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), responseJson));
 
             var torrents = await Subject.FetchRecent();
 
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.IndexerTests.HDBitsTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(v => v.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), Encoding.UTF8.GetBytes(responseJson))));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), Encoding.UTF8.GetBytes(responseJson)));
 
             var torrents = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/IPTorrentsTests/IPTorrentsFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/IPTorrentsTests/IPTorrentsFixture.cs
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Test.IndexerTests.IPTorrentsTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabFixture.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -75,7 +75,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -145,7 +145,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -173,7 +173,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), feed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), feed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaFixture.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/SeasonSearchFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/SeasonSearchFixture.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.Test.IndexerTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), "<xml></xml>")));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), "<xml></xml>"));
         }
 
         private void WithIndexer(bool paging, int resultCount)

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentRssIndexerTests/TorrentRssIndexerFixture.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentRssIndexerTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.IsAny<HttpRequest>()))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.Execute(It.IsAny<HttpRequest>()))

--- a/src/NzbDrone.Core.Test/IndexerTests/TorrentleechTests/TorrentleechFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorrentleechTests/TorrentleechFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorrentleechTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/TorznabTests/TorznabFixture.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -82,7 +82,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var releases = await Subject.FetchRecent();
 
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             var result = new NzbDroneValidationResult(Subject.Test());
             result.IsValid.Should().BeTrue();
@@ -190,7 +190,7 @@ namespace NzbDrone.Core.Test.IndexerTests.TorznabTests
 
             Mocker.GetMock<IHttpClient>()
                   .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                  .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                  .ReturnsAsync((HttpRequest r) => new HttpResponse(r, new HttpHeader(), recentFeed));
 
             (Subject.Definition.Settings as TorznabSettings).ApiPath = apiPath;
 

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -179,10 +179,9 @@ namespace NzbDrone.Integration.Test
 
             var cts = new CancellationTokenSource();
 
-            _signalrConnection.Closed += e =>
+            _signalrConnection.Closed += async _ =>
             {
-                cts.Cancel();
-                return Task.CompletedTask;
+                await cts.CancelAsync();
             };
 
             _signalrConnection.On<SignalRMessage>("receiveMessage", (message) =>
@@ -199,7 +198,7 @@ namespace NzbDrone.Integration.Test
                 {
                     Console.WriteLine("Connecting to signalR");
 
-                    await _signalrConnection.StartAsync();
+                    await _signalrConnection.StartAsync(cts.Token);
                     connected = true;
                     break;
                 }
@@ -212,7 +211,7 @@ namespace NzbDrone.Integration.Test
                 }
 
                 retryCount++;
-                Thread.Sleep(200);
+                await Task.Delay(200, cts.Token);
             }
         }
 

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NLog" Version="5.5.1" />


### PR DESCRIPTION
#### Description
- Bumping NUnit to v4 for better async support.

  https://docs.nunit.org/articles/nunit/Towards-NUnit4.html

- Enabling https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1849

  I wanted to fix the calls in HappyEyeballs.cs but I opted not to, considering it's already broken with private IPs from personal usage and needs to be properly fixed.

- Bump FluentAssertions to latest FOSS version according to their [homepage](https://fluentassertions.com/).