### PR TITLE
Fix formatting and indentation in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,8 +7,8 @@ body:
     label: Is there an existing issue for this?
     description: Please search to see if an open or closed issue already exists for the bug you encountered. If a bug exists and it is closed as complete it may not yet be in a stable release.
     options:
-    - label: I have searched the existing open and closed issues
-      required: true
+      - label: I have searched the existing open and closed issues
+        required: true
 - type: textarea
   attributes:
     label: Current Behavior
@@ -44,12 +44,12 @@ body:
         - **Browser**: Firefox 90 (If UI related)
         - **Database**: Sqlite 3.41.2
     value: |
-        - OS: 
-        - Sonarr: 
-        - Docker Install: 
-        - Using Reverse Proxy: 
-        - Browser: 
-        - Database: 
+      - OS: 
+      - Sonarr: 
+      - Docker Install: 
+      - Using Reverse Proxy: 
+      - Browser: 
+      - Database: 
     render: markdown
   validations:
     required: true
@@ -67,8 +67,8 @@ body:
     label: Trace Logs?
     description: |
       Trace Logs (https://wiki.servarr.com/sonarr/troubleshooting#logging-and-log-files) 
-      ***Generally speaking, all bug reports must have trace logs provided.***
-      *** Info Logs are not trace logs. If the logs do not say trace and are not from a file like `*.trace.*.txt` they are not trace logs.***
+      **Generally speaking, all bug reports must have trace logs provided.**
+      **Info Logs are not trace logs. If the logs do not say trace and are not from a file like `*.trace.*.txt` they are not trace logs.**
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Normalize indentation/formatting in the bug report GitHub issue template to ensure consistent parsing and readability.

#### Description

A few sentences describing the overall goals of the pull request's commits.

#### Screenshots for UI Changes

<!-- Remove if there are no screenshots -->

#### Database Migration

YES - ###

<!-- Remove if there is no database migration. If there is an database migration replace ### with the migration number -->

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [ ] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [ ] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #
