### PR TITLE
Fixed: Preserve subtitle suffixes when renaming

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Subtitles/SubtitleServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Subtitles/SubtitleServiceFixture.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Extras.Subtitles;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
 using NzbDrone.Core.Parser.Model;
@@ -153,6 +154,63 @@ namespace NzbDrone.Core.Test.Extras.Subtitles
             {
                 results[i].RelativePath.AsOsAgnostic().PathEquals(Path.Combine("Season 1", expectedOutputs[i]).AsOsAgnostic()).Should().Be(true);
             }
+        }
+
+        [Test]
+        [TestCase("nb", 15)]
+        [TestCase("nn", 0)]
+        [TestCase("no", 15)]
+        [TestCase("nb.forced.sdh", 15)]
+        public void should_preserve_existing_subtitle_suffix_when_renaming(string existingSuffix, int languageId)
+        {
+            _episodeFile.RelativePath = Path.Combine("Season 1", "Series Title - S01E01 - Pilot.mkv").AsOsAgnostic();
+            _episodeFile.Path = Path.Combine(_series.Path, _episodeFile.RelativePath).AsOsAgnostic();
+
+            var subtitleFile = new SubtitleFile
+            {
+                SeriesId = _series.Id,
+                EpisodeFileId = _episodeFile.Id,
+                RelativePath = Path.Combine("Season 1", $"Series Title - S01E01.{existingSuffix}.srt").AsOsAgnostic(),
+                Extension = ".srt",
+                Language = Language.FindById(languageId),
+                LanguageTags = existingSuffix.Split('.').Skip(1).ToList()
+            };
+
+            Mocker.GetMock<ISubtitleFileService>()
+                  .Setup(s => s.GetFilesBySeries(_series.Id))
+                  .Returns(new List<SubtitleFile> { subtitleFile });
+
+            var results = Subject.MoveFilesAfterRename(_series, new List<EpisodeFile> { _episodeFile }).ToList();
+
+            results.Count.Should().Be(1);
+            results[0].RelativePath.AsOsAgnostic().PathEquals(Path.Combine("Season 1", $"Series Title - S01E01 - Pilot.{existingSuffix}.srt").AsOsAgnostic()).Should().Be(true);
+        }
+
+        [Test]
+        public void should_preserve_existing_subtitle_title_and_suffix_when_renaming()
+        {
+            _episodeFile.RelativePath = Path.Combine("Season 1", "Series Title - S01E01 - Pilot.mkv").AsOsAgnostic();
+            _episodeFile.Path = Path.Combine(_series.Path, _episodeFile.RelativePath).AsOsAgnostic();
+
+            var subtitleFile = new SubtitleFile
+            {
+                SeriesId = _series.Id,
+                EpisodeFileId = _episodeFile.Id,
+                RelativePath = Path.Combine("Season 1", "Series Title - S01E01.Commentary.nb.forced.srt").AsOsAgnostic(),
+                Extension = ".srt",
+                Language = Language.Norwegian,
+                LanguageTags = new List<string> { "forced" },
+                Title = "Commentary"
+            };
+
+            Mocker.GetMock<ISubtitleFileService>()
+                  .Setup(s => s.GetFilesBySeries(_series.Id))
+                  .Returns(new List<SubtitleFile> { subtitleFile });
+
+            var results = Subject.MoveFilesAfterRename(_series, new List<EpisodeFile> { _episodeFile }).ToList();
+
+            results.Count.Should().Be(1);
+            results[0].RelativePath.AsOsAgnostic().PathEquals(Path.Combine("Season 1", "Series Title - S01E01 - Pilot.Commentary.nb.forced.srt").AsOsAgnostic()).Should().Be(true);
         }
 
         [Test]

