### PR TITLE
New: show more season titles

### DIFF
--- a/frontend/src/Utilities/Series/filterAlternateTitles.ts
+++ b/frontend/src/Utilities/Series/filterAlternateTitles.ts
@@ -63,6 +63,15 @@ function filterAlternateTitles(
           ? seasonNumber
           : sceneSeasonNumber;
 
+      // Add season titles with no mappedSeasonNumber
+      if (
+        mappedSeasonNumber === undefined &&
+        alternateTitle.seasonNumber === seasonNumber
+      ) {
+        seasonTitles.push(alternateTitle);
+        return;
+      }
+
       if (
         mappedSeasonNumber !== undefined &&
         mappedSeasonNumber === mappedAltSeasonNumber

--- a/frontend/src/Utilities/Series/filterAlternateTitles.ts
+++ b/frontend/src/Utilities/Series/filterAlternateTitles.ts
@@ -59,18 +59,9 @@ function filterAlternateTitles(
         : alternateTitle.sceneSeasonNumber;
       // Select scene or tvdb on the episode
       const mappedSeasonNumber =
-        alternateTitle.sceneOrigin === 'tvdb'
-          ? seasonNumber
-          : sceneSeasonNumber;
-
-      // Add season titles with no mappedSeasonNumber
-      if (
-        mappedSeasonNumber === undefined &&
-        alternateTitle.seasonNumber === seasonNumber
-      ) {
-        seasonTitles.push(alternateTitle);
-        return;
-      }
+        alternateTitle.sceneOrigin !== 'tvdb' && sceneSeasonNumber !== undefined
+          ? sceneSeasonNumber
+          : seasonNumber;
 
       if (
         mappedSeasonNumber !== undefined &&


### PR DESCRIPTION
#### Description
shows season titles from skyhook when no sceneOrigin was found and thus no mappedSeasonNumber determined.


#### Screenshots for UI Changes
<img width="400" height="177" alt="image" src="https://github.com/user-attachments/assets/066be4c3-2f9c-43c5-b398-628f57a73fc2" />


<img width="450" height="216" alt="image" src="https://github.com/user-attachments/assets/4ecf8ba2-54af-4c41-a7f1-56d7e9651712" />
