### PR TITLE
Fix calculating custom score using renamed filename before manual importing

### DIFF
--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -119,7 +119,7 @@ namespace NzbDrone.Core.CustomFormats
             var episodeInfo = new ParsedEpisodeInfo
             {
                 SeriesTitle = localEpisode.Series.Title,
-                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : fileName,
+                ReleaseTitle = localEpisode.SceneName.IsNotNullOrWhiteSpace() ? localEpisode.SceneName : Path.GetFileName(localEpisode.Path),
                 Quality = localEpisode.Quality,
                 Languages = localEpisode.Languages,
                 ReleaseGroup = localEpisode.ReleaseGroup

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -21,10 +21,10 @@ namespace NzbDrone.Core.Parser.Model
         public DownloadClientItem DownloadItem { get; set; }
         public ParsedEpisodeInfo FolderEpisodeInfo { get; set; }
         public Series Series { get; set; }
-        public List<Episode> Episodes { get; set; } = new();
+        public List<Episode> Episodes { get; set; } = [];
         public List<DeletedEpisodeFile> OldFiles { get; set; }
         public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; } = new();
+        public List<Language> Languages { get; set; } = [];
         public IndexerFlags IndexerFlags { get; set; }
         public ReleaseType ReleaseType { get; set; }
         public MediaInfoModel MediaInfo { get; set; }
@@ -34,9 +34,9 @@ namespace NzbDrone.Core.Parser.Model
         public string ReleaseHash { get; set; }
         public string SceneName { get; set; }
         public bool OtherVideoFiles { get; set; }
-        public List<CustomFormat> CustomFormats { get; set; } = new();
+        public List<CustomFormat> CustomFormats { get; set; } = [];
         public int CustomFormatScore { get; set; }
-        public List<CustomFormat> OriginalFileNameCustomFormats { get; set; } = new();
+        public List<CustomFormat> OriginalFileNameCustomFormats { get; set; } = [];
         public int OriginalFileNameCustomFormatScore { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
         public bool ScriptImported { get; set; }


### PR DESCRIPTION
#### Description

Just reverting the release title change from 33fb0a4e880a5a5a3dc3d04e26d85b0a22c73552 to allow calculating custom formats from original filename that won't be in the renamed filename, such as `dual-audio`, which leads to a difference in calculation compared with other `ParseCustomFormat` methods.

For the same exact file already imported:
`Not a Custom Format upgrade for existing episode file(s). New: [1080p, Anime Web Tier 03, Season Pack] (476) do not improve on Existing: [1080p, Anime Dual Audio, Anime Web Tier 03, Personal Anime Dual Audio, Season Pack] (1976)`

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

