### PR TITLE
New: Custom Filters for Wanted Missing and Cutoff Unmet

### DIFF
--- a/frontend/src/Utilities/Fetch/getQueryString.ts
+++ b/frontend/src/Utilities/Fetch/getQueryString.ts
@@ -27,7 +27,11 @@ const getQueryString = (queryParams?: QueryParams) => {
       if (Array.isArray(value)) {
         if (typeof value[0] === 'object') {
           (value as PropertyFilter[]).forEach((filter) => {
-            acc.append(filter.key, String(filter.value));
+            if (Array.isArray(filter.value)) {
+              filter.value.forEach((v) => acc.append(filter.key, String(v)));
+            } else {
+              acc.append(filter.key, String(filter.value));
+            }
           });
         } else {
           value.forEach((item) => {

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmet.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmet.tsx
@@ -27,6 +27,7 @@ import Episode from 'Episode/Episode';
 import { useToggleEpisodesMonitored } from 'Episode/useEpisode';
 import EpisodeFileProvider from 'EpisodeFile/EpisodeFileProvider';
 import { Filter } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import { align, icons, kinds } from 'Helpers/Props';
 import { SortDirection } from 'Helpers/Props/sortDirections';
 import { CheckInputChanged } from 'typings/inputs';
@@ -38,6 +39,8 @@ import {
   unregisterPagePopulator,
 } from 'Utilities/pagePopulator';
 import translate from 'Utilities/String/translate';
+import toWantedSearchCommandBody from 'Wanted/toWantedSearchCommandBody';
+import CutoffUnmetFilterModal from './CutoffUnmetFilterModal';
 import {
   setCutoffUnmetOption,
   setCutoffUnmetOptions,
@@ -67,7 +70,10 @@ function CutoffUnmetContent() {
     page,
     goToPage,
     refetch,
+    filters: activeFilters,
   } = useCutoffUnmet();
+
+  const customFilters = useCustomFiltersList('wanted.cutoffUnmet');
 
   const { columns, pageSize, sortKey, sortDirection, selectedFilterKey } =
     useCutoffUnmetOptions();
@@ -140,16 +146,17 @@ function CutoffUnmetContent() {
 
   const handleSearchAllCutoffUnmetConfirmed = useCallback(() => {
     executeCommand(
-      {
-        name: CommandNames.CutoffUnmetEpisodeSearch,
-      },
+      toWantedSearchCommandBody(
+        CommandNames.CutoffUnmetEpisodeSearch,
+        activeFilters
+      ),
       () => {
         refetch();
       }
     );
 
     setIsConfirmSearchAllModalOpen(false);
-  }, [executeCommand, refetch]);
+  }, [activeFilters, executeCommand, refetch]);
 
   const handleToggleSelectedPress = useCallback(() => {
     toggleEpisodesMonitored({
@@ -252,7 +259,8 @@ function CutoffUnmetContent() {
               alignMenu={align.RIGHT}
               selectedFilterKey={selectedFilterKey}
               filters={FILTERS}
-              customFilters={[]}
+              customFilters={customFilters}
+              filterModalConnectorComponent={CutoffUnmetFilterModal}
               onFilterSelect={handleFilterSelect}
             />
           </PageToolbarSection>

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetFilterModal.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetFilterModal.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback } from 'react';
+import { SetFilter } from 'Components/Filter/Filter';
+import FilterModal, { FilterModalProps } from 'Components/Filter/FilterModal';
+import Episode from 'Episode/Episode';
+import { setCutoffUnmetOption } from './cutoffUnmetOptionsStore';
+import useCutoffUnmet, { FILTER_BUILDER } from './useCutoffUnmet';
+
+type CutoffUnmetFilterModalProps = FilterModalProps<Episode>;
+
+export default function CutoffUnmetFilterModal(
+  props: CutoffUnmetFilterModalProps
+) {
+  const { records } = useCutoffUnmet();
+
+  const dispatchSetFilter = useCallback(({ selectedFilterKey }: SetFilter) => {
+    setCutoffUnmetOption('selectedFilterKey', selectedFilterKey);
+  }, []);
+
+  return (
+    <FilterModal
+      {...props}
+      sectionItems={records}
+      filterBuilderProps={FILTER_BUILDER}
+      customFilterType="wanted.cutoffUnmet"
+      dispatchSetFilter={dispatchSetFilter}
+    />
+  );
+}

--- a/frontend/src/Wanted/CutoffUnmet/useCutoffUnmet.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/useCutoffUnmet.tsx
@@ -1,10 +1,13 @@
 import { keepPreviousData } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import Episode from 'Episode/Episode';
 import { setEpisodeQueryKey } from 'Episode/useEpisode';
-import { Filter } from 'Filters/Filter';
+import { Filter, FilterBuilderProp } from 'Filters/Filter';
+import { useCustomFiltersList } from 'Filters/useCustomFilters';
 import usePage from 'Helpers/Hooks/usePage';
 import usePagedApiQuery from 'Helpers/Hooks/usePagedApiQuery';
+import { filterBuilderValueTypes } from 'Helpers/Props';
+import findSelectedFilters from 'Utilities/Filter/findSelectedFilters';
 import translate from 'Utilities/String/translate';
 import { useCutoffUnmetOptions } from './cutoffUnmetOptionsStore';
 
@@ -33,18 +36,60 @@ export const FILTERS: Filter[] = [
   },
 ];
 
+export const FILTER_BUILDER: FilterBuilderProp<Episode>[] = [
+  {
+    name: 'monitored',
+    label: () => translate('Monitored'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.BOOL,
+  },
+  {
+    name: 'seriesIds',
+    label: () => translate('Series'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.SERIES,
+  },
+  {
+    name: 'qualityProfileIds',
+    label: () => translate('QualityProfile'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.QUALITY_PROFILE,
+  },
+  {
+    name: 'seriesType',
+    label: () => translate('SeriesType'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.SERIES_TYPES,
+  },
+  {
+    name: 'seriesTags',
+    label: () => translate('Tags'),
+    type: 'array',
+    valueType: filterBuilderValueTypes.TAG,
+  },
+  {
+    name: 'quality',
+    label: () => translate('Quality'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.QUALITY,
+  },
+];
+
 const useCutoffUnmet = () => {
   const { page, goToPage } = usePage('cutoffUnmet');
   const { pageSize, selectedFilterKey, sortKey, sortDirection } =
     useCutoffUnmetOptions();
+  const customFilters = useCustomFiltersList('wanted.cutoffUnmet');
+
+  const filters = useMemo(() => {
+    return findSelectedFilters(selectedFilterKey, FILTERS, customFilters);
+  }, [selectedFilterKey, customFilters]);
 
   const { isPlaceholderData, queryKey, ...query } = usePagedApiQuery<Episode>({
     path: '/wanted/cutoff',
     page,
     pageSize,
-    queryParams: {
-      monitored: selectedFilterKey === 'monitored',
-    },
+    filters,
     sortKey,
     sortDirection,
     queryOptions: {
@@ -63,7 +108,12 @@ const useCutoffUnmet = () => {
     goToPage,
     isPlaceholderData,
     page,
+    filters,
   };
 };
 
 export default useCutoffUnmet;
+
+export const useFilters = () => {
+  return FILTERS;
+};

--- a/frontend/src/Wanted/Missing/Missing.tsx
+++ b/frontend/src/Wanted/Missing/Missing.tsx
@@ -33,6 +33,7 @@ import {
   unregisterPagePopulator,
 } from 'Utilities/pagePopulator';
 import translate from 'Utilities/String/translate';
+import toWantedSearchCommandBody from 'Wanted/toWantedSearchCommandBody';
 import MissingFilterModal from './MissingFilterModal';
 import {
   setMissingOption,
@@ -63,6 +64,7 @@ function MissingContent() {
     page,
     goToPage,
     refetch,
+    filters: activeFilters,
   } = useMissing();
 
   const { columns, pageSize, sortKey, sortDirection, selectedFilterKey } =
@@ -138,16 +140,17 @@ function MissingContent() {
 
   const handleSearchAllMissingConfirmed = useCallback(() => {
     executeCommand(
-      {
-        name: CommandNames.MissingEpisodeSearch,
-      },
+      toWantedSearchCommandBody(
+        CommandNames.MissingEpisodeSearch,
+        activeFilters
+      ),
       () => {
         refetch();
       }
     );
 
     setIsConfirmSearchAllModalOpen(false);
-  }, [executeCommand, refetch]);
+  }, [activeFilters, executeCommand, refetch]);
 
   const handleToggleSelectedPress = useCallback(() => {
     toggleEpisodesMonitored({

--- a/frontend/src/Wanted/Missing/useMissing.tsx
+++ b/frontend/src/Wanted/Missing/useMissing.tsx
@@ -51,7 +51,7 @@ export const FILTER_BUILDER: FilterBuilderProp<Episode>[] = [
   {
     name: 'monitored',
     label: () => translate('Monitored'),
-    type: 'exact',
+    type: 'equal',
     valueType: filterBuilderValueTypes.BOOL,
   },
   {
@@ -59,6 +59,30 @@ export const FILTER_BUILDER: FilterBuilderProp<Episode>[] = [
     label: () => translate('IncludeSpecials'),
     type: 'equal',
     valueType: filterBuilderValueTypes.BOOL,
+  },
+  {
+    name: 'seriesIds',
+    label: () => translate('Series'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.SERIES,
+  },
+  {
+    name: 'qualityProfileIds',
+    label: () => translate('QualityProfile'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.QUALITY_PROFILE,
+  },
+  {
+    name: 'seriesType',
+    label: () => translate('SeriesType'),
+    type: 'equal',
+    valueType: filterBuilderValueTypes.SERIES_TYPES,
+  },
+  {
+    name: 'seriesTags',
+    label: () => translate('Tags'),
+    type: 'array',
+    valueType: filterBuilderValueTypes.TAG,
   },
 ];
 
@@ -95,6 +119,7 @@ const useMissing = () => {
     goToPage,
     isPlaceholderData,
     page,
+    filters,
   };
 };
 

--- a/frontend/src/Wanted/toWantedSearchCommandBody.ts
+++ b/frontend/src/Wanted/toWantedSearchCommandBody.ts
@@ -1,0 +1,38 @@
+import { NewCommandBody } from 'Commands/Command';
+import { PropertyFilter } from 'Filters/Filter';
+
+export interface WantedSearchCommandBody extends NewCommandBody {
+  name: string;
+  seriesIds?: number[];
+  qualityProfileIds?: number[];
+  seriesType?: string[];
+  seriesTags?: number[];
+  quality?: number[];
+}
+
+const toWantedSearchCommandBody = (
+  name: string,
+  filters: PropertyFilter[]
+): WantedSearchCommandBody => {
+  const body: WantedSearchCommandBody = { name };
+
+  for (const f of filters) {
+    const value = Array.isArray(f.value) ? f.value : [f.value];
+
+    if (f.key === 'seriesIds') {
+      body.seriesIds = value as number[];
+    } else if (f.key === 'qualityProfileIds') {
+      body.qualityProfileIds = value as number[];
+    } else if (f.key === 'seriesType') {
+      body.seriesType = value as string[];
+    } else if (f.key === 'seriesTags') {
+      body.seriesTags = value as number[];
+    } else if (f.key === 'quality') {
+      body.quality = value as number[];
+    }
+  }
+
+  return body;
+};
+
+export default toWantedSearchCommandBody;

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/EpisodesWhereCutoffUnmetFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/EpisodesWhereCutoffUnmetFixture.cs
@@ -44,6 +44,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
                                               .With(s => s.Monitored = true)
                                               .With(s => s.TitleSlug = "Title3")
                                               .With(s => s.QualityProfileId = profile.Id)
+                                              .With(s => s.Tags = new HashSet<int> { 10, 20 })
                                               .BuildNew();
 
             _unmonitoredSeries = Builder<Series>.CreateNew()
@@ -52,6 +53,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
                                                 .With(s => s.Monitored = false)
                                                 .With(s => s.TitleSlug = "Title2")
                                                 .With(s => s.QualityProfileId = profile.Id)
+                                                .With(s => s.Tags = new HashSet<int> { 30 })
                                                 .BuildNew();
 
             _monitoredSeries.Id = Db.Insert(_monitoredSeries).Id;
@@ -190,6 +192,48 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
 
             spec.Records.Should().HaveCount(2);
             spec.Records.Should().OnlyContain(e => e.Series.Monitored);
+        }
+
+        [Test]
+        public void should_filter_cutoff_unmet_by_series_tags()
+        {
+            GivenMonitoredFilterExpression();
+
+            var result = Subject.EpisodesWhereCutoffUnmet(_pagingSpec, _qualitiesBelowCutoff, false, new HashSet<int> { 10 });
+
+            result.Records.Should().NotBeEmpty();
+            result.Records.Should().OnlyContain(e => e.SeriesId == _monitoredSeries.Id);
+        }
+
+        [Test]
+        public void should_filter_cutoff_unmet_by_quality()
+        {
+            GivenMonitoredFilterExpression();
+
+            var result = Subject.EpisodesWhereCutoffUnmet(_pagingSpec, _qualitiesBelowCutoff, false, null, new List<int> { Quality.SDTV.Id });
+
+            result.Records.Should().NotBeEmpty();
+            result.Records.Should().OnlyContain(e => e.EpisodeFile.Value.Quality.Quality == Quality.SDTV);
+        }
+
+        [Test]
+        public void should_ignore_empty_filter_arrays()
+        {
+            GivenMonitoredFilterExpression();
+
+            var withEmpty = Subject.EpisodesWhereCutoffUnmet(_pagingSpec, _qualitiesBelowCutoff, false, new HashSet<int>(), new List<int>());
+
+            var freshSpec = new PagingSpec<Episode>
+            {
+                Page = 1,
+                PageSize = 10,
+                SortKey = "AirDate",
+                SortDirection = SortDirection.Ascending
+            };
+            freshSpec.FilterExpressions.Add(e => e.Monitored == true && e.Series.Monitored == true);
+            var withNull = Subject.EpisodesWhereCutoffUnmet(freshSpec, _qualitiesBelowCutoff, false, null, null);
+
+            withEmpty.TotalRecords.Should().Be(withNull.TotalRecords);
         }
     }
 }

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/EpisodesWithoutFilesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/EpisodesWithoutFilesFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
@@ -24,6 +25,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
                                         .With(s => s.TvRageId = RandomNumber)
                                         .With(s => s.Runtime = 30)
                                         .With(s => s.Monitored = true)
+                                        .With(s => s.Tags = new HashSet<int> { 10, 20 })
                                         .With(s => s.TitleSlug = "Title3")
                                         .Build();
 
@@ -32,6 +34,7 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
                                         .With(s => s.TvdbId = RandomNumber)
                                         .With(s => s.Runtime = 30)
                                         .With(s => s.Monitored = false)
+                                        .With(s => s.Tags = new HashSet<int> { 30 })
                                         .With(s => s.TitleSlug = "Title2")
                                         .Build();
 
@@ -160,6 +163,48 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
 
             episodes.TotalRecords.Should().Be(4);
             episodes.Records.Where(e => e.Id == onAirEpisode.Id).Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_filter_by_series_tags_when_provided()
+        {
+            GivenMonitoredFilterExpression();
+
+            var episodes = Subject.EpisodesWithoutFiles(_pagingSpec, false, new HashSet<int> { 10 });
+
+            episodes.Records.Should().NotBeEmpty();
+            episodes.Records.Should().OnlyContain(e => e.SeriesId == _monitoredSeries.Id);
+        }
+
+        [Test]
+        public void should_filter_by_series_tags_with_unmonitored_series()
+        {
+            GivenUnmonitoredFilterExpression();
+
+            var episodes = Subject.EpisodesWithoutFiles(_pagingSpec, false, new HashSet<int> { 30 });
+
+            episodes.Records.Should().OnlyContain(e => e.SeriesId == _unmonitoredSeries.Id);
+        }
+
+        [Test]
+        public void should_match_no_series_when_tag_id_unknown()
+        {
+            GivenMonitoredFilterExpression();
+
+            var episodes = Subject.EpisodesWithoutFiles(_pagingSpec, false, new HashSet<int> { 9999 });
+
+            episodes.Records.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_ignore_empty_tag_list()
+        {
+            GivenMonitoredFilterExpression();
+
+            var withFilter = Subject.EpisodesWithoutFiles(_pagingSpec, false, new HashSet<int>());
+            var withNull = Subject.EpisodesWithoutFiles(_pagingSpec, false, null);
+
+            withFilter.TotalRecords.Should().Be(withNull.TotalRecords);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/CutoffUnmetEpisodeSearchCommand.cs
+++ b/src/NzbDrone.Core/IndexerSearch/CutoffUnmetEpisodeSearchCommand.cs
@@ -1,4 +1,6 @@
-﻿using NzbDrone.Core.Messaging.Commands;
+using System.Collections.Generic;
+using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -6,6 +8,11 @@ namespace NzbDrone.Core.IndexerSearch
     {
         public int? SeriesId { get; set; }
         public bool Monitored { get; set; }
+        public List<int> SeriesIds { get; set; } = [];
+        public List<int> QualityProfileIds { get; set; } = [];
+        public List<SeriesTypes> SeriesType { get; set; } = [];
+        public HashSet<int> SeriesTags { get; set; } = [];
+        public List<int> Quality { get; set; } = [];
 
         public override bool SendUpdatesToClient
         {

--- a/src/NzbDrone.Core/IndexerSearch/EpisodeSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/EpisodeSearchService.cs
@@ -151,7 +151,22 @@ namespace NzbDrone.Core.IndexerSearch
                     pagingSpec.FilterExpressions.Add(v => v.Monitored == false || v.Series.Monitored == false);
                 }
 
-                episodes = _episodeService.EpisodesWithoutFiles(pagingSpec, true).Records.ToList();
+                if (message.SeriesIds?.Any() == true)
+                {
+                    pagingSpec.FilterExpressions.Add(e => message.SeriesIds.Contains(e.SeriesId));
+                }
+
+                if (message.QualityProfileIds?.Any() == true)
+                {
+                    pagingSpec.FilterExpressions.Add(e => message.QualityProfileIds.Contains(e.Series.QualityProfileId));
+                }
+
+                if (message.SeriesType?.Any() == true)
+                {
+                    pagingSpec.FilterExpressions.Add(e => message.SeriesType.Contains(e.Series.SeriesType));
+                }
+
+                episodes = _episodeService.EpisodesWithoutFiles(pagingSpec, true, message.SeriesTags).Records.ToList();
             }
 
             var queue = GetQueuedEpisodeIds();
@@ -187,7 +202,22 @@ namespace NzbDrone.Core.IndexerSearch
                 pagingSpec.FilterExpressions.Add(v => v.Monitored == false || v.Series.Monitored == false);
             }
 
-            var episodes = _episodeCutoffService.EpisodesWhereCutoffUnmet(pagingSpec).Records.ToList();
+            if (message.SeriesIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(e => message.SeriesIds.Contains(e.SeriesId));
+            }
+
+            if (message.QualityProfileIds?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(e => message.QualityProfileIds.Contains(e.Series.QualityProfileId));
+            }
+
+            if (message.SeriesType?.Any() == true)
+            {
+                pagingSpec.FilterExpressions.Add(e => message.SeriesType.Contains(e.Series.SeriesType));
+            }
+
+            var episodes = _episodeCutoffService.EpisodesWhereCutoffUnmet(pagingSpec, message.SeriesTags, message.Quality).Records.ToList();
             var queue = GetQueuedEpisodeIds();
             var cutoffUnmet = episodes.Where(e => !queue.Contains(e.Id)).ToList();
 

--- a/src/NzbDrone.Core/IndexerSearch/MissingEpisodeSearchCommand.cs
+++ b/src/NzbDrone.Core/IndexerSearch/MissingEpisodeSearchCommand.cs
@@ -1,4 +1,6 @@
-﻿using NzbDrone.Core.Messaging.Commands;
+using System.Collections.Generic;
+using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -6,6 +8,10 @@ namespace NzbDrone.Core.IndexerSearch
     {
         public int? SeriesId { get; set; }
         public bool Monitored { get; set; }
+        public List<int> SeriesIds { get; set; } = [];
+        public List<int> QualityProfileIds { get; set; } = [];
+        public List<SeriesTypes> SeriesType { get; set; } = [];
+        public HashSet<int> SeriesTags { get; set; } = [];
 
         public override bool SendUpdatesToClient => true;
 

--- a/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeCutoffService.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Core.Tv
 {
     public interface IEpisodeCutoffService
     {
-        PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec);
+        PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, HashSet<int> seriesTags = null, List<int> quality = null);
     }
 
     public class EpisodeCutoffService : IEpisodeCutoffService
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Tv
             _qualityProfileService = qualityProfileService;
         }
 
-        public PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec)
+        public PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, HashSet<int> seriesTags = null, List<int> quality = null)
         {
             var qualitiesBelowCutoff = new List<QualitiesBelowCutoff>();
             var profiles = _qualityProfileService.All();
@@ -48,7 +48,7 @@ namespace NzbDrone.Core.Tv
                 return pagingSpec;
             }
 
-            return _episodeRepository.EpisodesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff, false);
+            return _episodeRepository.EpisodesWhereCutoffUnmet(pagingSpec, qualitiesBelowCutoff, false, seriesTags, quality);
         }
     }
 }

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.Tv
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> GetEpisodeByFileId(int fileId);
         List<Episode> EpisodesWithFiles(int seriesId);
-        PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials);
-        PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, bool includeSpecials);
+        PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials, HashSet<int> seriesTags = null);
+        PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, bool includeSpecials, HashSet<int> seriesTags = null, List<int> quality = null);
         List<Episode> FindEpisodesBySceneNumbering(int seriesId, int seasonNumber, int episodeNumber);
         List<Episode> FindEpisodesBySceneNumbering(int seriesId, int sceneAbsoluteEpisodeNumber);
         List<Episode> EpisodesBetweenDates(DateTime startDate, DateTime endDate, bool includeUnmonitored, bool includeSpecials);
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Tv
                 }).ToList();
         }
 
-        public PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials)
+        public PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials, HashSet<int> seriesTags = null)
         {
             var currentTime = DateTime.UtcNow;
             var startingSeasonNumber = 1;
@@ -117,13 +117,13 @@ namespace NzbDrone.Core.Tv
                 startingSeasonNumber = 0;
             }
 
-            pagingSpec.Records = GetPagedRecords(EpisodesWithoutFilesBuilder(currentTime, startingSeasonNumber), pagingSpec, PagedQuery);
-            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWithoutFilesBuilder(currentTime, startingSeasonNumber).SelectCountDistinct<Episode>(x => x.Id), pagingSpec);
+            pagingSpec.Records = GetPagedRecords(EpisodesWithoutFilesBuilder(currentTime, startingSeasonNumber, seriesTags), pagingSpec, PagedQuery);
+            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWithoutFilesBuilder(currentTime, startingSeasonNumber, seriesTags).SelectCountDistinct<Episode>(x => x.Id), pagingSpec);
 
             return pagingSpec;
         }
 
-        public PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, bool includeSpecials)
+        public PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, bool includeSpecials, HashSet<int> seriesTags = null, List<int> quality = null)
         {
             var startingSeasonNumber = 1;
 
@@ -132,10 +132,10 @@ namespace NzbDrone.Core.Tv
                 startingSeasonNumber = 0;
             }
 
