### PR TITLE
Fixed: Basic auth for qBittorrent

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV2.cs
@@ -359,6 +359,10 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 requestBuilder.Headers["Authorization"] = $"Bearer {settings.ApiKey}";
             }
+            else if (settings.Username.IsNotNullOrWhiteSpace() || settings.Password.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.NetworkCredential = new BasicNetworkCredential(settings.Username, settings.Password);
+            }
 
             return requestBuilder;
         }


### PR DESCRIPTION
#### Description

Regression since ae18ad61bd9865755b4067709de47c1404fd4078, adding back basic auth for qbit 5.2+ and seedboxes as a fallback to API key, meaning both authentication methods can't be used in the same time.

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Fixes #8636
