### PR TITLE
New: Parse releases with 3 digit season number

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -185,6 +185,10 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("S3E3 - Part 3 Seventeen Seconds [1080p]", "", 3, 3)]
         [TestCase("S03E03 - Part 3 Seventeen Seconds [1080p]", "", 3, 3)]
         [TestCase("[VARYG] Series at Age 29 S01E03 Rirui and Anyango 1080p CR WEB-DL AAC2.0 H.264 (29-sai Dokushin Chuuken Boukensha no Nichijou, Multi-Subs)", "Series at Age 29", 1, 3)]
+        [TestCase("Series S093E081 1080p ALL4 WEB-DL AAC2 0 H 264-JJUNAHJAMESON", "Series", 93, 81)]
+        [TestCase("Series S87E136 1080p WEB-DL x264-NGP", "Series", 87, 136)]
+        [TestCase("Series S092E001 1080p ALL4 WEB-DL AAC2 0 H 264-JJunahJameson", "Series", 92, 1)]
+        [TestCase("Series s90 e43 1080p HDTV AAC H264", "Series", 90, 43)]
 
         // [TestCase("", "", 0, 0)]
         public void should_parse_single_episode(string postTitle, string title, int seasonNumber, int episodeNumber)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -448,7 +448,11 @@ namespace NzbDrone.Core.Parser
 
                 // Anime OVA special
                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:[-_. ]+(?<special>special|ova|ovd|ncop|nced)).*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.mkv)",
-                    RegexOptions.IgnoreCase | RegexOptions.Compiled)
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+                // Episodes with a title, 3 digit season number, Single episodes (S001E05, 1x05, etc) & Multi-episode (S001E05E06, S001E05-06, S001E05 E06, etc)
+                new Regex(@"^(?<title>.+?)(?:(?:[-_\W](?<![()\[!]))+S?(?<season>(?<!\d+)(?:\d{3})(?!\d+))(?:[ex]|\W[ex]){1,2}(?<episode>\d{2,3}(?!\d+))(?:(?:\-|[ex]|\W[ex]|_){1,2}(?<episode>\d{2,3}(?!\d+)))*)(?:[-_. ]|$)",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
             };
 
         private static readonly Regex[] SpecialEpisodeTitleRegex = new Regex[]


### PR DESCRIPTION
#### Description

Parse releases with 3 digit season numbers.

Report came from the [forums](https://forums.sonarr.tv/t/countdown-1982-problem-with-finding-episodes-are-titled-with-season-000/40344)
