### PR TITLE
New: Support for VVC/H266 in media info

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -8,61 +8,66 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     [TestFixture]
     public class FormatVideoCodecFixture : TestBase
     {
-        [TestCase("mpeg2video, ", "Droned.S01E02.1080i.HDTV.DD5.1.MPEG2-NTb", "MPEG2")]
-        [TestCase("mpeg2video, ", "", "MPEG2")]
-        [TestCase("mpeg1video, ", "The.Simpsons.S13E04.INTERNAL-ANiVCD.mpg", "MPEG")]
-        [TestCase("vc1, WVC1", "B.N.S04E18.720p.WEB-DL", "VC1")]
-        [TestCase("vc1, V_MS/VFW/FOURCC/WVC1", "", "VC1")]
-        [TestCase("vc1, WMV3", "It's Always Sunny S07E13 The Gang's RevengeHDTV.XviD-2HD.avi", "VC1")]
-        [TestCase("h264, V.MPEG4/ISO/AVC", "pd.2015.S03E08.720p.iP.WEBRip.AAC2.0.H264-BTW", "h264")]
-        [TestCase("h264, V_MPEG4/ISO/AVC", "Resistance.2019.S01E03.1080p.RTE.WEB-DL.AAC2.0.x264-RTN", "x264")]
-        [TestCase("wmv1, WMV1", "Droned.wmv", "WMV")]
-        [TestCase("wmv2, WMV2", "Droned.wmv", "WMV")]
-        [TestCase("mpeg4, XVID", "", "XviD")]
-        [TestCase("mpeg4, DIVX", "", "DivX")]
-        [TestCase("mpeg4, divx", "", "DivX")]
-        [TestCase("mpeg4, DIV3", "spsm.dvdrip.divx.avi'.", "DivX")]
-        [TestCase("msmpeg4, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
-        [TestCase("msmpeg4v2, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
-        [TestCase("msmpeg4v3, DIV3", "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
-        [TestCase("vp6f, 4", "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
-        [TestCase("vp6, 4", "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
-        [TestCase("vp7, VP70", "Sweet Seymour.avi", "VP7")]
-        [TestCase("vp8, V_VP8", "Dick.mkv", "VP8")]
-        [TestCase("vp9, V_VP9", "Roadkill Ep3x11 - YouTube.webm", "VP9")]
-        [TestCase("h264, x264", "Ghost Advent - S04E05 - Stanley Hotel SDTV.avi", "x264")]
-        [TestCase("hevc, V_MPEGH/ISO/HEVC", "The BBT S11E12 The Matrimonial Metric 1080p 10bit AMZN WEB-DL", "h265")]
-        [TestCase("mpeg4, mp4v-20", "", "")]
-        [TestCase("mpeg4, XVID", "American.Chopper.S06E07.Mountain.Creek.Bike.DSR.XviD-KRS", "XviD")]
-        [TestCase("rpza, V_QUICKTIME", "Custom", "")]
-        [TestCase("mpeg4, FMP4", "", "")]
-        [TestCase("mpeg4, MP42", "", "")]
-        [TestCase("mpeg4, mp43", "Bubble.Guppies.S01E13.480p.WEB-DL.H.264-BTN-Custom", "")]
-        public void should_format_video_format(string videoFormatPack, string sceneName, string expectedFormat)
+        [TestCase(new[] { "mpeg2video", "" }, "Droned.S01E02.1080i.HDTV.DD5.1.MPEG2-NTb", "MPEG2")]
+        [TestCase(new[] { "mpeg2video", "" }, "", "MPEG2")]
+        [TestCase(new[] { "mpeg1video", "" }, "The.Simpsons.S13E04.INTERNAL-ANiVCD.mpg", "MPEG")]
+        [TestCase(new[] { "vc1", "WVC1" }, "B.N.S04E18.720p.WEB-DL", "VC1")]
+        [TestCase(new[] { "vc1", "V_MS/VFW/FOURCC/WVC1" }, "", "VC1")]
+        [TestCase(new[] { "vc1", "WMV3" }, "It's Always Sunny S07E13 The Gang's RevengeHDTV.XviD-2HD.avi", "VC1")]
+        [TestCase(new[] { "h264", "V.MPEG4/ISO/AVC" }, "pd.2015.S03E08.720p.iP.WEBRip.AAC2.0.H264-BTW", "h264")]
+        [TestCase(new[] { "h264", "V_MPEG4/ISO/AVC" }, "Resistance.2019.S01E03.1080p.RTE.WEB-DL.AAC2.0.x264-RTN", "x264")]
+        [TestCase(new[] { "wmv1", "WMV1" }, "Droned.wmv", "WMV")]
+        [TestCase(new[] { "wmv2", "WMV2" }, "Droned.wmv", "WMV")]
+        [TestCase(new[] { "mpeg4", "XVID" }, "", "XviD")]
+        [TestCase(new[] { "mpeg4", "DIVX" }, "", "DivX")]
+        [TestCase(new[] { "mpeg4", "divx" }, "", "DivX")]
+        [TestCase(new[] { "mpeg4", "DIV3" }, "spsm.dvdrip.divx.avi'.", "DivX")]
+        [TestCase(new[] { "msmpeg4", "DIV3" }, "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
+        [TestCase(new[] { "msmpeg4v2", "DIV3" }, "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
+        [TestCase(new[] { "msmpeg4v3", "DIV3" }, "Exit the Dragon, Enter the Tiger (1976) 360p MPEG Audio.avi", "DivX")]
+        [TestCase(new[] { "vp6f", "4" }, "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
+        [TestCase(new[] { "vp6", "4" }, "Top Gear - S12E01 - Lorries - SD TV.flv", "VP6")]
+        [TestCase(new[] { "vp7", "VP70" }, "Sweet Seymour.avi", "VP7")]
+        [TestCase(new[] { "vp8", "V_VP8" }, "Dick.mkv", "VP8")]
+        [TestCase(new[] { "vp9", "V_VP9" }, "Roadkill Ep3x11 - YouTube.webm", "VP9")]
+        [TestCase(new[] { "h264", "x264" }, "Ghost Advent - S04E05 - Stanley Hotel SDTV.avi", "x264")]
+        [TestCase(new[] { "hevc", "V_MPEGH/ISO/HEVC" }, "The BBT S11E12 The Matrimonial Metric 1080p 10bit AMZN WEB-DL", "h265")]
+        [TestCase(new[] { "mpeg4", "mp4v-20" }, "", "")]
+        [TestCase(new[] { "mpeg4", "XVID" }, "American.Chopper.S06E07.Mountain.Creek.Bike.DSR.XviD-KRS", "XviD")]
+        [TestCase(new[] { "rpza", "V_QUICKTIME" }, "Custom", "")]
+        [TestCase(new[] { "mpeg4", "FMP4" }, "", "")]
+        [TestCase(new[] { "mpeg4", "MP42" }, "", "")]
+        [TestCase(new[] { "mpeg4", "mp43" }, "Bubble.Guppies.S01E13.480p.WEB-DL.H.264-BTN-Custom", "")]
+        [TestCase(new[] { "vvc", "" }, "", "h266")]
+        [TestCase(new[] { "vvc", "" }, "Droned.S01E02.1080p.WEB-DL.DD5.1.VVC-NTb", "VVC")]
+        [TestCase(new[] { "vvc", "" }, "Droned.S01E02.1080p.WEB-DL.DD5.1.H266-NTb", "h266")]
+        [TestCase(new[] { "vvc", "x266" }, "Droned.S01E02.1080p.WEB-DL.DD5.1.H266-NTb", "x266")]
+        public void should_format_video_format(string[] videoFormat, string sceneName, string expectedFormat)
         {
-            var split = videoFormatPack.Split(new string[] { ", " }, System.StringSplitOptions.None);
             var mediaInfoModel = new MediaInfoModel
             {
-                VideoFormat = split[0],
-                VideoCodecID = split[1]
+                VideoFormat = videoFormat[0],
+                VideoCodecID = videoFormat[1],
             };
 
             MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, sceneName).Should().Be(expectedFormat);
         }
 
-        [TestCase("h264, x264", "Some.Video.S01E01.h264", "x264")] // Force mediainfo tag
-        [TestCase("hevc, x265", "Some.Video.S01E01.h265", "x265")] // Force mediainfo tag
-        [TestCase("h264, ", "Some.Video.S01E01.x264", "x264")] // Not seen in practice, but honor tag if otherwise unknown
-        [TestCase("hevc, ", "Some.Video.S01E01.x265", "x265")] // Not seen in practice, but honor tag if otherwise unknown
-        [TestCase("h264, ", "Some.Video.S01E01", "h264")] // Default value
-        [TestCase("hevc, ", "Some.Video.S01E01", "h265")] // Default value
-        public void should_format_video_format_fallbacks(string videoFormatPack, string sceneName, string expectedFormat)
+        [TestCase(new[] { "h264", "x264" }, "Some.Video.S01E01.h264", "x264")] // Force mediainfo tag
+        [TestCase(new[] { "hevc", "x265" }, "Some.Video.S01E01.h265", "x265")] // Force mediainfo tag
+        [TestCase(new[] { "vvc", "x266" }, "Some.Video.S01E01.h266", "x266")] // Force mediainfo tag
+        [TestCase(new[] { "h264", "" }, "Some.Video.S01E01.x264", "x264")] // Not seen in practice, but honor tag if otherwise unknown
+        [TestCase(new[] { "hevc", "" }, "Some.Video.S01E01.x265", "x265")] // Not seen in practice, but honor tag if otherwise unknown
+        [TestCase(new[] { "vvc", "" }, "Some.Video.S01E01.x266", "x266")] // Not seen in practice, but honor tag if otherwise unknown
+        [TestCase(new[] { "h264", "" }, "Some.Video.S01E01", "h264")] // Default value
+        [TestCase(new[] { "hevc", "" }, "Some.Video.S01E01", "h265")] // Default value
+        [TestCase(new[] { "vvc", "" }, "Some.Video.S01E01", "h266")] // Default value
+        public void should_format_video_format_fallbacks(string[] videoFormat, string sceneName, string expectedFormat)
         {
-            var split = videoFormatPack.Split(new string[] { ", " }, System.StringSplitOptions.None);
             var mediaInfoModel = new MediaInfoModel
             {
-                VideoFormat = split[0],
-                VideoCodecID = split[1]
+                VideoFormat = videoFormat[0],
+                VideoCodecID = videoFormat[1],
             };
 
             MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, sceneName).Should().Be(expectedFormat);

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -262,6 +262,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S01E05.Tavora.greift.an.German.DL.1080p.DisneyHD.h264-4SF", false)]
         [TestCase("Series.Title.S02E04.German.Dubbed.DL.AAC.1080p.WEB.AVC-GROUP", false)]
         [TestCase("Tiny.Series.2020.DOC.S01.MULTi.1080p.ATVP.WEB.Atmos.H.265-TFA", false)]
+        [TestCase("The.Series.S25E21.Pay.No1.1080p.WEB-DL.DD5.1.H.266-GROUP", false)]
+        [TestCase("Series.Title.S04E01.1080p.WEB.H266-GROUP", false)]
         public void should_parse_webdl1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.WEBDL1080p, proper);
@@ -274,6 +276,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.1x04.ITA.1080p.WEBMux.x264-NovaRip", false)]
         [TestCase("Series.Title.2019.S02E07.Chapter.15.The.Believer.4Kto1080p.DSNYP.Webrip.x265.10bit.EAC3.5.1.Atmos.GokiTAoE", false)]
         [TestCase("Series.Title.S01.1080p.AMZN.WEB-Rip.DDP5.1.H.264-Telly", false)]
+        [TestCase("Series Title S01 WEBRip 1080p x266-GROUP", false)]
+        [TestCase("Series Title S01 Complete German 1080p HDR UHD WEBRip h266-GROUP", false)]
         public void should_parse_webrip1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.WEBRip1080p, proper);
@@ -289,6 +293,9 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S02E02.This.Year.Will.Be.Different.2160p.WEB.H.265", false)]
         [TestCase("Series.Title.S02E04.German.Dubbed.DL.AAC.2160p.DV.HDR.WEB.HEVC-GROUP", false)]
         [TestCase("Series.S01.MULTi.2160p.NF.SDR.WEB.DDP.5.1.Atmos.h265-FRESH", false)]
+        [TestCase("Series.Title.2016.03.14.2160p.WEB.h266-GROUP", false)]
+        [TestCase("Series.Title.2016.03.14.2160p.WEB-DL.H.266-GROUP", false)]
+        [TestCase("Series Title S02 2013 WEB-DL 4k H266 AAC 2Audio-GROUP", false)]
         public void should_parse_webdl2160p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.WEBDL2160p, proper);
@@ -341,6 +348,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("S for Series 2005 1080p UHD BluRay DD+7.1 x264-LoRD.mkv", false)]
         [TestCase("Series.Title.2011.1080p.UHD.BluRay.DD5.1.HDR.x265-CtrlHD.mkv", false)]
         [TestCase("Fall.Of.The.Release.Groups.S02E13.1080p.BDLight.x265-AVCDVD", false)]
+        [TestCase("Series Title S01E01 1080p BluRay DD 5 1 Atmos x266-GROUP", false)]
         public void should_parse_bluray1080p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.Bluray1080p, proper);
@@ -367,6 +375,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.2014.2160p.UHD.BluRay.X265-IAMABLE.mkv", false)]
         [TestCase("Series.Title.2014.2160p.UHD.BluRay.X265-IAMABLE.mkv", false)]
         [TestCase("Series.Title.S05EO1.Episode.Title.2160p.BDRip.AAC.7.1.HDR10.x265.10bit-Markll", false)]
+        [TestCase("Series Title S01E01 2160p UHD BluRay H266-GROUP", false)]
         public void should_parse_bluray2160p_quality(string title, bool proper)
         {
             ParseAndVerifyQuality(title, Quality.Bluray2160p, proper);

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -191,6 +191,16 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return GetSceneNameMatch(sceneName, "HEVC", "x265", "h265");
             }
 
+            if (videoCodecId == "x266")
+            {
+                return "x266";
+            }
+
+            if (videoFormat == "vvc")
+            {
+                return GetSceneNameMatch(sceneName, "VVC", "x266", "h266");
+            }
+
             if (videoFormat == "mpeg2video")
             {
                 return "MPEG2";

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -522,7 +522,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex PercentRegex = new Regex(@"(?<=\b\d+)%", RegexOptions.Compiled);
 
-        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|1440|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(?<![a-f0-9])(8|10)[ -]?(b(?![a-z0-9])|bit))\s*?",
+        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|1440|2160)[ip]|[xh][\W_]?26[456]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(?<![a-f0-9])(8|10)[ -]?(b(?![a-z0-9])|bit))\s*?",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SourceRegex = new(@"\b(?:
                                                                 (?<bluray>BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$))|
-                                                                (?<webdl>WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?[ .]?5[. ]1)|[. ](?-i:WEB)$|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|\b\s\/\sWEB\s\/\s\b|(?:AMZN|ATVP|DP|NF)[. -]WEB[. -](?!Rip))|
+                                                                (?<webdl>WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[456]|AVC|HEVC|DDP?[ .]?5[. ]1)|[. ](?-i:WEB)$|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|\b\s\/\sWEB\s\/\s\b|(?:AMZN|ATVP|DP|NF)[. -]WEB[. -](?!Rip))|
                                                                 (?<webrip>WebRip|Web-Rip|WEBMux)|
                                                                 (?<hdtv>HDTV)|
                                                                 (?<bdrip>BDRip|BDLight)|
@@ -46,7 +46,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RealRegex = new(@"\b(?<real>REAL)\b",
                                                                 RegexOptions.Compiled);
 
-        private static readonly Regex ResolutionRegex = new(@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H265)|(?:UHD|HEVC|BD|H265)[-_. ]4k))\b",
+        private static readonly Regex ResolutionRegex = new(@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H26[56])|(?:UHD|HEVC|BD|H26[56])[-_. ]4k))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Handle cases where no resolution is in the release name (assume if UHD then 4k) or resolution is non-standard


### PR DESCRIPTION
#### Description
- Adding support for populating VVC/H266 data from ffprobe.
- Initial support for parsing release titles with H266

While I added detection for `x266` to match HEVC/x265 rules, there's no support or patches for detecting x266 in ffmpeg yet.

#### Screenshots

<img width="548" height="476" alt="Screenshot" src="https://github.com/user-attachments/assets/3ef03fbc-0a78-4b88-873f-46668353506b" />


#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
