### PR TITLE
Fix modals on iOS

### DIFF
--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -30,12 +30,6 @@
   overflow: hidden !important;
 }
 
-.modalOpenIOS {
-  position: fixed;
-  right: 0;
-  left: 0;
-}
-
 /*
  * Sizes
  */

--- a/frontend/src/Components/Modal/Modal.css.d.ts
+++ b/frontend/src/Components/Modal/Modal.css.d.ts
@@ -10,7 +10,6 @@ interface CssExports {
   'modalBackdrop': string;
   'modalContainer': string;
   'modalOpen': string;
-  'modalOpenIOS': string;
   'small': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Components/Modal/Modal.tsx
+++ b/frontend/src/Components/Modal/Modal.tsx
@@ -71,7 +71,6 @@ function Modal({
 }: ModalProps) {
   const backgroundRef = useRef<HTMLDivElement>(null);
   const isBackdropPressed = useRef(false);
-  const bodyScrollTop = useRef(0);
   const wasOpen = usePrevious(isOpen);
   const modalId = useId();
 
@@ -128,8 +127,6 @@ function Modal({
       if (openModals.length === 1) {
         if (isIOS()) {
           setScrollLock(true);
-          bodyScrollTop.current = document.body.scrollTop;
-          elementClass(document.body).add(styles.modalOpenIOS);
         } else {
           elementClass(document.body).add(styles.modalOpen);
         }
@@ -138,11 +135,8 @@ function Modal({
       removeFromOpenModals(modalId);
 
       if (openModals.length === 0) {
-        setScrollLock(false);
-
         if (isIOS()) {
-          elementClass(document.body).remove(styles.modalOpenIOS);
-          document.body.scrollTop = bodyScrollTop.current;
+          setScrollLock(false);
         } else {
           elementClass(document.body).remove(styles.modalOpen);
         }


### PR DESCRIPTION
#### Description

Modals were pretty broken on iOS, they'd sometimes close on open due to virtual lists and scroll position or they'd break scrolling after closing. Looks like ripping out the body manipulation fixes these issues.