-            pagingSpec.Records = GetPagedRecords(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber), pagingSpec, PagedQuery);
+            pagingSpec.Records = GetPagedRecords(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality), pagingSpec, PagedQuery);
 
             var countTemplate = $"SELECT COUNT(*) FROM (SELECT /**select**/ FROM \"{TableMapping.Mapper.TableNameMapping(typeof(Episode))}\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/) AS \"Inner\"";
-            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber).Select(typeof(Episode)), pagingSpec, countTemplate);
+            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality).Select(typeof(Episode)), pagingSpec, countTemplate);
 
             return pagingSpec;
         }
@@ -211,11 +211,21 @@ namespace NzbDrone.Core.Tv
             ModelUpdated(episode, true);
         }
 
-        private SqlBuilder EpisodesWithoutFilesBuilder(DateTime currentTime, int startingSeasonNumber) => Builder()
-            .Join<Episode, Series>((l, r) => l.SeriesId == r.Id)
-            .Where<Episode>(f => f.EpisodeFileId == 0)
-            .Where<Episode>(f => f.SeasonNumber >= startingSeasonNumber)
-            .Where(BuildAirDateUtcCutoffWhereClause(currentTime));
+        private SqlBuilder EpisodesWithoutFilesBuilder(DateTime currentTime, int startingSeasonNumber, HashSet<int> seriesTags)
+        {
+            var builder = Builder()
+                .Join<Episode, Series>((l, r) => l.SeriesId == r.Id)
+                .Where<Episode>(f => f.EpisodeFileId == 0)
+                .Where<Episode>(f => f.SeasonNumber >= startingSeasonNumber)
+                .Where(BuildAirDateUtcCutoffWhereClause(currentTime));
+
+            if (seriesTags is { Count: > 0 })
+            {
+                builder = builder.Where(BuildSeriesTagsWhereClause(seriesTags));
+            }
+
+            return builder;
+        }
 
         private string BuildAirDateUtcCutoffWhereClause(DateTime currentTime)
         {
@@ -229,16 +239,31 @@ namespace NzbDrone.Core.Tv
                                  currentTime.ToString("yyyy-MM-dd HH:mm:ss"));
         }
 
