### PR TITLE
Fixed: Don't log error when missing some translation files

### DIFF
--- a/src/NzbDrone.Core/Localization/LocalizationService.cs
+++ b/src/NzbDrone.Core/Localization/LocalizationService.cs
@@ -144,24 +144,28 @@ namespace NzbDrone.Core.Localization
 
             var alternativeFilenamePath = Path.Combine(prefix, GetResourceFilename(culture));
 
-            await CopyInto(dictionary, baseFilenamePath).ConfigureAwait(false);
+            await CopyInto(dictionary, baseFilenamePath, true).ConfigureAwait(false);
 
             if (culture.Contains('_'))
             {
                 var languageBaseFilenamePath = Path.Combine(prefix, GetResourceFilename(culture.Split('_')[0]));
-                await CopyInto(dictionary, languageBaseFilenamePath).ConfigureAwait(false);
+                await CopyInto(dictionary, languageBaseFilenamePath, false).ConfigureAwait(false);
             }
 
-            await CopyInto(dictionary, alternativeFilenamePath).ConfigureAwait(false);
+            await CopyInto(dictionary, alternativeFilenamePath, true).ConfigureAwait(false);
 
             return dictionary;
         }
 
-        private async Task CopyInto(IDictionary<string, string> dictionary, string resourcePath)
+        private async Task CopyInto(IDictionary<string, string> dictionary, string resourcePath, bool logMissing)
         {
             if (!File.Exists(resourcePath))
             {
-                _logger.Error("Missing translation/culture resource: {0}", resourcePath);
+                if (logMissing)
+                {
+                    _logger.Error("Missing translation/culture resource: {0}", resourcePath);
+                }
+
                 return;
             }
 


### PR DESCRIPTION
#### Description
Even when a specific variant for a language is fetched we attempt to get the base language as well, but that file may not exist. Not sure if we should also change the log level, but left it as `Error` for now.



#### Issues Fixed or Closed by this PR
* Closes #8604

