### PR TITLE
docs: note that issues must be filed via the web form (label requirement)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 We're always looking for people to help make Sonarr even better, there are a number of ways to contribute.
 
+## Reporting Issues
+
+Please file bug reports and feature requests through the [issue forms](https://github.com/Sonarr/Sonarr/issues/new/choose). The forms apply the required `needs-triage` label server-side; issues opened via the REST API (including `gh issue create --body-file`) are auto-closed because labels are silently dropped for users without push access.
+
 ## Documentation
 
 Setup guides, [FAQ](https://wiki.servarr.com/sonarr/faq), the more information we have on the [wiki](https://wiki.servarr.com/sonarr) the better.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ We're always looking for people to help make Sonarr even better, there are a num
 
 ## Reporting Issues
 
-Please file bug reports and feature requests through the [issue forms](https://github.com/Sonarr/Sonarr/issues/new/choose). The forms apply the required `needs-triage` label server-side; issues opened via the REST API (including `gh issue create --body-file`) are auto-closed because labels are silently dropped for users without push access.
+- Use the [issue forms](https://github.com/Sonarr/Sonarr/issues/new/choose) to file bug reports and feature requests — not the REST API or `gh issue create`.
+- The forms apply the required `needs-triage` label server-side. The REST API silently drops the `labels` parameter for users without push access, which leaves the issue unlabeled.
+- Unlabeled issues are auto-closed by [`.github/workflows/close_invalid_issues.yml`](./.github/workflows/close_invalid_issues.yml) on the `opened` event.
 
 ## Documentation
 


### PR DESCRIPTION
#### Description

Small docs-only addition to `CONTRIBUTING.md`.

The `close_invalid_issues.yml` workflow auto-closes any issue with zero labels on the `opened`/`reopened` events. The `bug_report.yml` and `feature_request.yml` templates carry `labels: [needs-triage]` (and `Status: Needs Triage` etc.) that GitHub applies server-side only when the issue is submitted via the web form at `/issues/new/choose`.

Issues created through the REST API path — including `gh issue create --body-file …` — bypass the form, and per GitHub's docs `labels` are *silently dropped* for users without push access. The result is that the issue opens with `labels: []`, the bot fires within seconds, and the contributor sees a confusing auto-close on what looked like a correctly-templated body.

I just hit this filing #8647 → #8649 (closed → re-filed); the auto-close comment ([example](https://github.com/Sonarr/Sonarr/issues/8647#issuecomment-4526985807)) explains the mechanic *after* it happens but doesn't help upfront. This adds a four-line note near the top of `CONTRIBUTING.md` so future API/CLI contributors know to use the web form.

#### Issues Fixed or Closed by this PR

(none — docs-only)

#### Database Migration

NO
