### PR TITLE
Allowing bypass authentication only for localhost

### DIFF
--- a/frontend/src/Settings/General/SecuritySettings.tsx
+++ b/frontend/src/Settings/General/SecuritySettings.tsx
@@ -61,6 +61,12 @@ export const authenticationRequiredOptions: EnhancedSelectInputValue<string>[] =
         return translate('DisabledForLocalAddresses');
       },
     },
+    {
+      key: 'disabledForLocalHost',
+      get value() {
+        return translate('DisabledForLocalhost');
+      },
+    },
   ];
 
 const certificateValidationOptions: EnhancedSelectInputValue<string>[] = [

--- a/src/NzbDrone.Core/Authentication/AuthenticationRequiredType.cs
+++ b/src/NzbDrone.Core/Authentication/AuthenticationRequiredType.cs
@@ -3,6 +3,7 @@ namespace NzbDrone.Core.Authentication
     public enum AuthenticationRequiredType
     {
         Enabled = 0,
-        DisabledForLocalAddresses = 1
+        DisabledForLocalAddresses = 1,
+        DisabledForLocalHost = 2,
     }
 }

--- a/src/NzbDrone.Core/Authentication/AuthenticationRequiredType.cs
+++ b/src/NzbDrone.Core/Authentication/AuthenticationRequiredType.cs
@@ -4,6 +4,6 @@ namespace NzbDrone.Core.Authentication
     {
         Enabled = 0,
         DisabledForLocalAddresses = 1,
-        DisabledForLocalHost = 2,
+        DisabledForLocalhost = 2,
     }
 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -424,6 +424,7 @@
   "Directory": "Directory",
   "Disabled": "Disabled",
   "DisabledForLocalAddresses": "Disabled for Local Addresses",
+  "DisabledForLocalhost": "Disabled for Localhost",
   "Discord": "Discord",
   "DiskSpace": "Disk Space",
   "DoNotBlocklist": "Do not Blocklist",

--- a/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -24,22 +24,25 @@ namespace NzbDrone.Http.Authentication
 
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, BypassableDenyAnonymousAuthorizationRequirement requirement)
         {
-            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses ||
-                    _authenticationRequired == AuthenticationRequiredType.DisabledForLocalhost)
+            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses
             {
                 if (context.Resource is HttpContext httpContext &&
                     IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
-                    if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalhost &&
-                            ipAddress.isLoopback())
-                    {
-                        context.Succeed(requirement);
-                    }
-                    else if (ipAddress.IsLocalAddress() ||
+                    if (ipAddress.IsLocalAddress() ||
                              (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
                     {
                         context.Succeed(requirement);
                     }
+                }
+            }
+            else if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalhost)
+            {
+                if (context.Resource is HttpContext httpContext &&
+                    IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress) &&
+                    IPAddress.IsLoopback(ipAddress))
+                {
+                    context.Succeed(requirement);
                 }
             }
 

--- a/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -24,13 +24,13 @@ namespace NzbDrone.Http.Authentication
 
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, BypassableDenyAnonymousAuthorizationRequirement requirement)
         {
-            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses
+            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses)
             {
                 if (context.Resource is HttpContext httpContext &&
                     IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
                     if (ipAddress.IsLocalAddress() ||
-                             (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
+                        (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
                     {
                         context.Succeed(requirement);
                     }

--- a/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -24,13 +24,19 @@ namespace NzbDrone.Http.Authentication
 
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, BypassableDenyAnonymousAuthorizationRequirement requirement)
         {
-            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses)
+            if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses ||
+                    _authenticationRequired == AuthenticationRequiredType.DisabledForLocalHost)
             {
                 if (context.Resource is HttpContext httpContext &&
                     IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
-                    if (ipAddress.IsLocalAddress() ||
-                        (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
+                    if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalHost &&
+                            ipAddress.isLoopback())
+                    {
+                        context.Succeed(requirement);
+                    }
+                    else if (ipAddress.IsLocalAddress() ||
+                             (_configService.TrustCgnatIpAddresses && ipAddress.IsCgnatIpAddress()))
                     {
                         context.Succeed(requirement);
                     }

--- a/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
+++ b/src/Sonarr.Http/Authentication/UiAuthorizationHandler.cs
@@ -25,12 +25,12 @@ namespace NzbDrone.Http.Authentication
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, BypassableDenyAnonymousAuthorizationRequirement requirement)
         {
             if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalAddresses ||
-                    _authenticationRequired == AuthenticationRequiredType.DisabledForLocalHost)
+                    _authenticationRequired == AuthenticationRequiredType.DisabledForLocalhost)
             {
                 if (context.Resource is HttpContext httpContext &&
                     IPAddress.TryParse(httpContext.GetRemoteIP(), out var ipAddress))
                 {
-                    if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalHost &&
+                    if (_authenticationRequired == AuthenticationRequiredType.DisabledForLocalhost &&
                             ipAddress.isLoopback())
                     {
                         context.Succeed(requirement);


### PR DESCRIPTION
#### Description
Currently we can either enable authentication for all or disable it for all local address within the same network. However, for people who's on the non-private network (such as school network), one might want to disable authentication just for the device itself, but keep authentication required for others on the same network.
Behavior: Modify the option in `Settings > General > Security` that allow disable authentication for localhost only.

#### Screenshots for UI Changes

TBD

#### Issues Fixed or Closed by this PR
* Closes #8608 

