### PR TITLE
Fixed: Kodi Metadata Files Issues

### DIFF
--- a/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatterTests/FormatAudioCodecFixture.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Extras.Metadata.Consumers.Xbmc;
+using NzbDrone.Core.MediaFiles.MediaInfo;
+using NzbDrone.Test.Common;
+
+namespace NzbDrone.Core.Test.Extras.Metadata.Consumers.Xbmc.XbmcMetadataFormatterTests
+{
+    [TestFixture]
+    public class FormatAudioCodecFixture : TestBase
+    {
+        [TestCase(new[] { "dts", "DTS-HD MA" }, "dtshd_ma")]
+        [TestCase(new[] { "dts", "DTS" }, "dts")]
+        [TestCase(new[] { "truehd", "Dolby TrueHD + Dolby Atmos" }, "truehd_atmos")]
+        [TestCase(new[] { "truehd", "" }, "truehd")]
+        [TestCase(new[] { "eac3", "Dolby Digital Plus + Dolby Atmos" }, "eac3_ddp_atmos")]
+        [TestCase(new[] { "eac3", "" }, "eac3")]
+        [TestCase(new[] { "aac", "" }, "aac")]
+        [TestCase(new[] { "aac", "HE-AAC" }, "he_aac")]
+        public void should_format_audio_format(string[] audioFormat, string expectedFormat)
+        {
+            var mediaInfo = new MediaInfoAudioStreamModel
+            {
+                Format = audioFormat[0],
+                Profile = audioFormat[1]
+            };
+
+            XbmcMetadataFormatter.FormatAudioCodec(mediaInfo).Should().Be(expectedFormat);
+        }
+
+        [Test]
+        public void should_return_audio_format_by_default()
+        {
+            var mediaInfo = new MediaInfoAudioStreamModel
+            {
+                Format = "Other Audio Format",
+            };
+
+            XbmcMetadataFormatter.FormatAudioCodec(mediaInfo).Should().Be(mediaInfo.Format);
+        }
+
+        [Test]
+        public void should_return_empty_if_audio_stream_is_null()
+        {
+            XbmcMetadataFormatter.FormatAudioCodec(null).Should().Be(string.Empty);
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase(new[] { "mp3", "", "" }, "climbing.mp4", "MP3")]
         [TestCase(new[] { "dts", "", "DTS-HD MA" }, "DTS-HD.MA", "DTS-HD MA")]
         [TestCase(new[] { "dts", "", "DTS:X" }, "DTS-X", "DTS-X")]
+        [TestCase(new[] { "dts", "", "DTS-HD MA + DTS:X" }, "DTS-X", "DTS-X")]
         [TestCase(new[] { "dts", "", "DTS-HD MA + DTS:X IMAX" }, "DTS-X", "DTS-X")]
         [TestCase(new[] { "dts", "", "DTS-HD MA" }, "DTS-HD.MA", "DTS-HD MA")]
         [TestCase(new[] { "dts", "", "DTS-ES" }, "DTS-ES", "DTS-ES")]

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -354,8 +354,8 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     var video = new XElement("video");
                     video.Add(new XElement("aspect", (float)episodeFile.MediaInfo.Width / (float)episodeFile.MediaInfo.Height));
                     video.Add(new XElement("bitrate", episodeFile.MediaInfo.VideoBitrate));
-                    video.Add(new XElement("codec", MediaInfoFormatter.FormatVideoCodec(episodeFile.MediaInfo, sceneName)));
-                    video.Add(new XElement("framerate", episodeFile.MediaInfo.VideoFps));
+                    video.Add(new XElement("codec", episodeFile.MediaInfo.VideoFormat));
+                    video.Add(new XElement("framerate", episodeFile.MediaInfo.VideoFps.ToString("0.###")));
                     video.Add(new XElement("height", episodeFile.MediaInfo.Height));
                     video.Add(new XElement("scantype", episodeFile.MediaInfo.ScanType));
                     video.Add(new XElement("width", episodeFile.MediaInfo.Width));
@@ -389,7 +389,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                             var audio = new XElement("audio");
                             audio.Add(new XElement("bitrate", audioStream.Bitrate));
                             audio.Add(new XElement("channels", audioStream.Channels));
-                            audio.Add(new XElement("codec", MediaInfoFormatter.FormatAudioCodec(audioStream, sceneName)));
+                            audio.Add(new XElement("codec", XbmcMetadataFormatter.FormatAudioCodec(audioStream)));
                             audio.Add(new XElement("language", audioStream.Language));
                             streamDetails.Add(audio);
                         }

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataFormatter.cs
@@ -1,0 +1,54 @@
+using NzbDrone.Core.MediaFiles.MediaInfo;
+
+namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
+{
+    public static class XbmcMetadataFormatter
+    {
+        public static string FormatAudioCodec(MediaInfoAudioStreamModel audioStream)
+        {
+            if (audioStream?.Format == null)
+            {
+                return string.Empty;
+            }
+
+            var audioFormat = audioStream.Format;
+            var audioProfile = audioStream.Profile ?? string.Empty;
+
+            // profile name definitions here https://github.com/FFmpeg/FFmpeg/blob/n8.1.2/libavcodec/profiles.c
+            return audioFormat switch
+            {
+                // Missing Kodi dedicated codes for "DTS-ES" "DTS Express" "DTS 96/24"
+                "dts" => audioProfile switch
+                {
+                    "DTS-HD HRA" => "dtshd_hra",
+                    "DTS-HD MA" => "dtshd_ma",
+                    "DTS-HD MA + DTS:X" => "dtshd_ma_x",
+                    "DTS-HD MA + DTS:X IMAX" => "dtshd_ma_x_imax",
+                    _ => audioFormat,
+                },
+                "truehd" => audioProfile switch
+                {
+                    "Dolby TrueHD + Dolby Atmos" => "truehd_atmos",
+                    _ => audioFormat
+                },
+                "eac3" => audioProfile switch
+                {
+                    "Dolby Digital Plus + Dolby Atmos" => "eac3_ddp_atmos",
+                    _ => audioFormat
+                },
+
+                // Missing Kodi dedicated codes for "LD", "ELD", "Main", "xHE-AAC"
+                "aac" => audioProfile switch
+                {
+                    "LC" => "aac_lc",
+                    "HE-AAC" => "he_aac",
+                    "HE-AACv2" => "he_aac_v2",
+                    "SSR" => "aac_ssr",
+                    "LTP" => "aac_ltp",
+                    _ => audioFormat,
+                },
+                _ => audioFormat
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             {
                 return audioProfile switch
                 {
-                    "DTS:X" or "DTS-HD MA + DTS:X IMAX" => "DTS-X",
+                    "DTS:X" or "DTS-HD MA + DTS:X" or "DTS-HD MA + DTS:X IMAX" => "DTS-X",
                     "DTS-HD MA" => "DTS-HD MA",
                     "DTS-ES" => "DTS-ES",
                     "DTS-HD HRA" => "DTS-HD HRA",


### PR DESCRIPTION
#### Description

Port of Radarr https://github.com/Radarr/Radarr/pull/11520 (more information and discussion there)
Original issue brought up in https://github.com/Radarr/Radarr/issues/11516

Fix a few issues in the `<streamdetails>` section of the generated Kodi .nfo files:
- `<codec>` is supposed to be the ffmpeg codec name or Kodi specific codes when profiles are involved
- `<framerate>` had an excessive number of decimals. Reduced to 3.

Differences with the Radarr PR:
- ffprobe 8.1.2 recognizes natively the hd formats with objects (Atmos and DTS:X) so standard profile names of ffmpeg are used instead of the custom workaround patches on top of ffprobe 5.1.4
- no fix needed to address audio language duplication since a previous change lists multiple audio streams correctly.

#### Database Migration

NO - ###

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [X] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [X] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR
