### PR TITLE
Fixed: Slow series monitoring changes on series with many episodes

### DIFF
--- a/frontend/src/Series/Details/EpisodeRow.tsx
+++ b/frontend/src/Series/Details/EpisodeRow.tsx
@@ -322,6 +322,4 @@ function EpisodeRow({
   );
 }
 
-// Memoized so that updating one episode's monitored state (which preserves the
-// object identity of unchanged episodes in the cache) doesn't re-render every row.
-export default React.memo(EpisodeRow);
+export default EpisodeRow;

--- a/frontend/src/Series/Details/EpisodeRow.tsx
+++ b/frontend/src/Series/Details/EpisodeRow.tsx
@@ -322,4 +322,6 @@ function EpisodeRow({
   );
 }
 
-export default EpisodeRow;
+// Memoized so that updating one episode's monitored state (which preserves the
+// object identity of unchanged episodes in the cache) doesn't re-render every row.
+export default React.memo(EpisodeRow);

--- a/frontend/src/Series/useSeries.ts
+++ b/frontend/src/Series/useSeries.ts
@@ -918,7 +918,13 @@ export const useUpdateSeriesMonitor = (
     mutationOptions: {
       onSuccess: (_, variables) => {
         if (shouldFetchEpisodesAfterUpdate) {
-          queryClient.invalidateQueries({ queryKey: ['/episode'] });
+          // Only refetch episodes for the series that actually changed, instead of
+          // invalidating every cached `/episode` query in the app.
+          variables.series.forEach((s) => {
+            queryClient.invalidateQueries({
+              queryKey: ['/episode', { seriesId: s.id }],
+            });
+          });
         }
 
         queryClient.setQueryData<Series[]>(['/series'], (oldSeries) => {

--- a/frontend/src/Series/useSeries.ts
+++ b/frontend/src/Series/useSeries.ts
@@ -918,8 +918,6 @@ export const useUpdateSeriesMonitor = (
     mutationOptions: {
       onSuccess: (_, variables) => {
         if (shouldFetchEpisodesAfterUpdate) {
-          // Only refetch episodes for the series that actually changed, instead of
-          // invalidating every cached `/episode` query in the app.
           variables.series.forEach((s) => {
             queryClient.invalidateQueries({
               queryKey: ['/episode', { seriesId: s.id }],

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -110,7 +110,6 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
         [Test]
         public void should_not_monitor_first_season_when_monitoring_pilot()
         {
-            // The pilot episode in the first season is monitored, but the season itself must not be.
             GivenMonitoredSeasons(1);
 
             Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Pilot });

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -26,14 +26,13 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
                                                             })
                                      .Build();
 
-            // By default no seasons have monitored episodes after the update; individual tests override.
             GivenMonitoredSeasons();
         }
 
         private void GivenMonitoredSeasons(params int[] seasonNumbers)
         {
             Mocker.GetMock<IEpisodeService>()
-                  .Setup(s => s.GetMonitoredSeasonNumbers(It.IsAny<int>()))
+                  .Setup(s => s.SetEpisodeMonitoredBySeries(It.IsAny<int>(), It.IsAny<MonitorTypes>(), It.IsAny<int>(), It.IsAny<int>()))
                   .Returns(seasonNumbers.ToList());
         }
 

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
-using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 
@@ -14,63 +12,33 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
     public class SetEpisodeMontitoredFixture : CoreTest<EpisodeMonitoredService>
     {
         private Series _series;
-        private List<Episode> _episodes;
 
         [SetUp]
         public void Setup()
         {
-            var seasons = 4;
-
             _series = Builder<Series>.CreateNew()
-                                     .With(s => s.Seasons = Builder<Season>.CreateListOfSize(seasons)
-                                                                           .All()
-                                                                           .With(n => n.Monitored = true)
-                                                                           .Build()
-                                                                           .ToList())
+                                     .With(s => s.Status = SeriesStatusType.Continuing)
+                                     .With(s => s.Seasons = new List<Season>
+                                                            {
+                                                                new Season { SeasonNumber = 0, Monitored = true },
+                                                                new Season { SeasonNumber = 1, Monitored = true },
+                                                                new Season { SeasonNumber = 2, Monitored = true }
+                                                            })
                                      .Build();
 
-            _episodes = Builder<Episode>.CreateListOfSize(seasons)
-                                        .All()
-                                        .With(e => e.Monitored = true)
-                                        .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-7))
-
-                                        // Missing
-                                        .TheFirst(1)
-                                        .With(e => e.EpisodeFileId = 0)
-
-                                        // Has File
-                                        .TheNext(1)
-                                        .With(e => e.EpisodeFileId = 1)
-
-                                         // Future
-                                        .TheNext(1)
-                                        .With(e => e.EpisodeFileId = 0)
-                                        .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(7))
-
-                                        // Future/TBA
-                                        .TheNext(1)
-                                        .With(e => e.EpisodeFileId = 0)
-                                        .With(e => e.AirDateUtc = null)
-                                        .Build()
-                                        .ToList();
-
-            Mocker.GetMock<IEpisodeService>()
-                  .Setup(s => s.GetEpisodeBySeries(It.IsAny<int>()))
-                  .Returns(_episodes);
+            // By default no seasons have monitored episodes after the update; individual tests override.
+            GivenMonitoredSeasons();
         }
 
-        private void GivenSpecials()
+        private void GivenMonitoredSeasons(params int[] seasonNumbers)
         {
-            foreach (var episode in _episodes)
-            {
-                episode.SeasonNumber = 0;
-            }
-
-            _series.Seasons = new List<Season> { new Season { Monitored = false, SeasonNumber = 0 } };
+            Mocker.GetMock<IEpisodeService>()
+                  .Setup(s => s.GetMonitoredSeasonNumbers(It.IsAny<int>()))
+                  .Returns(seasonNumbers.ToList());
         }
 
         [Test]
-        public void should_be_able_to_monitor_series_without_changing_episodes()
+        public void should_update_series_without_changing_episodes_when_options_are_null()
         {
             Subject.SetEpisodeMonitoredStatus(_series, null);
 
@@ -78,351 +46,122 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
                   .Verify(v => v.UpdateSeries(It.IsAny<Series>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Once());
 
             Mocker.GetMock<IEpisodeService>()
-                  .Verify(v => v.UpdateEpisodes(It.IsAny<List<Episode>>()), Times.Never());
+                  .Verify(v => v.SetEpisodeMonitoredBySeries(It.IsAny<int>(), It.IsAny<MonitorTypes>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never());
         }
 
         [Test]
-        public void should_be_able_to_monitor_all_episodes()
+        public void should_do_nothing_when_skip()
         {
-            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions());
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Skip });
 
             Mocker.GetMock<IEpisodeService>()
-                  .Verify(v => v.UpdateEpisodes(It.Is<List<Episode>>(l => l.All(e => e.Monitored))));
+                  .Verify(v => v.SetEpisodeMonitoredBySeries(It.IsAny<int>(), It.IsAny<MonitorTypes>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never());
+
+            Mocker.GetMock<ISeriesService>()
+                  .Verify(v => v.UpdateSeries(It.IsAny<Series>(), It.IsAny<bool>(), It.IsAny<bool>()), Times.Never());
         }
 
         [Test]
-        public void should_be_able_to_monitor_missing_episodes_only()
+        public void should_apply_monitored_status_with_first_and_last_season()
         {
-            var monitoringOptions = new MonitoringOptions
-                                    {
-                                        Monitor = MonitorTypes.Missing
-                                    };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyMonitored(e => !e.HasFile);
-            VerifyNotMonitored(e => e.HasFile);
-        }
-
-        [Test]
-        public void should_be_able_to_monitor_new_episodes_only()
-        {
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.Future
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyMonitored(e => e.AirDateUtc.HasValue && e.AirDateUtc.Value.After(DateTime.UtcNow));
-            VerifyMonitored(e => !e.AirDateUtc.HasValue);
-            VerifyNotMonitored(e => e.AirDateUtc.HasValue && e.AirDateUtc.Value.Before(DateTime.UtcNow));
-        }
-
-        [Test]
-        public void should_not_monitor_missing_specials()
-        {
-            GivenSpecials();
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.Missing
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyNotMonitored(e => e.SeasonNumber == 0);
-        }
-
-        [Test]
-        public void should_not_monitor_new_specials()
-        {
-            GivenSpecials();
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.Future
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyNotMonitored(e => e.SeasonNumber == 0);
-        }
-
-        [Test]
-        public void should_monitor_specials()
-        {
-            GivenSpecials();
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.MonitorSpecials
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyMonitored(e => e.SeasonNumber == 0);
-        }
-
-        [Test]
-        public void should_unmonitor_specials()
-        {
-            GivenSpecials();
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.UnmonitorSpecials
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyNotMonitored(e => e.SeasonNumber == 0);
-        }
-
-        [Test]
-        public void should_unmonitor_specials_after_monitoring()
-        {
-            GivenSpecials();
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.MonitorSpecials
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.UnmonitorSpecials
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifyNotMonitored(e => e.SeasonNumber == 0);
-        }
-
-        [Test]
-        public void should_not_monitor_season_when_all_episodes_are_monitored_except_last_season()
-        {
-            _series.Seasons = Builder<Season>.CreateListOfSize(2)
-                                             .All()
-                                             .With(n => n.Monitored = true)
-                                             .Build()
-                                             .ToList();
-
-            _episodes = Builder<Episode>.CreateListOfSize(5)
-                                        .All()
-                                        .With(e => e.SeasonNumber = 1)
-                                        .With(e => e.EpisodeFileId = 0)
-                                        .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-5))
-                                        .TheLast(1)
-                                        .With(e => e.SeasonNumber = 2)
-                                        .Build()
-                                        .ToList();
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Missing });
 
             Mocker.GetMock<IEpisodeService>()
-                  .Setup(s => s.GetEpisodeBySeries(It.IsAny<int>()))
-                  .Returns(_episodes);
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.LastSeason
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifySeasonMonitored(n => n.SeasonNumber == 2);
-            VerifySeasonNotMonitored(n => n.SeasonNumber == 1);
+                  .Verify(v => v.SetEpisodeMonitoredBySeries(_series.Id, MonitorTypes.Missing, 1, 2), Times.Once());
         }
 
         [Test]
-        public void should_be_able_to_monitor_no_episodes()
+        public void should_monitor_last_season_when_monitoring_all()
         {
-            var monitoringOptions = new MonitoringOptions
-                                    {
-                                        Monitor = MonitorTypes.None
-                                    };
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.All });
 
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            Mocker.GetMock<IEpisodeService>()
-                  .Verify(v => v.UpdateEpisodes(It.Is<List<Episode>>(l => l.All(e => !e.Monitored))));
+            VerifySeasonMonitored(2);
         }
 
         [Test]
-        public void should_monitor_missing_episodes()
+        public void should_monitor_last_season_when_monitoring_future_and_series_continuing()
         {
-            var monitoringOptions = new MonitoringOptions
-                                    {
-                                        Monitor = MonitorTypes.Missing
-                                    };
+            _series.Status = SeriesStatusType.Continuing;
 
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Future });
 
