### PR TITLE
Add support for localized series and episode titles using Radarr-style

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TranslatedTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TranslatedTitleFixture.cs
@@ -1,0 +1,204 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Organizer;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
+{
+    [TestFixture]
+
+    public class TranslatedTitleFixture : CoreTest<FileNameBuilder>
+    {
+        private Series _series;
+        private Episode _episode1;
+        private EpisodeFile _episodeFile;
+        private NamingConfig _namingConfig;
+
+        [SetUp]
+        public void Setup()
+        {
+            _series = Builder<Series>
+                    .CreateNew()
+                    .With(s => s.Title = "South Park")
+                    .Build();
+
+            _namingConfig = NamingConfig.Default;
+            _namingConfig.RenameEpisodes = true;
+
+            Mocker.GetMock<INamingConfigService>()
+                  .Setup(c => c.GetConfig()).Returns(_namingConfig);
+
+            _episode1 = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "City Sushi")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 6)
+                            .With(e => e.AbsoluteEpisodeNumber = 100)
+                            .Build();
+
+            _episodeFile = new EpisodeFile { Quality = new QualityModel(Quality.HDTV720p), ReleaseGroup = "SonarrTest" };
+
+            Mocker.GetMock<IQualityDefinitionService>()
+                .Setup(v => v.Get(Moq.It.IsAny<Quality>()))
+                .Returns<Quality>(v => Quality.DefaultQualityDefinitions.First(c => c.Quality == v));
+
+            Mocker.GetMock<ICustomFormatService>()
+                  .Setup(v => v.All())
+                  .Returns(new List<CustomFormat>());
+        }
+
+        [Test]
+        public void should_replace_series_title_with_french_translation_when_token_has_FR()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series Title:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park FR");
+        }
+
+        [Test]
+        public void should_replace_series_title_with_german_translation_when_token_has_DE()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "DE", Title = "South Park DE" });
+            _namingConfig.StandardEpisodeFormat = "{Series Title:DE}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park DE");
+        }
+
+        [Test]
+        public void should_fallback_to_original_series_title_when_translation_not_found()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series Title:DE}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park");
+        }
+
+        [Test]
+        public void should_fallback_to_original_series_title_when_translations_empty()
+        {
+            _namingConfig.StandardEpisodeFormat = "{Series Title:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park");
+        }
+
+        [Test]
+        public void should_match_language_code_case_insensitively()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series Title:fr}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park FR");
+        }
+
+        [Test]
+        public void should_replace_episode_title_with_french_translation_when_token_has_FR()
+        {
+            _episode1.Translations.Add(new EpisodeTranslation { Language = "FR", Title = "City Sushi FR" });
+            _namingConfig.StandardEpisodeFormat = "{Episode Title:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("City Sushi FR");
+        }
+
+        [Test]
+        public void should_fallback_to_original_episode_title_when_translation_not_found()
+        {
+            _episode1.Translations.Add(new EpisodeTranslation { Language = "FR", Title = "City Sushi FR" });
+            _namingConfig.StandardEpisodeFormat = "{Episode Title:DE}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("City Sushi");
+        }
+
+        [Test]
+        public void should_fallback_to_original_episode_title_when_translations_empty()
+        {
+            _namingConfig.StandardEpisodeFormat = "{Episode Title:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("City Sushi");
+        }
+
+        [Test]
+        public void should_use_translated_title_with_Series_CleanTitle_token()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series CleanTitle:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South.Park.FR");
+        }
+
+        [Test]
+        public void should_use_translated_title_with_Series_TitleYear_token()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series TitleYear:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("South Park FR (2010)");
+        }
+
+        [Test]
+        public void should_use_translated_title_with_Series_TitleThe_token()
+        {
+            _series.Title = "The Series";
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "La Série" });
+            _namingConfig.StandardEpisodeFormat = "{Series TitleThe:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("La Série");
+        }
+
+        [Test]
+        public void should_use_translated_title_with_Series_TitleFirstCharacter_token()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _namingConfig.StandardEpisodeFormat = "{Series TitleFirstCharacter:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
+                   .Should().Be("S");
+        }
+
+        [Test]
+        public void should_use_multi_episode_translated_titles()
+        {
+            var episode2 = Builder<Episode>.CreateNew()
+                            .With(e => e.Title = "Episode Two")
+                            .With(e => e.SeasonNumber = 15)
+                            .With(e => e.EpisodeNumber = 7)
+                            .Build();
+
+            _episode1.Translations.Add(new EpisodeTranslation { Language = "FR", Title = "City Sushi FR" });
+            episode2.Translations.Add(new EpisodeTranslation { Language = "FR", Title = "Episode Two FR" });
+
+            _namingConfig.StandardEpisodeFormat = "{Episode Title:FR}";
+
+            Subject.BuildFileName(new List<Episode> { _episode1, episode2 }, _series, _episodeFile)
+                   .Should().Be("City Sushi FR + Episode Two FR");
+        }
+
+        [Test]
+        public void should_still_truncate_when_customFormat_is_numeric_instead_of_language()
+        {
+            _series.Translations.Add(new SeriesTranslation { Language = "FR", Title = "South Park FR" });
+            _series.Title = "The Fantastic Life of Mr. Sisko";
+            _namingConfig.SeriesFolderFormat = "{Series Title:16}";
+
+            var result = Subject.GetSeriesFolder(_series, _namingConfig);
+            result.Should().Be("The Fantasti...");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/Migration/231_add_translations.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/231_add_translations.cs
@@ -1,0 +1,18 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(231)]
+    public class add_translations : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series")
+                 .AddColumn("Translations").AsString().Nullable();
+
+            Alter.Table("Episodes")
+                 .AddColumn("Translations").AsString().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -64,10 +64,72 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
-            var episodes = httpResponse.Resource.Episodes.Select(MapEpisode);
+            var episodes = httpResponse.Resource.Episodes.Select(MapEpisode).ToList();
             var series = MapSeries(httpResponse.Resource);
 
