### PR TITLE
Enable Call async methods when in an async method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,8 @@ dotnet_diagnostic.IDE0005.severity = error
 dotnet_diagnostic.IDE0007.severity = error
 # Inline variable declaration
 dotnet_diagnostic.IDE0018.severity = error
+# Call async methods when in an async method
+dotnet_diagnostic.CA1849.severity = warning
 
 # Stylecop Rules
 dotnet_diagnostic.SA0001.severity = none

--- a/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
+++ b/src/NzbDrone.Common/Http/HappyEyeballs/HappyEyeballs.cs
@@ -131,7 +131,9 @@ public class HappyEyeballs<TSocket>
                 await delayCts.CancelAsync().ConfigureAwait(false);
                 await timeoutTask.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
 
+#pragma warning disable CA1849
                 completedTask = whenAnyDone.Result;
+#pragma warning restore CA1849
             }
             else
             {
@@ -165,7 +167,9 @@ public class HappyEyeballs<TSocket>
         {
             if (task.IsCompletedSuccessfully)
             {
+#pragma warning disable CA1849
                 task.Result.Dispose();
+#pragma warning restore CA1849
             }
         }
 
@@ -176,6 +180,8 @@ public class HappyEyeballs<TSocket>
             throw new AggregateException(innerExceptions);
         }
 
+#pragma warning disable CA1849
         return successTask.Result;
+#pragma warning restore CA1849
     }
 }

--- a/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTestBase.cs
@@ -179,10 +179,9 @@ namespace NzbDrone.Integration.Test
 
             var cts = new CancellationTokenSource();
 
-            _signalrConnection.Closed += e =>
+            _signalrConnection.Closed += async _ =>
             {
-                cts.Cancel();
-                return Task.CompletedTask;
+                await cts.CancelAsync();
             };
 
             _signalrConnection.On<SignalRMessage>("receiveMessage", (message) =>
@@ -199,7 +198,7 @@ namespace NzbDrone.Integration.Test
                 {
                     Console.WriteLine("Connecting to signalR");
 
-                    await _signalrConnection.StartAsync();
+                    await _signalrConnection.StartAsync(cts.Token);
                     connected = true;
                     break;
                 }
@@ -212,7 +211,7 @@ namespace NzbDrone.Integration.Test
                 }
 
                 retryCount++;
-                Thread.Sleep(200);
+                await Task.Delay(200, cts.Token);
             }
         }
 


### PR DESCRIPTION
#### Description
Enabling https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1849

I wanted to fix the calls in HappyEyeballs.cs but I opted not to, considering it's already broken with private IPs from personal usage and needs to be properly fixed.