### PR TITLE
Fix select inputs not working on mobile

### DIFF
--- a/frontend/src/Components/Form/Select/EnhancedSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/EnhancedSelectInput.tsx
@@ -174,6 +174,17 @@ function EnhancedSelectInput<T extends EnhancedSelectInputValue<V>, V>(
   const isMultiSelect = Array.isArray(value);
   const selectedOption = getSelectedOption(selectedIndex, values);
 
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (isMobile) {
+        return;
+      }
+
+      setIsOpen(open);
+    },
+    [isMobile]
+  );
+
   const { refs, context, floatingStyles } = useFloating({
     middleware: [
       flip({
@@ -195,7 +206,7 @@ function EnhancedSelectInput<T extends EnhancedSelectInputValue<V>, V>(
     open: isOpen,
     placement: 'bottom-start',
     whileElementsMounted: autoUpdate,
-    onOpenChange: setIsOpen,
+    onOpenChange: handleOpenChange,
   });
 
   const click = useClick(context);


### PR DESCRIPTION
#### Description

Select inputs weren't working on responsive because the floating handler used on desktop browsers was triggering them to close on any click (and before the option was pressed).

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review