-            return new Tuple<Series, List<Episode>>(series, episodes.ToList());
+            FetchTranslations(series, episodes, tvdbSeriesId);
+
+            return new Tuple<Series, List<Episode>>(series, episodes);
+        }
+
+        private void FetchTranslations(Series series, List<Episode> episodes, int tvdbSeriesId)
+        {
+            var translationLanguages = new[] { "fr", "de", "es", "it", "pt", "nl", "ru", "ja", "ko", "zh", "ar" };
+
+            foreach (var language in translationLanguages)
+            {
+                try
+                {
+                    var translationRequest = _requestBuilder.Create()
+                                                            .SetSegment("route", "shows")
+                                                            .SetSegment("language", language, true)
+                                                            .Resource(tvdbSeriesId.ToString())
+                                                            .Build();
+
+                    translationRequest.AllowAutoRedirect = true;
+                    translationRequest.SuppressHttpError = true;
+
+                    var translationResponse = _httpClient.Get<ShowResource>(translationRequest);
+
+                    if (translationResponse.HasHttpError)
+                    {
+                        continue;
+                    }
+
+                    var translatedSeries = translationResponse.Resource;
+
+                    if (translatedSeries.Title != series.Title)
+                    {
+                        series.Translations.Add(new SeriesTranslation
+                        {
+                            Language = language.ToUpperInvariant(),
+                            Title = translatedSeries.Title,
+                            Overview = translatedSeries.Overview
+                        });
+                    }
+
+                    foreach (var translatedTvdbEpisode in translatedSeries.Episodes)
+                    {
+                        var episode = episodes.FirstOrDefault(e =>
+                            e.SeasonNumber == translatedTvdbEpisode.SeasonNumber &&
+                            e.EpisodeNumber == translatedTvdbEpisode.EpisodeNumber);
+
+                        if (episode != null && translatedTvdbEpisode.Title != episode.Title)
+                        {
+                            episode.Translations.Add(new EpisodeTranslation
+                            {
+                                Language = language.ToUpperInvariant(),
+                                Title = translatedTvdbEpisode.Title,
+                                Overview = translatedTvdbEpisode.Overview
+                            });
+                        }
+                    }
+                }
+                catch
+                {
+                    _logger.Trace("Failed to fetch translations for language: {0}", language);
+                }
+            }
         }
 
         public List<Series> SearchForNewSeriesByImdbId(string imdbId)

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Organizer
         private readonly ICached<bool> _patternHasEpisodeIdentifierCache;
         private readonly Logger _logger;
 
