### PR TITLE
Fixed: Label remaining selection checkboxes

### DIFF
--- a/frontend/src/Components/Table/TableSelectAllHeaderCell.tsx
+++ b/frontend/src/Components/Table/TableSelectAllHeaderCell.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
+import translate from 'Utilities/String/translate';
 import VirtualTableHeaderCell from './TableHeaderCell';
 import styles from './TableSelectAllHeaderCell.css';
 
@@ -33,6 +34,7 @@ function TableSelectAllHeaderCell({
       <CheckInput
         className={styles.input}
         name="selectAll"
+        ariaLabel={translate('SelectAll')}
         value={value}
         onChange={onSelectAllChange}
       />

--- a/frontend/src/Components/Table/VirtualTableSelectAllHeaderCell.tsx
+++ b/frontend/src/Components/Table/VirtualTableSelectAllHeaderCell.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import CheckInput from 'Components/Form/CheckInput';
 import { CheckInputChanged } from 'typings/inputs';
+import translate from 'Utilities/String/translate';
 import VirtualTableHeaderCell from './VirtualTableHeaderCell';
 import styles from './VirtualTableSelectAllHeaderCell.css';
 
@@ -33,6 +34,7 @@ function VirtualTableSelectAllHeaderCell({
       <CheckInput
         className={styles.input}
         name="selectAll"
+        ariaLabel={translate('SelectAll')}
         value={value}
         onChange={onSelectAllChange}
       />

--- a/frontend/src/Organize/OrganizePreviewModalContent.tsx
+++ b/frontend/src/Organize/OrganizePreviewModalContent.tsx
@@ -162,6 +162,7 @@ function OrganizePreviewModalContentInner({
             className={styles.selectAllInput}
             containerClassName={styles.selectAllInputContainer}
             name="selectAll"
+            ariaLabel={translate('SelectAll')}
             value={selectAllValue}
             onChange={handleSelectAllChange}
           />

--- a/frontend/src/Organize/OrganizePreviewRow.tsx
+++ b/frontend/src/Organize/OrganizePreviewRow.tsx
@@ -4,6 +4,7 @@ import CheckInput from 'Components/Form/CheckInput';
 import Icon from 'Components/Icon';
 import { icons, kinds } from 'Helpers/Props';
 import { CheckInputChanged } from 'typings/inputs';
+import translate from 'Utilities/String/translate';
 import { OrganizePreviewModel } from './useOrganizePreview';
 import styles from './OrganizePreviewRow.css';
 
@@ -45,6 +46,7 @@ function OrganizePreviewRow({
       <CheckInput
         containerClassName={styles.selectedContainer}
         name={id.toString()}
+        ariaLabel={translate('SelectRow')}
         value={isSelected}
         onChange={handleSelectedChange}
       />


### PR DESCRIPTION
#### Description

Adds accessible labels to the remaining unlabeled selection checkboxes in shared table headers and the organize preview modal.

This keeps the visible UI unchanged while making those controls announce properly for screen reader users.

#### Testing

- Ran eslint on touched frontend files
- Ran a focused check for the updated checkbox labels and existing translation keys

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review