-            VerifyMonitored(e => !e.HasFile);
-            VerifyNotMonitored(e => e.HasFile);
+            VerifySeasonMonitored(2);
         }
 
         [Test]
-        public void should_monitor_last_season_if_all_episodes_aired_more_than_90_days_ago()
+        public void should_monitor_last_season_when_monitoring_future_and_series_upcoming()
         {
-            _series.Seasons = Builder<Season>.CreateListOfSize(2)
-                .All()
-                .With(n => n.Monitored = true)
-                .Build()
-                .ToList();
+            _series.Status = SeriesStatusType.Upcoming;
 
-            _episodes = Builder<Episode>.CreateListOfSize(5)
-                .All()
-                .With(e => e.SeasonNumber = 1)
-                .With(e => e.EpisodeFileId = 0)
-                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-200))
-                .TheLast(2)
-                .With(e => e.SeasonNumber = 2)
-                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-100))
-                .Build()
-                .ToList();
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Future });
 
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.LastSeason
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifySeasonMonitored(n => n.SeasonNumber == 2);
-            VerifyMonitored(n => n.SeasonNumber == 2);
-
-            VerifySeasonNotMonitored(n => n.SeasonNumber == 1);
-            VerifyNotMonitored(n => n.SeasonNumber == 1);
+            VerifySeasonMonitored(2);
         }
 
         [Test]
-        public void should_not_monitor_any_recent_episodes_if_all_episodes_aired_more_than_90_days_ago()
+        public void should_not_monitor_last_season_when_monitoring_future_and_series_ended()
         {
-            _episodes.ForEach(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-100));
+            _series.Status = SeriesStatusType.Ended;
 
