### PR TITLE
Fallback matching grabbed/blocklisted releases by info URL in Interactive Search

### DIFF
--- a/src/Sonarr.Api.V5/Release/ReleaseController.cs
+++ b/src/Sonarr.Api.V5/Release/ReleaseController.cs
@@ -285,8 +285,8 @@ public class ReleaseController : RestController<ReleaseResource>
     private ReleaseHistoryResource? AddHistory(ReleaseInfo release, List<EpisodeHistory> history)
     {
         var grabbed = history.FirstOrDefault(h => h.EventType == EpisodeHistoryEventType.Grabbed &&
-                                                  h.Data.TryGetValue("guid", out var guid) &&
-                                                  guid == release.Guid);
+                                                  ((h.Data.TryGetValue("guid", out var guid) && guid == release.Guid) ||
+                                                   (h.Data.TryGetValue("nzbInfoUrl", out var infoUrl) && infoUrl.IsNotNullOrWhiteSpace() && infoUrl.Equals(release.InfoUrl, StringComparison.Ordinal))));
 
         if (grabbed == null && release.DownloadProtocol == DownloadProtocol.Torrent)
         {


### PR DESCRIPTION
#### Description

Fallback to matching by info URL for cases where the guid won't match from the start like for [push releases](https://github.com/Sonarr/Sonarr/blob/1915ec281c19248718c7c6d5973f13ee3e231ece/src/Sonarr.Api.V5/Release/ReleasePushController.cs#L63) or where guid contains authkey/passkey that are rotated.