### PR TITLE
Fix filename builder for files without streams

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
@@ -11,53 +10,52 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     {
         private const string SceneName = "My.Series.S01E01-Sonarr";
 
-        [TestCase("mp2, ,  ", "droned.s01e03.swedish.720p.hdtv.x264-prince", "MP2")]
-        [TestCase("vorbis, ,  ", "DB Super HDTV", "Vorbis")]
-        [TestCase("pcm_s16le, ,  ", "DW DVDRip XviD-idTV, ", "PCM")]
-        [TestCase("truehd, ,  ", "", "TrueHD")]
-        [TestCase("truehd, ,  ", "TrueHD", "TrueHD")]
-        [TestCase("truehd, thd+,  ", "Atmos", "TrueHD Atmos")]
-        [TestCase("truehd, thd+,  ", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
-        [TestCase("truehd, thd+,  ", "", "TrueHD Atmos")]
-        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "Atmos", "TrueHD Atmos")]
-        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
-        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "", "TrueHD Atmos")]
-        [TestCase("wmav1, , ", "Droned.wmv", "WMA")]
-        [TestCase("wmav2, , ", "B.N.S04E18.720p.WEB-DL", "WMA")]
-        [TestCase("opus, ,  ", "Roadkill Ep3x11 - YouTube.webm", "Opus")]
-        [TestCase("mp3, ,  ", "climbing.mp4", "MP3")]
-        [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
-        [TestCase("dts, , DTS:X", "DTS-X", "DTS-X")]
-        [TestCase("dts, , DTS-HD MA + DTS:X IMAX", "DTS-X", "DTS-X")]
-        [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
-        [TestCase("dts, , DTS-ES", "DTS-ES", "DTS-ES")]
-        [TestCase("dts, , DTS-ES", "DTS", "DTS-ES")]
-        [TestCase("dts, , DTS-HD HRA", "DTSHD-HRA", "DTS-HD HRA")]
-        [TestCase("dts, , DTS", "DTS", "DTS")]
-        [TestCase("eac3, ec+3,  ", "EAC3.Atmos", "EAC3 Atmos")]
-        [TestCase("eac3, , Dolby Digital Plus + Dolby Atmos", "EAC3.Atmos", "EAC3 Atmos")]
-        [TestCase("eac3, ,  ", "DDP5.1", "EAC3")]
-        [TestCase("ac3, ,  ", "DD5.1", "AC3")]
-        [TestCase("aac, ,  ", "AAC2.0", "AAC")]
-        [TestCase("aac, , HE-AAC", "AAC2.0", "HE-AAC")]
-        [TestCase("aac, , xHE-AAC", "AAC2.0", "xHE-AAC")]
-        [TestCase("adpcm_ima_qt, ,  ", "Custom?", "PCM")]
-        [TestCase("adpcm_ms, ,  ", "Custom", "PCM")]
-        public void should_format_audio_format(string audioFormatPack, string sceneName, string expectedFormat)
+        [TestCase(new[] { "mp2", "", "" }, "droned.s01e03.swedish.720p.hdtv.x264-prince", "MP2")]
+        [TestCase(new[] { "vorbis", "", "" }, "DB Super HDTV", "Vorbis")]
+        [TestCase(new[] { "pcm_s16le", "", "" }, "DW DVDRip XviD-idTV, ", "PCM")]
+        [TestCase(new[] { "truehd", "", "" }, "", "TrueHD")]
+        [TestCase(new[] { "truehd", "", "" }, "TrueHD", "TrueHD")]
+        [TestCase(new[] { "truehd", "thd+", "" }, "Atmos", "TrueHD Atmos")]
+        [TestCase(new[] { "truehd", "thd+", "" }, "TrueHD.Atmos.7.1", "TrueHD Atmos")]
+        [TestCase(new[] { "truehd", "thd+", "" }, "", "TrueHD Atmos")]
+        [TestCase(new[] { "truehd", "", "Dolby TrueHD + Dolby Atmos" }, "Atmos", "TrueHD Atmos")]
+        [TestCase(new[] { "truehd", "", "Dolby TrueHD + Dolby Atmos" }, "TrueHD.Atmos.7.1", "TrueHD Atmos")]
+        [TestCase(new[] { "truehd", "", "Dolby TrueHD + Dolby Atmos" }, "", "TrueHD Atmos")]
+        [TestCase(new[] { "wmav1", "", "" }, "Droned.wmv", "WMA")]
+        [TestCase(new[] { "wmav2", "", "" }, "B.N.S04E18.720p.WEB-DL", "WMA")]
+        [TestCase(new[] { "opus", "", "" }, "Roadkill Ep3x11 - YouTube.webm", "Opus")]
+        [TestCase(new[] { "mp3", "", "" }, "climbing.mp4", "MP3")]
+        [TestCase(new[] { "dts", "", "DTS-HD MA" }, "DTS-HD.MA", "DTS-HD MA")]
+        [TestCase(new[] { "dts", "", "DTS:X" }, "DTS-X", "DTS-X")]
+        [TestCase(new[] { "dts", "", "DTS-HD MA + DTS:X IMAX" }, "DTS-X", "DTS-X")]
+        [TestCase(new[] { "dts", "", "DTS-HD MA" }, "DTS-HD.MA", "DTS-HD MA")]
+        [TestCase(new[] { "dts", "", "DTS-ES" }, "DTS-ES", "DTS-ES")]
+        [TestCase(new[] { "dts", "", "DTS-ES" }, "DTS", "DTS-ES")]
+        [TestCase(new[] { "dts", "", "DTS-HD HRA" }, "DTSHD-HRA", "DTS-HD HRA")]
+        [TestCase(new[] { "dts", "", "DTS" }, "DTS", "DTS")]
+        [TestCase(new[] { "eac3", "ec+3", "" }, "EAC3.Atmos", "EAC3 Atmos")]
+        [TestCase(new[] { "eac3", "", "Dolby Digital Plus + Dolby Atmos" }, "EAC3.Atmos", "EAC3 Atmos")]
+        [TestCase(new[] { "eac3", "", "" }, "DDP5.1", "EAC3")]
+        [TestCase(new[] { "ac3", "", "" }, "DD5.1", "AC3")]
+        [TestCase(new[] { "aac", "", "" }, "AAC2.0", "AAC")]
+        [TestCase(new[] { "aac", "", "HE-AAC" }, "AAC2.0", "HE-AAC")]
+        [TestCase(new[] { "aac", "", "xHE-AAC" }, "AAC2.0", "xHE-AAC")]
+        [TestCase(new[] { "adpcm_ima_qt", "", "" }, "Custom?", "PCM")]
+        [TestCase(new[] { "adpcm_ms", "", "" }, "Custom", "PCM")]
+        public void should_format_audio_format(string[] audioFormat, string sceneName, string expectedFormat)
         {
-            var split = audioFormatPack.Split(',', StringSplitOptions.TrimEntries);
             var audioStreamModel = new MediaInfoAudioStreamModel
             {
-                Format = split[0],
-                CodecId = split[1],
-                Profile = split[2],
+                Format = audioFormat[0],
+                CodecId = audioFormat[1],
+                Profile = audioFormat[2],
             };
 
             MediaInfoFormatter.FormatAudioCodec(audioStreamModel, sceneName).Should().Be(expectedFormat);
         }
 
         [Test]
-        public void should_return_AudioFormat_by_default()
+        public void should_return_audio_format_by_default()
         {
             var audioStreamModel = new MediaInfoAudioStreamModel
             {
@@ -66,6 +64,12 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
             };
 
             MediaInfoFormatter.FormatAudioCodec(audioStreamModel, SceneName).Should().Be(audioStreamModel.Format);
+        }
+
+        [Test]
+        public void should_return_null_if_audio_stream_is_null()
+        {
+            MediaInfoFormatter.FormatAudioCodec(null, SceneName).Should().Be(string.Empty);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatVideoCodecFixture.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         }
 
         [Test]
-        public void should_return_VideoFormat_by_default()
+        public void should_return_video_format_by_default()
         {
             var mediaInfoModel = new MediaInfoModel
             {
@@ -77,6 +77,12 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
             };
 
             MediaInfoFormatter.FormatVideoCodec(mediaInfoModel, null).Should().Be(mediaInfoModel.VideoFormat);
+        }
+
+        [Test]
+        public void should_return_null_if_video_stream_is_null()
+        {
+            MediaInfoFormatter.FormatVideoCodec(null, null).Should().Be(string.Empty);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -99,12 +99,10 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                         }
 
                         // Prefer the release type from the grabbed history
-                        if (Enum.TryParse(grabHistory?.Data.GetValueOrDefault("releaseType"), true, out ReleaseType releaseType))
+                        if (Enum.TryParse(grabHistory?.Data.GetValueOrDefault("releaseType"), true, out ReleaseType releaseType) &&
+                            releaseType != ReleaseType.Unknown)
                         {
-                            if (releaseType != ReleaseType.Unknown)
-                            {
-                                episodeFile.ReleaseType = releaseType;
-                            }
+                            episodeFile.ReleaseType = releaseType;
                         }
                     }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -451,8 +451,12 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             if (decision.LocalEpisode.Series != null)
             {
                 item.Series = decision.LocalEpisode.Series;
-                item.CustomFormats = _localEpisodeFormatCalculator.ParseEpisodeCustomFormats(decision.LocalEpisode);
-                item.CustomFormatScore = item.Series.QualityProfile?.Value.CalculateCustomFormatScore(item.CustomFormats) ?? 0;
+
+                if (item.SeasonNumber.HasValue)
+                {
+                    item.CustomFormats = _localEpisodeFormatCalculator.ParseEpisodeCustomFormats(decision.LocalEpisode);
+                    item.CustomFormatScore = item.Series.QualityProfile?.Value.CalculateCustomFormatScore(item.CustomFormats) ?? 0;
+                }
             }
 
             return item;

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -23,24 +23,24 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioChannels is null or 0.0m)
             {
-                audioChannels = audioStream.Channels;
+                audioChannels = audioStream?.Channels;
             }
 
