### PR TITLE
Fixed: Differentiate Repack and Proper quality token

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -63,6 +63,12 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _episodeFile.Quality.Revision.Version = 2;
         }
 
+        private void GivenRepack()
+        {
+            _episodeFile.Quality.Revision.Version = 2;
+            _episodeFile.Quality.Revision.IsRepack = true;
+        }
+
         private void GivenReal()
         {
             _episodeFile.Quality.Revision.Real = 1;
@@ -767,6 +773,17 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
                    .Should().Be("South Park - S15E06 [HDTV-720p Proper]");
+        }
+
+        [Test]
+        public void should_replace_quality_full_with_quality_title_and_repack_only_when_a_repack()
+        {
+            _namingConfig.StandardEpisodeFormat = "{Series Title} - S{season:00}E{episode:00} [{Quality Full}]";
+
+            GivenRepack();
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park - S15E06 [HDTV-720p Repack]");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -1097,6 +1097,11 @@ namespace NzbDrone.Core.Organizer
                     return "v" + quality.Revision.Version;
                 }
 
+                if (quality.Revision.IsRepack)
+                {
+                    return "Repack";
+                }
+
                 return "Proper";
             }
 


### PR DESCRIPTION
#### Description

Differentiates Repack and Proper when expanding the `{Quality Full}` naming token. Non-anime releases with stored `Revision.IsRepack` now render `Repack`; other revision upgrades keep the existing `Proper` label. Anime version naming remains unchanged.

#### Screenshots for UI Changes

N/A

#### Database Migration

No

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #7455

#### Validation

- `dotnet test src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj --filter "FullyQualifiedName~OrganizerTests.FileNameBuilderTests.FileNameBuilderFixture" --no-restore -p:RunAnalyzers=false`