### PR TITLE
Debounce quality profile score changes

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.tsx
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 import Alert from 'Components/Alert';
 import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
@@ -446,7 +447,7 @@ function EditQualityProfileModalContent({
     setMode(newMode);
   }, []);
 
-  const handleFormatItemScoreChange = useCallback(
+  const handleFormatItemScoreChange = useDebouncedCallback(
     (formatId: number, score: number) => {
       const newFormatItems = formatItems.value.map((formatItem) => {
         if (formatItem.format === formatId) {
@@ -461,7 +462,7 @@ function EditQualityProfileModalContent({
 
       updateValue('formatItems', newFormatItems);
     },
-    [formatItems, updateValue]
+    1000
   );
 
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "reselect": "4.1.8",
     "stacktrace-js": "2.0.2",
     "typescript": "5.7.2",
-    "use-debounce": "10.0.4",
+    "use-debounce": "10.1.1",
     "zustand": "5.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6794,10 +6794,10 @@ use-callback-ref@^1.3.0:
   dependencies:
     tslib "^2.0.0"
 
-use-debounce@10.0.4:
-  version "10.0.4"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-10.0.4.tgz#2135be498ad855416c4495cfd8e0e130bd33bb24"
-  integrity sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==
+use-debounce@10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-10.1.1.tgz#b08b596b60a55fd4c18b44b37fdc02f058baf30a"
+  integrity sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==
 
 use-sidecar@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
#### Description

Adding a 1 second debounce for score changes in quality profiles, as it's currently in v4.

https://github.com/Sonarr/Sonarr/blob/80ca1a6ac29f46bc3bfbe35201bad9851cfd566b/frontend/src/Settings/Profiles/Quality/QualityProfileFormatItems.js#L53

And bumping `use-debounce` to current latest as there seems to be some good fixes since firstly added.
https://github.com/xnimorz/use-debounce/blob/master/CHANGELOG.md

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review


