### PR TITLE
Fixed: Label table selection checkboxes

### DIFF
--- a/frontend/src/Components/Form/CheckInput.tsx
+++ b/frontend/src/Components/Form/CheckInput.tsx
@@ -12,6 +12,7 @@ interface ChangeEvent<T = Element> extends SyntheticEvent<T, MouseEvent> {
 }
 
 export interface CheckInputProps {
+  ariaLabel?: string;
   className?: string;
   containerClassName?: string;
   name: string;
@@ -27,6 +28,7 @@ export interface CheckInputProps {
 
 function CheckInput(props: CheckInputProps) {
   const {
+    ariaLabel,
     className = styles.input,
     containerClassName = styles.container,
     name,
@@ -103,6 +105,7 @@ function CheckInput(props: CheckInputProps) {
           className={styles.checkbox}
           type="checkbox"
           name={name}
+          aria-label={ariaLabel}
           checked={isChecked}
           disabled={isDisabled}
           onChange={handleChange}

--- a/frontend/src/Components/Table/Cells/TableSelectCell.tsx
+++ b/frontend/src/Components/Table/Cells/TableSelectCell.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
 import { SelectStateInputProps } from 'typings/props';
+import translate from 'Utilities/String/translate';
 import TableRowCell, { TableRowCellProps } from './TableRowCell';
 import styles from './TableSelectCell.css';
 
@@ -49,6 +50,7 @@ function TableSelectCell<T extends number | string = number>({
       <CheckInput
         className={styles.input}
         name={id.toString()}
+        ariaLabel={translate('SelectRow')}
         value={isSelected}
         {...otherProps}
         onChange={handleChange}

--- a/frontend/src/Components/Table/Cells/VirtualTableSelectCell.tsx
+++ b/frontend/src/Components/Table/Cells/VirtualTableSelectCell.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
 import { SelectStateInputProps } from 'typings/props';
+import translate from 'Utilities/String/translate';
 import VirtualTableRowCell, {
   VirtualTableRowCellProps,
 } from './VirtualTableRowCell';
@@ -36,6 +37,7 @@ function VirtualTableSelectCell<T extends number | string = number>({
       <CheckInput
         className={inputClassName}
         name={id.toString()}
+        ariaLabel={translate('SelectRow')}
         value={isSelected}
         isDisabled={isDisabled}
         onChange={handleChange}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1970,6 +1970,7 @@
   "SelectReleaseType": "Select Release Type",
   "SelectSeason": "Select Season",
   "SelectSeasonModalTitle": "{modalTitle} - Select Season",
+  "SelectRow": "Select row",
   "SelectSeries": "Select Series",
   "SendAnonymousUsageData": "Send Anonymous Usage Data",
   "Series": "Series",


### PR DESCRIPTION
#### Description

Labels the table row selection checkboxes so screen readers announce a useful name instead of leaving the checkbox unnamed.

The label uses a new localized row selection string, and the shared checkbox component now passes an optional accessible label through to the native checkbox input.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review