-            return audioChannels.Value;
+            return audioChannels ?? 0;
         }
 
         public static string FormatAudioCodec(MediaInfoAudioStreamModel audioStream, string sceneName)
         {
             if (audioStream?.Format == null)
             {
-                return null;
+                return string.Empty;
             }
 
-            var audioFormat = audioStream.Format;
+            var audioFormat = audioStream.Format?.Trim();
             var audioCodecId = audioStream.CodecId ?? string.Empty;
             var audioProfile = audioStream.Profile ?? string.Empty;
 
-            if (audioFormat.Empty())
+            if (audioFormat.IsNullOrWhiteSpace())
             {
                 return string.Empty;
             }
@@ -150,24 +150,22 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                   .WriteSentryWarn("UnknownAudioFormatFFProbe", audioStream.Format, audioCodecId)
                   .Log();
 
-            return audioStream.Format;
+            return audioFormat;
         }
 
         public static string FormatVideoCodec(MediaInfoModel mediaInfo, string sceneName)
         {
             if (mediaInfo?.VideoFormat == null)
             {
-                return null;
+                return string.Empty;
             }
 
-            var videoFormat = mediaInfo.VideoFormat;
+            var videoFormat = mediaInfo.VideoFormat?.Trim();
             var videoCodecId = mediaInfo.VideoCodecID ?? string.Empty;
 
-            var result = videoFormat.Trim();
-
-            if (videoFormat.Empty())
+            if (videoFormat.IsNullOrWhiteSpace())
             {
-                return result;
+                return string.Empty;
             }
 
             // see definitions here: https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/codec_desc.c
@@ -265,7 +263,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                   .WriteSentryWarn("UnknownVideoFormatFFProbe", mediaInfo.ContainerFormat, videoFormat, videoCodecId)
                   .Log();
 
-            return result;
+            return videoFormat;
         }
 
         private static decimal? FormatAudioChannelsFromAudioChannelPositions(MediaInfoAudioStreamModel audioStream)