-        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-z0-9+-]+(?<![- ])))?(?<suffix>[- ._)\]]*)\}",
+        private static readonly Regex TitleRegex = new Regex(@"(?<escaped>\{\{|\}\})|\{(?<prefix>[- ._\[(]*)(?<token>(?:[a-z0-9]+)(?:(?<separator>[- ._]+)(?:[a-z0-9]+))?)(?::(?<customFormat>[ ,a-zA-Z0-9+-]+(?<![- ])))?(?<suffix>[- ._)\]]*)\}",
                                                              RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         public static readonly Regex EpisodeRegex = new Regex(@"(?<episode>\{episode(?:\:0+)?})",
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Organizer
 
         public static readonly Regex AirDateRegex = new Regex(@"\{Air(\s|\W|_)Date\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static readonly Regex SeriesTitleRegex = new Regex(@"(?<token>\{(?:Series)(?<separator>[- ._])(Clean)?Title(The)?(Without)?(Year)?(?::(?<customFormat>[0-9-]+))?\})",
+        public static readonly Regex SeriesTitleRegex = new Regex(@"(?<token>\{(?:Series)(?<separator>[- ._])(Clean)?Title(The)?(Without)?(Year)?(?::(?<customFormat>[a-zA-Z0-9-]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
@@ -450,19 +450,19 @@ namespace NzbDrone.Core.Organizer
 
         private void AddSeriesTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Series series)
         {
-            tokenHandlers["{Series Title}"] = m => Truncate(series.Title, m.CustomFormat);
-            tokenHandlers["{Series CleanTitle}"] = m => Truncate(CleanTitle(series.Title), m.CustomFormat);
-            tokenHandlers["{Series TitleYear}"] = m => Truncate(TitleYear(series.Title, series.Year), m.CustomFormat);
-            tokenHandlers["{Series CleanTitleYear}"] = m => Truncate(CleanTitle(TitleYear(series.Title, series.Year)), m.CustomFormat);
-            tokenHandlers["{Series TitleWithoutYear}"] = m => Truncate(TitleWithoutYear(series.Title), m.CustomFormat);
-            tokenHandlers["{Series CleanTitleWithoutYear}"] = m => Truncate(CleanTitle(TitleWithoutYear(series.Title)), m.CustomFormat);
-            tokenHandlers["{Series TitleThe}"] = m => Truncate(TitleThe(series.Title), m.CustomFormat);
-            tokenHandlers["{Series CleanTitleThe}"] = m => Truncate(CleanTitleThe(series.Title), m.CustomFormat);
-            tokenHandlers["{Series TitleTheYear}"] = m => Truncate(TitleYear(TitleThe(series.Title), series.Year), m.CustomFormat);
-            tokenHandlers["{Series CleanTitleTheYear}"] = m => Truncate(CleanTitleTheYear(series.Title, series.Year), m.CustomFormat);
-            tokenHandlers["{Series TitleTheWithoutYear}"] = m => Truncate(TitleWithoutYear(TitleThe(series.Title)), m.CustomFormat);
-            tokenHandlers["{Series CleanTitleTheWithoutYear}"] = m => Truncate(CleanTitleThe(TitleWithoutYear(series.Title)), m.CustomFormat);
-            tokenHandlers["{Series TitleFirstCharacter}"] = m => Truncate(TitleFirstCharacter(TitleThe(series.Title)), m.CustomFormat);
+            tokenHandlers["{Series Title}"] = m => Truncate(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations), m.CustomFormat);
+            tokenHandlers["{Series CleanTitle}"] = m => Truncate(CleanTitle(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations)), m.CustomFormat);
+            tokenHandlers["{Series TitleYear}"] = m => Truncate(TitleYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations), series.Year), m.CustomFormat);
+            tokenHandlers["{Series CleanTitleYear}"] = m => Truncate(CleanTitle(TitleYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations), series.Year)), m.CustomFormat);
+            tokenHandlers["{Series TitleWithoutYear}"] = m => Truncate(TitleWithoutYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations)), m.CustomFormat);
+            tokenHandlers["{Series CleanTitleWithoutYear}"] = m => Truncate(CleanTitle(TitleWithoutYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations))), m.CustomFormat);
+            tokenHandlers["{Series TitleThe}"] = m => Truncate(TitleThe(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations)), m.CustomFormat);
+            tokenHandlers["{Series CleanTitleThe}"] = m => Truncate(CleanTitleThe(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations)), m.CustomFormat);
+            tokenHandlers["{Series TitleTheYear}"] = m => Truncate(TitleYear(TitleThe(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations)), series.Year), m.CustomFormat);
+            tokenHandlers["{Series CleanTitleTheYear}"] = m => Truncate(CleanTitleTheYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations), series.Year), m.CustomFormat);
+            tokenHandlers["{Series TitleTheWithoutYear}"] = m => Truncate(TitleWithoutYear(TitleThe(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations))), m.CustomFormat);
+            tokenHandlers["{Series CleanTitleTheWithoutYear}"] = m => Truncate(CleanTitleThe(TitleWithoutYear(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations))), m.CustomFormat);
+            tokenHandlers["{Series TitleFirstCharacter}"] = m => Truncate(TitleFirstCharacter(TitleThe(GetTranslatedTitle(series.Title, m.CustomFormat, series.Translations))), m.CustomFormat);
             tokenHandlers["{Series Year}"] = m => series.Year.ToString();
         }
 