-        private SqlBuilder EpisodesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff, int startingSeasonNumber) => Builder()
-            .Join<Episode, Series>((e, s) => e.SeriesId == s.Id)
-            .LeftJoin<Episode, EpisodeFile>((e, ef) => e.EpisodeFileId == ef.Id)
-            .Where<Episode>(e => e.EpisodeFileId != 0)
-            .Where<Episode>(e => e.SeasonNumber >= startingSeasonNumber)
-            .Where(
-                string.Format("({0})",
-                    BuildQualityCutoffWhereClause(qualitiesBelowCutoff)))
-            .GroupBy<Episode>(e => e.Id)
-            .GroupBy<Series>(s => s.Id);
+        private SqlBuilder EpisodesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff, int startingSeasonNumber, HashSet<int> seriesTags, List<int> qualities)
+        {
+            var builder = Builder()
+                .Join<Episode, Series>((e, s) => e.SeriesId == s.Id)
+                .LeftJoin<Episode, EpisodeFile>((e, ef) => e.EpisodeFileId == ef.Id)
+                .Where<Episode>(e => e.EpisodeFileId != 0)
+                .Where<Episode>(e => e.SeasonNumber >= startingSeasonNumber)
+                .Where(
+                    string.Format("({0})",
+                        BuildQualityCutoffWhereClause(qualitiesBelowCutoff)));
+
+            if (seriesTags is { Count: > 0 })
+            {
+                builder = builder.Where(BuildSeriesTagsWhereClause(seriesTags));
+            }
+
+            if (qualities is { Count: > 0 })
+            {
+                builder = builder.Where(BuildQualityFilterWhereClause(qualities));
+            }
+
+            return builder
+                .GroupBy<Episode>(e => e.Id)
+                .GroupBy<Series>(s => s.Id);
+        }
 
         private string BuildQualityCutoffWhereClause(List<QualitiesBelowCutoff> qualitiesBelowCutoff)
         {
@@ -251,6 +276,31 @@ namespace NzbDrone.Core.Tv
                     clauses.Add(string.Format("(\"Series\".\"QualityProfileId\" = {0} AND \"EpisodeFiles\".\"Quality\" LIKE '%_quality_: {1},%')", profile.ProfileId, belowCutoff));
                 }
             }
