### PR TITLE
Display external ID only for main series link group and update Trakt link

### DIFF
--- a/frontend/src/Series/Details/SeriesDetailsLinks.tsx
+++ b/frontend/src/Series/Details/SeriesDetailsLinks.tsx
@@ -13,7 +13,7 @@ type SeriesDetailsLinksProps = Pick<
 >;
 
 interface SeriesDetailsLink {
-  externalId: string | number;
+  externalId?: string | number;
   name: string;
   url: string;
 }
@@ -25,18 +25,11 @@ function SeriesDetailsLinks(props: SeriesDetailsLinksProps) {
     const validLinks: SeriesDetailsLink[] = [];
 
     if (tvdbId) {
-      validLinks.push(
-        {
-          externalId: tvdbId,
-          name: 'The TVDB',
-          url: `https://www.thetvdb.com/?tab=series&id=${tvdbId}`,
-        },
-        {
-          externalId: tvdbId,
-          name: 'Trakt',
-          url: `https://trakt.tv/search/tvdb/${tvdbId}?id_type=show`,
-        }
-      );
+      validLinks.push({
+        externalId: tvdbId,
+        name: 'The TVDB',
+        url: `https://www.thetvdb.com/?tab=series&id=${tvdbId}`,
+      });
     }
 
     if (tvMazeId) {
@@ -55,7 +48,10 @@ function SeriesDetailsLinks(props: SeriesDetailsLinksProps) {
           url: `https://imdb.com/title/${imdbId}/`,
         },
         {
-          externalId: imdbId,
+          name: 'Trakt',
+          url: `https://trakt.tv/shows/${imdbId}`,
+        },
+        {
           name: 'MDBList',
           url: `https://mdblist.com/show/${imdbId}`,
         }
@@ -70,7 +66,9 @@ function SeriesDetailsLinks(props: SeriesDetailsLinksProps) {
       });
     }
 
-    return validLinks;
+    return validLinks.sort(
+      (a, b) => Number(!a.externalId) - Number(!b.externalId)
+    );
   }, [tvdbId, tvMazeId, imdbId, tmdbId]);
 
   return (
@@ -87,13 +85,15 @@ function SeriesDetailsLinks(props: SeriesDetailsLinksProps) {
             </Label>
           </Link>
 
-          <ClipboardButton
-            value={`${link.externalId}`}
-            title={translate('CopyToClipboard')}
-            kind={kinds.DEFAULT}
-            size={sizes.SMALL}
-            label={link.externalId}
-          />
+          {link.externalId ? (
+            <ClipboardButton
+              value={`${link.externalId}`}
+              title={translate('CopyToClipboard')}
+              kind={kinds.DEFAULT}
+              size={sizes.SMALL}
+              label={link.externalId}
+            />
+          ) : null}
         </div>
       ))}
     </div>


### PR DESCRIPTION
#### Description
Show the external ID just once, and fix link to Trakt.

#### Screenshots for UI Changes
Before
<img width="1922" height="224" alt="before" src="https://github.com/user-attachments/assets/cf84ecf2-d2f0-4b98-833c-8229def883af" />

After
<img width="1568" height="228" alt="after" src="https://github.com/user-attachments/assets/48f8ec56-3906-4ec2-ac63-910c92fe066e" />

