### PR TITLE
Bump FluentAssertions to 7.2.2

### DIFF
--- a/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Sonarr.Test.Common.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NLog" Version="5.5.1" />


### PR DESCRIPTION
#### Description
Bump FluentAssertions to latest FOSS version according to their [homepage](https://fluentassertions.com/).