@@ -617,8 +617,8 @@ namespace NzbDrone.Core.Organizer
 
         private void AddEpisodeTitleTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, List<Episode> episodes, int maxLength)
         {
-            tokenHandlers["{Episode Title}"] = m => GetEpisodeTitle(GetEpisodeTitles(episodes), "+", maxLength, m.CustomFormat);
-            tokenHandlers["{Episode CleanTitle}"] = m => GetEpisodeTitle(GetEpisodeTitles(episodes).Select(CleanTitle).ToList(), "and", maxLength, m.CustomFormat);
+            tokenHandlers["{Episode Title}"] = m => GetEpisodeTitle(GetEpisodeTitles(episodes, m.CustomFormat), "+", maxLength, m.CustomFormat);
+            tokenHandlers["{Episode CleanTitle}"] = m => GetEpisodeTitle(GetEpisodeTitles(episodes, m.CustomFormat).Select(CleanTitle).ToList(), "and", maxLength, m.CustomFormat);
         }
 
         private void AddEpisodeFileTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, EpisodeFile episodeFile, bool useCurrentFilenameAsFallback)
@@ -1013,24 +1013,24 @@ namespace NzbDrone.Core.Organizer
             });
         }
 
-        private List<string> GetEpisodeTitles(List<Episode> episodes)
+        private List<string> GetEpisodeTitles(List<Episode> episodes, string language = null)
         {
             if (episodes.Count == 1)
             {
                 return new List<string>
                        {
-                           episodes.First().Title.TrimEnd(EpisodeTitleTrimCharacters)
+                           GetTranslatedTitle(episodes.First().Title, language, episodes.First().Translations).TrimEnd(EpisodeTitleTrimCharacters)
                        };
             }
 
-            var titles = episodes.Select(c => c.Title.TrimEnd(EpisodeTitleTrimCharacters))
+            var titles = episodes.Select(c => GetTranslatedTitle(c.Title, language, c.Translations).TrimEnd(EpisodeTitleTrimCharacters))
                                  .Select(CleanupEpisodeTitle)
                                  .Distinct()
                                  .ToList();
 
             if (titles.All(t => t.IsNullOrWhiteSpace()))
             {
-                titles = episodes.Select(c => c.Title.TrimEnd(EpisodeTitleTrimCharacters))
+                titles = episodes.Select(c => GetTranslatedTitle(c.Title, language, c.Translations).TrimEnd(EpisodeTitleTrimCharacters))
                                  .Distinct()
                                  .ToList();
             }
@@ -1202,6 +1202,34 @@ namespace NzbDrone.Core.Organizer
             }
 
             return result.TrimStart(' ', '.').TrimEnd(' ');