-            var monitoringOptions = new MonitoringOptions
-                                    {
-                                        Monitor = MonitorTypes.Recent
-                                    };
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Future });
 
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            Mocker.GetMock<IEpisodeService>()
-                  .Verify(v => v.UpdateEpisodes(It.Is<List<Episode>>(l => l.All(e => !e.Monitored))));
+            VerifySeasonNotMonitored(2);
         }
 
         [Test]
-        public void should_not_monitor_last_season_for_future_episodes_if_all_episodes_already_aired()
+        public void should_not_monitor_first_season_when_monitoring_pilot()
         {
-            _episodes.ForEach(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-7));
+            // The pilot episode in the first season is monitored, but the season itself must not be.
+            GivenMonitoredSeasons(1);
 
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.Future
-            };
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Pilot });
 
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifySeasonNotMonitored(n => n.SeasonNumber > 0);
-            VerifyNotMonitored(n => n.SeasonNumber > 0);
+            VerifySeasonNotMonitored(1);
         }
 
         [Test]
-        public void should_monitor_any_recent_and_future_episodes_if_all_episodes_aired_within_90_days()
+        public void should_monitor_season_with_monitored_episodes()
         {
-            _series.Seasons = Builder<Season>.CreateListOfSize(1)
-                .All()
-                .With(n => n.Monitored = true)
-                .Build()
-                .ToList();
+            GivenMonitoredSeasons(1);
 
-            _episodes = Builder<Episode>.CreateListOfSize(5)
-                .All()
-                .With(e => e.SeasonNumber = 1)
-                .With(e => e.EpisodeFileId = 0)
-                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-200))
-                .TheLast(3)
-                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-5))
-                .TheLast(1)
-                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(30))
-                .Build()
-                .ToList();
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Missing });
 
-            Mocker.GetMock<IEpisodeService>()
-                .Setup(s => s.GetEpisodeBySeries(It.IsAny<int>()))
-                .Returns(_episodes);
-
-            var monitoringOptions = new MonitoringOptions
-            {
-                Monitor = MonitorTypes.Recent
-            };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifySeasonMonitored(n => n.SeasonNumber == 1);
-            VerifyNotMonitored(n => n.AirDateUtc.HasValue && n.AirDateUtc.Value.Before(DateTime.UtcNow.AddDays(-90)));
-            VerifyMonitored(n => n.AirDateUtc.HasValue && n.AirDateUtc.Value.After(DateTime.UtcNow.AddDays(-90)));
+            VerifySeasonMonitored(1);
+            VerifySeasonNotMonitored(2);
         }
 
         [Test]
-        public void should_monitor_latest_season_if_some_episodes_have_aired()
+        public void should_unmonitor_seasons_without_monitored_episodes()
         {
-            _series.Seasons = Builder<Season>.CreateListOfSize(2)
-                                             .All()
-                                             .With(n => n.Monitored = true)
-                                             .Build()
-                                             .ToList();
+            GivenMonitoredSeasons();
 
-            _episodes = Builder<Episode>.CreateListOfSize(5)
-                                        .All()
-                                        .With(e => e.SeasonNumber = 1)
-                                        .With(e => e.EpisodeFileId = 0)
-                                        .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-100))
-                                        .TheLast(2)
-                                        .With(e => e.SeasonNumber = 2)
-                                        .TheLast(1)
-                                        .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(100))
-                                        .Build()
-                                        .ToList();
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.None });
 
-            var monitoringOptions = new MonitoringOptions
-                                    {
-                                        Monitor = MonitorTypes.LastSeason
-                                    };
-
-            Subject.SetEpisodeMonitoredStatus(_series, monitoringOptions);
-
-            VerifySeasonMonitored(n => n.SeasonNumber == 2);
-            VerifyMonitored(n => n.SeasonNumber == 2);
-
-            VerifySeasonNotMonitored(n => n.SeasonNumber == 1);
-            VerifyNotMonitored(n => n.SeasonNumber == 1);
+            VerifySeasonNotMonitored(0);
+            VerifySeasonNotMonitored(1);
+            VerifySeasonNotMonitored(2);
         }
 
-        private void VerifyMonitored(Func<Episode, bool> predicate)
+        [Test]
+        public void should_monitor_specials_season_when_specials_have_monitored_episodes()
         {
-            Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.UpdateEpisodes(It.Is<List<Episode>>(l => l.Where(predicate).All(e => e.Monitored))));
+            GivenMonitoredSeasons(0);
+
+            Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.MonitorSpecials });
+
+            VerifySeasonMonitored(0);
         }
 
-        private void VerifyNotMonitored(Func<Episode, bool> predicate)
-        {
-            Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.UpdateEpisodes(It.Is<List<Episode>>(l => l.Where(predicate).All(e => !e.Monitored))));
-        }
-
-        private void VerifySeasonMonitored(Func<Season, bool> predicate)
+        private void VerifySeasonMonitored(int seasonNumber)
         {
             Mocker.GetMock<ISeriesService>()
-                  .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Where(predicate).All(n => n.Monitored)), It.IsAny<bool>(), It.IsAny<bool>()));
+                  .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Single(n => n.SeasonNumber == seasonNumber).Monitored), It.IsAny<bool>(), It.IsAny<bool>()));
         }
 
-        private void VerifySeasonNotMonitored(Func<Season, bool> predicate)
+        private void VerifySeasonNotMonitored(int seasonNumber)
         {
             Mocker.GetMock<ISeriesService>()
-                  .Verify(v => v.UpdateSeries(It.Is<Series>(s => s.Seasons.Where(predicate).All(n => !n.Monitored)), It.IsAny<bool>(), It.IsAny<bool>()));
+                  .Verify(v => v.UpdateSeries(It.Is<Series>(s => !s.Seasons.Single(n => n.SeasonNumber == seasonNumber).Monitored), It.IsAny<bool>(), It.IsAny<bool>()));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeMonitoredServiceTests/SetEpisodeMontitoredFixture.cs
@@ -26,7 +26,9 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
                                                             })
                                      .Build();
 
-            GivenMonitoredSeasons();
+            GivenMonitoredSeasons(_series.Seasons.Where(s => s.SeasonNumber > 0 && s.Monitored)
+                                                 .Select(s => s.SeasonNumber)
+                                                 .ToArray());
         }
 
         private void GivenMonitoredSeasons(params int[] seasonNumbers)
@@ -101,6 +103,8 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeMonitoredServiceTests
         public void should_not_monitor_last_season_when_monitoring_future_and_series_ended()
         {
             _series.Status = SeriesStatusType.Ended;
+
+            GivenMonitoredSeasons();
 
             Subject.SetEpisodeMonitoredStatus(_series, new MonitoringOptions { Monitor = MonitorTypes.Future });
 

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
@@ -185,7 +185,6 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
             var monitored = MonitoredByEpisodeId();
             monitored[special.Id].Should().BeTrue();
 
-            // Regular seasons must be left untouched.
             monitored[regularMonitored.Id].Should().BeTrue();
             monitored[regularUnmonitored.Id].Should().BeFalse();
         }
