### PR TITLE
Fixed: Make tooltip and popover anchors keyboard accessible

### DIFF
--- a/frontend/src/Activity/Queue/QueueStatus.tsx
+++ b/frontend/src/Activity/Queue/QueueStatus.tsx
@@ -143,6 +143,7 @@ function QueueStatus(props: QueueStatusProps) {
   return (
     <Popover
       anchor={<Icon name={iconName} kind={iconKind} />}
+      accessibleLabel={title}
       title={title}
       body={
         hasWarning || hasError

--- a/frontend/src/Components/Tooltip/Tooltip.css
+++ b/frontend/src/Components/Tooltip/Tooltip.css
@@ -1,3 +1,8 @@
+.reference:focus-visible {
+  outline: 2px solid var(--linkColor);
+  outline-offset: 2px;
+}
+
 .tooltipContainer {
   z-index: $popperZIndex;
 }

--- a/frontend/src/Components/Tooltip/Tooltip.css.d.ts
+++ b/frontend/src/Components/Tooltip/Tooltip.css.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'body': string;
   'default': string;
   'inverse': string;
+  'reference': string;
   'tooltip': string;
   'tooltipContainer': string;
 }

--- a/frontend/src/Components/Tooltip/Tooltip.tsx
+++ b/frontend/src/Components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import {
   autoUpdate,
   flip,
   FloatingArrow,
+  FloatingFocusManager,
   FloatingPortal,
   offset,
   Placement,
@@ -11,8 +12,10 @@ import {
   useClick,
   useDismiss,
   useFloating,
+  useFocus,
   useHover,
   useInteractions,
+  useRole,
 } from '@floating-ui/react';
 import classNames from 'classnames';
 import React, { useRef, useState } from 'react';
@@ -23,10 +26,13 @@ import { isMobile } from 'Utilities/browser';
 import styles from './Tooltip.css';
 
 export interface TooltipProps {
+  accessibleLabel?: string;
   className?: string;
   bodyClassName?: string;
   anchor: React.ReactNode;
   tooltip: string | React.ReactNode;
+  contentRole?: 'dialog' | 'tooltip';
+  isAnchorFocusable?: boolean;
   kind?: Extract<Kind, 'default' | 'inverse'>;
   position?: Placement;
   canFlip?: boolean;
@@ -34,10 +40,13 @@ export interface TooltipProps {
 
 function Tooltip(props: TooltipProps) {
   const {
+    accessibleLabel,
     className,
     bodyClassName = styles.body,
     anchor,
     tooltip,
+    contentRole = 'tooltip',
+    isAnchorFocusable = true,
     kind = kinds.DEFAULT,
     position,
     canFlip = true,
@@ -71,41 +80,66 @@ function Tooltip(props: TooltipProps) {
   });
 
   const click = useClick(context, {
-    enabled: isMobile(),
+    enabled: isMobile() || contentRole === 'dialog',
   });
   const dismiss = useDismiss(context);
+  const focus = useFocus(context, {
+    enabled: contentRole === 'tooltip',
+  });
   const hover = useHover(context, {
     handleClose: safePolygon(),
   });
+  const role = useRole(context, { role: contentRole });
 
   const { getReferenceProps, getFloatingProps } = useInteractions([
     click,
     dismiss,
+    focus,
     hover,
+    role,
   ]);
+
+  const floatingContent = (
+    <div
+      ref={refs.setFloating}
+      className={styles.tooltipContainer}
+      style={floatingStyles}
+      {...getFloatingProps()}
+    >
+      <FloatingArrow ref={arrowRef} context={context} fill={arrowColor} />
+      <div className={classNames(styles.tooltip, styles[kind])}>
+        <div className={bodyClassName}>{tooltip}</div>
+      </div>
+    </div>
+  );
 
   return (
     <>
       <span
         ref={refs.setReference}
-        {...getReferenceProps()}
-        className={className}
+        {...getReferenceProps({
+          'aria-label': accessibleLabel,
+          role: contentRole === 'dialog' ? 'button' : undefined,
+          tabIndex: isAnchorFocusable ? 0 : undefined,
+        })}
+        className={classNames(styles.reference, className)}
       >
         {anchor}
       </span>
       {isOpen ? (
         <FloatingPortal id="portal-root">
-          <div
-            ref={refs.setFloating}
-            className={styles.tooltipContainer}
-            style={floatingStyles}
-            {...getFloatingProps()}
-          >
-            <FloatingArrow ref={arrowRef} context={context} fill={arrowColor} />
-            <div className={classNames(styles.tooltip, styles[kind])}>
-              <div className={bodyClassName}>{tooltip}</div>
-            </div>
-          </div>
+          {contentRole === 'dialog' ? (
+            <FloatingFocusManager
+              context={context}
+              initialFocus={-1}
+              modal={false}
+              order={['reference', 'content']}
+            >
+              {floatingContent}
+            </FloatingFocusManager>
+          ) : (
+            floatingContent
+          )}
         </FloatingPortal>
       ) : null}
     </>

--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -532,6 +532,7 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
               {indexerFlags ? (
                 <Popover
                   anchor={<Icon name={icons.FLAG} />}
+                  isAnchorFocusable={false}
                   title={translate('IndexerFlags')}
                   body={<IndexerFlags indexerFlags={indexerFlags} />}
                   position={tooltipPositions.LEFT}

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -636,6 +636,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                   </Label>
 
                   <Tooltip
+                    accessibleLabel={translate('Links')}
                     anchor={
                       <Label className={styles.detailsLabel} size={sizes.LARGE}>
                         <div>
@@ -749,6 +750,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                         </div>
                       </Label>
                     }
+                    contentRole="dialog"
                     tooltip={
                       <SeriesDetailsLinks
                         tvdbId={tvdbId}


### PR DESCRIPTION
#### Description

Tooltip and popover anchors are currently designed around pointer interaction, which leaves most of them unavailable to keyboard and screen reader users.

This updates the existing shared Tooltip component so informational content opens when its anchor receives focus, is connected to the anchor for screen readers, and closes with Escape. The existing shared Popover component is built on Tooltip, so its consumers inherit the same behavior. Interactive tooltip content can use button and dialog semantics so Enter or Space opens it and keyboard users can move into its links.

Existing hover and mobile click behavior is preserved. The Indexer Flags popover opts out of an additional tab stop because it is already inside a focusable table cell.

I reviewed the existing Tooltip and Popover uses and kept the interactive behavior explicit at the Series Links call site.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review