### PR TITLE
Add experimental series edition support

### DIFF
--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.tsx
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.tsx
@@ -22,7 +22,7 @@ import ModalHeader from 'Components/Modal/ModalHeader';
 import Popover from 'Components/Tooltip/Popover';
 import { getValidationFailures } from 'Helpers/Hooks/useApiMutation';
 import { icons, inputTypes, kinds, tooltipPositions } from 'Helpers/Props';
-import { SeriesType } from 'Series/Series';
+import { SeriesEdition, SeriesType } from 'Series/Series';
 import SeriesPoster from 'Series/SeriesPoster';
 import selectSettings from 'Store/Selectors/selectSettings';
 import { useIsWindows } from 'System/Status/useSystemStatus';
@@ -61,6 +61,9 @@ function AddNewSeriesModalContent({
       ? settings.seriesType.value
       : initialSeriesType
   );
+  const [seriesEdition, setSeriesEdition] = useState<SeriesEdition>(
+    settings.seriesEdition.value
+  );
 
   const {
     monitor,
@@ -69,6 +72,7 @@ function AddNewSeriesModalContent({
     searchForCutoffUnmetEpisodes,
     searchForMissingEpisodes,
     seasonFolder,
+    seriesEdition: seriesEditionSetting,
     seriesType: seriesTypeSetting,
     tags,
   } = settings;
@@ -97,12 +101,14 @@ function AddNewSeriesModalContent({
         searchForCutoffUnmetEpisodes: searchForCutoffUnmetEpisodes.value,
       },
       qualityProfileId: qualityProfileId.value,
+      seriesEdition,
       seriesType,
       seasonFolder: seasonFolder.value,
       tags: tags.value,
     });
   }, [
     series,
+    seriesEdition,
     seriesType,
     rootFolderPath,
     monitor,
@@ -117,6 +123,10 @@ function AddNewSeriesModalContent({
   useEffect(() => {
     setSeriesType(seriesTypeSetting.value);
   }, [seriesTypeSetting]);
+
+  useEffect(() => {
+    setSeriesEdition(seriesEditionSetting.value);
+  }, [seriesEditionSetting]);
 
   return (
     <ModalContent onModalClose={onModalClose}>
@@ -226,6 +236,19 @@ function AddNewSeriesModalContent({
                   {...seriesTypeSetting}
                   value={seriesType}
                   helpText={translate('SeriesTypesHelpText')}
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <FormLabel>{translate('SeriesEdition')}</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.SERIES_EDITION_SELECT}
+                  name="seriesEdition"
+                  onChange={handleInputChange}
+                  {...seriesEditionSetting}
+                  value={seriesEdition}
+                  helpText={translate('SeriesEditionHelpText')}
                 />
               </FormGroup>
 

--- a/frontend/src/AddSeries/addSeriesOptionsStore.ts
+++ b/frontend/src/AddSeries/addSeriesOptionsStore.ts
@@ -1,10 +1,11 @@
 import { createOptionsStore } from 'Helpers/Hooks/useOptionsStore';
-import { SeriesMonitor, SeriesType } from 'Series/Series';
+import { SeriesEdition, SeriesMonitor, SeriesType } from 'Series/Series';
 
 export interface AddSeriesOptions {
   rootFolderPath: string;
   monitor: SeriesMonitor;
   qualityProfileId: number;
+  seriesEdition: SeriesEdition;
   seriesType: SeriesType;
   seasonFolder: boolean;
   searchForMissingEpisodes: boolean;
@@ -18,6 +19,7 @@ const { useOptions, useOption, setOption } =
       rootFolderPath: '',
       monitor: 'all',
       qualityProfileId: 0,
+      seriesEdition: 'standard',
       seriesType: 'standard',
       seasonFolder: true,
       searchForMissingEpisodes: false,

--- a/frontend/src/Components/Form/FormInputGroup.tsx
+++ b/frontend/src/Components/Form/FormInputGroup.tsx
@@ -46,6 +46,9 @@ import QualityProfileSelectInput, {
 import RootFolderSelectInput, {
   RootFolderSelectInputProps,
 } from './Select/RootFolderSelectInput';
+import SeriesEditionSelectInput, {
+  SeriesEditionSelectInputProps,
+} from './Select/SeriesEditionSelectInput';
 import SeriesTypeSelectInput, {
   SeriesTypeSelectInputProps,
 } from './Select/SeriesTypeSelectInput';
@@ -82,6 +85,7 @@ const componentMap: Record<InputType, ElementType> = {
   rootFolderSelect: RootFolderSelectInput,
   select: EnhancedSelectInput,
   seriesTag: SeriesTagInput,
+  seriesEditionSelect: SeriesEditionSelectInput,
   seriesTypeSelect: SeriesTypeSelectInput,
   tag: SeriesTagInput,
   tagSelect: TagSelectInput,
@@ -142,6 +146,8 @@ type PickProps<V, C extends InputType> = C extends 'text'
     EnhancedSelectInputProps<any, V>
   : C extends 'seriesTag'
   ? SeriesTagInputProps<V>
+  : C extends 'seriesEditionSelect'
+  ? SeriesEditionSelectInputProps
   : C extends 'seriesTypeSelect'
   ? SeriesTypeSelectInputProps
   : C extends 'tag'

--- a/frontend/src/Components/Form/Select/SeriesEditionSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/SeriesEditionSelectInput.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo } from 'react';
+import * as seriesEditions from 'Utilities/Series/seriesEditions';
+import translate from 'Utilities/String/translate';
+import EnhancedSelectInput, {
+  EnhancedSelectInputProps,
+  EnhancedSelectInputValue,
+} from './EnhancedSelectInput';
+
+export interface SeriesEditionSelectInputProps
+  extends Omit<
+    EnhancedSelectInputProps<EnhancedSelectInputValue<string>, string>,
+    'values'
+  > {
+  includeNoChange?: boolean;
+  includeNoChangeDisabled?: boolean;
+  includeMixed?: boolean;
+}
+
+interface SeriesEditionOption {
+  key: string;
+  value: string;
+  isDisabled?: boolean;
+}
+
+const seriesEditionOptions: SeriesEditionOption[] = [
+  {
+    key: seriesEditions.STANDARD,
+    value: 'Standard',
+  },
+  {
+    key: seriesEditions.DIRECTORS_CUT,
+    value: "Director's Cut",
+  },
+  {
+    key: seriesEditions.CUSTOM,
+    value: 'Custom',
+  },
+];
+
+function SeriesEditionSelectInput(props: SeriesEditionSelectInputProps) {
+  const {
+    includeNoChange = false,
+    includeNoChangeDisabled = true,
+    includeMixed = false,
+  } = props;
+
+  const values = useMemo(() => {
+    const result = [...seriesEditionOptions];
+
+    if (includeNoChange) {
+      result.unshift({
+        key: 'noChange',
+        value: translate('NoChange'),
+        isDisabled: includeNoChangeDisabled,
+      });
+    }
+
+    if (includeMixed) {
+      result.unshift({
+        key: 'mixed',
+        value: `(${translate('Mixed')})`,
+        isDisabled: true,
+      });
+    }
+
+    return result;
+  }, [includeNoChange, includeNoChangeDisabled, includeMixed]);
+
+  return <EnhancedSelectInput {...props} values={values} />;
+}
+
+export default SeriesEditionSelectInput;

--- a/frontend/src/Helpers/Props/inputTypes.ts
+++ b/frontend/src/Helpers/Props/inputTypes.ts
@@ -19,6 +19,7 @@ export const ROOT_FOLDER_SELECT = 'rootFolderSelect';
 export const SELECT = 'select';
 export const SERIES_TAG = 'seriesTag';
 export const DYNAMIC_SELECT = 'dynamicSelect';
+export const SERIES_EDITION_SELECT = 'seriesEditionSelect';
 export const SERIES_TYPE_SELECT = 'seriesTypeSelect';
 export const TAG = 'tag';
 export const TEXT = 'text';
@@ -48,6 +49,7 @@ export const all = [
   SELECT,
   SERIES_TAG,
   DYNAMIC_SELECT,
+  SERIES_EDITION_SELECT,
   SERIES_TYPE_SELECT,
   TAG,
   TEXT,
@@ -81,6 +83,7 @@ export type InputType =
   | 'select'
   | 'seriesTag'
   | 'dynamicSelect'
+  | 'seriesEditionSelect'
   | 'seriesTypeSelect'
   | 'tag'
   | 'text'

--- a/frontend/src/Series/Edit/EditSeriesModalContent.tsx
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.tsx
@@ -51,6 +51,7 @@ function EditSeriesModalContent({
     monitorNewItems,
     seasonFolder,
     qualityProfileId,
+    seriesEdition,
     seriesType,
     path,
     tags,
@@ -78,6 +79,7 @@ function EditSeriesModalContent({
         monitorNewItems,
         seasonFolder,
         qualityProfileId,
+        seriesEdition,
         seriesType,
         path,
         tags,
@@ -90,6 +92,7 @@ function EditSeriesModalContent({
     monitorNewItems,
     seasonFolder,
     qualityProfileId,
+    seriesEdition,
     seriesType,
     path,
     tags,
@@ -232,6 +235,18 @@ function EditSeriesModalContent({
               name="seriesType"
               {...settings.seriesType}
               helpText={translate('SeriesTypesHelpText')}
+              onChange={handleInputChange}
+            />
+          </FormGroup>
+
+          <FormGroup size={sizes.MEDIUM}>
+            <FormLabel>{translate('SeriesEdition')}</FormLabel>
+
+            <FormInputGroup
+              type={inputTypes.SERIES_EDITION_SELECT}
+              name="seriesEdition"
+              {...settings.seriesEdition}
+              helpText={translate('SeriesEditionHelpText')}
               onChange={handleInputChange}
             />
           </FormGroup>

--- a/frontend/src/Series/Series.ts
+++ b/frontend/src/Series/Series.ts
@@ -4,6 +4,7 @@ import Language from 'Language/Language';
 import Quality from 'Quality/Quality';
 
 export type SeriesType = 'anime' | 'daily' | 'standard';
+export type SeriesEdition = 'standard' | 'directors_cut' | 'custom';
 export type SeriesMonitor =
   | 'all'
   | 'future'
@@ -94,6 +95,7 @@ interface Series extends ModelBase {
   runtime: number;
   seasonFolder: boolean;
   seasons: Season[];
+  seriesEdition: SeriesEdition;
   seriesType: SeriesType;
   sortTitle: string;
   statistics?: Statistics;

--- a/frontend/src/Utilities/Series/getNewSeries.ts
+++ b/frontend/src/Utilities/Series/getNewSeries.ts
@@ -1,5 +1,6 @@
 import Series, {
   MonitorNewItems,
+  SeriesEdition,
   SeriesMonitor,
   SeriesType,
 } from 'Series/Series';
@@ -9,6 +10,7 @@ interface NewSeriesPayload {
   monitor: SeriesMonitor;
   monitorNewItems: MonitorNewItems;
   qualityProfileId: number;
+  seriesEdition: SeriesEdition;
   seriesType: SeriesType;
   seasonFolder: boolean;
   tags: number[];
@@ -22,6 +24,7 @@ function getNewSeries(series: Series, payload: NewSeriesPayload) {
     monitor,
     monitorNewItems,
     qualityProfileId,
+    seriesEdition,
     seriesType,
     seasonFolder,
     tags,
@@ -39,6 +42,7 @@ function getNewSeries(series: Series, payload: NewSeriesPayload) {
   series.monitored = true;
   series.monitorNewItems = monitorNewItems;
   series.qualityProfileId = qualityProfileId;
+  series.seriesEdition = seriesEdition;
   series.rootFolderPath = rootFolderPath;
   series.seriesType = seriesType;
   series.seasonFolder = seasonFolder;

--- a/frontend/src/Utilities/Series/seriesEditions.ts
+++ b/frontend/src/Utilities/Series/seriesEditions.ts
@@ -1,0 +1,3 @@
+export const STANDARD = 'standard';
+export const DIRECTORS_CUT = 'directors_cut';
+export const CUSTOM = 'custom';

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/SeriesEditionSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/SeriesEditionSpecificationFixture.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.DecisionEngine;
+using NzbDrone.Core.DecisionEngine.Specifications;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.DecisionEngineTests
+{
+    [TestFixture]
+    public class SeriesEditionSpecificationFixture : TestBase<SeriesEditionSpecification>
+    {
+        [Test]
+        public void should_reject_rezero_directors_cut_release_without_marker()
+        {
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series
+                {
+                    TvdbId = 305089,
+                    SeriesEdition = SeriesEditions.DirectorsCut
+                },
+                Release = new ReleaseInfo
+                {
+                    Title = "Re Zero S01E01 1080p WEB-DL"
+                }
+            };
+
+            var decision = Subject.IsSatisfiedBy(remoteEpisode, new ReleaseDecisionInformation(false, null));
+
+            decision.Accepted.Should().BeFalse();
+            decision.Reason.Should().Be(DownloadRejectionReason.WrongSeriesEdition);
+        }
+
+        [Test]
+        public void should_accept_rezero_directors_cut_release_with_marker()
+        {
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series
+                {
+                    TvdbId = 305089,
+                    SeriesEdition = SeriesEditions.DirectorsCut
+                },
+                Release = new ReleaseInfo
+                {
+                    Title = "Re Zero Directors Cut S01E01 1080p WEB-DL"
+                }
+            };
+
+            Subject.IsSatisfiedBy(remoteEpisode, new ReleaseDecisionInformation(false, null)).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_reject_generic_directors_cut_release_without_marker()
+        {
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series
+                {
+                    TvdbId = 1,
+                    Title = "Some Show",
+                    SeriesEdition = SeriesEditions.DirectorsCut
+                },
+                Release = new ReleaseInfo
+                {
+                    Title = "Some Show S01E01 1080p WEB-DL"
+                }
+            };
+
+            var decision = Subject.IsSatisfiedBy(remoteEpisode, new ReleaseDecisionInformation(false, null));
+
+            decision.Accepted.Should().BeFalse();
+            decision.Reason.Should().Be(DownloadRejectionReason.WrongSeriesEdition);
+        }
+
+        [Test]
+        public void should_accept_generic_directors_cut_release_with_marker()
+        {
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series
+                {
+                    TvdbId = 1,
+                    Title = "Some Show",
+                    SeriesEdition = SeriesEditions.DirectorsCut
+                },
+                Release = new ReleaseInfo
+                {
+                    Title = "Some Show Directors Cut S01E01 1080p WEB-DL"
+                }
+            };
+
+            Subject.IsSatisfiedBy(remoteEpisode, new ReleaseDecisionInformation(false, null)).Accepted.Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/TvTests/AddSeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/AddSeriesFixture.cs
@@ -83,6 +83,41 @@ namespace NzbDrone.Core.Test.TvTests
         }
 
         [Test]
+        public void should_treat_missing_series_edition_as_standard()
+        {
+            var newSeries = new Series
+            {
+                TvdbId = 1,
+                RootFolderPath = @"C:\Test\TV"
+            };
+
+            GivenValidSeries(newSeries.TvdbId);
+            GivenValidPath();
+
+            var series = Subject.AddSeries(newSeries);
+
+            series.SeriesEdition.Should().Be(SeriesEditions.Standard);
+        }
+
+        [Test]
+        public void should_preserve_series_edition()
+        {
+            var newSeries = new Series
+            {
+                TvdbId = 1,
+                SeriesEdition = SeriesEditions.DirectorsCut,
+                RootFolderPath = @"C:\Test\TV"
+            };
+
+            GivenValidSeries(newSeries.TvdbId);
+            GivenValidPath();
+
+            var series = Subject.AddSeries(newSeries);
+
+            series.SeriesEdition.Should().Be(SeriesEditions.DirectorsCut);
+        }
+
+        [Test]
         public void should_throw_if_series_validation_fails()
         {
             var newSeries = new Series

--- a/src/NzbDrone.Core.Test/TvTests/SeriesEditionsFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesEditionsFixture.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.TvTests
+{
+    [TestFixture]
+    public class SeriesEditionsFixture
+    {
+        [Test]
+        public void should_normalize_missing_series_edition_to_standard()
+        {
+            SeriesEditions.Normalize(null).Should().Be(SeriesEditions.Standard);
+            SeriesEditions.Normalize("").Should().Be(SeriesEditions.Standard);
+        }
+
+        [Test]
+        public void should_return_rezero_directors_cut_aliases()
+        {
+            var series = new Series
+            {
+                TvdbId = 305089,
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            var aliases = SeriesEditions.GetSearchAliases(series);
+
+            aliases.Should().Contain("Re Zero Director's Cut");
+            aliases.Should().Contain("Re Zero Shin Henshuu-ban");
+            aliases.Should().Contain("Re Zero New Edit Version");
+        }
+
+        [Test]
+        public void should_return_generic_directors_cut_aliases_for_any_series()
+        {
+            var series = new Series
+            {
+                TvdbId = 1,
+                Title = "Some Show",
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            var aliases = SeriesEditions.GetSearchAliases(series);
+
+            aliases.Should().Contain("Some Show Director's Cut");
+            aliases.Should().Contain("Some Show Directors Cut");
+            aliases.Should().Contain("Some Show New Edit Version");
+        }
+
+        [Test]
+        public void should_append_generic_directors_cut_display_suffix_for_any_series()
+        {
+            var series = new Series
+            {
+                TvdbId = 1,
+                Title = "Some Show",
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            SeriesEditions.GetDisplayTitle(series).Should().Be("Some Show [Director's Cut]");
+        }
+
+        [Test]
+        public void should_filter_rezero_directors_cut_season_one_to_13_episodes()
+        {
+            var series = new Series
+            {
+                TvdbId = 305089,
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            var episodes = Enumerable.Range(1, 25)
+                                     .Select(i => new Episode { SeasonNumber = 1, EpisodeNumber = i })
+                                     .ToList();
+
+            SeriesEditions.ApplyEpisodeOverrides(series, episodes).Should().HaveCount(13);
+        }
+
+        [Test]
+        public void should_map_rezero_directors_cut_titles_to_combined_episodes()
+        {
+            var series = new Series
+            {
+                TvdbId = 305089,
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            var episodes = Enumerable.Range(1, 25)
+                                     .Select(i => new Episode
+                                     {
+                                         SeasonNumber = 1,
+                                         EpisodeNumber = i,
+                                         Title = $"Episode {i}",
+                                         Runtime = 25
+                                     })
+                                     .ToList();
+
+            var mappedEpisodes = SeriesEditions.ApplyEpisodeOverrides(series, episodes);
+
+            mappedEpisodes.Should().HaveCount(13);
+            mappedEpisodes.First(e => e.EpisodeNumber == 2).Title.Should().Be("Reunion with the Witch \\ Starting Life from Zero in Another World");
+            mappedEpisodes.First(e => e.EpisodeNumber == 13).Title.Should().Be("The Self-Proclaimed Knight and the Greatest Knight \\ That's All This Story Is About");
+            mappedEpisodes.First(e => e.EpisodeNumber == 13).Runtime.Should().Be(50);
+            mappedEpisodes.First(e => e.EpisodeNumber == 13).AirDate.Should().Be("2020-04-01");
+        }
+
+        [Test]
+        public void should_not_filter_standard_rezero_episodes()
+        {
+            var series = new Series
+            {
+                TvdbId = 305089,
+                SeriesEdition = SeriesEditions.Standard
+            };
+
+            var episodes = Enumerable.Range(1, 25)
+                                     .Select(i => new Episode { SeasonNumber = 1, EpisodeNumber = i })
+                                     .ToList();
+
+            SeriesEditions.ApplyEpisodeOverrides(series, episodes).Should().HaveCount(25);
+        }
+
+        [Test]
+        public void should_not_apply_episode_overrides_to_generic_directors_cut_without_profile()
+        {
+            var series = new Series
+            {
+                TvdbId = 1,
+                SeriesEdition = SeriesEditions.DirectorsCut
+            };
+
+            var episodes = Enumerable.Range(1, 25)
+                                     .Select(i => new Episode { SeasonNumber = 1, EpisodeNumber = i })
+                                     .ToList();
+
+            SeriesEditions.ApplyEpisodeOverrides(series, episodes).Should().HaveCount(25);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/TvTests/SeriesRepositoryTests/SeriesRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/SeriesRepositoryTests/SeriesRepositoryFixture.cs
@@ -34,6 +34,45 @@ namespace NzbDrone.Core.Test.TvTests.SeriesRepositoryTests
             StoredModel.QualityProfile.Should().NotBeNull();
         }
 
+        private Series BuildSeries(int tvdbId, string seriesEdition, string titleSlug)
+        {
+            return Builder<Series>.CreateNew()
+                .With(s => s.Id = 0)
+                .With(s => s.TvdbId = tvdbId)
+                .With(s => s.SeriesEdition = seriesEdition)
+                .With(s => s.TitleSlug = titleSlug)
+                .With(s => s.Path = $@"C:\Test\{titleSlug}")
+                .BuildNew();
+        }
+
+        [Test]
+        public void should_allow_same_tvdbid_with_different_series_edition()
+        {
+            Subject.Insert(BuildSeries(305089, SeriesEditions.Standard, "rezero"));
+            Subject.Insert(BuildSeries(305089, SeriesEditions.DirectorsCut, "rezero-directors-cut"));
+
+            Subject.FindAllByTvdbId(305089).Should().HaveCount(2);
+        }
+
+        [Test]
+        public void should_find_standard_series_by_legacy_tvdbid_lookup()
+        {
+            Subject.Insert(BuildSeries(305089, SeriesEditions.Standard, "rezero"));
+            Subject.Insert(BuildSeries(305089, SeriesEditions.DirectorsCut, "rezero-directors-cut"));
+
+            Subject.FindByTvdbId(305089).SeriesEdition.Should().Be(SeriesEditions.Standard);
+        }
+
+        [Test]
+        public void should_not_allow_duplicate_tvdbid_and_series_edition()
+        {
+            Subject.Insert(BuildSeries(305089, SeriesEditions.DirectorsCut, "rezero-directors-cut"));
+
+            System.Action duplicate = () => Subject.Insert(BuildSeries(305089, SeriesEditions.DirectorsCut, "rezero-directors-cut-2"));
+
+            duplicate.Should().Throw<System.Exception>();
+        }
+
         private void GivenSeries()
         {
             var series = Builder<Series>.CreateListOfSize(2)

--- a/src/NzbDrone.Core/Datastore/Migration/231_add_series_edition.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/231_add_series_edition.cs
@@ -1,0 +1,28 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(231)]
+    public class add_series_edition : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series")
+                 .AddColumn("SeriesEdition").AsString().NotNullable().WithDefaultValue(SeriesEditions.Standard);
+
+            Execute.Sql("DROP INDEX IF EXISTS \"IX_Series_TvdbId\"");
+            Execute.Sql("DROP INDEX IF EXISTS \"IX_Series_TvdbId_SeriesEdition\"");
+
+            Alter.Table("Series")
+                 .AlterColumn("TvdbId").AsInt32();
+
+            Create.Index("IX_Series_TvdbId_SeriesEdition")
+                  .OnTable("Series")
+                  .OnColumn("TvdbId").Ascending()
+                  .OnColumn("SeriesEdition").Ascending()
+                  .WithOptions().Unique();
+        }
+    }
+}

--- a/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadRejectionReason.cs
@@ -28,6 +28,7 @@ public enum DownloadRejectionReason
     WrongEpisode,
     WrongSeason,
     WrongSeries,
+    WrongSeriesEdition,
     FullSeason,
     UnknownRuntime,
     BelowMinimumSize,

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/SeriesEditionSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/SeriesEditionSpecification.cs
@@ -1,0 +1,36 @@
+using NLog;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications
+{
+    public class SeriesEditionSpecification : IDownloadDecisionEngineSpecification
+    {
+        private readonly Logger _logger;
+
+        public SeriesEditionSpecification(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public SpecificationPriority Priority => SpecificationPriority.Default;
+        public RejectionType Type => RejectionType.Permanent;
+
+        public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
+        {
+            if (subject.Series == null || subject.Release == null)
+            {
+                return DownloadSpecDecision.Accept();
+            }
+
+            if (SeriesEditions.HasRequiredMarker(subject.Series, subject.Release.Title))
+            {
+                return DownloadSpecDecision.Accept();
+            }
+
+            _logger.Debug("Release {0} does not contain a required marker for series edition {1}", subject.Release.Title, subject.Series.SeriesEdition);
+
+            return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeriesEdition, "Release does not contain a required series edition marker");
+        }
+    }
+}

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -469,6 +469,7 @@ namespace NzbDrone.Core.IndexerSearch
             spec.SceneTitles = _sceneMapping.GetSceneNames(series.TvdbId,
                                                            episodes.Select(e => e.SeasonNumber).Distinct().ToList(),
                                                            episodes.Select(e => e.SceneSeasonNumber ?? e.SeasonNumber).Distinct().ToList());
+            spec.SceneTitles.AddRange(SeriesEditions.GetSearchAliases(series));
 
             spec.Episodes = episodes;
             spec.MonitoredEpisodesOnly = monitoredOnly;
@@ -490,6 +491,8 @@ namespace NzbDrone.Core.IndexerSearch
 
             spec.Series = series;
             spec.SceneTitles = mapping.SceneTitles;
+            spec.SceneTitles.AddRange(SeriesEditions.GetSearchAliases(series));
+            spec.SceneTitles = spec.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             spec.SearchMode = mapping.SearchMode;
 
             spec.Episodes = new List<Episode> { mapping.Episode };
@@ -507,6 +510,8 @@ namespace NzbDrone.Core.IndexerSearch
 
             spec.Series = series;
             spec.SceneTitles = mapping.SceneTitles;
+            spec.SceneTitles.AddRange(SeriesEditions.GetSearchAliases(series));
+            spec.SceneTitles = spec.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             spec.SearchMode = mapping.SearchMode;
 
             spec.Episodes = mapping.Episodes;

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -2002,6 +2002,8 @@
   "SeriesTitle": "Series Title",
   "SeriesTitleToExcludeHelpText": "The name of the series to exclude",
   "SeriesType": "Series Type",
+  "SeriesEdition": "Series Edition",
+  "SeriesEditionHelpText": "Experimental edition variant used to keep alternate cuts or episode orders separate",
   "SeriesTypes": "Series Types",
   "SeriesTypesHelpText": "Series type is used for renaming, parsing and searching",
   "SetIndexerFlags": "Set Indexer Flags",

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -431,6 +431,12 @@ namespace NzbDrone.Core.Parser
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Title);
                 }
 
+                if (searchCriteria.SceneTitles != null &&
+                    searchCriteria.SceneTitles.Any(t => t.CleanSeriesTitle() == parsedEpisodeInfo.SeriesTitle.CleanSeriesTitle()))
+                {
+                    return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Alias);
+                }
+
                 if (tvdbId > 0 && tvdbId == searchCriteria.Series.TvdbId)
                 {
                     _logger.ForDebugEvent()

--- a/src/NzbDrone.Core/Tv/AddSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/AddSeriesService.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Tv
         {
             var added = DateTime.UtcNow;
             var seriesToAdd = new List<Series>();
-            var existingSeriesTvdbIds = _seriesService.AllSeriesTvdbIds();
+            var existingSeriesTvdbIdEditions = _seriesService.AllSeriesTvdbIdEditions();
 
             foreach (var s in newSeries)
             {
@@ -76,15 +76,15 @@ namespace NzbDrone.Core.Tv
                     var series = AddSkyhookData(s);
                     series = SetPropertiesAndValidate(series);
                     series.Added = added;
-                    if (existingSeriesTvdbIds.Any(f => f == series.TvdbId))
+                    if (existingSeriesTvdbIdEditions.Any(f => f.TvdbId == series.TvdbId && f.SeriesEdition == series.SeriesEdition))
                     {
-                        _logger.Debug("TVDB ID {0} was not added due to validation failure: Series {1} already exists in database", s.TvdbId, s);
+                        _logger.Debug("TVDB ID {0} edition {1} was not added due to validation failure: Series {2} already exists in database", s.TvdbId, s.SeriesEdition, s);
                         continue;
                     }
 
-                    if (seriesToAdd.Any(f => f.TvdbId == series.TvdbId))
+                    if (seriesToAdd.Any(f => f.TvdbId == series.TvdbId && f.SeriesEdition == series.SeriesEdition))
                     {
-                        _logger.Trace("TVDB ID {0} was already added from another import list, not adding series {1} again", s.TvdbId, s);
+                        _logger.Trace("TVDB ID {0} edition {1} was already added from another import list, not adding series {2} again", s.TvdbId, s.SeriesEdition, s);
                         continue;
                     }
 
@@ -135,8 +135,17 @@ namespace NzbDrone.Core.Tv
             newSeries.Seasons = newSeries.Seasons != null && newSeries.Seasons.Any() ? newSeries.Seasons : series.Seasons;
 
             series.ApplyChanges(newSeries);
+            ApplyEditionOverrides(series);
 
             return series;
+        }
+
+        private void ApplyEditionOverrides(Series series)
+        {
+            series.SeriesEdition = SeriesEditions.Normalize(series.SeriesEdition);
+
+            series.TitleSlug = SeriesEditions.GetTitleSlug(series);
+            series.Title = SeriesEditions.GetDisplayTitle(series);
         }
 
         private Series SetPropertiesAndValidate(Series newSeries)
@@ -149,6 +158,7 @@ namespace NzbDrone.Core.Tv
 
             newSeries.CleanTitle = newSeries.Title.CleanSeriesTitle();
             newSeries.SortTitle = SeriesTitleNormalizer.Normalize(newSeries.Title, newSeries.TvdbId);
+            newSeries.SeriesEdition = SeriesEditions.Normalize(newSeries.SeriesEdition);
             newSeries.Added = DateTime.UtcNow;
 
             if (newSeries.AddOptions != null && newSeries.AddOptions.Monitor == MonitorTypes.None)

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -45,6 +45,8 @@ namespace NzbDrone.Core.Tv
                 dupeFreeRemoteEpisodes = MapAbsoluteEpisodeNumbers(dupeFreeRemoteEpisodes);
             }
 
+            dupeFreeRemoteEpisodes = SeriesEditions.ApplyEpisodeOverrides(series, dupeFreeRemoteEpisodes);
+
             var orderedEpisodes = OrderEpisodes(series, dupeFreeRemoteEpisodes).ToList();
             var episodesPerSeason = orderedEpisodes.GroupBy(s => s.SeasonNumber).ToDictionary(g => g.Key, g => g.Count());
             var latestSeason = seasons.MaxBy(s => s.SeasonNumber);

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -19,9 +19,11 @@ namespace NzbDrone.Core.Tv
             OriginalLanguage = Language.English;
             MalIds = new HashSet<int>();
             AniListIds = new HashSet<int>();
+            SeriesEdition = SeriesEditions.Standard;
         }
 
         public int TvdbId { get; set; }
+        public string SeriesEdition { get; set; }
         public int TvRageId { get; set; }
         public int TvMazeId { get; set; }
         public string ImdbId { get; set; }
@@ -64,12 +66,13 @@ namespace NzbDrone.Core.Tv
 
         public override string ToString()
         {
-            return string.Format("[{0}][{1}]", TvdbId, Title.NullSafe());
+            return string.Format("[{0}][{1}][{2}]", TvdbId, SeriesEdition.NullSafe(), Title.NullSafe());
         }
 
         public void ApplyChanges(Series otherSeries)
         {
             TvdbId = otherSeries.TvdbId;
+            SeriesEdition = SeriesEditions.Normalize(otherSeries.SeriesEdition);
 
             Seasons = otherSeries.Seasons;
             Path = otherSeries.Path;

--- a/src/NzbDrone.Core/Tv/SeriesEditions.cs
+++ b/src/NzbDrone.Core/Tv/SeriesEditions.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Core.Tv
+{
+    public static class SeriesEditions
+    {
+        public const string Standard = "standard";
+        public const string DirectorsCut = "directors_cut";
+        public const string Custom = "custom";
+
+        private static readonly HashSet<string> ValidEditions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Standard,
+            DirectorsCut,
+            Custom
+        };
+
+        private static readonly Regex DirectorsCutMarker = new Regex(
+            @"\b(director'?s?\s*cut|shin\s*henshuu[-\s]*ban|shin\s*henshuuban|new\s*edit\s*version|new\s*edition|2020)\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly IReadOnlyList<EditionProfile> EditionProfiles = new List<EditionProfile>
+        {
+            new EditionProfile
+            {
+                TvdbId = 305089,
+                SeriesEdition = DirectorsCut,
+                DisplayTitle = "Re:ZERO -Starting Life in Another World- [Director's Cut]",
+                SearchAliases = new List<string>
+                {
+                    "Re Zero Director's Cut",
+                    "Re Zero Directors Cut",
+                    "Re Zero Shin Henshuu-ban",
+                    "Re Zero Shin Henshuuban",
+                    "Re Zero New Edit Version",
+                    "Re Zero New Edition",
+                    "Re Zero 2020"
+                },
+                RequiredMarker = DirectorsCutMarker,
+                EpisodeMaps = new List<EditionEpisodeMap>
+                {
+                    new(1, 1, 1, 1, "The End of the Beginning and the Beginning of the End", "2020-01-01", 53),
+                    new(1, 2, 1, 2, "Reunion with the Witch \\ Starting Life from Zero in Another World", "2020-01-08", 50),
+                    new(1, 3, 1, 4, "The Happy Roswaal Mansion Family \\ The Morning of Our Promise Is Still Distant", "2020-01-15", 50),
+                    new(1, 4, 1, 6, "The Sound of Chains \\ Natsuki Subaru's Restart", "2020-01-22", 50),
+                    new(1, 5, 1, 8, "I Cried, Cried My Lungs Out, and Stopped Crying \\ The Meaning of Courage", "2020-01-29", 50),
+                    new(1, 6, 1, 10, "Fanatical Methods Like a Demon \\ Rem", "2020-02-05", 50),
+                    new(1, 7, 1, 12, "Return to the Capital \\ Self-Proclaimed Knight Natsuki Subaru", "2020-02-19", 50),
+                    new(1, 8, 1, 14, "The Sickness Called Despair \\ The Outside of Madness", "2020-02-26", 50),
+                    new(1, 9, 1, 16, "The Greed of a Pig \\ Disgrace in the Extreme", "2020-03-04", 50),
+                    new(1, 10, 1, 18, "From Zero \\ Battle Against the White Whale", "2020-03-11", 50),
+                    new(1, 11, 1, 20, "Wilhelm van Astrea \\ A Wager that Defies Despair", "2020-03-18", 50),
+                    new(1, 12, 1, 22, "A Flash of Sloth \\ Nefarious Sloth", "2020-03-25", 50),
+                    new(1, 13, 1, 24, "The Self-Proclaimed Knight and the Greatest Knight \\ That's All This Story Is About", "2020-04-01", 50, "season")
+                }
+            }
+        };
+
+        public static string Normalize(string seriesEdition)
+        {
+            if (seriesEdition.IsNullOrWhiteSpace())
+            {
+                return Standard;
+            }
+
+            var normalized = seriesEdition.Trim().ToLowerInvariant();
+
+            return IsValid(normalized) ? normalized : seriesEdition;
+        }
+
+        public static bool IsValid(string seriesEdition)
+        {
+            return ValidEditions.Contains(NormalizeKnownValue(seriesEdition));
+        }
+
+        public static bool IsStandard(string seriesEdition)
+        {
+            return Normalize(seriesEdition).Equals(Standard, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string GetDisplayTitle(Series series)
+        {
+            var profile = GetEditionProfile(series);
+
+            if (profile?.DisplayTitle.IsNotNullOrWhiteSpace() == true)
+            {
+                return profile.DisplayTitle;
+            }
+
+            var edition = Normalize(series.SeriesEdition);
+
+            if (edition.Equals(DirectorsCut, StringComparison.OrdinalIgnoreCase))
+            {
+                return AppendEditionSuffix(series.Title, "Director's Cut");
+            }
+
+            if (edition.Equals(Custom, StringComparison.OrdinalIgnoreCase))
+            {
+                return AppendEditionSuffix(series.Title, "Custom");
+            }
+
+            return series.Title;
+        }
+
+        public static string GetTitleSlug(Series series)
+        {
+            if (!IsStandard(series.SeriesEdition) && series.TitleSlug.IsNotNullOrWhiteSpace())
+            {
+                var slugEdition = Normalize(series.SeriesEdition).Replace("_", "-");
+                var suffix = $"-{slugEdition}";
+
+                if (!series.TitleSlug.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return $"{series.TitleSlug}{suffix}";
+                }
+            }
+
+            return series.TitleSlug;
+        }
+
+        public static List<string> GetSearchAliases(Series series)
+        {
+            var aliases = new List<string>();
+            var profile = GetEditionProfile(series);
+
+            if (profile?.SearchAliases != null)
+            {
+                aliases.AddRange(profile.SearchAliases);
+            }
+
+            if (Normalize(series.SeriesEdition).Equals(DirectorsCut, StringComparison.OrdinalIgnoreCase))
+            {
+                var baseTitle = GetBaseTitle(series.Title);
+
+                if (baseTitle.IsNotNullOrWhiteSpace())
+                {
+                    aliases.Add($"{baseTitle} Director's Cut");
+                    aliases.Add($"{baseTitle} Directors Cut");
+                    aliases.Add($"{baseTitle} New Edit Version");
+                    aliases.Add($"{baseTitle} New Edition");
+                }
+            }
+
+            return aliases
+                .Where(a => a.IsNotNullOrWhiteSpace())
+                .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                .ToList();
+        }
+
+        public static bool HasRequiredMarker(Series series, string releaseTitle)
+        {
+            if (series == null || releaseTitle.IsNullOrWhiteSpace())
+            {
+                return IsStandard(series?.SeriesEdition);
+            }
+
+            var edition = Normalize(series.SeriesEdition);
+
+            if (edition.Equals(Standard, StringComparison.OrdinalIgnoreCase) ||
+                edition.Equals(Custom, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var profile = GetEditionProfile(series);
+            var marker = profile?.RequiredMarker ?? DirectorsCutMarker;
+
+            return marker.IsMatch(releaseTitle);
+        }
+
+        public static List<Episode> ApplyEpisodeOverrides(Series series, IEnumerable<Episode> episodes)
+        {
+            var episodeList = episodes.ToList();
+            var profile = GetEditionProfile(series);
+
+            if (profile?.EpisodeMaps == null || !profile.EpisodeMaps.Any())
+            {
+                return episodeList;
+            }
+
+            return ApplyEpisodeMap(profile, episodeList);
+        }
+
+        private static List<Episode> ApplyEpisodeMap(EditionProfile profile, List<Episode> episodes)
+        {
+            var maps = profile.EpisodeMaps;
+            var sourceEpisodes = episodes.ToDictionary(e => new EpisodeKey(e.SeasonNumber, e.EpisodeNumber));
+            var mappedSeasons = maps.Select(m => m.SeasonNumber).Distinct().ToHashSet();
+            var mappedEpisodes = new List<Episode>();
+
+            foreach (var map in maps)
+            {
+                var sourceKey = new EpisodeKey(map.SourceSeasonNumber, map.SourceEpisodeNumber);
+                var targetKey = new EpisodeKey(map.SeasonNumber, map.EpisodeNumber);
+
+                if (!sourceEpisodes.TryGetValue(sourceKey, out var sourceEpisode) &&
+                    !sourceEpisodes.TryGetValue(targetKey, out sourceEpisode))
+                {
+                    continue;
+                }
+
+                mappedEpisodes.Add(new Episode
+                {
+                    TvdbId = sourceEpisode.TvdbId,
+                    SeriesId = sourceEpisode.SeriesId,
+                    SeasonNumber = map.SeasonNumber,
+                    EpisodeNumber = map.EpisodeNumber,
+                    AbsoluteEpisodeNumber = map.EpisodeNumber,
+                    Title = map.Title,
+                    Overview = sourceEpisode.Overview,
+                    AirDate = map.AirDate,
+                    AirDateUtc = GetAirDateUtc(map.AirDate),
+                    Runtime = map.Runtime,
+                    FinaleType = map.FinaleType ?? sourceEpisode.FinaleType,
+                    Ratings = sourceEpisode.Ratings,
+                    Images = sourceEpisode.Images
+                });
+            }
+
+            return episodes
+                .Where(e => !mappedSeasons.Contains(e.SeasonNumber))
+                .Concat(mappedEpisodes)
+                .ToList();
+        }
+
+        private static EditionProfile GetEditionProfile(Series series)
+        {
+            if (series == null)
+            {
+                return null;
+            }
+
+            var edition = Normalize(series.SeriesEdition);
+
+            return EditionProfiles.FirstOrDefault(p => p.TvdbId == series.TvdbId &&
+                                                       p.SeriesEdition.Equals(edition, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string AppendEditionSuffix(string title, string suffix)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return title;
+            }
+
+            var bracketedSuffix = $"[{suffix}]";
+
+            if (title.EndsWith(bracketedSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return title;
+            }
+
+            return $"{title} {bracketedSuffix}";
+        }
+
+        private static string GetBaseTitle(string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return title;
+            }
+
+            return Regex.Replace(title, @"\s+\[(director'?s?\s*cut|custom)\]\s*$", string.Empty, RegexOptions.IgnoreCase);
+        }
+
+        private static DateTime? GetAirDateUtc(string airDate)
+        {
+            if (airDate.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            return DateTime.SpecifyKind(DateTime.Parse($"{airDate}T15:00:00"), DateTimeKind.Utc);
+        }
+
+        private static string NormalizeKnownValue(string seriesEdition)
+        {
+            return seriesEdition.IsNullOrWhiteSpace() ? Standard : seriesEdition.Trim().ToLowerInvariant();
+        }
+
+        private sealed class EditionProfile
+        {
+            public int TvdbId { get; init; }
+            public string SeriesEdition { get; init; }
+            public string DisplayTitle { get; init; }
+            public IReadOnlyList<string> SearchAliases { get; init; } = new List<string>();
+            public Regex RequiredMarker { get; init; }
+            public IReadOnlyList<EditionEpisodeMap> EpisodeMaps { get; init; } = new List<EditionEpisodeMap>();
+        }
+
+        private sealed record EditionEpisodeMap(int SeasonNumber, int EpisodeNumber, int SourceSeasonNumber, int SourceEpisodeNumber, string Title, string AirDate, int Runtime, string FinaleType = null);
+        private sealed record EpisodeKey(int SeasonNumber, int EpisodeNumber);
+    }
+}

--- a/src/NzbDrone.Core/Tv/SeriesRepository.cs
+++ b/src/NzbDrone.Core/Tv/SeriesRepository.cs
@@ -13,10 +13,13 @@ namespace NzbDrone.Core.Tv
         Series FindByTitle(string cleanTitle, int year);
         List<Series> FindByTitleInexact(string cleanTitle);
         Series FindByTvdbId(int tvdbId);
+        Series FindByTvdbId(int tvdbId, string seriesEdition);
+        List<Series> FindAllByTvdbId(int tvdbId);
         Series FindByTvRageId(int tvRageId);
         Series FindByImdbId(string imdbId);
         Series FindByPath(string path);
         List<int> AllSeriesTvdbIds();
+        List<Series> AllSeriesTvdbIdEditions();
         Dictionary<int, string> AllSeriesPaths();
         Dictionary<int, List<int>> AllSeriesTags();
         Dictionary<int, int> AllSeriesQualityProfiles();
@@ -67,7 +70,19 @@ namespace NzbDrone.Core.Tv
 
         public Series FindByTvdbId(int tvdbId)
         {
-            return Query(s => s.TvdbId == tvdbId).SingleOrDefault();
+            return FindByTvdbId(tvdbId, SeriesEditions.Standard);
+        }
+
+        public Series FindByTvdbId(int tvdbId, string seriesEdition)
+        {
+            var edition = SeriesEditions.Normalize(seriesEdition);
+
+            return Query(s => s.TvdbId == tvdbId && s.SeriesEdition == edition).SingleOrDefault();
+        }
+
+        public List<Series> FindAllByTvdbId(int tvdbId)
+        {
+            return Query(s => s.TvdbId == tvdbId).ToList();
         }
 
         public Series FindByTvRageId(int tvRageId)
@@ -90,7 +105,15 @@ namespace NzbDrone.Core.Tv
         {
             using (var conn = _database.OpenConnection())
             {
-                return conn.Query<int>("SELECT \"TvdbId\" FROM \"Series\"").ToList();
+                return conn.Query<int>("SELECT \"TvdbId\" FROM \"Series\" WHERE \"SeriesEdition\" = @seriesEdition", new { seriesEdition = SeriesEditions.Standard }).ToList();
+            }
+        }
+
+        public List<Series> AllSeriesTvdbIdEditions()
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<Series>("SELECT \"TvdbId\", \"SeriesEdition\" FROM \"Series\"").ToList();
             }
         }
 

--- a/src/NzbDrone.Core/Tv/SeriesService.cs
+++ b/src/NzbDrone.Core/Tv/SeriesService.cs
@@ -16,6 +16,8 @@ namespace NzbDrone.Core.Tv
         Series AddSeries(Series newSeries);
         List<Series> AddSeries(List<Series> newSeries);
         Series FindByTvdbId(int tvdbId);
+        Series FindByTvdbId(int tvdbId, string seriesEdition);
+        List<Series> FindAllByTvdbId(int tvdbId);
         Series FindByTvRageId(int tvRageId);
         Series FindByImdbId(string imdbId);
         Series FindByTitle(string title);
@@ -25,6 +27,7 @@ namespace NzbDrone.Core.Tv
         void DeleteSeries(List<int> seriesIds, bool deleteFiles, bool addImportListExclusion);
         List<Series> GetAllSeries();
         List<int> AllSeriesTvdbIds();
+        List<Series> AllSeriesTvdbIdEditions();
         Dictionary<int, string> GetAllSeriesPaths();
         Dictionary<int, List<int>> GetAllSeriesTags();
         List<Series> AllForTag(int tagId);
@@ -72,6 +75,7 @@ namespace NzbDrone.Core.Tv
 
         public Series AddSeries(Series newSeries)
         {
+            newSeries.SeriesEdition = SeriesEditions.Normalize(newSeries.SeriesEdition);
             _seriesRepository.Insert(newSeries);
             _eventAggregator.PublishEvent(new SeriesAddedEvent(GetSeries(newSeries.Id)));
 
@@ -80,6 +84,7 @@ namespace NzbDrone.Core.Tv
 
         public List<Series> AddSeries(List<Series> newSeries)
         {
+            newSeries.ForEach(s => s.SeriesEdition = SeriesEditions.Normalize(s.SeriesEdition));
             _seriesRepository.InsertMany(newSeries);
             _eventAggregator.PublishEvent(new SeriesImportedEvent(newSeries.Select(s => s.Id).ToList()));
 
@@ -89,6 +94,16 @@ namespace NzbDrone.Core.Tv
         public Series FindByTvdbId(int tvRageId)
         {
             return _seriesRepository.FindByTvdbId(tvRageId);
+        }
+
+        public Series FindByTvdbId(int tvdbId, string seriesEdition)
+        {
+            return _seriesRepository.FindByTvdbId(tvdbId, seriesEdition);
+        }
+
+        public List<Series> FindAllByTvdbId(int tvdbId)
+        {
+            return _seriesRepository.FindAllByTvdbId(tvdbId);
         }
 
         public Series FindByTvRageId(int tvRageId)
@@ -175,6 +190,11 @@ namespace NzbDrone.Core.Tv
         public List<int> AllSeriesTvdbIds()
         {
             return _seriesRepository.AllSeriesTvdbIds().ToList();
+        }
+
+        public List<Series> AllSeriesTvdbIdEditions()
+        {
+            return _seriesRepository.AllSeriesTvdbIdEditions().ToList();
         }
 
         public Dictionary<int, string> GetAllSeriesPaths()

--- a/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesExistsValidator.cs
@@ -24,8 +24,22 @@ namespace NzbDrone.Core.Validation.Paths
             }
 
             var tvdbId = Convert.ToInt32(context.PropertyValue.ToString());
+            dynamic instance = context.ParentContext.InstanceToValidate;
+            string seriesEdition = SeriesEditions.Standard;
 
-            return !_seriesService.AllSeriesTvdbIds().Any(s => s == tvdbId);
+            try
+            {
+                seriesEdition = instance.SeriesEdition;
+            }
+            catch
+            {
+                seriesEdition = SeriesEditions.Standard;
+            }
+
+            seriesEdition = SeriesEditions.Normalize(seriesEdition);
+
+            return !_seriesService.AllSeriesTvdbIdEditions()
+                                  .Any(s => s.TvdbId == tvdbId && s.SeriesEdition == seriesEdition);
         }
     }
 }

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -102,6 +102,10 @@ namespace Sonarr.Api.V3.Series
                 .ValidId()
                 .SetValidator(qualityProfileExistsValidator);
 
+            SharedValidator.RuleFor(s => s.SeriesEdition)
+                .Must(SeriesEditions.IsValid)
+                .WithMessage("Series edition must be one of: standard, directors_cut, custom");
+
             PostValidator.RuleFor(s => s.Title).NotEmpty();
             PostValidator.RuleFor(s => s.TvdbId).GreaterThan(0).SetValidator(seriesExistsValidator);
         }
@@ -115,7 +119,7 @@ namespace Sonarr.Api.V3.Series
 
             if (tvdbId.HasValue)
             {
-                seriesResources.AddIfNotNull(_seriesService.FindByTvdbId(tvdbId.Value).ToResource(includeSeasonImages));
+                seriesResources.AddRange(_seriesService.FindAllByTvdbId(tvdbId.Value).Select(s => s.ToResource(includeSeasonImages)));
             }
             else
             {

--- a/src/Sonarr.Api.V3/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesResource.cs
@@ -49,6 +49,7 @@ namespace Sonarr.Api.V3.Series
         public bool UseSceneNumbering { get; set; }
         public int Runtime { get; set; }
         public int TvdbId { get; set; }
+        public string SeriesEdition { get; set; }
         public int TvRageId { get; set; }
         public int TvMazeId { get; set; }
         public int TmdbId { get; set; }
@@ -122,6 +123,7 @@ namespace Sonarr.Api.V3.Series
                        UseSceneNumbering = model.UseSceneNumbering,
                        Runtime = model.Runtime,
                        TvdbId = model.TvdbId,
+                       SeriesEdition = SeriesEditions.Normalize(model.SeriesEdition),
                        TvRageId = model.TvRageId,
                        TvMazeId = model.TvMazeId,
                        TmdbId = model.TmdbId,
@@ -187,6 +189,7 @@ namespace Sonarr.Api.V3.Series
                        UseSceneNumbering = resource.UseSceneNumbering,
                        Runtime = resource.Runtime,
                        TvdbId = resource.TvdbId,
+                       SeriesEdition = SeriesEditions.Normalize(resource.SeriesEdition),
                        TvRageId = resource.TvRageId,
                        TvMazeId = resource.TvMazeId,
                        TmdbId = resource.TmdbId,

--- a/src/Sonarr.Api.V5/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesController.cs
@@ -103,6 +103,10 @@ public class SeriesController : RestControllerWithSignalR<SeriesResource, NzbDro
             .ValidId()
             .SetValidator(qualityProfileExistsValidator);
 
+        SharedValidator.RuleFor(s => s.SeriesEdition)
+            .Must(SeriesEditions.IsValid)
+            .WithMessage("Series edition must be one of: standard, directors_cut, custom");
+
         PostValidator.RuleFor(s => s.Title).NotEmpty();
         PostValidator.RuleFor(s => s.TvdbId).GreaterThan(0).SetValidator(seriesExistsValidator);
     }
@@ -117,7 +121,7 @@ public class SeriesController : RestControllerWithSignalR<SeriesResource, NzbDro
 
         if (tvdbId.HasValue)
         {
-            seriesResources.AddIfNotNull(_seriesService.FindByTvdbId(tvdbId.Value)?.ToResource(includeSeasonImages));
+            seriesResources.AddRange(_seriesService.FindAllByTvdbId(tvdbId.Value).Select(s => s.ToResource(includeSeasonImages)));
         }
         else
         {

--- a/src/Sonarr.Api.V5/Series/SeriesResource.cs
+++ b/src/Sonarr.Api.V5/Series/SeriesResource.cs
@@ -34,6 +34,7 @@ public class SeriesResource : RestResource
     public bool UseSceneNumbering { get; set; }
     public int Runtime { get; set; }
     public int TvdbId { get; set; }
+    public string? SeriesEdition { get; set; }
     public int TvRageId { get; set; }
     public int TvMazeId { get; set; }
     public int TmdbId { get; set; }
@@ -87,6 +88,7 @@ public static class SeriesResourceMapper
             UseSceneNumbering = model.UseSceneNumbering,
             Runtime = model.Runtime,
             TvdbId = model.TvdbId,
+            SeriesEdition = SeriesEditions.Normalize(model.SeriesEdition),
             TvRageId = model.TvRageId,
             TvMazeId = model.TvMazeId,
             TmdbId = model.TmdbId,
@@ -130,6 +132,7 @@ public static class SeriesResourceMapper
             UseSceneNumbering = resource.UseSceneNumbering,
             Runtime = resource.Runtime,
             TvdbId = resource.TvdbId,
+            SeriesEdition = SeriesEditions.Normalize(resource.SeriesEdition),
             TvRageId = resource.TvRageId,
             TvMazeId = resource.TvMazeId,
             TmdbId = resource.TmdbId,


### PR DESCRIPTION
#### Description

Adds experimental support for series editions, which enables two or more Sonarr series to share the same TVDB id if each of them is a different edition.

This work paves a way for a new `SeriesEdition` field where the first set of possible values are `standard`, `directors_cut`, and `custom`. Old series will be `standard` by default and non-standard editions will be able to have their own path/root folder separately added. Besides that, the PR is edition-aware as far as duplicate checking, API/resource mapping, minimum add/edit UI support, searching aliases, and rejecting Director's Cut releases when the edition markers do not match, are concerned.

Alongside in the same initial MVP, R : ZERO Director's Cut is available as the first static version profile to prove the approach. It maps season 1 to the 13-episode Director's Cut order, yet the standard 25-episode series is kept as a different entry.

#### Screenshots for UI Changes

<img width="1061" height="710" alt="image" src="https://github.com/user-attachments/assets/b865d276-de6b-4d29-8b4b-b607d0454adf" />

#### Database Migration

YES 231

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