@@ -202,7 +201,6 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
             var monitored = MonitoredByEpisodeId();
             monitored[special.Id].Should().BeFalse();
 
-            // Regular seasons must be left untouched.
             monitored[regularMonitored.Id].Should().BeTrue();
             monitored[regularUnmonitored.Id].Should().BeFalse();
         }
@@ -217,7 +215,6 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
 
             var monitoredSeasons = Subject.SetMonitored(_series.Id, MonitorTypes.Missing, 1, 3);
 
-            // Only seasons 1 and 2 have a missing (and now monitored) episode.
             monitoredSeasons.Should().BeEquivalentTo(new[] { 1, 2 });
         }
     }

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
@@ -208,15 +208,16 @@ namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
         }
 
         [Test]
-        public void should_return_distinct_monitored_season_numbers()
+        public void should_return_distinct_season_numbers_with_monitored_episodes()
         {
-            GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
-            GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-1), monitored: true);
-            GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
-            GivenEpisode(3, 1, false, DateTime.UtcNow.AddDays(-1));
+            GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1));
+            GivenEpisode(1, 2, true, DateTime.UtcNow.AddDays(-1));
+            GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1));
+            GivenEpisode(3, 1, true, DateTime.UtcNow.AddDays(-1));
 
-            var monitoredSeasons = Subject.GetMonitoredSeasonNumbers(_series.Id);
+            var monitoredSeasons = Subject.SetMonitored(_series.Id, MonitorTypes.Missing, 1, 3);
 
+            // Only seasons 1 and 2 have a missing (and now monitored) episode.
             monitoredSeasons.Should().BeEquivalentTo(new[] { 1, 2 });
         }
     }

--- a/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/TvTests/EpisodeRepositoryTests/SetEpisodeMonitoredBySeriesFixture.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.TvTests.EpisodeRepositoryTests
+{
+    [TestFixture]
+    public class SetEpisodeMonitoredBySeriesFixture : DbTest<EpisodeRepository, Episode>
+    {
+        private Series _series;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>.CreateNew()
+                                     .With(s => s.Id = 0)
+                                     .With(s => s.Runtime = 30)
+                                     .With(s => s.Monitored = true)
+                                     .Build();
+
+            _series.Id = Db.Insert(_series).Id;
+        }
+
+        private Episode GivenEpisode(int seasonNumber, int episodeNumber, bool hasFile, DateTime? airDateUtc, bool monitored = false)
+        {
+            var episode = Builder<Episode>.CreateNew()
+                                          .With(e => e.Id = 0)
+                                          .With(e => e.SeriesId = _series.Id)
+                                          .With(e => e.SeasonNumber = seasonNumber)
+                                          .With(e => e.EpisodeNumber = episodeNumber)
+                                          .With(e => e.EpisodeFileId = hasFile ? 1 : 0)
+                                          .With(e => e.AirDateUtc = airDateUtc)
+                                          .With(e => e.Monitored = monitored)
+                                          .Build();
+
+            return Db.Insert(episode);
+        }
+
+        private Dictionary<int, bool> MonitoredByEpisodeId()
+        {
+            return Subject.GetEpisodes(_series.Id).ToDictionary(e => e.Id, e => e.Monitored);
+        }
+
+        [Test]
+        public void should_monitor_all_regular_episodes_and_unmonitor_specials_for_all()
+        {
+            var special = GivenEpisode(0, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var aired = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1));
+            var withFile = GivenEpisode(2, 1, true, DateTime.UtcNow.AddDays(-1));
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.All, 1, 2);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[special.Id].Should().BeFalse();
+            monitored[aired.Id].Should().BeTrue();
+            monitored[withFile.Id].Should().BeTrue();
+        }
+
+        [Test]
+        public void should_unmonitor_everything_for_none()
+        {
+            var special = GivenEpisode(0, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var regular = GivenEpisode(1, 1, true, DateTime.UtcNow.AddDays(-1), monitored: true);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.None, 1, 2);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[special.Id].Should().BeFalse();
+            monitored[regular.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_monitor_only_episodes_without_files_for_missing()
+        {
+            var missing = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1));
+            var existing = GivenEpisode(1, 2, true, DateTime.UtcNow.AddDays(-1), monitored: true);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.Missing, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[missing.Id].Should().BeTrue();
+            monitored[existing.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_monitor_only_episodes_with_files_for_existing()
+        {
+            var missing = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var existing = GivenEpisode(1, 2, true, DateTime.UtcNow.AddDays(-1));
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.Existing, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[missing.Id].Should().BeFalse();
+            monitored[existing.Id].Should().BeTrue();
+        }
+
+        [Test]
+        public void should_monitor_future_and_tba_episodes_for_future()
+        {
+            var aired = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var future = GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(7));
+            var tba = GivenEpisode(1, 3, false, null);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.Future, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[aired.Id].Should().BeFalse();
+            monitored[future.Id].Should().BeTrue();
+            monitored[tba.Id].Should().BeTrue();
+        }
+
+        [Test]
+        public void should_monitor_episodes_within_90_days_and_future_for_recent()
+        {
+            var old = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-200), monitored: true);
+            var recent = GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-5));
+            var future = GivenEpisode(1, 3, false, DateTime.UtcNow.AddDays(30));
+            var tba = GivenEpisode(1, 4, false, null);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.Recent, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[old.Id].Should().BeFalse();
+            monitored[recent.Id].Should().BeTrue();
+            monitored[future.Id].Should().BeTrue();
+            monitored[tba.Id].Should().BeTrue();
+        }
+
+        [Test]
+        public void should_monitor_only_pilot_for_pilot()
+        {
+            var pilot = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1));
+            var other = GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var laterSeason = GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.Pilot, 1, 2);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[pilot.Id].Should().BeTrue();
+            monitored[other.Id].Should().BeFalse();
+            monitored[laterSeason.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_monitor_only_first_season_for_first_season()
+        {
+            var firstSeason = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1));
+            var secondSeason = GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.FirstSeason, 1, 2);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[firstSeason.Id].Should().BeTrue();
+            monitored[secondSeason.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_monitor_only_last_season_for_last_season()
+        {
+            var firstSeason = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var lastSeason = GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1));
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.LastSeason, 1, 2);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[firstSeason.Id].Should().BeFalse();
+            monitored[lastSeason.Id].Should().BeTrue();
+        }
+
+        [Test]
+        public void should_only_change_specials_for_monitor_specials()
+        {
+            var special = GivenEpisode(0, 1, false, DateTime.UtcNow.AddDays(-1));
+            var regularMonitored = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var regularUnmonitored = GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-1));
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.MonitorSpecials, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[special.Id].Should().BeTrue();
+
+            // Regular seasons must be left untouched.
+            monitored[regularMonitored.Id].Should().BeTrue();
+            monitored[regularUnmonitored.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_only_change_specials_for_unmonitor_specials()
+        {
+            var special = GivenEpisode(0, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var regularMonitored = GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            var regularUnmonitored = GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-1));
+
+            Subject.SetMonitored(_series.Id, MonitorTypes.UnmonitorSpecials, 1, 1);
+
+            var monitored = MonitoredByEpisodeId();
+            monitored[special.Id].Should().BeFalse();
+
+            // Regular seasons must be left untouched.
+            monitored[regularMonitored.Id].Should().BeTrue();
+            monitored[regularUnmonitored.Id].Should().BeFalse();
+        }
+
+        [Test]
+        public void should_return_distinct_monitored_season_numbers()
+        {
+            GivenEpisode(1, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            GivenEpisode(1, 2, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            GivenEpisode(2, 1, false, DateTime.UtcNow.AddDays(-1), monitored: true);
+            GivenEpisode(3, 1, false, DateTime.UtcNow.AddDays(-1));
+
+            var monitoredSeasons = Subject.GetMonitoredSeasonNumbers(_series.Id);
+
+            monitoredSeasons.Should().BeEquivalentTo(new[] { 1, 2 });
+        }
+    }
+}

