### PR TITLE
Additional help text for queue removal with no show association

### DIFF
--- a/frontend/src/Activity/Queue/QueueRow.tsx
+++ b/frontend/src/Activity/Queue/QueueRow.tsx
@@ -434,6 +434,7 @@ function QueueRow(props: QueueRowProps) {
         canChangeCategory={!!downloadClientHasPostImportCategory}
         canIgnore={!!series}
         isPending={isPending}
+        downloadClient={downloadClient}
         onRemovePress={handleRemoveQueueItemModalConfirmed}
         onModalClose={handleRemoveQueueItemModalClose}
       />

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
@@ -164,6 +164,11 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
                 value={removalMethod}
                 values={removalMethodOptions}
                 isDisabled={!canChangeCategory && !canIgnore}
+                helpText={
+                  !canChangeCategory && !canIgnore
+                    ? translate('RemoveQueueItemRemovalMethodDisabledHelpText')
+                    : undefined
+                }
                 helpTextWarning={translate(
                   'RemoveQueueItemRemovalMethodHelpTextWarning'
                 )}

--- a/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
+++ b/frontend/src/Activity/Queue/RemoveQueueItemModal.tsx
@@ -26,6 +26,7 @@ interface RemoveQueueItemModalProps {
   canIgnore: boolean;
   isPending: boolean;
   selectedCount?: number;
+  downloadClient?: string;
   onRemovePress(): void;
   onModalClose: () => void;
 }
@@ -38,6 +39,7 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
     canChangeCategory,
     isPending,
     selectedCount,
+    downloadClient,
     onRemovePress,
     onModalClose,
   } = props;
@@ -166,7 +168,14 @@ function RemoveQueueItemModal(props: RemoveQueueItemModalProps) {
                 isDisabled={!canChangeCategory && !canIgnore}
                 helpText={
                   !canChangeCategory && !canIgnore
-                    ? translate('RemoveQueueItemRemovalMethodDisabledHelpText')
+                    ? translate(
+                        'RemoveQueueItemRemovalMethodDisabledHelpText',
+                        {
+                          downloadClient: downloadClient
+                            ? downloadClient
+                            : translate('DownloadClient'),
+                        }
+                      )
                     : undefined
                 }
                 helpTextWarning={translate(

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1820,7 +1820,7 @@
   "RemoveQueueItem": "Remove - {sourceTitle}",
   "RemoveQueueItemConfirmation": "Are you sure you want to remove '{sourceTitle}' from the queue?",
   "RemoveQueueItemRemovalMethod": "Removal Method",
-  "RemoveQueueItemRemovalMethodDisabledHelpText": "No other removal options can be selected as the download is not associated with a show in {appName}. Either select 'Remove from Download Client' or change its category manually.",
+  "RemoveQueueItemRemovalMethodDisabledHelpText": "No other removal options can be selected as the download is not associated with a series in {appName}. Either select 'Remove from Download Client' or change its category manually in {downloadClient}.",
   "RemoveQueueItemRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the download and the file(s) from the download client.",
   "RemoveQueueItemsRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the downloads and the files from the download client.",
   "RemoveRootFolder": "Remove Root Folder",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1820,6 +1820,7 @@
   "RemoveQueueItem": "Remove - {sourceTitle}",
   "RemoveQueueItemConfirmation": "Are you sure you want to remove '{sourceTitle}' from the queue?",
   "RemoveQueueItemRemovalMethod": "Removal Method",
+  "RemoveQueueItemRemovalMethodDisabledHelpText": "No other removal options can be selected as the download is not associated with a show in {appName}. Either select 'Remove from Download Client' or change its category manually.",
   "RemoveQueueItemRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the download and the file(s) from the download client.",
   "RemoveQueueItemsRemovalMethodHelpTextWarning": "'Remove from Download Client' will remove the downloads and the files from the download client.",
   "RemoveRootFolder": "Remove Root Folder",


### PR DESCRIPTION
#### Description
When a download is not associated with a show its category cannot be changed and it cannot be ignored.
To avoid further support questions why, add additional help text when removal options are disabled due to no association with a show.


#### Screenshots for UI Changes

<img width="729" height="518" alt="image" src="https://github.com/user-attachments/assets/b5b04f00-c460-429f-a2d7-6d419ab6d2b8" />

