### PR TITLE
Fixed: Error when fetching non-existing tags in import script

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
+++ b/src/NzbDrone.Core/MediaFiles/ScriptImportDecider.cs
@@ -142,7 +142,7 @@ namespace NzbDrone.Core.MediaFiles
             environmentVariables.Add("Sonarr_Series_Type", series.SeriesType.ToString());
             environmentVariables.Add("Sonarr_Series_OriginalLanguage", IsoLanguages.Get(series.OriginalLanguage).ThreeLetterCode);
             environmentVariables.Add("Sonarr_Series_Genres", string.Join("|", series.Genres));
-            environmentVariables.Add("Sonarr_Series_Tags", string.Join("|", series.Tags.Select(t => _tagRepository.Get(t).Label)));
+            environmentVariables.Add("Sonarr_Series_Tags", string.Join("|", _tagRepository.GetTags(series.Tags).Select(t => t.Label)));
 
             environmentVariables.Add("Sonarr_EpisodeFile_EpisodeCount", localEpisode.Episodes.Count.ToString());
             environmentVariables.Add("Sonarr_EpisodeFile_EpisodeIds", string.Join(",", localEpisode.Episodes.Select(e => e.Id)));


### PR DESCRIPTION
#### Description

Fix for ModelNotFoundException while fetching non-existing tags. 

```
NzbDrone.Core.Datastore.ModelNotFoundException: Tag with ID 3 does not exist
   at NzbDrone.Core.Datastore.BasicRepository`1.Get(Int32 id) in ./NzbDrone.Core/Datastore/BasicRepository.cs:line 128
   at NzbDrone.Core.MediaFiles.ImportScriptService.<>c__DisplayClass10_0.<TryImport>b__0(Int32 t) in ./NzbDrone.Core/MediaFiles/ScriptImportDecider.cs:line 145
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
   at NzbDrone.Core.MediaFiles.ImportScriptService.TryImport(String sourcePath, String destinationFilePath, LocalEpisode localEpisode, EpisodeFile episodeFile, TransferMode mode) in ./NzbDrone.Core/MediaFiles/ScriptImportDecider.cs:line 145
```
#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