--- a/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
@@ -51,13 +51,9 @@ namespace NzbDrone.Core.Tv
 
             _logger.Debug("[{0}] Setting episode monitored status to {1}", series.Title, monitoringOptions.Monitor);
 
-            // Apply the monitored flag with a single set-based update in the database instead of
-            // loading every episode, flipping a flag in memory and writing each row back.
-            _episodeService.SetEpisodeMonitoredBySeries(series.Id, monitoringOptions.Monitor, firstSeason, lastSeason);
-
-            // Recompute season monitored flags from the resulting episode state (one DISTINCT query
-            // over the small set of seasons rather than the full episode list).
-            var monitoredSeasons = _episodeService.GetMonitoredSeasonNumbers(series.Id);
+            // Apply the monitored flag with a set-based database update and use the resulting set of
+            // monitored seasons to recompute the season monitored flags.
+            var monitoredSeasons = _episodeService.SetEpisodeMonitoredBySeries(series.Id, monitoringOptions.Monitor, firstSeason, lastSeason);
 
             foreach (var season in series.Seasons)
             {

--- a/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
@@ -51,8 +51,6 @@ namespace NzbDrone.Core.Tv
 
             _logger.Debug("[{0}] Setting episode monitored status to {1}", series.Title, monitoringOptions.Monitor);
 
-            // Apply the monitored flag with a set-based database update and use the resulting set of
-            // monitored seasons to recompute the season monitored flags.
             var monitoredSeasons = _episodeService.SetEpisodeMonitoredBySeries(series.Id, monitoringOptions.Monitor, firstSeason, lastSeason);
 
             foreach (var season in series.Seasons)

--- a/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs
@@ -48,91 +48,16 @@ namespace NzbDrone.Core.Tv
 
             var firstSeason = series.Seasons.Select(s => s.SeasonNumber).Where(s => s > 0).MinOrDefault();
             var lastSeason = series.Seasons.Select(s => s.SeasonNumber).MaxOrDefault();
-            var episodes = _episodeService.GetEpisodeBySeries(series.Id);
 
-            switch (monitoringOptions.Monitor)
-            {
-                case MonitorTypes.All:
-                    _logger.Debug("[{0}] Monitoring all episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0);
+            _logger.Debug("[{0}] Setting episode monitored status to {1}", series.Title, monitoringOptions.Monitor);
 
-                    break;
+            // Apply the monitored flag with a single set-based update in the database instead of
+            // loading every episode, flipping a flag in memory and writing each row back.
+            _episodeService.SetEpisodeMonitoredBySeries(series.Id, monitoringOptions.Monitor, firstSeason, lastSeason);
 
-                case MonitorTypes.Future:
-                    _logger.Debug("[{0}] Monitoring future episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && (!e.AirDateUtc.HasValue || e.AirDateUtc >= DateTime.UtcNow));
-
-                    break;
-
-                case MonitorTypes.Missing:
-                    _logger.Debug("[{0}] Monitoring missing episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && !e.HasFile);
-
-                    break;
-
-                case MonitorTypes.Existing:
-                    _logger.Debug("[{0}] Monitoring existing episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.HasFile);
-
-                    break;
-
-                case MonitorTypes.Pilot:
-                    _logger.Debug("[{0}] Monitoring first episode episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes,
-                        e => e.SeasonNumber > 0 && e.SeasonNumber == firstSeason && e.EpisodeNumber == 1);
-
-                    break;
-
-                case MonitorTypes.FirstSeason:
-                    _logger.Debug("[{0}] Monitoring first season episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.SeasonNumber == firstSeason);
-
-                    break;
-
-                case MonitorTypes.LastSeason:
-                #pragma warning disable CS0612
-                case MonitorTypes.LatestSeason:
-                #pragma warning restore CS0612
-                    _logger.Debug("[{0}] Monitoring latest season episodes", series.Title);
-
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 && e.SeasonNumber == lastSeason);
-
-                    break;
-
-                case MonitorTypes.Recent:
-                    _logger.Debug("[{0}] Monitoring recent and future episodes", series.Title);
-
-                    ToggleEpisodesMonitoredState(episodes, e => e.SeasonNumber > 0 &&
-                                                                (!e.AirDateUtc.HasValue || (
-                                                                        e.AirDateUtc.Value.Before(DateTime.UtcNow) &&
-                                                                        e.AirDateUtc.Value.InLastDays(90))
-                                                                    || e.AirDateUtc.Value.After(DateTime.UtcNow)));
-
-                    break;
-
-                case MonitorTypes.MonitorSpecials:
-                    _logger.Debug("[{0}] Monitoring special episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes.Where(e => e.SeasonNumber == 0), true);
-
-                    break;
-
-                case MonitorTypes.UnmonitorSpecials:
-                    _logger.Debug("[{0}] Unmonitoring special episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes.Where(e => e.SeasonNumber == 0), false);
-
-                    break;
-
-                case MonitorTypes.None:
-                    _logger.Debug("[{0}] Unmonitoring all episodes", series.Title);
-                    ToggleEpisodesMonitoredState(episodes, e => false);
-
-                    break;
-            }
-
-            var monitoredSeasons = episodes.Where(e => e.Monitored)
-                                           .Select(e => e.SeasonNumber)
-                                           .Distinct()
-                                           .ToList();
+            // Recompute season monitored flags from the resulting episode state (one DISTINCT query
+            // over the small set of seasons rather than the full episode list).
+            var monitoredSeasons = _episodeService.GetMonitoredSeasonNumbers(series.Id);
 
             foreach (var season in series.Seasons)
             {
@@ -168,7 +93,6 @@ namespace NzbDrone.Core.Tv
                 }
             }
 
-            _episodeService.UpdateEpisodes(episodes);
             _seriesService.UpdateSeries(series, false);
         }
 

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -206,10 +206,9 @@ namespace NzbDrone.Core.Tv
             {
                 SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId AND \"SeasonNumber\" = 0", monitor == MonitorTypes.MonitorSpecials, parameters);
 
-                return GetMonitoredSeasonNumbers(conn, seriesId);
+                return GetSeasonNumbersWithMonitoredEpisodes(conn, seriesId);
             }
 
-            // None unmonitors every episode in the series.
             if (monitor == MonitorTypes.None)
             {
                 SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId", false, parameters);
@@ -261,7 +260,7 @@ namespace NzbDrone.Core.Tv
             }
             else
             {
-                return GetMonitoredSeasonNumbers(conn, seriesId);
+                return GetSeasonNumbersWithMonitoredEpisodes(conn, seriesId);
             }
 
             using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
@@ -271,7 +270,7 @@ namespace NzbDrone.Core.Tv
                 tran.Commit();
             }
 
-            return GetMonitoredSeasonNumbers(conn, seriesId);
+            return GetSeasonNumbersWithMonitoredEpisodes(conn, seriesId);
         }
 
         public void SetFileId(Episode episode, int fileId)
@@ -387,7 +386,7 @@ namespace NzbDrone.Core.Tv
             return string.Format("({0})", string.Join(" OR ", clauses));
         }
 
-        private List<int> GetMonitoredSeasonNumbers(IDbConnection conn, int seriesId)
+        private List<int> GetSeasonNumbersWithMonitoredEpisodes(IDbConnection conn, int seriesId)
         {
             return conn.Query<int>("SELECT DISTINCT \"SeasonNumber\" FROM \"Episodes\" WHERE \"SeriesId\" = @seriesId AND \"Monitored\" = @monitored",
                 new { seriesId, monitored = true }).ToList();

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using Dapper;
 using NLog;
@@ -29,6 +30,8 @@ namespace NzbDrone.Core.Tv
         void SetMonitoredFlat(Episode episode, bool monitored);
         void SetMonitoredBySeason(int seriesId, int seasonNumber, bool monitored);
         void SetMonitored(IEnumerable<int> ids, bool monitored);
+        void SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
+        List<int> GetMonitoredSeasonNumbers(int seriesId);
         void SetFileId(Episode episode, int fileId);
         void ClearFileId(Episode episode, bool unmonitor);
     }
@@ -190,6 +193,96 @@ namespace NzbDrone.Core.Tv
         {
             var episodes = ids.Select(x => new Episode { Id = x, Monitored = monitored }).ToList();
             SetFields(episodes, p => p.Monitored);
+        }
+
+        public void SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("seriesId", seriesId);
+
+            // Specials-only adjustments must not touch regular seasons, so they're a single scoped update.
+            if (monitor == MonitorTypes.MonitorSpecials || monitor == MonitorTypes.UnmonitorSpecials)
+            {
+                using (var conn = _database.OpenConnection())
+                {
+                    SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId AND \"SeasonNumber\" = 0", monitor == MonitorTypes.MonitorSpecials, parameters);
+                }
+
+                return;
+            }
+
+            // The predicate describes which episodes should be monitored. Everything else in the
+            // series is unmonitored, mirroring the previous in-memory ToggleEpisodesMonitoredState.
+            string predicate;
+
+            switch (monitor)
+            {
+                case MonitorTypes.All:
+                    predicate = "\"SeasonNumber\" > 0";
+                    break;
+                case MonitorTypes.Future:
+                    predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @now)";
+                    parameters.Add("now", DateTime.UtcNow);
+                    break;
+                case MonitorTypes.Missing:
+                    predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" = 0";
+                    break;
+                case MonitorTypes.Existing:
+                    predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" <> 0";
+                    break;
+                case MonitorTypes.Pilot:
+                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason AND \"EpisodeNumber\" = 1";
+                    parameters.Add("firstSeason", firstSeason);
+                    break;
+                case MonitorTypes.FirstSeason:
+                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason";
+                    parameters.Add("firstSeason", firstSeason);
+                    break;
+                case MonitorTypes.LastSeason:
+#pragma warning disable CS0612
+                case MonitorTypes.LatestSeason:
+#pragma warning restore CS0612
+                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @lastSeason";
+                    parameters.Add("lastSeason", lastSeason);
+                    break;
+                case MonitorTypes.Recent:
+                    predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @cutoff)";
+                    parameters.Add("cutoff", DateTime.UtcNow.AddDays(-90));
+                    break;
+                case MonitorTypes.None:
+                    // Matches nothing, so the "unmonitor the rest" pass clears the whole series.
+                    predicate = "1 = 0";
+                    break;
+                default:
+                    // Unknown monitor type: leave episodes untouched (matches previous no-op switch behavior).
+                    return;
+            }
+
+            using (var conn = _database.OpenConnection())
+            using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
+            {
+                SetMonitoredWhere(conn, tran, $"\"SeriesId\" = @seriesId AND ({predicate})", true, parameters);
+                SetMonitoredWhere(conn, tran, $"\"SeriesId\" = @seriesId AND NOT ({predicate})", false, parameters);
+                tran.Commit();
+            }
+        }
+
+        public List<int> GetMonitoredSeasonNumbers(int seriesId)
+        {
+            using (var conn = _database.OpenConnection())
+            {
+                return conn.Query<int>("SELECT DISTINCT \"SeasonNumber\" FROM \"Episodes\" WHERE \"SeriesId\" = @seriesId AND \"Monitored\" = @monitored",
+                    new { seriesId, monitored = true }).ToList();
+            }
+        }
+
+        private void SetMonitoredWhere(IDbConnection conn, IDbTransaction tran, string whereClause, bool monitored, DynamicParameters parameters)
+        {
+            var p = new DynamicParameters(parameters);
+            p.Add("monitored", monitored);
+
+            // The "Monitored" <> @monitored guard means only rows that actually change are written.
+            conn.Execute($"UPDATE \"Episodes\" SET \"Monitored\" = @monitored WHERE {whereClause} AND \"Monitored\" <> @monitored", p, tran);
         }
 
         public void SetFileId(Episode episode, int fileId)

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -30,8 +30,7 @@ namespace NzbDrone.Core.Tv
         void SetMonitoredFlat(Episode episode, bool monitored);
         void SetMonitoredBySeason(int seriesId, int seasonNumber, bool monitored);
         void SetMonitored(IEnumerable<int> ids, bool monitored);
