### PR TITLE
Apply Radarr's Post-Backup Cleanup

### DIFF
--- a/src/NzbDrone.Core/Backup/BackupService.cs
+++ b/src/NzbDrone.Core/Backup/BackupService.cs
@@ -98,6 +98,8 @@ namespace NzbDrone.Core.Backup
 
             _archiveService.CreateZip(backupPath, _diskProvider.GetFiles(_backupTempFolder, false));
 
+            Cleanup();
+
             _logger.ProgressDebug("Backup zip created");
         }
 


### PR DESCRIPTION
Description

Sonarr never really cleans up the files it creates in the temp folder like the other arrs do, I used the way Radarr does it, which is just call the same Cleanup() function Sonarr does pre backup also post zip creation. This way it leaves the sonarr_backup folder empty in the temp folder until the next backup.