### PR TITLE
Fixed: Exclude known titles from release title custom formats

### DIFF
--- a/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/CustomFormatCalculationServiceFixture.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.CustomFormats
+{
+    [TestFixture]
+    public class CustomFormatCalculationServiceFixture : CoreTest<CustomFormatCalculationService>
+    {
+        private Series _series;
+        private Episode _episode;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew()
+                .With(s => s.Title = "Futurama")
+                .Build();
+
+            _episode = Builder<Episode>.CreateNew()
+                .With(e => e.Title = "Amazon Women in the Mood")
+                .With(e => e.SeasonNumber = 3)
+                .With(e => e.EpisodeNumber = 1)
+                .Build();
+        }
+
+        [Test]
+        public void should_not_match_release_title_custom_format_from_episode_title_in_renamed_file()
+        {
+            var customFormat = GivenReleaseTitleCustomFormat("Amazon", @"\bAmazon\b");
+            var localEpisode = GivenLocalEpisode();
+
+            GivenCustomFormats(customFormat);
+
+            var result = Subject.ParseCustomFormat(localEpisode, "Futurama.S03E01.Amazon.Women.in.the.Mood.1080p.WEB-DL.mkv");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_match_release_title_custom_format_from_series_title_in_renamed_file()
+        {
+            var customFormat = GivenReleaseTitleCustomFormat("Futurama", @"\bFuturama\b");
+            var localEpisode = GivenLocalEpisode();
+
+            GivenCustomFormats(customFormat);
+
+            var result = Subject.ParseCustomFormat(localEpisode, "Futurama.S03E01.1080p.WEB-DL.mkv");
+
+            result.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_still_match_release_title_custom_format_outside_known_titles()
+        {
+            var customFormat = GivenReleaseTitleCustomFormat("Amazon", @"\bAmazon\b");
+            var localEpisode = GivenLocalEpisode();
+
+            GivenCustomFormats(customFormat);
+
+            var result = Subject.ParseCustomFormat(localEpisode, "Futurama.S03E01.Amazon.Women.in.the.Mood.1080p.Amazon.WEB-DL.mkv");
+
+            result.Should().BeEquivalentTo(new[] { customFormat });
+        }
+
+        [Test]
+        public void should_exclude_episode_title_when_calculating_custom_formats_for_existing_file()
+        {
+            var customFormat = GivenReleaseTitleCustomFormat("Amazon", @"\bAmazon\b");
+            var episodeFile = new EpisodeFile
+            {
+                RelativePath = "Futurama.S03E01.Amazon.Women.in.the.Mood.1080p.WEB-DL.mkv",
+                Quality = new QualityModel(Quality.WEBDL1080p),
+                Languages = new List<Language> { Language.English },
+                Series = _series,
+                Episodes = new List<Episode> { _episode }
+            };
+
+            GivenCustomFormats(customFormat);
+
+            var result = Subject.ParseCustomFormat(episodeFile, _series);
+
+            result.Should().BeEmpty();
+        }
+
+        private LocalEpisode GivenLocalEpisode()
+        {
+            return new LocalEpisode
+            {
+                Series = _series,
+                Episodes = new List<Episode> { _episode },
+                Path = "/tv/Futurama/Season 03/Futurama.S03E01.Amazon.Women.in.the.Mood.1080p.WEB-DL.mkv",
+                Quality = new QualityModel(Quality.WEBDL1080p),
+                Languages = new List<Language> { Language.English },
+                ReleaseType = ReleaseType.SingleEpisode
+            };
+        }
+
+        private static CustomFormat GivenReleaseTitleCustomFormat(string name, string regex)
+        {
+            return new CustomFormat(name, new ReleaseTitleSpecification { Value = regex });
+        }
+
+        private void GivenCustomFormats(params CustomFormat[] customFormats)
+        {
+            Mocker.GetMock<ICustomFormatService>()
+                .Setup(s => s.All())
+                .Returns(new List<CustomFormat>(customFormats));
+        }
+    }
+}

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -133,7 +133,8 @@ namespace NzbDrone.Core.CustomFormats
                 Languages = localEpisode.Languages,
                 IndexerFlags = localEpisode.IndexerFlags,
                 ReleaseType = localEpisode.ReleaseType,
-                Filename = fileName
+                Filename = fileName,
+                ReleaseTitleExclusions = GetReleaseTitleExclusions(localEpisode.Series, localEpisode.Episodes)
             };
 
             return ParseCustomFormat(input);
