### PR TITLE
Fixed: Label series status indicators

### DIFF
--- a/frontend/src/Series/Index/Table/SeriesStatusCell.tsx
+++ b/frontend/src/Series/Index/Table/SeriesStatusCell.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import Icon from 'Components/Icon';
 import MonitorToggleButton from 'Components/MonitorToggleButton';
+import StatusIndicator from 'Components/StatusIndicator';
 import VirtualTableRowCell from 'Components/Table/Cells/TableRowCell';
 import { icons } from 'Helpers/Props';
 import { SeriesStatus } from 'Series/Series';
@@ -45,22 +46,30 @@ function SeriesStatusCell({
           onPress={onMonitoredPress}
         />
       ) : (
-        <Icon
+        <StatusIndicator
           className={styles.statusIcon}
-          name={monitored ? icons.MONITORED : icons.UNMONITORED}
+          label={
+            monitored
+              ? translate('SeriesIsMonitored')
+              : translate('SeriesIsUnmonitored')
+          }
           title={
             monitored
               ? translate('SeriesIsMonitored')
               : translate('SeriesIsUnmonitored')
           }
-        />
+        >
+          <Icon name={monitored ? icons.MONITORED : icons.UNMONITORED} />
+        </StatusIndicator>
       )}
 
-      <Icon
+      <StatusIndicator
         className={styles.statusIcon}
-        name={statusDetails.icon}
+        label={statusDetails.message}
         title={`${statusDetails.title}: ${statusDetails.message}`}
-      />
+      >
+        <Icon name={statusDetails.icon} />
+      </StatusIndicator>
     </Component>
   );
 }


### PR DESCRIPTION
#### Description

Series status icons in the series table currently rely on tooltip text to communicate whether a series is monitored and whether it is continuing, upcoming, ended, or deleted.

This uses the existing StatusIndicator component so those statuses are also available to screen readers. It uses the existing translated status descriptions directly and does not add separate accessible label state.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review