+
+            return string.Format("({0})", string.Join(" OR ", clauses));
+        }
+
+        private string BuildSeriesTagsWhereClause(HashSet<int> tagIds)
+        {
+            var ids = string.Join(",", tagIds);
+
+            if (_database.DatabaseType == DatabaseType.PostgreSQL)
+            {
+                return string.Format(
+                    "EXISTS (SELECT 1 FROM jsonb_array_elements_text(\"Series\".\"Tags\"::jsonb) AS elem WHERE elem::int IN ({0}))",
+                    ids);
+            }
+
+            return string.Format(
+                "EXISTS (SELECT 1 FROM json_each(\"Series\".\"Tags\") WHERE json_each.value IN ({0}))",
+                ids);
+        }
+
+        private string BuildQualityFilterWhereClause(List<int> qualityIds)
+        {
+            var clauses = qualityIds
+                .Select(id => string.Format("\"EpisodeFiles\".\"Quality\" LIKE '%_quality_: {0},%'", id))
+                .ToList();
 
             return string.Format("({0})", string.Join(" OR ", clauses));
         }

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Tv
         List<Episode> GetEpisodesBySeason(int seriesId, int seasonNumber);
         List<Episode> GetEpisodesBySceneSeason(int seriesId, int sceneSeasonNumber);
         List<Episode> EpisodesWithFiles(int seriesId);
