### PR TITLE
Reuse authentification cookies for qBittorrent calls

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -373,14 +373,14 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
         private string ProcessRequest(HttpRequestBuilder requestBuilder, QBittorrentSettings settings)
         {
-            var request = requestBuilder.Build();
-            request.LogResponseContent = true;
-
             if (settings.ApiKey.IsNotNullOrWhiteSpace())
             {
+                var requestWithApiKey = requestBuilder.Build();
+                requestWithApiKey.LogResponseContent = true;
+
                 try
                 {
-                    return _httpClient.Execute(request).Content;
+                    return _httpClient.Execute(requestWithApiKey).Content;
                 }
                 catch (HttpException ex)
                 {
@@ -401,6 +401,8 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             AuthenticateClient(requestBuilder, settings);
 
+            var request = requestBuilder.Build();
+            request.LogResponseContent = true;
             request.SuppressHttpErrorStatusCodes = [HttpStatusCode.Forbidden];
 
             try


### PR DESCRIPTION
#### Description
Minor regression since 6a6639105ededc4d24ebc963bb8be4e677792a0d due to the fact `AuthenticateClient` sets the auth cookies to the request builder which requires `HttpRequestBuilder.Build()` to be called after each `AuthenticateClient` call in order to use the cached cookies.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
