### PR TITLE
udpate support-request labeller to v5

### DIFF
--- a/.github/workflows/support-requests.yml
+++ b/.github/workflows/support-requests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Sonarr/Sonarr'
     steps:
-      - uses: dessant/support-requests@v4
+      - uses: dessant/support-requests@v5
         with:
           github-token: ${{ github.token }}
           support-label: 'support'


### PR DESCRIPTION
#### Description

udpate support-request labeller to v5 to allow for longer than 100 char github tokens
ref: https://github.com/dessant/support-requests/commit/247766c362b8b696ef69353f4b78faa2948cdf97


- [X] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [X] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
