### PR TITLE
Fixed: Use shared cards for add setting tiles

### DIFF
--- a/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.css
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.css
@@ -6,10 +6,6 @@
   height: 100px;
 }
 
-.underlay {
-  @add-mixin cover;
-}
-
 .overlay {
   @add-mixin linkOverlay;
 

--- a/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.css.d.ts
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.css.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'presetsMenu': string;
   'presetsMenuButton': string;
   'specification': string;
-  'underlay': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.tsx
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Specifications/AddSpecificationItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
+import Card from 'Components/Card';
 import Button from 'Components/Link/Button';
-import Link from 'Components/Link/Link';
 import Menu from 'Components/Menu/Menu';
 import MenuContent from 'Components/Menu/MenuContent';
 import { sizes } from 'Helpers/Props';
@@ -34,44 +34,48 @@ function AddSpecificationItem({
   }, [implementation, onSpecificationSelect]);
 
   return (
-    <div className={styles.specification}>
-      <Link className={styles.underlay} onPress={handleCustomSelect} />
+    <Card
+      className={styles.specification}
+      overlayClassName={styles.overlay}
+      overlayContent={true}
+      aria-label={translate('AddConditionImplementation', {
+        implementationName,
+      })}
+      onPress={handleCustomSelect}
+    >
+      <div className={styles.name}>{implementationName}</div>
 
-      <div className={styles.overlay}>
-        <div className={styles.name}>{implementationName}</div>
+      <div className={styles.actions}>
+        {hasPresets ? (
+          <span>
+            <Button size={sizes.SMALL} onPress={handleCustomSelect}>
+              {translate('Custom')}
+            </Button>
 
-        <div className={styles.actions}>
-          {hasPresets ? (
-            <span>
-              <Button size={sizes.SMALL} onPress={handleCustomSelect}>
-                {translate('Custom')}
+            <Menu className={styles.presetsMenu}>
+              <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
+                {translate('Presets')}
               </Button>
 
-              <Menu className={styles.presetsMenu}>
-                <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
-                  {translate('Presets')}
-                </Button>
+              <MenuContent>
+                {presets.map((preset) => (
+                  <AddSpecificationPresetMenuItem
+                    key={preset.name}
+                    name={preset.name}
+                    implementation={implementation}
+                    onPress={onSpecificationSelect}
+                  />
+                ))}
+              </MenuContent>
+            </Menu>
+          </span>
+        ) : null}
 
-                <MenuContent>
-                  {presets.map((preset) => (
-                    <AddSpecificationPresetMenuItem
-                      key={preset.name}
-                      name={preset.name}
-                      implementation={implementation}
-                      onPress={onSpecificationSelect}
-                    />
-                  ))}
-                </MenuContent>
-              </Menu>
-            </span>
-          ) : null}
-
-          <Button to={infoLink} size={sizes.SMALL}>
-            {translate('MoreInfo')}
-          </Button>
-        </div>
+        <Button to={infoLink} size={sizes.SMALL}>
+          {translate('MoreInfo')}
+        </Button>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.css
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.css
@@ -6,10 +6,6 @@
   height: 100px;
 }
 
-.underlay {
-  @add-mixin cover;
-}
-
 .overlay {
   @add-mixin linkOverlay;
 

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.css.d.ts
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.css.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'overlay': string;
   'presetsMenu': string;
   'presetsMenuButton': string;
-  'underlay': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.tsx
+++ b/frontend/src/Settings/ImportLists/ImportLists/AddImportListItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
+import Card from 'Components/Card';
 import Button from 'Components/Link/Button';
-import Link from 'Components/Link/Link';
 import Menu from 'Components/Menu/Menu';
 import MenuContent from 'Components/Menu/MenuContent';
 import { sizes } from 'Helpers/Props';
@@ -32,47 +32,51 @@ function AddImportListItem({
   }, [implementation, implementationName, onImportListSelect]);
 
   return (
-    <div className={styles.list}>
-      <Link className={styles.underlay} onPress={handleImportListSelect} />
+    <Card
+      className={styles.list}
+      overlayClassName={styles.overlay}
+      overlayContent={true}
+      aria-label={translate('AddImportListImplementation', {
+        implementationName,
+      })}
+      onPress={handleImportListSelect}
+    >
+      <div className={styles.name}>{implementationName}</div>
 
-      <div className={styles.overlay}>
-        <div className={styles.name}>{implementationName}</div>
+      <div className={styles.actions}>
+        {hasPresets && (
+          <span>
+            <Button size={sizes.SMALL} onPress={handleImportListSelect}>
+              {translate('Custom')}
+            </Button>
 
-        <div className={styles.actions}>
-          {hasPresets && (
-            <span>
-              <Button size={sizes.SMALL} onPress={handleImportListSelect}>
-                {translate('Custom')}
+            <Menu className={styles.presetsMenu}>
+              <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
+                {translate('Presets')}
               </Button>
 
-              <Menu className={styles.presetsMenu}>
-                <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
-                  {translate('Presets')}
-                </Button>
+              <MenuContent>
+                {presets.map((preset) => {
+                  return (
+                    <AddImportListPresetMenuItem
+                      key={preset.name}
+                      name={preset.name}
+                      implementation={implementation}
+                      implementationName={implementationName}
+                      onPress={onImportListSelect}
+                    />
+                  );
+                })}
+              </MenuContent>
+            </Menu>
+          </span>
+        )}
 
-                <MenuContent>
-                  {presets.map((preset) => {
-                    return (
-                      <AddImportListPresetMenuItem
-                        key={preset.name}
-                        name={preset.name}
-                        implementation={implementation}
-                        implementationName={implementationName}
-                        onPress={onImportListSelect}
-                      />
-                    );
-                  })}
-                </MenuContent>
-              </Menu>
-            </span>
-          )}
-
-          <Button to={infoLink} size={sizes.SMALL}>
-            {translate('MoreInfo')}
-          </Button>
-        </div>
+        <Button to={infoLink} size={sizes.SMALL}>
+          {translate('MoreInfo')}
+        </Button>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.css
+++ b/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.css
@@ -6,10 +6,6 @@
   height: 100px;
 }
 
-.underlay {
-  @add-mixin cover;
-}
-
 .overlay {
   @add-mixin linkOverlay;
 

--- a/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.css.d.ts
+++ b/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.css.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'overlay': string;
   'presetsMenu': string;
   'presetsMenuButton': string;
-  'underlay': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.tsx
+++ b/frontend/src/Settings/Notifications/Notifications/AddNotificationItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
+import Card from 'Components/Card';
 import Button from 'Components/Link/Button';
-import Link from 'Components/Link/Link';
 import Menu from 'Components/Menu/Menu';
 import MenuContent from 'Components/Menu/MenuContent';
 import { sizes } from 'Helpers/Props';
@@ -32,47 +32,51 @@ function AddNotificationItem({
   }, [implementation, implementationName, onNotificationSelect]);
 
   return (
-    <div className={styles.notification}>
-      <Link className={styles.underlay} onPress={handleNotificationSelect} />
+    <Card
+      className={styles.notification}
+      overlayClassName={styles.overlay}
+      overlayContent={true}
+      aria-label={translate('AddConnectionImplementation', {
+        implementationName,
+      })}
+      onPress={handleNotificationSelect}
+    >
+      <div className={styles.name}>{implementationName}</div>
 
-      <div className={styles.overlay}>
-        <div className={styles.name}>{implementationName}</div>
+      <div className={styles.actions}>
+        {hasPresets ? (
+          <span>
+            <Button size={sizes.SMALL} onPress={handleNotificationSelect}>
+              {translate('Custom')}
+            </Button>
 
-        <div className={styles.actions}>
-          {hasPresets ? (
-            <span>
-              <Button size={sizes.SMALL} onPress={handleNotificationSelect}>
-                {translate('Custom')}
+            <Menu className={styles.presetsMenu}>
+              <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
+                {translate('Presets')}
               </Button>
 
-              <Menu className={styles.presetsMenu}>
-                <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
-                  {translate('Presets')}
-                </Button>
+              <MenuContent>
+                {presets.map((preset) => {
+                  return (
+                    <AddNotificationPresetMenuItem
+                      key={preset.name}
+                      name={preset.name}
+                      implementation={implementation}
+                      implementationName={implementationName}
+                      onPress={onNotificationSelect}
+                    />
+                  );
+                })}
+              </MenuContent>
+            </Menu>
+          </span>
+        ) : null}
 
-                <MenuContent>
-                  {presets.map((preset) => {
-                    return (
-                      <AddNotificationPresetMenuItem
-                        key={preset.name}
-                        name={preset.name}
-                        implementation={implementation}
-                        implementationName={implementationName}
-                        onPress={onNotificationSelect}
-                      />
-                    );
-                  })}
-                </MenuContent>
-              </Menu>
-            </span>
-          ) : null}
-
-          <Button to={infoLink} size={sizes.SMALL}>
-            {translate('MoreInfo')}
-          </Button>
-        </div>
+        <Button to={infoLink} size={sizes.SMALL}>
+          {translate('MoreInfo')}
+        </Button>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.css
+++ b/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.css
@@ -6,10 +6,6 @@
   height: 100px;
 }
 
-.underlay {
-  @add-mixin cover;
-}
-
 .overlay {
   @add-mixin linkOverlay;
 

--- a/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.css.d.ts
+++ b/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.css.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'presetsMenu': string;
   'presetsMenuButton': string;
   'specification': string;
-  'underlay': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.tsx
+++ b/frontend/src/Settings/Tags/AutoTagging/Specifications/AddSpecificationItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
+import Card from 'Components/Card';
 import Button from 'Components/Link/Button';
-import Link from 'Components/Link/Link';
 import Menu from 'Components/Menu/Menu';
 import MenuContent from 'Components/Menu/MenuContent';
 import { sizes } from 'Helpers/Props';
@@ -35,47 +35,51 @@ export default function AddSpecificationItem({
   const hasPresets = !!presets && !!presets.length;
 
   return (
-    <div className={styles.specification}>
-      <Link className={styles.underlay} onPress={handleSpecificationSelect} />
+    <Card
+      className={styles.specification}
+      overlayClassName={styles.overlay}
+      overlayContent={true}
+      aria-label={translate('AddConditionImplementation', {
+        implementationName,
+      })}
+      onPress={handleSpecificationSelect}
+    >
+      <div className={styles.name}>{implementationName}</div>
 
-      <div className={styles.overlay}>
-        <div className={styles.name}>{implementationName}</div>
+      <div className={styles.actions}>
+        {hasPresets ? (
+          <span>
+            <Button size={sizes.SMALL} onPress={handleSpecificationSelect}>
+              {translate('Custom')}
+            </Button>
 
-        <div className={styles.actions}>
-          {hasPresets ? (
-            <span>
-              <Button size={sizes.SMALL} onPress={handleSpecificationSelect}>
-                {translate('Custom')}
+            <Menu className={styles.presetsMenu}>
+              <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
+                {translate('Presets')}
               </Button>
 
-              <Menu className={styles.presetsMenu}>
-                <Button className={styles.presetsMenuButton} size={sizes.SMALL}>
-                  {translate('Presets')}
-                </Button>
+              <MenuContent>
+                {presets.map((preset, index) => {
+                  return (
+                    <AddSpecificationPresetMenuItem
+                      key={index}
+                      name={preset.name}
+                      implementation={implementation}
+                      onPress={handleSpecificationSelect}
+                    />
+                  );
+                })}
+              </MenuContent>
+            </Menu>
+          </span>
+        ) : null}
 
-                <MenuContent>
-                  {presets.map((preset, index) => {
-                    return (
-                      <AddSpecificationPresetMenuItem
-                        key={index}
-                        name={preset.name}
-                        implementation={implementation}
-                        onPress={handleSpecificationSelect}
-                      />
-                    );
-                  })}
-                </MenuContent>
-              </Menu>
-            </span>
-          ) : null}
-
-          {infoLink ? (
-            <Button to={infoLink} size={sizes.SMALL}>
-              {translate('MoreInfo')}
-            </Button>
-          ) : null}
-        </div>
+        {infoLink ? (
+          <Button to={infoLink} size={sizes.SMALL}>
+            {translate('MoreInfo')}
+          </Button>
+        ) : null}
       </div>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
#### Description

Moves the remaining add-setting tiles that use an overlay click target onto the shared card wrapper.

This keeps the visible layout the same while using the same card behavior and accessible labels as the other settings add tiles.

#### Testing

- Ran eslint on touched frontend files
- Ran stylelint on touched CSS files
- Ran a focused check for the converted add tiles and existing translation keys

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review