### PR TITLE
Fixed sorting on manage modals

### DIFF
--- a/frontend/src/Settings/DownloadClients/DownloadClients/Manage/ManageDownloadClientsModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/Manage/ManageDownloadClientsModalContent.tsx
@@ -91,7 +91,10 @@ function ManageDownloadClientsModalContentInner({
   onModalClose,
 }: ManageDownloadClientsModalContentProps) {
   const { sortKey, sortDirection } = useManageDownloadClientsOptions();
-  const { data, isFetching, isFetched, error } = useSortedDownloadClients();
+  const { data, isFetching, isFetched, error } = useSortedDownloadClients(
+    sortKey,
+    sortDirection
+  );
 
   const { isDeleting, bulkDeleteDownloadClients } =
     useBulkDeleteDownloadClients();

--- a/frontend/src/Settings/DownloadClients/DownloadClients/useDownloadClients.ts
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/useDownloadClients.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import DownloadProtocol from 'DownloadClient/DownloadProtocol';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import {
   SelectedSchema,
   useProviderSchema,
@@ -15,6 +16,7 @@ import {
 import Provider from 'typings/Provider';
 import { sortByProp } from 'Utilities/Array/sortByProp';
 import { ApiError } from 'Utilities/Fetch/fetchJson';
+import clientSideFilterAndSort from 'Utilities/Filter/clientSideFilterAndSort';
 import translate from 'Utilities/String/translate';
 
 export interface DownloadClientModel extends Provider {
@@ -49,12 +51,32 @@ export const useDownloadClientsData = () => {
   return data;
 };
 
-export const useSortedDownloadClients = () => {
+const SORT_PREDICATES = {
+  name: (item: DownloadClientModel) => item.name.toLowerCase(),
+  protocol: (item: DownloadClientModel) =>
+    item.protocol === 'usenet' ? 'nzb' : item.protocol,
+};
+
+export const useSortedDownloadClients = (
+  sortKey: keyof DownloadClientModel = 'name',
+  sortDirection: SortDirection = 'ascending'
+) => {
   const result = useDownloadClients();
 
   const sortedData = useMemo(
-    () => [...result.data].sort(sortByProp('name')),
-    [result.data]
+    () =>
+      clientSideFilterAndSort<
+        DownloadClientModel,
+        never,
+        typeof SORT_PREDICATES
+      >(result.data, {
+        sortKey,
+        sortDirection,
+        secondarySortKey: 'name',
+        secondarySortDirection: 'ascending',
+        sortPredicates: SORT_PREDICATES,
+      }).data,
+    [result.data, sortKey, sortDirection]
   );
 
   return {

--- a/frontend/src/Settings/DownloadClients/useManageDownloadClientsOptionsStore.ts
+++ b/frontend/src/Settings/DownloadClients/useManageDownloadClientsOptionsStore.ts
@@ -1,8 +1,9 @@
 import { createOptionsStore } from 'Helpers/Hooks/useOptionsStore';
 import { SortDirection } from 'Helpers/Props/sortDirections';
+import { DownloadClientModel } from 'Settings/DownloadClients/DownloadClients/useDownloadClients';
 
 export interface ManageDownloadClientsOptions {
-  sortKey: string;
+  sortKey: keyof DownloadClientModel;
   sortDirection: SortDirection;
 }
 

--- a/frontend/src/Settings/ImportLists/ImportLists/Manage/ManageImportListsModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportLists/Manage/ManageImportListsModalContent.tsx
@@ -9,6 +9,7 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
+import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
 import { kinds } from 'Helpers/Props';
@@ -19,6 +20,10 @@ import {
   useImportListsData,
   useSortedImportLists,
 } from 'Settings/ImportLists/ImportLists/useImportLists';
+import {
+  setManageImportListsSort,
+  useManageImportListsOptions,
+} from 'Settings/ImportLists/useManageImportListsOptionsStore';
 import { CheckInputChanged } from 'typings/inputs';
 import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import translate from 'Utilities/String/translate';
@@ -27,7 +32,7 @@ import ManageImportListsModalRow from './ManageImportListsModalRow';
 import TagsModal from './Tags/TagsModal';
 import styles from './ManageImportListsModalContent.css';
 
-const COLUMNS = [
+const COLUMNS: Column[] = [
   {
     name: 'name',
     label: () => translate('Name'),
@@ -85,7 +90,11 @@ function ManageImportListsModalContentInner(
 ) {
   const { onModalClose } = props;
 
-  const { data, isFetching, isFetched, error } = useSortedImportLists();
+  const { sortKey, sortDirection } = useManageImportListsOptions();
+  const { data, isFetching, isFetched, error } = useSortedImportLists(
+    sortKey,
+    sortDirection
+  );
 
   const { isDeleting, bulkDeleteImportLists } = useBulkDeleteImportLists();
   const { isSaving, bulkEditImportLists } = useBulkEditImportLists();
@@ -173,6 +182,10 @@ function ManageImportListsModalContentInner(
     [selectAll, unselectAll]
   );
 
+  const onSortPress = useCallback((value: string) => {
+    setManageImportListsSort({ sortKey: value });
+  }, []);
+
   const errorMessage = getErrorMessage(error, 'Unable to load import lists.');
 
   return (
@@ -194,7 +207,10 @@ function ManageImportListsModalContentInner(
             selectAll={true}
             allSelected={allSelected}
             allUnselected={allUnselected}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
             onSelectAllChange={onSelectAllChange}
+            onSortPress={onSortPress}
           >
             <TableBody>
               {data.map((item) => {

--- a/frontend/src/Settings/ImportLists/ImportLists/useImportLists.ts
+++ b/frontend/src/Settings/ImportLists/ImportLists/useImportLists.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import { MonitorNewItems, SeriesMonitor, SeriesType } from 'Series/Series';
 import {
   SelectedSchema,
@@ -13,8 +14,8 @@ import {
   useProviderSettings,
 } from 'Settings/useProviderSettings';
 import Provider from 'typings/Provider';
-import { sortByProp } from 'Utilities/Array/sortByProp';
 import { ApiError } from 'Utilities/Fetch/fetchJson';
+import clientSideFilterAndSort from 'Utilities/Filter/clientSideFilterAndSort';
 import translate from 'Utilities/String/translate';
 
 export interface ImportListModel extends Provider {
@@ -56,12 +57,29 @@ export const useImportListsData = () => {
   return data;
 };
 
-export const useSortedImportLists = () => {
+const SORT_PREDICATES = {
+  name: (item: ImportListModel) => item.name.toLowerCase(),
+};
+
+export const useSortedImportLists = (
+  sortKey: keyof ImportListModel = 'name',
+  sortDirection: SortDirection = 'ascending'
+) => {
   const result = useImportLists();
 
   const sortedData = useMemo(
-    () => [...result.data].sort(sortByProp('name')),
-    [result.data]
+    () =>
+      clientSideFilterAndSort<ImportListModel, never, typeof SORT_PREDICATES>(
+        result.data,
+        {
+          sortKey,
+          sortDirection,
+          secondarySortKey: 'name',
+          secondarySortDirection: 'ascending',
+          sortPredicates: SORT_PREDICATES,
+        }
+      ).data,
+    [result.data, sortKey, sortDirection]
   );
 
   return {

--- a/frontend/src/Settings/ImportLists/useManageImportListsOptionsStore.ts
+++ b/frontend/src/Settings/ImportLists/useManageImportListsOptionsStore.ts
@@ -1,0 +1,21 @@
+import { createOptionsStore } from 'Helpers/Hooks/useOptionsStore';
+import { SortDirection } from 'Helpers/Props/sortDirections';
+import { ImportListModel } from 'Settings/ImportLists/ImportLists/useImportLists';
+
+export interface ManageImportListsOptions {
+  sortKey: keyof ImportListModel;
+  sortDirection: SortDirection;
+}
+
+const { useOptions, setSort } = createOptionsStore<ManageImportListsOptions>(
+  'manage_import_lists_options',
+  () => {
+    return {
+      sortKey: 'name',
+      sortDirection: 'ascending',
+    };
+  }
+);
+
+export const useManageImportListsOptions = useOptions;
+export const setManageImportListsSort = setSort;

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
@@ -103,7 +103,10 @@ function ManageIndexersModalContentInner(
   const { onModalClose } = props;
 
   const { sortKey, sortDirection } = useManageIndexersOptions();
-  const { data, isFetching, isFetched, error } = useSortedIndexers();
+  const { data, isFetching, isFetched, error } = useSortedIndexers(
+    sortKey,
+    sortDirection
+  );
 
   const { isDeleting, bulkDeleteIndexers } = useBulkDeleteIndexers();
   const { isSaving, bulkEditIndexers } = useBulkEditIndexers();

--- a/frontend/src/Settings/Indexers/useIndexers.ts
+++ b/frontend/src/Settings/Indexers/useIndexers.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import DownloadProtocol from 'DownloadClient/DownloadProtocol';
 import useApiMutation from 'Helpers/Hooks/useApiMutation';
+import { SortDirection } from 'Helpers/Props/sortDirections';
 import {
   SelectedSchema,
   useProviderSchema,
@@ -13,8 +14,8 @@ import {
   useProviderSettings,
 } from 'Settings/useProviderSettings';
 import Provider from 'typings/Provider';
-import { sortByProp } from 'Utilities/Array/sortByProp';
 import { ApiError } from 'Utilities/Fetch/fetchJson';
+import clientSideFilterAndSort from 'Utilities/Filter/clientSideFilterAndSort';
 import translate from 'Utilities/String/translate';
 
 export interface IndexerModel extends Provider {
@@ -63,12 +64,31 @@ export const useIndexersData = () => {
   return data;
 };
 
-export const useSortedIndexers = () => {
+const SORT_PREDICATES = {
+  name: (item: IndexerModel) => item.name.toLowerCase(),
+  protocol: (item: IndexerModel) =>
+    item.protocol === 'usenet' ? 'nzb' : item.protocol,
+};
+
+export const useSortedIndexers = (
+  sortKey: keyof IndexerModel = 'name',
+  sortDirection: SortDirection = 'ascending'
+) => {
   const result = useIndexers();
 
   const sortedData = useMemo(
-    () => [...result.data].sort(sortByProp('name')),
-    [result.data]
+    () =>
+      clientSideFilterAndSort<IndexerModel, never, typeof SORT_PREDICATES>(
+        result.data,
+        {
+          sortKey,
+          sortDirection,
+          secondarySortKey: 'name',
+          secondarySortDirection: 'ascending',
+          sortPredicates: SORT_PREDICATES,
+        }
+      ).data,
+    [result.data, sortKey, sortDirection]
   );
 
   return {

--- a/frontend/src/Settings/Indexers/useManageIndexersOptionsStore.ts
+++ b/frontend/src/Settings/Indexers/useManageIndexersOptionsStore.ts
@@ -1,8 +1,9 @@
 import { createOptionsStore } from 'Helpers/Hooks/useOptionsStore';
 import { SortDirection } from 'Helpers/Props/sortDirections';
+import { IndexerModel } from 'Settings/Indexers/useIndexers';
 
 export interface ManageIndexersOptions {
-  sortKey: string;
+  sortKey: keyof IndexerModel;
   sortDirection: SortDirection;
 }
 


### PR DESCRIPTION
#### Description

Sorting wasn't working in "manage" modals, now it is. Also added sorting for Import Lists which didn't work in v4.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
