### PR TITLE
Fixed: Grab matching full season pack during anime episode search

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/AnimeSearchFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SingleEpisodeSearchMatchSpecificationTests/AnimeSearchFixture.cs
@@ -1,9 +1,11 @@
-﻿using FluentAssertions;
+using System.Collections.Generic;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.DecisionEngine;
 using NzbDrone.Core.DecisionEngine.Specifications.Search;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatchSpecificationTests
@@ -25,6 +27,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
         [Test]
         public void should_return_false_if_full_season_result_for_single_episode_search()
         {
+            // No mapped episodes cover the requested episode, so the full-season pack is skipped
             _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
 
             Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
@@ -45,6 +48,45 @@ namespace NzbDrone.Core.Test.DecisionEngineTests.Search.SingleEpisodeSearchMatch
             _searchCriteria.IsSeasonSearch = true;
 
             Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_full_season_pack_covers_searched_episode()
+        {
+            _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
+            _remoteEpisode.ParsedEpisodeInfo.SeasonNumber = 1;
+            _remoteEpisode.Episodes = new List<Episode> { new Episode { SeasonNumber = 1, EpisodeNumber = 5 } };
+
+            _searchCriteria.SeasonNumber = 1;
+            _searchCriteria.EpisodeNumber = 5;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_full_season_pack_is_for_a_different_season()
+        {
+            _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
+            _remoteEpisode.ParsedEpisodeInfo.SeasonNumber = 2;
+            _remoteEpisode.Episodes = new List<Episode> { new Episode { SeasonNumber = 2, EpisodeNumber = 5 } };
+
+            _searchCriteria.SeasonNumber = 1;
+            _searchCriteria.EpisodeNumber = 5;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_full_season_pack_does_not_cover_searched_episode()
+        {
+            _remoteEpisode.ParsedEpisodeInfo.FullSeason = true;
+            _remoteEpisode.ParsedEpisodeInfo.SeasonNumber = 1;
+            _remoteEpisode.Episodes = new List<Episode> { new Episode { SeasonNumber = 1, EpisodeNumber = 5 } };
+
+            _searchCriteria.SeasonNumber = 1;
+            _searchCriteria.EpisodeNumber = 9;
+
+            Subject.IsSatisfiedBy(_remoteEpisode, _information).Accepted.Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SingleEpisodeSearchMatchSpecification.cs
@@ -67,8 +67,24 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
 
         private DownloadSpecDecision IsSatisfiedBy(RemoteEpisode remoteEpisode, AnimeEpisodeSearchCriteria animeEpisodeSpec)
         {
-            if (remoteEpisode.ParsedEpisodeInfo.FullSeason && !animeEpisodeSpec.IsSeasonSearch)
+            if (remoteEpisode.ParsedEpisodeInfo.FullSeason)
             {
+                if (animeEpisodeSpec.IsSeasonSearch)
+                {
+                    return DownloadSpecDecision.Accept();
+                }
+
+                // A standard-format full-season pack (e.g. a dubbed "<Title> S01" release) carries no
+                // absolute episode numbers, so it would otherwise be skipped during an episode search.
+                // Accept it only when it maps to the searched season and actually covers the requested
+                // episode. Absolute-numbered packs have episode numbers and never reach this branch.
+                if (remoteEpisode.ParsedEpisodeInfo.SeasonNumber == animeEpisodeSpec.SeasonNumber &&
+                    remoteEpisode.Episodes.Any(e => e.SeasonNumber == animeEpisodeSpec.SeasonNumber &&
+                                                    e.EpisodeNumber == animeEpisodeSpec.EpisodeNumber))
+                {
+                    return DownloadSpecDecision.Accept();
+                }
+
                 _logger.Debug("Full season result during single episode search, skipping.");
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.FullSeason, "Full season pack");
             }


### PR DESCRIPTION
#### Description

For anime series the episode-search path in `SingleEpisodeSearchMatchSpecification` rejects every full-season pack with "Full season pack". As a result an anime series whose only available releases are standard-format season packs — e.g. dubbed `<Title> S01` releases, common on non-English trackers — can never be grabbed by the automatic missing-episode search or by an interactive episode search, even when the pack maps cleanly to the season and its files are correctly named (`Title.S01E01...`).

This accepts a full-season pack during an anime episode search **only when** it maps to the searched season and actually covers the requested episode:

```csharp
if (remoteEpisode.ParsedEpisodeInfo.FullSeason)
{
    if (animeEpisodeSpec.IsSeasonSearch)
    {
        return DownloadSpecDecision.Accept();
    }

    if (remoteEpisode.ParsedEpisodeInfo.SeasonNumber == animeEpisodeSpec.SeasonNumber &&
        remoteEpisode.Episodes.Any(e => e.SeasonNumber == animeEpisodeSpec.SeasonNumber &&
                                        e.EpisodeNumber == animeEpisodeSpec.EpisodeNumber))
    {
        return DownloadSpecDecision.Accept();
    }

    // skip
}
```

Why this is safe / narrow:

- It is **strictly narrower** than the existing season-search behaviour, which already accepts any full-season pack unconditionally (`IsSeasonSearch`). The new path adds the same acceptance for `IsSeasonSearch == false` but gated by a season **and** episode-coverage check.
- It does **not** touch absolute-numbered grabbing: those releases carry episode numbers (`FullSeason == false`) and never enter this branch. Zero change for absolute-only anime.
- Wrong-season and different-season packs are rejected by the season check; packs that don't contain the requested episode are rejected by the episode-coverage check (verified by unit tests).

This implements one concrete subcase of #6495 (Improve Searching For Anime Seasons) and addresses the "breaks known behaviour" concern that closed #7556: episode searching is not disabled and absolute matching is untouched.

#### Issues Fixed or Closed by this PR

Related to #6495

#### Did you read the contributing guidelines before submitting this pull request?

Yes

#### Tests

`AnimeSearchFixture` extended: full-season pack covering the searched episode → accepted; different season → rejected; pack missing the searched episode → rejected; existing season-search and non-full-season cases unchanged.