@@ -205,9 +206,29 @@ namespace NzbDrone.Core.CustomFormats
                 IndexerFlags = episodeFile.IndexerFlags,
                 ReleaseType = episodeFile.ReleaseType,
                 Filename = Path.GetFileName(episodeFile.RelativePath),
+                ReleaseTitleExclusions = GetReleaseTitleExclusions(series, episodeFile.Episodes?.Value)
             };
 
             return ParseCustomFormat(input, allCustomFormats);
+        }
+
+        private static List<string> GetReleaseTitleExclusions(Series series, IEnumerable<Episode> episodes)
+        {
+            var titles = new List<string>();
+
+            if (series?.Title.IsNotNullOrWhiteSpace() == true)
+            {
+                titles.Add(series.Title);
+            }
+
+            if (episodes != null)
+            {
+                titles.AddRange(episodes
+                    .Select(e => e.Title)
+                    .Where(t => t.IsNotNullOrWhiteSpace()));
+            }
+
+            return titles.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         }
     }
 }

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatInput.cs
@@ -13,11 +13,13 @@ namespace NzbDrone.Core.CustomFormats
         public IndexerFlags IndexerFlags { get; set; }
         public List<Language> Languages { get; set; }
         public string Filename { get; set; }
+        public List<string> ReleaseTitleExclusions { get; set; }
         public ReleaseType ReleaseType { get; set; }
 
         public CustomFormatInput()
         {
             Languages = new List<Language>();
+            ReleaseTitleExclusions = new List<string>();
         }
 
         // public CustomFormatInput(ParsedEpisodeInfo episodeInfo, Series series)

--- a/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/ReleaseTitleSpecification.cs
@@ -1,14 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NzbDrone.Common.Extensions;
+
 namespace NzbDrone.Core.CustomFormats
 {
     public class ReleaseTitleSpecification : RegexSpecificationBase
     {
+        private static readonly Regex TitleTokenRegex = new(@"[\p{L}\p{N}]+", RegexOptions.Compiled);
+
         public override int Order => 1;
         public override string ImplementationName => "Release Title";
         public override string InfoLink => "https://wiki.servarr.com/sonarr/settings#custom-formats-2";
 
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
-            return MatchString(input.EpisodeInfo?.ReleaseTitle) || MatchString(input.Filename);
+            return MatchString(RemoveExcludedTitles(input.EpisodeInfo?.ReleaseTitle, input.ReleaseTitleExclusions)) ||
+                   MatchString(RemoveExcludedTitles(input.Filename, input.ReleaseTitleExclusions));
+        }
+
+        private static string RemoveExcludedTitles(string title, IEnumerable<string> excludedTitles)
+        {
+            if (title.IsNullOrWhiteSpace() || excludedTitles == null)
+            {
+                return title;
+            }
+
+            foreach (var excludedTitle in excludedTitles.Where(t => t.IsNotNullOrWhiteSpace()))
+            {
+                var pattern = GetTitlePattern(excludedTitle);
+
+                if (pattern.IsNotNullOrWhiteSpace())
+                {
+                    title = Regex.Replace(title, pattern, " ", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+                }
+            }
+
+            return title;
+        }
+
+        private static string GetTitlePattern(string title)
+        {
+            var titleTokens = TitleTokenRegex.Matches(title)
+                .Cast<Match>()
+                .Select(m => Regex.Escape(m.Value))
+                .ToList();
+
+            if (titleTokens.Empty())
+            {
+                return null;
+            }
+
+            return $@"(?<![\p{{L}}\p{{N}}]){string.Join(@"[^\p{L}\p{N}]+", titleTokens)}(?![\p{{L}}\p{{N}}])";
         }
     }
 }


### PR DESCRIPTION
#### Description

Prevents Release Title custom format specifications from matching known series and episode titles when custom formats are recalculated from renamed files. This avoids false matches such as a streaming-service keyword appearing only in an episode title.

The release title and filename are checked after known series/episode title text is stripped, while unrelated release tokens remain available for matching.

#### Screenshots for UI Changes

N/A

#### Database Migration

No

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #7456

#### Validation

- `dotnet test src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj --filter "FullyQualifiedName~CustomFormatCalculationServiceFixture" --no-restore -p:RunAnalyzers=false`