### PR TITLE
Fixed: Exclude streaming extentions for probing media info

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/UpdateMediaInfoServiceFixture.cs
@@ -294,10 +294,12 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo
                 .Verify(v => v.Update(episodeFile), Times.Never());
         }
 
-        [Test]
-        public void should_not_update_media_info_if_file_does_not_support_media_info()
+        [TestCase(".iso")]
+        [TestCase(".m3u")]
+        [TestCase(".strm")]
+        public void should_not_update_media_info_if_file_does_not_support_media_info(string extension)
         {
-            var path = Path.Combine(_series.Path, "media.iso");
+            var path = Path.Combine(_series.Path, "media" + extension);
 
             var episodeFile = Builder<EpisodeFile>.CreateNew()
                 .With(v => v.Path = path)

--- a/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
@@ -6,81 +6,74 @@ namespace NzbDrone.Core.MediaFiles
 {
     public static class MediaFileExtensions
     {
-        private static Dictionary<string, Quality> _fileExtensions;
-
-        static MediaFileExtensions()
+        private static readonly Dictionary<string, Quality> FileExtensions = new(StringComparer.OrdinalIgnoreCase)
         {
-            _fileExtensions = new Dictionary<string, Quality>(StringComparer.OrdinalIgnoreCase)
-            {
-                // Unknown
-                { ".webm", Quality.Unknown },
+            // Unknown
+            { ".webm", Quality.Unknown },
 
-                // SDTV
-                { ".m4v", Quality.SDTV },
-                { ".3gp", Quality.SDTV },
-                { ".nsv", Quality.SDTV },
-                { ".ty", Quality.SDTV },
-                { ".strm", Quality.SDTV },
-                { ".rm", Quality.SDTV },
-                { ".rmvb", Quality.SDTV },
-                { ".m3u", Quality.SDTV },
-                { ".ifo", Quality.SDTV },
-                { ".mov", Quality.SDTV },
-                { ".qt", Quality.SDTV },
-                { ".divx", Quality.SDTV },
-                { ".xvid", Quality.SDTV },
-                { ".bivx", Quality.SDTV },
-                { ".nrg", Quality.SDTV },
-                { ".pva", Quality.SDTV },
-                { ".wmv", Quality.SDTV },
-                { ".asf", Quality.SDTV },
-                { ".asx", Quality.SDTV },
-                { ".ogm", Quality.SDTV },
-                { ".ogv", Quality.SDTV },
-                { ".m2v", Quality.SDTV },
-                { ".avi", Quality.SDTV },
-                { ".bin", Quality.SDTV },
-                { ".dat", Quality.SDTV },
-                { ".dvr-ms", Quality.SDTV },
-                { ".mpg", Quality.SDTV },
-                { ".mpeg", Quality.SDTV },
-                { ".mp4", Quality.SDTV },
-                { ".avc", Quality.SDTV },
-                { ".vp3", Quality.SDTV },
-                { ".svq3", Quality.SDTV },
-                { ".nuv", Quality.SDTV },
-                { ".viv", Quality.SDTV },
-                { ".dv", Quality.SDTV },
-                { ".fli", Quality.SDTV },
-                { ".flv", Quality.SDTV },
-                { ".wpl", Quality.SDTV },
+            // SDTV
+            { ".m4v", Quality.SDTV },
+            { ".3gp", Quality.SDTV },
+            { ".nsv", Quality.SDTV },
+            { ".ty", Quality.SDTV },
+            { ".strm", Quality.SDTV },
+            { ".rm", Quality.SDTV },
+            { ".rmvb", Quality.SDTV },
+            { ".m3u", Quality.SDTV },
+            { ".ifo", Quality.SDTV },
+            { ".mov", Quality.SDTV },
+            { ".qt", Quality.SDTV },
+            { ".divx", Quality.SDTV },
+            { ".xvid", Quality.SDTV },
+            { ".bivx", Quality.SDTV },
+            { ".nrg", Quality.SDTV },
+            { ".pva", Quality.SDTV },
+            { ".wmv", Quality.SDTV },
+            { ".asf", Quality.SDTV },
+            { ".asx", Quality.SDTV },
+            { ".ogm", Quality.SDTV },
+            { ".ogv", Quality.SDTV },
+            { ".m2v", Quality.SDTV },
+            { ".avi", Quality.SDTV },
+            { ".bin", Quality.SDTV },
+            { ".dat", Quality.SDTV },
+            { ".dvr-ms", Quality.SDTV },
+            { ".mpg", Quality.SDTV },
+            { ".mpeg", Quality.SDTV },
+            { ".mp4", Quality.SDTV },
+            { ".avc", Quality.SDTV },
+            { ".vp3", Quality.SDTV },
+            { ".svq3", Quality.SDTV },
+            { ".nuv", Quality.SDTV },
+            { ".viv", Quality.SDTV },
+            { ".dv", Quality.SDTV },
+            { ".fli", Quality.SDTV },
+            { ".flv", Quality.SDTV },
+            { ".wpl", Quality.SDTV },
 
-                // DVD
-                { ".img", Quality.DVD },
-                { ".iso", Quality.DVD },
-                { ".vob", Quality.DVD },
+            // DVD
+            { ".img", Quality.DVD },
+            { ".iso", Quality.DVD },
+            { ".vob", Quality.DVD },
 
-                // HD
-                { ".mkv", Quality.HDTV720p },
-                { ".ts", Quality.HDTV720p },
-                { ".wtv", Quality.HDTV720p },
+            // HD
+            { ".mkv", Quality.HDTV720p },
+            { ".ts", Quality.HDTV720p },
+            { ".wtv", Quality.HDTV720p },
 
-                // Bluray
-                { ".m2ts", Quality.Bluray720p }
-            };
-        }
+            // Bluray
+            { ".m2ts", Quality.Bluray720p },
+        };
 
-        public static HashSet<string> Extensions => new HashSet<string>(_fileExtensions.Keys, StringComparer.OrdinalIgnoreCase);
-        public static HashSet<string> DiskExtensions => new HashSet<string>(new[] { ".img", ".iso", ".vob" }, StringComparer.OrdinalIgnoreCase);
+        public static HashSet<string> Extensions => new(FileExtensions.Keys, StringComparer.OrdinalIgnoreCase);
+
+        public static HashSet<string> DiskExtensions => new([".img", ".iso", ".vob"], StringComparer.OrdinalIgnoreCase);
+
+        public static HashSet<string> StreamingExtensions => new([".m3u", ".strm"], StringComparer.OrdinalIgnoreCase);
 
         public static Quality GetQualityForExtension(string extension)
         {
-            if (_fileExtensions.ContainsKey(extension))
-            {
-                return _fileExtensions[extension];
-            }
-
-            return Quality.Unknown;
+            return FileExtensions.TryGetValue(extension, out var quality) ? quality : Quality.Unknown;
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -45,7 +45,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 throw new FileNotFoundException("Media file does not exist: " + filename);
             }
 
-            if (MediaFileExtensions.DiskExtensions.Contains(Path.GetExtension(filename)))
+            if (MediaFileExtensions.DiskExtensions
+                .Concat(MediaFileExtensions.StreamingExtensions)
+                .Contains(Path.GetExtension(filename)))
             {
                 return null;
             }


### PR DESCRIPTION
#### Description
Ignoring non-media files from being probed by ffprobe leading to a fail on execution.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #8727