-        void SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
-        List<int> GetMonitoredSeasonNumbers(int seriesId);
+        List<int> SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
         void SetFileId(Episode episode, int fileId);
         void ClearFileId(Episode episode, bool unmonitor);
     }
@@ -195,94 +194,84 @@ namespace NzbDrone.Core.Tv
             SetFields(episodes, p => p.Monitored);
         }
 
-        public void SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
+        public List<int> SetMonitored(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
         {
             var parameters = new DynamicParameters();
             parameters.Add("seriesId", seriesId);
 
-            // Specials-only adjustments must not touch regular seasons, so they're a single scoped update.
-            if (monitor == MonitorTypes.MonitorSpecials || monitor == MonitorTypes.UnmonitorSpecials)
-            {
-                using (var conn = _database.OpenConnection())
-                {
-                    SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId AND \"SeasonNumber\" = 0", monitor == MonitorTypes.MonitorSpecials, parameters);
-                }
+            using var conn = _database.OpenConnection();
 
-                return;
+            // Specials are toggled on their own and the regular seasons are left untouched.
+            if (monitor is MonitorTypes.MonitorSpecials or MonitorTypes.UnmonitorSpecials)
+            {
+                SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId AND \"SeasonNumber\" = 0", monitor == MonitorTypes.MonitorSpecials, parameters);
+
+                return GetMonitoredSeasonNumbers(conn, seriesId);
             }
 
-            // The predicate describes which episodes should be monitored. Everything else in the
-            // series is unmonitored, mirroring the previous in-memory ToggleEpisodesMonitoredState.
+            // None unmonitors every episode in the series.
+            if (monitor == MonitorTypes.None)
+            {
+                SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId", false, parameters);
+
+                return new List<int>();
+            }
+
+            // The predicate selects the episodes to monitor; everything else in the series is unmonitored.
             string predicate;
 
-            switch (monitor)
+            if (monitor == MonitorTypes.All)
             {
-                case MonitorTypes.All:
-                    predicate = "\"SeasonNumber\" > 0";
-                    break;
-                case MonitorTypes.Future:
-                    predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @now)";
-                    parameters.Add("now", DateTime.UtcNow);
-                    break;
-                case MonitorTypes.Missing:
-                    predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" = 0";
-                    break;
-                case MonitorTypes.Existing:
-                    predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" <> 0";
-                    break;
-                case MonitorTypes.Pilot:
-                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason AND \"EpisodeNumber\" = 1";
-                    parameters.Add("firstSeason", firstSeason);
-                    break;
-                case MonitorTypes.FirstSeason:
-                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason";
-                    parameters.Add("firstSeason", firstSeason);
-                    break;
-                case MonitorTypes.LastSeason:
+                predicate = "\"SeasonNumber\" > 0";
+            }
+            else if (monitor == MonitorTypes.Future)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @now)";
+                parameters.Add("now", DateTime.UtcNow);
+            }
+            else if (monitor == MonitorTypes.Missing)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" = 0";
+            }
+            else if (monitor == MonitorTypes.Existing)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND \"EpisodeFileId\" <> 0";
+            }
+            else if (monitor == MonitorTypes.Pilot)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason AND \"EpisodeNumber\" = 1";
+                parameters.Add("firstSeason", firstSeason);
+            }
+            else if (monitor == MonitorTypes.FirstSeason)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @firstSeason";
+                parameters.Add("firstSeason", firstSeason);
+            }
 #pragma warning disable CS0612
