### PR TITLE
Fixed: Label icon-only settings actions

### DIFF
--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.tsx
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMapping.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React, { useCallback, useState } from 'react';
-import Icon from 'Components/Icon';
-import Link from 'Components/Link/Link';
+import IconButton from 'Components/Link/IconButton';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
 import { icons, kinds } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
@@ -62,9 +61,12 @@ function RemotePathMapping({
       <div className={styles.path}>{localPath}</div>
 
       <div className={styles.actions}>
-        <Link onPress={handleEditRemotePathMappingPress}>
-          <Icon name={icons.EDIT} />
-        </Link>
+        <IconButton
+          name={icons.EDIT}
+          aria-label={translate('EditRemotePathMapping')}
+          title={translate('EditRemotePathMapping')}
+          onPress={handleEditRemotePathMappingPress}
+        />
       </div>
 
       <EditRemotePathMappingModal

--- a/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.tsx
+++ b/frontend/src/Settings/DownloadClients/RemotePathMappings/RemotePathMappings.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import Alert from 'Components/Alert';
 import FieldSet from 'Components/FieldSet';
-import Icon from 'Components/Icon';
-import Link from 'Components/Link/Link';
+import IconButton from 'Components/Link/IconButton';
 import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
 import PageSectionContent from 'Components/Page/PageSectionContent';
 import { icons, kinds } from 'Helpers/Props';
@@ -56,12 +55,13 @@ function RemotePathMappings() {
         </div>
 
         <div className={styles.addRemotePathMapping}>
-          <Link
+          <IconButton
             className={styles.addButton}
+            name={icons.ADD}
+            aria-label={translate('AddRemotePathMapping')}
+            title={translate('AddRemotePathMapping')}
             onPress={handleAddRemotePathMappingPress}
-          >
-            <Icon name={icons.ADD} />
-          </Link>
+          />
         </div>
 
         <EditRemotePathMappingModal

--- a/frontend/src/Settings/Profiles/Delay/DelayProfile.tsx
+++ b/frontend/src/Settings/Profiles/Delay/DelayProfile.tsx
@@ -198,8 +198,8 @@ function DelayProfile({
         <div className={styles.actions}>
           <IconButton
             name={icons.EDIT}
-            aria-label={translate('EditDelayProfile')}
             className={id === 1 ? styles.editButton : undefined}
+            aria-label={translate('EditDelayProfile')}
             title={translate('EditDelayProfile')}
             onPress={handleEditDelayProfilePress}
           />

--- a/frontend/src/Settings/Profiles/Delay/DelayProfile.tsx
+++ b/frontend/src/Settings/Profiles/Delay/DelayProfile.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { DragSourceMonitor, useDrag, useDrop, XYCoord } from 'react-dnd';
 import Icon from 'Components/Icon';
-import Link from 'Components/Link/Link';
+import IconButton from 'Components/Link/IconButton';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
 import TagList from 'Components/TagList';
 import DragType from 'Helpers/DragType';
@@ -196,12 +196,13 @@ function DelayProfile({
         <TagList tags={tags} tagList={tagList} />
 
         <div className={styles.actions}>
-          <Link
+          <IconButton
+            name={icons.EDIT}
+            aria-label={translate('EditDelayProfile')}
             className={id === 1 ? styles.editButton : undefined}
+            title={translate('EditDelayProfile')}
             onPress={handleEditDelayProfilePress}
-          >
-            <Icon name={icons.EDIT} />
-          </Link>
+          />
 
           {id === 1 ? null : (
             <div ref={dragRef} className={styles.dragHandle}>

--- a/frontend/src/Settings/Profiles/Delay/DelayProfiles.tsx
+++ b/frontend/src/Settings/Profiles/Delay/DelayProfiles.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import FieldSet from 'Components/FieldSet';
-import Icon from 'Components/Icon';
-import Link from 'Components/Link/Link';
+import IconButton from 'Components/Link/IconButton';
 import PageSectionContent from 'Components/Page/PageSectionContent';
 import Scroller from 'Components/Scroller/Scroller';
 import { icons, scrollDirections } from 'Helpers/Props';
@@ -136,12 +135,13 @@ function DelayProfiles() {
         </Scroller>
 
         <div className={styles.addDelayProfile}>
-          <Link
+          <IconButton
             className={styles.addButton}
+            name={icons.ADD}
+            aria-label={translate('AddDelayProfile')}
+            title={translate('AddDelayProfile')}
             onPress={handleAddDelayProfilePress}
-          >
-            <Icon name={icons.ADD} />
-          </Link>
+          />
         </div>
 
         <EditDelayProfileModal


### PR DESCRIPTION
#### Description

Uses the shared `IconButton` component for the icon-only add and edit actions in delay profiles and remote path mappings.

These controls already have matching translated text, so the existing translation keys are used for both the accessible label and tooltip text.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review