-        PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials);
+        PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials, HashSet<int> seriesTags = null);
         List<Episode> GetEpisodesByFileId(int episodeFileId);
         void UpdateEpisode(Episode episode);
         void SetEpisodeMonitored(int episodeId, bool monitored);
@@ -158,9 +158,9 @@ namespace NzbDrone.Core.Tv
             return _episodeRepository.EpisodesWithFiles(seriesId);
         }
 
-        public PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials)
+        public PagingSpec<Episode> EpisodesWithoutFiles(PagingSpec<Episode> pagingSpec, bool includeSpecials, HashSet<int> seriesTags = null)
         {
-            return _episodeRepository.EpisodesWithoutFiles(pagingSpec, includeSpecials);
+            return _episodeRepository.EpisodesWithoutFiles(pagingSpec, includeSpecials, seriesTags);
         }
 
         public List<Episode> GetEpisodesByFileId(int episodeFileId)

--- a/src/Sonarr.Api.V3/Wanted/CutoffController.cs
+++ b/src/Sonarr.Api.V3/Wanted/CutoffController.cs
@@ -52,7 +52,7 @@ namespace Sonarr.Api.V3.Wanted
                 pagingSpec.FilterExpressions.Add(v => v.Monitored == false || v.Series.Monitored == false);
             }
 