-                case MonitorTypes.LatestSeason:
+            else if (monitor is MonitorTypes.LastSeason or MonitorTypes.LatestSeason)
 #pragma warning restore CS0612
-                    predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @lastSeason";
-                    parameters.Add("lastSeason", lastSeason);
-                    break;
-                case MonitorTypes.Recent:
-                    predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @cutoff)";
-                    parameters.Add("cutoff", DateTime.UtcNow.AddDays(-90));
-                    break;
-                case MonitorTypes.None:
-                    // Matches nothing, so the "unmonitor the rest" pass clears the whole series.
-                    predicate = "1 = 0";
-                    break;
-                default:
-                    // Unknown monitor type: leave episodes untouched (matches previous no-op switch behavior).
-                    return;
+            {
+                predicate = "\"SeasonNumber\" > 0 AND \"SeasonNumber\" = @lastSeason";
+                parameters.Add("lastSeason", lastSeason);
+            }
+            else if (monitor == MonitorTypes.Recent)
+            {
+                predicate = "\"SeasonNumber\" > 0 AND (\"AirDateUtc\" IS NULL OR \"AirDateUtc\" >= @cutoff)";
+                parameters.Add("cutoff", DateTime.UtcNow.AddDays(-90));
+            }
+            else
+            {
+                return GetMonitoredSeasonNumbers(conn, seriesId);
             }
 
-            using (var conn = _database.OpenConnection())
             using (var tran = conn.BeginTransaction(IsolationLevel.ReadCommitted))
             {
                 SetMonitoredWhere(conn, tran, $"\"SeriesId\" = @seriesId AND ({predicate})", true, parameters);
                 SetMonitoredWhere(conn, tran, $"\"SeriesId\" = @seriesId AND NOT ({predicate})", false, parameters);
                 tran.Commit();
             }
-        }
 