+        }
+
+        private string GetTranslatedTitle(string originalTitle, string language, List<EpisodeTranslation> translations)
+        {
+            if (language != null && translations != null && translations.Count > 0)
+            {
+                var translation = translations.FirstOrDefault(t => t.Language == language.ToUpperInvariant());
+                if (translation != null && !translation.Title.IsNullOrWhiteSpace())
+                {
+                    return translation.Title;
+                }
+            }
+
+            return originalTitle;
+        }
+
+        private string GetTranslatedTitle(string originalTitle, string language, List<SeriesTranslation> translations)
+        {
+            if (language != null && translations != null && translations.Count > 0)
+            {
+                var translation = translations.FirstOrDefault(t => t.Language == language.ToUpperInvariant());
+                if (translation != null && !translation.Title.IsNullOrWhiteSpace())
+                {
+                    return translation.Title;
+                }
+            }
+
+            return originalTitle;
         }
 
         private string Truncate(string input, string formatter)

--- a/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameSampleService.cs
@@ -49,7 +49,12 @@ namespace NzbDrone.Core.Organizer
                 ImdbId = "tt12345",
                 TvdbId = 12345,
                 TvMazeId = 54321,
-                TmdbId = 11223
+                TmdbId = 11223,
+                Translations = new List<SeriesTranslation>
+                {
+                    new SeriesTranslation { Language = "FR", Title = "Le Titre de la Série!" },
+                    new SeriesTranslation { Language = "DE", Title = "Der Serientitel!" }
+                }
             };
 
             _dailySeries = new Series
@@ -60,7 +65,12 @@ namespace NzbDrone.Core.Organizer
                 ImdbId = "tt12345",
                 TvdbId = 12345,
                 TvMazeId = 54321,
-                TmdbId = 11223
+                TmdbId = 11223,
+                Translations = new List<SeriesTranslation>
+                {
+                    new SeriesTranslation { Language = "FR", Title = "Le Titre de la Série!" },
+                    new SeriesTranslation { Language = "DE", Title = "Der Serientitel!" }
+                }
             };
 
             _animeSeries = new Series
@@ -71,7 +81,12 @@ namespace NzbDrone.Core.Organizer
                 ImdbId = "tt12345",
                 TvdbId = 12345,
                 TvMazeId = 54321,
-                TmdbId = 11223
+                TmdbId = 11223,
+                Translations = new List<SeriesTranslation>
+                {
+                    new SeriesTranslation { Language = "FR", Title = "Le Titre de la Série!" },
+                    new SeriesTranslation { Language = "DE", Title = "Der Serientitel!" }
+                }
             };
 
             _episode1 = new Episode
@@ -81,6 +96,11 @@ namespace NzbDrone.Core.Organizer
                 Title = "Episode Title (1)",
                 AirDate = "2013-10-30",
                 AbsoluteEpisodeNumber = 1,
+                Translations = new List<EpisodeTranslation>
+                {
+                    new EpisodeTranslation { Language = "FR", Title = "Titre de l'épisode (1)" },
+                    new EpisodeTranslation { Language = "DE", Title = "Episodentitel (1)" }
+                }
             };
 
             _episode2 = new Episode
@@ -88,7 +108,12 @@ namespace NzbDrone.Core.Organizer
                 SeasonNumber = 1,
                 EpisodeNumber = 2,
                 Title = "Episode Title (2)",
-                AbsoluteEpisodeNumber = 2
+                AbsoluteEpisodeNumber = 2,
+                Translations = new List<EpisodeTranslation>
+                {
+                    new EpisodeTranslation { Language = "FR", Title = "Titre de l'épisode (2)" },
+                    new EpisodeTranslation { Language = "DE", Title = "Episodentitel (2)" }
+                }
             };
 
             _episode3 = new Episode
@@ -96,7 +121,12 @@ namespace NzbDrone.Core.Organizer
                 SeasonNumber = 1,
                 EpisodeNumber = 3,
                 Title = "Episode Title (3)",
-                AbsoluteEpisodeNumber = 3
+                AbsoluteEpisodeNumber = 3,
+                Translations = new List<EpisodeTranslation>
+                {
+                    new EpisodeTranslation { Language = "FR", Title = "Titre de l'épisode (3)" },
+                    new EpisodeTranslation { Language = "DE", Title = "Episodentitel (3)" }
+                }
             };
 
             _singleEpisode = new List<Episode> { _episode1 };