### PR DESCRIPTION
#### Description

- Fixing filename building for files with missing streams
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.MediaFiles.MediaInfo.MediaInfoFormatter.FormatAudioChannels(MediaInfoAudioStreamModel audioStream) in ./NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs:line 26
   at NzbDrone.Core.Organizer.FileNameBuilder.AddMediaInfoTokens(Dictionary`2 tokenHandlers, EpisodeFile episodeFile) in ./NzbDrone.Core/Organizer/FileNameBuilder.cs:line 664
```

- Since 33fb0a4 LocalEpisode.ToEpisodeFile() calls SeasonNumber which throws an exception since not yet defined for files without season/episode information.
```
NzbDrone.Core.Parser.InvalidSeasonException: Expected one season, but found none
   at NzbDrone.Core.Parser.Model.LocalEpisode.get_SeasonNumber() in ./NzbDrone.Core/Parser/Model/LocalEpisode.cs:line 57
   at NzbDrone.Core.Parser.Model.LocalEpisode.ToEpisodeFile() in ./NzbDrone.Core/Parser/Model/LocalEpisode.cs:line 93
   at NzbDrone.Core.MediaFiles.EpisodeImport.LocalEpisodeCustomFormatCalculationService.ParseEpisodeCustomFormats(LocalEpisode localEpisode) in ./NzbDrone.Core/MediaFiles/EpisodeImport/LocalEpisodeCustomFormatCalculationService.cs:line 28
   at NzbDrone.Core.MediaFiles.EpisodeImport.Manual.ManualImportService.MapItem(ImportDecision decision, String rootFolder, String downloadId, String folderName) in ./NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs:line 454
```

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
