### PR TITLE
Fix vertical alignment for ratings on series table

### DIFF
--- a/frontend/src/Series/Index/Table/SeriesIndexRow.css
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.css
@@ -145,7 +145,7 @@
 }
 
 .ratings {
-  composes: cell from '~Components/Table/Cells/VirtualTableRowCell.css';
+  composes: cell;
 
   flex: 0 0 80px;
 }

--- a/frontend/src/Series/useSeries.ts
+++ b/frontend/src/Series/useSeries.ts
@@ -95,7 +95,7 @@ export const FILTERS: Filter[] = [
 ];
 
 const SORT_PREDICATES = {
-  status: (item: Series, _direction: SortDirection) => {
+  status: (item: Series, _: SortDirection) => {
     let result = 0;
 
     if (item.monitored) {
@@ -109,11 +109,11 @@ const SORT_PREDICATES = {
     return result;
   },
 
-  sizeOnDisk: (item: Series, _direction: SortDirection) => {
+  sizeOnDisk: (item: Series, _: SortDirection) => {
     return item.statistics?.sizeOnDisk ?? 0;
   },
 
-  averageSizePerEpisode: (item: Series, _direction: SortDirection) => {
+  averageSizePerEpisode: (item: Series, _: SortDirection) => {
     const totalEpisodeCount = item.statistics?.totalEpisodeCount ?? 0;
 
     return totalEpisodeCount > 0
@@ -121,41 +121,35 @@ const SORT_PREDICATES = {
       : 0;
   },
 
-  network: (item: Series, _direction: SortDirection) => {
-    const network = item.network;
+  network: (item: Series, _: SortDirection) => {
+    const { network } = item;
 
-    return network ? network.toLowerCase() : '';
+    return network?.toLowerCase() ?? '';
   },
 
   nextAiring: (item: Series, direction: SortDirection) => {
-    const nextAiring = item.nextAiring;
+    const { nextAiring } = item;
 
     if (nextAiring) {
       return moment(nextAiring).unix();
     }
 
-    if (direction === sortDirections.DESCENDING) {
-      return 0;
-    }
-
-    return Number.MAX_VALUE;
+    return direction === sortDirections.DESCENDING ? 0 : Number.MAX_VALUE;
   },
 
   previousAiring: (item: Series, direction: SortDirection) => {
-    const previousAiring = item.previousAiring;
+    const { previousAiring } = item;
 
     if (previousAiring) {
       return moment(previousAiring).unix();
     }
 
-    if (direction === sortDirections.DESCENDING) {
-      return -Number.MAX_VALUE;
-    }
-
-    return Number.MAX_VALUE;
+    return direction === sortDirections.DESCENDING
+      ? Number.MAX_VALUE * -1
+      : Number.MAX_VALUE;
   },
 
-  episodeProgress: (item: Series, _direction: SortDirection) => {
+  episodeProgress: (item: Series, _: SortDirection) => {
     const statistics = item.statistics;
 
     const episodeCount = statistics?.episodeCount ?? 0;
@@ -168,34 +162,34 @@ const SORT_PREDICATES = {
     return progress + episodeCount / 1000000;
   },
 
-  episodeCount: (item: Series, _direction: SortDirection) => {
+  episodeCount: (item: Series, _: SortDirection) => {
     return item.statistics?.totalEpisodeCount ?? 0;
   },
 
-  seasonCount: (item: Series, _direction: SortDirection) => {
+  seasonCount: (item: Series, _: SortDirection) => {
     return item.statistics?.seasonCount ?? 0;
   },
 
-  originalLanguage: (item: Series, _direction: SortDirection) => {
+  originalLanguage: (item: Series, _: SortDirection) => {
     const { originalLanguage } = item;
 
     return originalLanguage?.name ?? '';
   },
 
-  ratings: (item: Series, _direction: SortDirection) => {
+  ratings: (item: Series, _: SortDirection) => {
     const { ratings } = item;
 
     return ratings.value ?? 0;
   },
 
-  monitorNewItems: (item: Series, _direction: SortDirection) => {
+  monitorNewItems: (item: Series, _: SortDirection) => {
     return item.monitorNewItems === 'all' ? 1 : 0;
   },
 } as const;
 
 const FILTER_PREDICATES = {
   episodeProgress: (item: Series, filterValue: number, type: FilterType) => {
-    const statistics = item.statistics;
+    const { statistics } = item;
     const episodeCount = statistics?.episodeCount ?? 0;
     const episodeFileCount = statistics?.episodeFileCount ?? 0;
 
@@ -207,8 +201,8 @@ const FILTER_PREDICATES = {
     return predicate(progress, filterValue);
   },
 
-  missing: (item: Series, _filterValue: boolean, _type: FilterType) => {
-    const statistics = item.statistics;
+  missing: (item: Series, _filterValue: boolean, _: FilterType) => {
+    const { statistics } = item;
     const episodeCount = statistics?.episodeCount ?? 0;
     const episodeFileCount = statistics?.episodeFileCount ?? 0;
     return episodeCount - episodeFileCount > 0;
@@ -300,7 +294,7 @@ const FILTER_PREDICATES = {
 
   hasMissingSeason: (item: Series, filterValue: boolean, type: FilterType) => {
     const predicate = getFilterTypePredicate(type);
-    const seasons = item.seasons ?? [];
+    const { seasons = [] } = item;
 
     const hasMissingSeason = seasons.some((season) => {
       const { seasonNumber } = season;
@@ -326,7 +320,7 @@ const FILTER_PREDICATES = {
     type: FilterType
   ) => {
     const predicate = getFilterTypePredicate(type);
-    const seasons = item.seasons ?? [];
+    const { seasons = [] } = item;
 
     const { monitoredCount, unmonitoredCount } = seasons.reduce(
       (acc, { seasonNumber, monitored }) => {


### PR DESCRIPTION
#### Description
On table view with banners enabled, the ratings aren't vertically aligned.

Minor changes to sort and filtering predicates to use object destructing, optional chaining and nullish coalescing.

#### Screenshots
Before
<img width="926" height="288" alt="Screenshot 2026-05-17 at 11 52 28" src="https://github.com/user-attachments/assets/b66fe313-134c-4af5-8cd3-2499a42c97d2" />

After
<img width="958" height="280" alt="Screenshot 2026-05-17 at 12 47 53" src="https://github.com/user-attachments/assets/a4bcc49a-4837-4e0a-a2e8-c30bbb486492" />