-            var resource = pagingSpec.ApplyToPage(_episodeCutoffService.EpisodesWhereCutoffUnmet, v => MapToResource(v, includeSeries, includeEpisodeFile, includeImages));
+            var resource = pagingSpec.ApplyToPage(spec => _episodeCutoffService.EpisodesWhereCutoffUnmet(spec), v => MapToResource(v, includeSeries, includeEpisodeFile, includeImages));
 
             return resource;
         }

--- a/src/Sonarr.Api.V5/Wanted/CutoffController.cs
+++ b/src/Sonarr.Api.V5/Wanted/CutoffController.cs
@@ -30,7 +30,15 @@ public class CutoffController : EpisodeControllerWithSignalR
 
     [HttpGet]
     [Produces("application/json")]
-    public Ok<PagingResource<EpisodeResource>> GetCutoffUnmetEpisodes([FromQuery] PagingRequestResource paging, bool monitored = true, [FromQuery] CutoffSubresource[]? includeSubresources = null)
+    public Ok<PagingResource<EpisodeResource>> GetCutoffUnmetEpisodes(
+        [FromQuery] PagingRequestResource paging,
+        [FromQuery] bool monitored = true,
+        [FromQuery] List<int>? seriesIds = null,
+        [FromQuery] List<int>? qualityProfileIds = null,
+        [FromQuery] List<SeriesTypes>? seriesType = null,
+        [FromQuery] HashSet<int>? seriesTags = null,
+        [FromQuery] List<int>? quality = null,
+        [FromQuery] CutoffSubresource[]? includeSubresources = null)
     {
         var pagingResource = new PagingResource<EpisodeResource>(paging);
         var pagingSpec = pagingResource.MapToPagingSpec<EpisodeResource, Episode>(
@@ -52,11 +60,26 @@ public class CutoffController : EpisodeControllerWithSignalR
             pagingSpec.FilterExpressions.Add(v => v.Monitored == false || v.Series.Monitored == false);
         }
 
+        if (seriesIds?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => seriesIds.Contains(e.SeriesId));
+        }
+
+        if (qualityProfileIds?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => qualityProfileIds.Contains(e.Series.QualityProfileId));
+        }
+
+        if (seriesType?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => seriesType.Contains(e.Series.SeriesType));
+        }
+
         var includeSeries = includeSubresources.Contains(CutoffSubresource.Series);
         var includeEpisodeFile = includeSubresources.Contains(CutoffSubresource.EpisodeFile);
         var includeImages = includeSubresources.Contains(CutoffSubresource.Images);
 
