### PR TITLE
Fixed: ManualImport NRE when TrackedDownload.ImportItem is null

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -598,7 +598,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 var importedSeries = imported.First().ImportDecision.LocalEpisode.Series;
                 var outputPath = trackedDownload.ImportItem?.OutputPath?.FullPath;
 
-                if (outputPath.IsNotNullOrWhiteSpace() && _diskProvider.FolderExists(outputPath))
+                if (outputPath.IsNullOrWhiteSpace())
+                {
+                    _logger.Debug("Skipping post-import folder cleanup for tracked download {0}; ImportItem.OutputPath is not available", trackedDownload.DownloadItem?.DownloadId);
+                }
+                else if (_diskProvider.FolderExists(outputPath))
                 {
                     if (_downloadedEpisodesImportService.ShouldDeleteFolder(
                             new DirectoryInfo(outputPath), importedSeries) &&

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -596,9 +596,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             {
                 var trackedDownload = groupedTrackedDownload.First().TrackedDownload;
                 var importedSeries = imported.First().ImportDecision.LocalEpisode.Series;
-                var outputPath = trackedDownload.ImportItem.OutputPath.FullPath;
+                var outputPath = trackedDownload.ImportItem?.OutputPath?.FullPath;
 
-                if (_diskProvider.FolderExists(outputPath))
+                if (outputPath.IsNotNullOrWhiteSpace() && _diskProvider.FolderExists(outputPath))
                 {
                     if (_downloadedEpisodesImportService.ShouldDeleteFolder(
                             new DirectoryInfo(outputPath), importedSeries) &&


### PR DESCRIPTION
#### Description

The `ManualImport` command's post-import folder-cleanup loop crashes with `NullReferenceException` when `_trackedDownloadService.Find(downloadId)` returns a `TrackedDownload` whose `ImportItem` (or nested `ImportItem.OutputPath`) is null.

The files themselves import successfully — the hardlink/move runs immediately before the cleanup loop — but the cleanup loop crashes, so the command is marked Failed and no `DownloadCompletedEvent` is fired. From the operator's point of view it looks like the import failed; the data is actually in the library.

This fix coerces the cleanup path through null-conditional access on `ImportItem?.OutputPath?.FullPath`, and skips the folder-cleanup branch when the resulting path is null/whitespace. Two lines of diff. No behavior change when `ImportItem`/`OutputPath` are populated.

For background and a full stack trace see #8649.

#### Notes

- Same risky dereference of `trackedDownload.ImportItem.OutputPath` exists at `ManualImportService.cs:127` (`GetMediaFiles`) and at `CompletedDownloadService.cs:147,267,309`. Left untouched here to keep this PR scoped to the user-visible bug; happy to broaden the audit in a follow-up if desired.
- Workaround for API callers in the meantime: omit `downloadId` from each ManualImport file entry — the file then goes through the untracked-import path and the cleanup loop is skipped entirely.
- No tests added. `ManualImportService` has 14 constructor dependencies and no existing test fixture; standing up the first fixture for a 2-line null-guard felt disproportionate. Happy to add one if you'd prefer — let me know.

#### Issues Fixed or Closed by this PR

* Closes #8647

