### PR TITLE
Defer deserialize JSON response resource with Lazy

### DIFF
--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -101,12 +101,14 @@ namespace NzbDrone.Common.Http
     public class HttpResponse<T> : HttpResponse
         where T : new()
     {
+        private readonly Lazy<T> _resource;
+
         public HttpResponse(HttpResponse response)
             : base(response.Request, response.Headers, response.ResponseData, response.StatusCode, response.Version)
         {
-            Resource = Json.Deserialize<T>(response.Content);
+            _resource = new Lazy<T>(() => Json.Deserialize<T>(response.Content));
         }
 
-        public T Resource { get; private set; }
+        public T Resource => _resource.Value;
     }
 }


### PR DESCRIPTION
#### Description
Defer JSON deserialization for HTTP requests with a resource, to allow status checks in cases where the JSON is invalid.

Like for the refresh series.
https://github.com/Sonarr/Sonarr/blob/bf5d48c76a6a793b7d2adc540bb11d9c51bcc3cb/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs#L53-L65