-        var resource = pagingSpec.ApplyToPage(_episodeCutoffService.EpisodesWhereCutoffUnmet, v => MapToResource(v, includeSeries, includeEpisodeFile, includeImages));
+        var resource = pagingSpec.ApplyToPage(spec => _episodeCutoffService.EpisodesWhereCutoffUnmet(spec, seriesTags, quality), v => MapToResource(v, includeSeries, includeEpisodeFile, includeImages));
 
         return TypedResults.Ok(resource);
     }

--- a/src/Sonarr.Api.V5/Wanted/MissingController.cs
+++ b/src/Sonarr.Api.V5/Wanted/MissingController.cs
@@ -26,7 +26,15 @@ public class MissingController : EpisodeControllerWithSignalR
 
     [HttpGet]
     [Produces("application/json")]
-    public Ok<PagingResource<EpisodeResource>> GetMissingEpisodes([FromQuery] PagingRequestResource paging, bool monitored = true, bool includeSpecials = true, [FromQuery] MissingSubresource[]? includeSubresources = null)
+    public Ok<PagingResource<EpisodeResource>> GetMissingEpisodes(
+        [FromQuery] PagingRequestResource paging,
+        [FromQuery] bool monitored = true,
+        [FromQuery] bool includeSpecials = true,
+        [FromQuery] List<int>? seriesIds = null,
+        [FromQuery] List<int>? qualityProfileIds = null,
+        [FromQuery] List<SeriesTypes>? seriesType = null,
+        [FromQuery] HashSet<int>? seriesTags = null,
+        [FromQuery] MissingSubresource[]? includeSubresources = null)
     {
         var pagingResource = new PagingResource<EpisodeResource>(paging);
         var pagingSpec = pagingResource.MapToPagingSpec<EpisodeResource, Episode>(
@@ -48,10 +56,25 @@ public class MissingController : EpisodeControllerWithSignalR
             pagingSpec.FilterExpressions.Add(v => v.Monitored == false || v.Series.Monitored == false);
         }
 
+        if (seriesIds?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => seriesIds.Contains(e.SeriesId));
+        }
+
+        if (qualityProfileIds?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => qualityProfileIds.Contains(e.Series.QualityProfileId));
+        }
+
+        if (seriesType?.Any() == true)
+        {
+            pagingSpec.FilterExpressions.Add(e => seriesType.Contains(e.Series.SeriesType));
+        }
+
         var includeSeries = includeSubresources.Contains(MissingSubresource.Series);
         var includeImages = includeSubresources.Contains(MissingSubresource.Images);
 
-        var resource = pagingSpec.ApplyToPage(spec => _episodeService.EpisodesWithoutFiles(spec, includeSpecials), v => MapToResource(v, includeSeries, false, includeImages));
+        var resource = pagingSpec.ApplyToPage(spec => _episodeService.EpisodesWithoutFiles(spec, includeSpecials, seriesTags), v => MapToResource(v, includeSeries, false, includeImages));
 
         return TypedResults.Ok(resource);
     }


### PR DESCRIPTION
#### Description

Adds Custom Filters for Wanted Missing and Cutoff Unmet. Searching for episodes when a custom filter is applied will limit searches to those displayed same as built-in filters.

Also fixes the value sent to the API for arrays of items (such as multiple quality profile IDs).

#### Screenshots for UI Changes
<img width="1083" height="424" alt="image" src="https://github.com/user-attachments/assets/c571fff4-3f4b-4408-a7f7-bb8a58b7c455" />


#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes 3657