-        public List<int> GetMonitoredSeasonNumbers(int seriesId)
-        {
-            using (var conn = _database.OpenConnection())
-            {
-                return conn.Query<int>("SELECT DISTINCT \"SeasonNumber\" FROM \"Episodes\" WHERE \"SeriesId\" = @seriesId AND \"Monitored\" = @monitored",
-                    new { seriesId, monitored = true }).ToList();
-            }
-        }
-
-        private void SetMonitoredWhere(IDbConnection conn, IDbTransaction tran, string whereClause, bool monitored, DynamicParameters parameters)
-        {
-            var p = new DynamicParameters(parameters);
-            p.Add("monitored", monitored);
-
-            // The "Monitored" <> @monitored guard means only rows that actually change are written.
-            conn.Execute($"UPDATE \"Episodes\" SET \"Monitored\" = @monitored WHERE {whereClause} AND \"Monitored\" <> @monitored", p, tran);
+            return GetMonitoredSeasonNumbers(conn, seriesId);
         }
 
         public void SetFileId(Episode episode, int fileId)
@@ -396,6 +385,21 @@ namespace NzbDrone.Core.Tv
                 .ToList();
 
             return string.Format("({0})", string.Join(" OR ", clauses));
+        }
+
+        private List<int> GetMonitoredSeasonNumbers(IDbConnection conn, int seriesId)
+        {
+            return conn.Query<int>("SELECT DISTINCT \"SeasonNumber\" FROM \"Episodes\" WHERE \"SeriesId\" = @seriesId AND \"Monitored\" = @monitored",
+                new { seriesId, monitored = true }).ToList();
+        }
+
+        private void SetMonitoredWhere(IDbConnection conn, IDbTransaction tran, string whereClause, bool monitored, DynamicParameters parameters)
+        {
+            var p = new DynamicParameters(parameters);
+            p.Add("monitored", monitored);
+
+            // Only rows that actually change are written.
+            conn.Execute($"UPDATE \"Episodes\" SET \"Monitored\" = @monitored WHERE {whereClause} AND \"Monitored\" <> @monitored", p, tran);
         }
 
         private Episode FindOneByAirDate(int seriesId, string date)

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -201,7 +201,6 @@ namespace NzbDrone.Core.Tv
 
             using var conn = _database.OpenConnection();
 
-            // Specials are toggled on their own and the regular seasons are left untouched.
             if (monitor is MonitorTypes.MonitorSpecials or MonitorTypes.UnmonitorSpecials)
             {
                 SetMonitoredWhere(conn, null, "\"SeriesId\" = @seriesId AND \"SeasonNumber\" = 0", monitor == MonitorTypes.MonitorSpecials, parameters);
@@ -216,7 +215,6 @@ namespace NzbDrone.Core.Tv
                 return new List<int>();
             }
 
-            // The predicate selects the episodes to monitor; everything else in the series is unmonitored.
             string predicate;
 
             if (monitor == MonitorTypes.All)
@@ -397,7 +395,6 @@ namespace NzbDrone.Core.Tv
             var p = new DynamicParameters(parameters);
             p.Add("monitored", monitored);
 
-            // Only rows that actually change are written.
             conn.Execute($"UPDATE \"Episodes\" SET \"Monitored\" = @monitored WHERE {whereClause} AND \"Monitored\" <> @monitored", p, tran);
         }
 

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -39,6 +39,8 @@ namespace NzbDrone.Core.Tv
         void UpdateMany(List<Episode> episodes);
         void DeleteMany(List<Episode> episodes);
         void SetEpisodeMonitoredBySeason(int seriesId, int seasonNumber, bool monitored);
+        void SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
+        List<int> GetMonitoredSeasonNumbers(int seriesId);
     }
 
     public class EpisodeService : IEpisodeService,
@@ -189,6 +191,16 @@ namespace NzbDrone.Core.Tv
         public void SetEpisodeMonitoredBySeason(int seriesId, int seasonNumber, bool monitored)
         {
             _episodeRepository.SetMonitoredBySeason(seriesId, seasonNumber, monitored);
+        }
+
+        public void SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
+        {
+            _episodeRepository.SetMonitored(seriesId, monitor, firstSeason, lastSeason);
+        }
+
+        public List<int> GetMonitoredSeasonNumbers(int seriesId)
+        {
+            return _episodeRepository.GetMonitoredSeasonNumbers(seriesId);
         }
 
         public void UpdateEpisodes(List<Episode> episodes)

--- a/src/NzbDrone.Core/Tv/EpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeService.cs
@@ -39,8 +39,7 @@ namespace NzbDrone.Core.Tv
         void UpdateMany(List<Episode> episodes);
         void DeleteMany(List<Episode> episodes);
         void SetEpisodeMonitoredBySeason(int seriesId, int seasonNumber, bool monitored);
-        void SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
-        List<int> GetMonitoredSeasonNumbers(int seriesId);
+        List<int> SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason);
     }
 
     public class EpisodeService : IEpisodeService,
@@ -193,14 +192,9 @@ namespace NzbDrone.Core.Tv
             _episodeRepository.SetMonitoredBySeason(seriesId, seasonNumber, monitored);
         }
 
-        public void SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
+        public List<int> SetEpisodeMonitoredBySeries(int seriesId, MonitorTypes monitor, int firstSeason, int lastSeason)
         {
-            _episodeRepository.SetMonitored(seriesId, monitor, firstSeason, lastSeason);
-        }
-
-        public List<int> GetMonitoredSeasonNumbers(int seriesId)
-        {
-            return _episodeRepository.GetMonitoredSeasonNumbers(seriesId);
+            return _episodeRepository.SetMonitored(seriesId, monitor, firstSeason, lastSeason);
         }
 
         public void UpdateEpisodes(List<Episode> episodes)


### PR DESCRIPTION
#### Description

Changing a series' monitoring (the Series Monitoring dialog or the bulk Season Pass) was slow on series with a large episode count — the save would hang for several seconds on something like Pokémon (~1,300 episodes).

The cause was per-row work. `SetEpisodeMonitoredStatus` loaded every episode for the series, flipped the `Monitored` flag in memory, and wrote them all back. That write happens as one `UPDATE ... WHERE Id = @Id` per episode, so the cost scaled with the episode count and ran synchronously inside the Season Pass request.

This replaces it with a set-based update in `EpisodeRepository`: a scoped `UPDATE` applies the monitoring rule directly in SQL (special seasons handled separately). `SetMonitored` returns the season numbers that still have monitored episodes, so `EpisodeMonitoredService` recomputes the season monitored flags without a second query.

On the frontend, the Season Pass success handler now invalidates the cached episodes only for the series that changed, instead of every `/episode` query.

Existing `EpisodeMonitoredService` tests were updated to the new service API, and a `SetEpisodeMonitoredBySeriesFixture` was added to cover the repository behaviour against a real database for each monitor type.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #8738