--- a/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/SubtitleService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -19,6 +20,9 @@ namespace NzbDrone.Core.Extras.Subtitles
 {
     public class SubtitleService : ExtraFileManager<SubtitleFile>
     {
+        private static readonly Regex SubtitleSuffixRegex = new(@"(?<suffix>([-_. ](?<tags>forced|foreign|default|cc|psdh|sdh))*[-_. ](?<iso_code>[a-z]{2,3})([-_. ](?<tags>forced|foreign|default|cc|psdh|sdh))*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly HashSet<string> AdditionalNorwegianSubtitleCodes = new(StringComparer.OrdinalIgnoreCase) { "nn" };
+
         private readonly IDiskProvider _diskProvider;
         private readonly IDetectSample _detectSample;
         private readonly ISubtitleFileService _subtitleFileService;
@@ -77,7 +81,7 @@ namespace NzbDrone.Core.Extras.Subtitles
             foreach (var episodeFile in episodeFiles)
             {
                 var groupedExtraFilesForEpisodeFile = subtitleFiles.Where(m => m.EpisodeFileId == episodeFile.Id)
-                                                            .GroupBy(s => s.AggregateString).ToList();
+                                                            .GroupBy(s => GetRenameSuffix(s, false) + s.Extension, StringComparer.OrdinalIgnoreCase).ToList();
 
                 foreach (var group in groupedExtraFilesForEpisodeFile)
                 {
@@ -92,7 +96,7 @@ namespace NzbDrone.Core.Extras.Subtitles
                             subtitleFile.Copy = ++copy;
                         }
 
-                        var suffix = GetSuffix(subtitleFile.Language, subtitleFile.Copy, subtitleFile.LanguageTags, multipleCopies, subtitleFile.Title);
+                        var suffix = GetRenameSuffix(subtitleFile, multipleCopies);
 
                         movedFiles.AddIfNotNull(MoveFile(series, episodeFile, subtitleFile, suffix));
                     }
@@ -236,6 +240,60 @@ namespace NzbDrone.Core.Extras.Subtitles
             }
 
             return importedFiles;
+        }
+
+        private string GetRenameSuffix(SubtitleFile subtitleFile, bool multipleCopies)
+        {
+            var languageSuffix = GetExistingLanguageSuffix(subtitleFile);
+
+            if (languageSuffix is null)
+            {
+                return GetSuffix(subtitleFile.Language, subtitleFile.Copy, subtitleFile.LanguageTags, multipleCopies, subtitleFile.Title);
+            }
+
+            var suffixBuilder = new StringBuilder();
+
+            if (subtitleFile.Title is not null)
+            {
+                suffixBuilder.Append('.');
+                suffixBuilder.Append(subtitleFile.Title);
+
+                if (multipleCopies)
+                {
+                    suffixBuilder.Append(" - ");
+                    suffixBuilder.Append(subtitleFile.Copy);
+                }
+            }
+            else if (multipleCopies)
+            {
+                suffixBuilder.Append('.');
+                suffixBuilder.Append(subtitleFile.Copy);
+            }
+
+            suffixBuilder.Append(languageSuffix);
+
+            return suffixBuilder.ToString();
+        }
+
+        private string GetExistingLanguageSuffix(SubtitleFile subtitleFile)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(subtitleFile.RelativePath);
+            var match = SubtitleSuffixRegex.Match(fileName);
+
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            var isoCode = match.Groups["iso_code"].Value.ToLowerInvariant();
+            var isoLanguage = IsoLanguages.Find(isoCode);
+
+            if (isoLanguage is null && !AdditionalNorwegianSubtitleCodes.Contains(isoCode))
+            {
+                return null;
+            }
+
+            return match.Groups["suffix"].Value;
         }
 
         private string GetSuffix(Language language, int copy, List<string> languageTags, bool multipleCopies = false, string title = null)


### PR DESCRIPTION
#### Description

Preserves existing external subtitle language suffixes when subtitles are renamed after an episode file rename. This avoids normalizing existing subtitle suffixes such as `nb` into broader two-letter language codes such as `no`.

The rename path now reuses a recognized existing subtitle suffix, including language tags and subtitle title text, instead of rebuilding the suffix only from the stored language value.

#### Screenshots for UI Changes

N/A

#### Database Migration

No

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #8505

#### Validation

- `dotnet test src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj --filter "FullyQualifiedName~NzbDrone.Core.Test.Extras.Subtitles.SubtitleServiceFixture" --no-restore -p:RunAnalyzers=false`