--- a/src/NzbDrone.Core/Tv/Episode.cs
+++ b/src/NzbDrone.Core/Tv/Episode.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.Tv
         public Episode()
         {
             Images = new List<MediaCover.MediaCover>();
+            Translations = new List<EpisodeTranslation>();
         }
 
         public const string AIR_DATE_FORMAT = "yyyy-MM-dd";
@@ -44,6 +45,8 @@ namespace NzbDrone.Core.Tv
         public LazyLoaded<EpisodeFile> EpisodeFile { get; set; }
 
         public Series Series { get; set; }
+
+        public List<EpisodeTranslation> Translations { get; set; }
 
         public bool HasFile => EpisodeFileId > 0;
         public bool AbsoluteEpisodeNumberAdded { get; set; }
@@ -79,5 +82,12 @@ namespace NzbDrone.Core.Tv
 
             return 0;
         }
+    }
+
+    public class EpisodeTranslation : IEmbeddedDocument
+    {
+        public string Language { get; set; }
+        public string Title { get; set; }
+        public string Overview { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -91,6 +91,7 @@ namespace NzbDrone.Core.Tv
                     episodeToUpdate.FinaleType = episode.FinaleType;
                     episodeToUpdate.Ratings = episode.Ratings;
                     episodeToUpdate.Images = episode.Images;
+                    episodeToUpdate.Translations = episode.Translations;
 
                     // TheTVDB has a severe lack of season/series finales, this helps smooth out that limitation so they can be displayed in the UI
                     if (series.Status == SeriesStatusType.Ended &&

--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -112,6 +112,7 @@ namespace NzbDrone.Core.Tv
             series.Genres = seriesInfo.Genres;
             series.Certification = seriesInfo.Certification;
             series.OriginalCountry = seriesInfo.OriginalCountry;
+            series.Translations = seriesInfo.Translations;
 
             try
             {

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Tv
             OriginalLanguage = Language.English;
             MalIds = new HashSet<int>();
             AniListIds = new HashSet<int>();
+            Translations = new List<SeriesTranslation>();
         }
 
         public int TvdbId { get; set; }
@@ -61,6 +62,7 @@ namespace NzbDrone.Core.Tv
         public List<Season> Seasons { get; set; }
         public HashSet<int> Tags { get; set; }
         public AddSeriesOptions AddOptions { get; set; }
+        public List<SeriesTranslation> Translations { get; set; }
 
         public override string ToString()
         {
@@ -84,5 +86,12 @@ namespace NzbDrone.Core.Tv
             Tags = otherSeries.Tags;
             AddOptions = otherSeries.AddOptions;
         }
+    }
+
+    public class SeriesTranslation : IEmbeddedDocument
+    {
+        public string Language { get; set; }
+        public string Title { get; set; }
+        public string Overview { get; set; }
     }
 }


### PR DESCRIPTION
#### Description

Adds support for translated series and episode titles in naming formats using language tokens, similar to Radarr's implementation. 
 
Users can specify a language code after the colon in title tokens: 
- `{Series Title:FR}` → French translation of the series title 
- `{Episode Title:DE}` → German translation of the episode title 
- `{Series CleanTitle:FR}` → Cleaned French title
- `{Series TitleYear:ES}` → Spanish title with year
- `{Series TitleThe:IT}` → Italian title with "The" moved
 
Translations are fetched from TVDB (via SkyHook API) for 11 languages: French, German, Spanish, Italian, Portuguese, Dutch, Russian, Japanese, Korean, Chinese,Arabic. Data is stored as embedded JSON in the Series and Episodes tables. When no translation exists, the original English title is used as fallback - no breaking changes to existing naming patterns.
 
An updated FileNameSampleService provides sample French/German translations so the rename preview UI shows translated titles when language tokens are configured.
 
#### Database Migration
 
YES - 231
 
#### Issues Fixed or Closed by this PR 
 
N/A
 
 
Checkboxes : 
 
- [X] I have read CONTRIBUTING.md (/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [X] I have fully reviewed all code in this PR and confirm it works as intended 
- [ ] This PR was authored and submitted by an AI agent without human review 
