### PR TITLE
Fixed: Loading eligible pending releases on RSS sync runs

### DIFF
--- a/src/NzbDrone.Core/Download/Pending/PendingRelease.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingRelease.cs
@@ -16,6 +16,11 @@ namespace NzbDrone.Core.Download.Pending
 
         // Not persisted
         public RemoteEpisode RemoteEpisode { get; set; }
+
+        public PendingRelease Clone()
+        {
+            return MemberwiseClone() as PendingRelease;
+        }
     }
 
     public class PendingReleaseAdditionalInfo

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -101,12 +101,10 @@ namespace NzbDrone.Core.Download.Pending
 
         public void AddMany(List<Tuple<DownloadDecision, PendingReleaseReason>> decisions)
         {
-            var pending = _pendingReleases;
-
             foreach (var seriesDecisions in decisions.GroupBy(v => v.Item1.RemoteEpisode.Series.Id))
             {
                 var series = seriesDecisions.First().Item1.RemoteEpisode.Series;
-                var alreadyPending = _pendingReleases.Where(p => p.SeriesId == series.Id).SelectList(s => s.JsonClone());
+                var alreadyPending = _pendingReleases.Where(p => p.SeriesId == series.Id).SelectList(s => s.Clone());
 
                 // TODO: Do we need IncludeRemoteEpisodes?
                 alreadyPending = IncludeRemoteEpisodes(alreadyPending, seriesDecisions.ToDictionaryIgnoreDuplicates(v => v.Item1.RemoteEpisode.Release.Title, v => v.Item1.RemoteEpisode));


### PR DESCRIPTION
#### Description

In some niche cases when you have pending releases (with a failed download client I think it might be easiest way to reproduce), on RSS sync runs it would use JsonClone for cloning but `Json.Deserialize` fails due to lack of converter for ICustomFormatSpecification. `CustomFormatSpecificationListConverter` exists in Core, so it's pragmatic to use `MemberwiseClone` than move the converter(s) between projects considering the same exact outcome.

JsonClone usage added in 8718f28fbd652d3254873d197b0875859c508ae9.

Stacktrace:
```
Newtonsoft.Json.JsonSerializationException: Could not create an instance of type NzbDrone.Core.CustomFormats.ICustomFormatSpecification. Type is an interface or abstract class and cannot be instantiated. Path 'remoteEpisode.customFormats[0].specifications[0].order', line 2571, position 20.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at NzbDrone.Common.Serializer.Json.Deserialize[T](String json) in ./NzbDrone.Common/Serializer/Newtonsoft.Json/Json.cs:line 44
   at NzbDrone.Common.Extensions.ObjectExtensions.JsonClone[T](T source) in ./NzbDrone.Common/Extensions/ObjectExtensions.cs:line 11
   at NzbDrone.Core.Download.Pending.PendingReleaseService.<>c.<AddMany>b__16_2(PendingRelease s) in ./NzbDrone.Core/Download/Pending/PendingReleaseService.cs:line 109
   at System.Linq.Enumerable.ArrayWhereSelectIterator`2.ToList(ReadOnlySpan`1 source, Func`2 predicate, Func`2 selector)
   at NzbDrone.Common.Extensions.EnumerableExtensions.SelectList[TSource,TResult](IEnumerable`1 source, Func`2 predicate) in ./NzbDrone.Common/Extensions/IEnumerableExtensions.cs:line 110
   at NzbDrone.Core.Download.Pending.PendingReleaseService.AddMany(List`1 decisions) in ./NzbDrone.Core/Download/Pending/PendingReleaseService.cs:line 109
   at NzbDrone.Core.Download.ProcessDownloadDecisions.ProcessDecisions(List`1 decisions) in ./NzbDrone.Core/Download/ProcessDownloadDecisions.cs:line 121
   at NzbDrone.Core.Indexers.RssSyncService.Sync() in ./NzbDrone.Core/Indexers/RssSyncService.cs:line 46
   at NzbDrone.Core.Indexers.RssSyncService.Execute(RssSyncCommand message) in ./NzbDrone.Core/Indexers/RssSyncService.cs:line 62
   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommand[TCommand](TCommand command, CommandModel commandModel) in ./NzbDrone.Core/Messaging/Commands/CommandExecutor.cs:line 84
   at System.Dynamic.UpdateDelegates.UpdateAndExecuteVoid3[T0,T1,T2](CallSite site, T0 arg0, T1 arg1, T2 arg2)
   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommands() in ./NzbDrone.Core/Messaging/Commands/CommandExecutor.cs:line 42
```

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
