### PR TITLE
New: Sorting Blocklist, History and Queue by Quality

### DIFF
--- a/frontend/src/Activity/Blocklist/blocklistOptionsStore.ts
+++ b/frontend/src/Activity/Blocklist/blocklistOptionsStore.ts
@@ -34,6 +34,7 @@ const { useOptions, useOption, setOptions, setOption, setSort } =
         {
           name: 'quality',
           label: () => translate('Quality'),
+          isSortable: true,
           isVisible: true,
         },
         {

--- a/frontend/src/Activity/History/historyOptionsStore.ts
+++ b/frontend/src/Activity/History/historyOptionsStore.ts
@@ -48,6 +48,7 @@ const { useOptions, useOption, setOptions, setOption, setSort } =
         {
           name: 'quality',
           label: () => translate('Quality'),
+          isSortable: true,
           isVisible: true,
         },
         {

--- a/frontend/src/EpisodeFile/EpisodeFileQuality.tsx
+++ b/frontend/src/EpisodeFile/EpisodeFileQuality.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Label from 'Components/Label';
+import EpisodeQuality from 'Episode/EpisodeQuality';
+import translate from 'Utilities/String/translate';
+import { useEpisodeFile } from './EpisodeFileProvider';
+
+interface EpisodeFileQualityProps {
+  episodeFileId: number | undefined;
+}
+
+function EpisodeFileQuality({ episodeFileId }: EpisodeFileQualityProps) {
+  const episodeFile = useEpisodeFile(episodeFileId);
+
+  if (!episodeFile?.quality) {
+    return <Label>{translate('Unknown')}</Label>;
+  }
+
+  return <EpisodeQuality quality={episodeFile.quality} />;
+}
+
+export default EpisodeFileQuality;

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
@@ -11,6 +11,7 @@ import EpisodeStatus from 'Episode/EpisodeStatus';
 import EpisodeTitleLink from 'Episode/EpisodeTitleLink';
 import SeasonEpisodeNumber from 'Episode/SeasonEpisodeNumber';
 import EpisodeFileLanguages from 'EpisodeFile/EpisodeFileLanguages';
+import EpisodeFileQuality from 'EpisodeFile/EpisodeFileQuality';
 import SeriesTitleLink from 'Series/SeriesTitleLink';
 import { useSingleSeries } from 'Series/useSeries';
 import { SelectStateInputProps } from 'typings/props';
@@ -144,6 +145,14 @@ function CutoffUnmetRow({
           return (
             <TableRowCell key={name} className={styles.languages}>
               <EpisodeFileLanguages episodeFileId={episodeFileId} />
+            </TableRowCell>
+          );
+        }
+
+        if (name === 'quality') {
+          return (
+            <TableRowCell key={name}>
+              <EpisodeFileQuality episodeFileId={episodeFileId} />
             </TableRowCell>
           );
         }

--- a/frontend/src/Wanted/CutoffUnmet/cutoffUnmetOptionsStore.ts
+++ b/frontend/src/Wanted/CutoffUnmet/cutoffUnmetOptionsStore.ts
@@ -46,6 +46,12 @@ const { useOptions, useOption, setOptions, setOption, setSort } =
           isVisible: false,
         },
         {
+          name: 'quality',
+          label: () => translate('Quality'),
+          isSortable: true,
+          isVisible: true,
+        },
+        {
           name: 'status',
           label: () => translate('Status'),
           isVisible: true,

--- a/src/NzbDrone.Core.Test/Profiles/Qualities/QualityProfileRankIntegrationFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/Qualities/QualityProfileRankIntegrationFixture.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Blocklisting;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.History;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.Qualities
+{
+    [TestFixture]
+    public class QualityProfileRankIntegrationFixture : DbTest
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Mocker.SetConstant<IQualityProfileRepository>(Mocker.Resolve<QualityProfileRepository>());
+            Mocker.SetConstant<IQualityProfileRankRepository>(Mocker.Resolve<QualityProfileRankRepository>());
+            Mocker.SetConstant<IQualityProfileRankService>(Mocker.Resolve<QualityProfileRankService>());
+            Mocker.SetConstant<IQualityProfileService>(Mocker.Resolve<QualityProfileService>());
+        }
+
+        [Test]
+        public void quality_sort_orders_history_across_two_profiles_by_normalized_score()
+        {
+            var profileA = AddProfile("A", Quality.HDTV720p, Quality.SDTV, Quality.HDTV720p);
+            var profileB = AddProfile("B", Quality.Bluray1080p, Quality.SDTV, Quality.HDTV720p, Quality.WEBDL1080p, Quality.Bluray1080p);
+
+            var seriesA = AddSeries("a", profileA.Id);
+            var seriesB = AddSeries("b", profileB.Id);
+
+            var episodeA = AddEpisode(seriesA.Id, 1, 1);
+            var episodeB1 = AddEpisode(seriesB.Id, 1, 1);
+            var episodeB2 = AddEpisode(seriesB.Id, 1, 2);
+
+            Mocker.SetConstant<IHistoryRepository>(Mocker.Resolve<HistoryRepository>());
+
+            InsertHistory(seriesA.Id, episodeA.Id, Quality.HDTV720p);
+            InsertHistory(seriesB.Id, episodeB1.Id, Quality.HDTV720p);
+            InsertHistory(seriesB.Id, episodeB2.Id, Quality.Bluray1080p);
+
+            var spec = new PagingSpec<EpisodeHistory>
+            {
+                Page = 1,
+                PageSize = 10,
+                SortKey = "quality",
+                SortDirection = SortDirection.Ascending
+            };
+
+            var result = Mocker.Resolve<IHistoryRepository>().GetPaged(spec, null, null);
+
+            var rows = result.Records
+                .Select(r => (seriesId: r.SeriesId, qualityId: r.Quality.Quality.Id))
+                .ToList();
+
+            rows.Should().HaveCount(3);
+            rows[0].Should().Be((seriesB.Id, Quality.HDTV720p.Id));
+            rows.Skip(1).Should().Contain((seriesA.Id, Quality.HDTV720p.Id));
+            rows.Skip(1).Should().Contain((seriesB.Id, Quality.Bluray1080p.Id));
+        }
+
+        [Test]
+        public void quality_sort_orders_blocklist_across_two_profiles_by_normalized_score()
+        {
+            var profileA = AddProfile("A", Quality.HDTV720p, Quality.SDTV, Quality.HDTV720p);
+            var profileB = AddProfile("B", Quality.Bluray1080p, Quality.SDTV, Quality.HDTV720p, Quality.WEBDL1080p, Quality.Bluray1080p);
+
+            var seriesA = AddSeries("a", profileA.Id);
+            var seriesB = AddSeries("b", profileB.Id);
+
+            InsertBlocklist(seriesA.Id, Quality.HDTV720p);
+            InsertBlocklist(seriesB.Id, Quality.HDTV720p);
+            InsertBlocklist(seriesB.Id, Quality.Bluray1080p);
+
+            var spec = new PagingSpec<Blocklist>
+            {
+                Page = 1,
+                PageSize = 10,
+                SortKey = "quality",
+                SortDirection = SortDirection.Ascending
+            };
+
+            var result = Mocker.Resolve<BlocklistRepository>().GetPaged(spec);
+
+            var rows = result.Records
+                .Select(b => (seriesId: b.SeriesId, qualityId: b.Quality.Quality.Id))
+                .ToList();
+
+            rows.Should().HaveCount(3);
+            rows[0].Should().Be((seriesB.Id, Quality.HDTV720p.Id));
+            rows.Skip(1).Should().Contain((seriesA.Id, Quality.HDTV720p.Id));
+            rows.Skip(1).Should().Contain((seriesB.Id, Quality.Bluray1080p.Id));
+        }
+
+        [Test]
+        public void quality_sort_orders_cutoff_unmet_by_normalized_score()
+        {
+            var profile = AddProfile("A", Quality.Bluray1080p, Quality.SDTV, Quality.HDTV720p, Quality.WEBDL1080p, Quality.Bluray1080p);
+            var series = AddSeries("a", profile.Id);
+
+            var sdFile = InsertEpisodeFile(Quality.SDTV);
+            var hdFile = InsertEpisodeFile(Quality.HDTV720p);
+            var webFile = InsertEpisodeFile(Quality.WEBDL1080p);
+
+            AddEpisode(series.Id, 1, 1, sdFile.Id);
+            AddEpisode(series.Id, 1, 2, hdFile.Id);
+            AddEpisode(series.Id, 1, 3, webFile.Id);
+
+            var qualitiesBelowCutoff = new List<QualitiesBelowCutoff>
+            {
+                new(profile.Id, new[] { Quality.SDTV.Id, Quality.HDTV720p.Id, Quality.WEBDL1080p.Id })
+            };
+
+            var spec = new PagingSpec<Episode>
+            {
+                Page = 1,
+                PageSize = 10,
+                SortKey = "quality",
+                SortDirection = SortDirection.Ascending
+            };
+
+            var result = Mocker.Resolve<EpisodeRepository>().EpisodesWhereCutoffUnmet(spec, qualitiesBelowCutoff, false);
+
+            result.Records.Select(e => e.EpisodeFileId)
+                  .Should().Equal(sdFile.Id, hdFile.Id, webFile.Id);
+        }
+
+        private QualityProfile AddProfile(string name, Quality cutoff, params Quality[] qualities)
+        {
+            var profile = new QualityProfile
+            {
+                Name = name,
+                Cutoff = cutoff.Id,
+                Items = qualities.Select(q => new QualityProfileQualityItem { Quality = q, Allowed = true }).ToList()
+            };
+
+            Mocker.Resolve<IQualityProfileService>().Add(profile);
+
+            return profile;
+        }
+
+        private Series AddSeries(string slug, int profileId)
+        {
+            var series = new Series
+            {
+                Title = slug,
+                CleanTitle = slug,
+                SortTitle = slug,
+                TitleSlug = slug,
+                Path = $"/series/{slug}",
+                TvdbId = RandomNumber,
+                QualityProfileId = profileId
+            };
+
+            series.Id = Db.Insert(series).Id;
+
+            return series;
+        }
+
+        private Episode AddEpisode(int seriesId, int seasonNumber, int episodeNumber, int episodeFileId = 0)
+        {
+            var episode = new Episode
+            {
+                SeriesId = seriesId,
+                SeasonNumber = seasonNumber,
+                EpisodeNumber = episodeNumber,
+                Title = $"s{seasonNumber}e{episodeNumber}",
+                EpisodeFileId = episodeFileId,
+                Monitored = true,
+                AirDateUtc = DateTime.UtcNow.AddDays(-1)
+            };
+
+            episode.Id = Db.Insert(episode).Id;
+
+            return episode;
+        }
+
+        private EpisodeFile InsertEpisodeFile(Quality quality)
+        {
+            return Mocker.Resolve<MediaFileRepository>().Insert(new EpisodeFile
+            {
+                RelativePath = $"file-{quality.Id}",
+                Quality = new QualityModel(quality),
+                Languages = new List<Language> { Language.English }
+            });
+        }
+
+        private void InsertHistory(int seriesId, int episodeId, Quality quality)
+        {
+            Mocker.Resolve<IHistoryRepository>().Insert(new EpisodeHistory
+            {
+                SeriesId = seriesId,
+                EpisodeId = episodeId,
+                SourceTitle = "test",
+                Date = DateTime.UtcNow,
+                Quality = new QualityModel(quality),
+                EventType = EpisodeHistoryEventType.Grabbed,
+                Languages = new List<Language> { Language.English }
+            });
+        }
+
+        private void InsertBlocklist(int seriesId, Quality quality)
+        {
+            Mocker.Resolve<BlocklistRepository>().Insert(new Blocklist
+            {
+                SeriesId = seriesId,
+                EpisodeIds = new List<int>(),
+                SourceTitle = "test",
+                Quality = new QualityModel(quality),
+                Date = DateTime.UtcNow,
+                Languages = new List<Language> { Language.English }
+            });
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/Profiles/Qualities/QualityProfileRankServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Profiles/Qualities/QualityProfileRankServiceFixture.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Qualities
+{
+    [TestFixture]
+    public class QualityProfileRankServiceFixture : CoreTest<QualityProfileRankService>
+    {
+        private QualityProfile BuildProfile(int id, params Quality[] items)
+        {
+            return new QualityProfile
+            {
+                Id = id,
+                Items = items.Select(q => new QualityProfileQualityItem { Quality = q, Allowed = true }).ToList()
+            };
+        }
+
+        [Test]
+        public void should_score_single_item_profile_as_1()
+        {
+            var profile = BuildProfile(7, Quality.SDTV);
+
+            var ranks = Subject.ComputeRanks(profile).ToList();
+
+            ranks.Should().HaveCount(1);
+            ranks[0].ProfileId.Should().Be(7);
+            ranks[0].QualityId.Should().Be(Quality.SDTV.Id);
+            ranks[0].Score.Should().Be(1.0);
+        }
+
+        [Test]
+        public void should_score_first_item_as_0_and_last_as_1()
+        {
+            var profile = BuildProfile(3, Quality.SDTV, Quality.HDTV720p, Quality.Bluray1080p);
+
+            var ranks = Subject.ComputeRanks(profile)
+                .ToDictionary(r => r.QualityId, r => r.Score);
+
+            ranks[Quality.SDTV.Id].Should().Be(0.0);
+            ranks[Quality.HDTV720p.Id].Should().Be(0.5);
+            ranks[Quality.Bluray1080p.Id].Should().Be(1.0);
+        }
+
+        [Test]
+        public void should_flatten_grouped_items_and_share_group_index()
+        {
+            var profile = new QualityProfile
+            {
+                Id = 4,
+                Items = new List<QualityProfileQualityItem>
+                {
+                    new() { Quality = Quality.SDTV, Allowed = true },
+                    new()
+                    {
+                        Id = 1000,
+                        Name = "HD",
+                        Allowed = true,
+                        Items = new List<QualityProfileQualityItem>
+                        {
+                            new() { Quality = Quality.HDTV720p, Allowed = true },
+                            new() { Quality = Quality.WEBDL720p, Allowed = true }
+                        }
+                    },
+                    new() { Quality = Quality.Bluray1080p, Allowed = true }
+                }
+            };
+
+            var ranks = Subject.ComputeRanks(profile)
+                .ToDictionary(r => r.QualityId, r => r.Score);
+
+            ranks[Quality.SDTV.Id].Should().Be(0.0);
+            ranks[Quality.HDTV720p.Id].Should().Be(0.5);
+            ranks[Quality.WEBDL720p.Id].Should().Be(0.5);
+            ranks[Quality.Bluray1080p.Id].Should().Be(1.0);
+        }
+
+        [Test]
+        public void should_emit_ranks_for_disallowed_items_too()
+        {
+            var profile = BuildProfile(9, Quality.SDTV, Quality.HDTV720p);
+            profile.Items[0].Allowed = false;
+
+            var ranks = Subject.ComputeRanks(profile).ToList();
+
+            ranks.Should().HaveCount(2);
+        }
+
+        [Test]
+        public void seed_should_upsert_ranks_for_every_profile()
+        {
+            var p1 = BuildProfile(1, Quality.SDTV, Quality.HDTV720p);
+            var p2 = BuildProfile(2, Quality.Bluray1080p);
+
+            Subject.SeedAll(new List<QualityProfile> { p1, p2 });
+
+            Mocker.GetMock<IQualityProfileRankRepository>()
+                  .Verify(x => x.ReplaceForProfile(1, It.Is<IEnumerable<QualityProfileQualityRank>>(r => r.Count() == 2)), Times.Once);
+            Mocker.GetMock<IQualityProfileRankRepository>()
+                  .Verify(x => x.ReplaceForProfile(2, It.Is<IEnumerable<QualityProfileQualityRank>>(r => r.Count() == 1)), Times.Once);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Blocklisting/BlocklistRepository.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Messaging.Events;
@@ -42,18 +43,35 @@ namespace NzbDrone.Core.Blocklisting
 
         public override PagingSpec<Blocklist> GetPaged(PagingSpec<Blocklist> pagingSpec)
         {
-            pagingSpec.Records = GetPagedRecords(PagedBuilder(), pagingSpec, PagedQuery);
+            var sortingByQuality = string.Equals(pagingSpec.SortKey, "quality", StringComparison.OrdinalIgnoreCase);
+            var customSortExpression = sortingByQuality ? "COALESCE(\"r\".\"Score\", -1)" : null;
+
+            pagingSpec.Records = GetPagedRecords(PagedBuilder(sortingByQuality), pagingSpec, PagedQuery, customSortExpression);
 
             var countTemplate = $"SELECT COUNT(*) FROM (SELECT /**select**/ FROM \"{TableMapping.Mapper.TableNameMapping(typeof(Blocklist))}\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/) AS \"Inner\"";
-            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder().Select(typeof(Blocklist)), pagingSpec, countTemplate);
+            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder(sortingByQuality).Select(typeof(Blocklist)), pagingSpec, countTemplate);
 
             return pagingSpec;
         }
 
-        protected override SqlBuilder PagedBuilder()
+        protected override SqlBuilder PagedBuilder() => PagedBuilder(false);
+
+        private SqlBuilder PagedBuilder(bool joinQualityRanks)
         {
             var builder = Builder()
                 .Join<Blocklist, Series>((b, m) => b.SeriesId == m.Id);
+
+            if (joinQualityRanks)
+            {
+                var qualityIdExpr = _database.DatabaseType == DatabaseType.PostgreSQL
+                    ? "(\"Blocklist\".\"Quality\"::jsonb ->> 'quality')::int"
+                    : "json_extract(\"Blocklist\".\"Quality\", '$.quality')";
+
+                builder.LeftJoin(
+                    $"\"QualityProfileQualityRanks\" AS \"r\" " +
+                    $"ON \"r\".\"ProfileId\" = \"Series\".\"QualityProfileId\" " +
+                    $"AND \"r\".\"QualityId\" = {qualityIdExpr}");
+            }
 
             return builder;
         }

--- a/src/NzbDrone.Core/Datastore/BasicRepository.cs
+++ b/src/NzbDrone.Core/Datastore/BasicRepository.cs
@@ -447,7 +447,7 @@ namespace NzbDrone.Core.Datastore
             }
         }
 
-        protected List<TModel> GetPagedRecords(SqlBuilder builder, PagingSpec<TModel> pagingSpec, Func<SqlBuilder, IEnumerable<TModel>> queryFunc)
+        protected List<TModel> GetPagedRecords(SqlBuilder builder, PagingSpec<TModel> pagingSpec, Func<SqlBuilder, IEnumerable<TModel>> queryFunc, string customSortExpression = null)
         {
             AddFilters(builder, pagingSpec);
 
@@ -456,9 +456,17 @@ namespace NzbDrone.Core.Datastore
                 pagingSpec.SortKey = $"{_table}.{_keyProperty.Name}";
             }
 
-            var sortKey = TableMapping.Mapper.GetSortKey(pagingSpec.SortKey);
             var sortDirection = pagingSpec.SortDirection == SortDirection.Descending ? "DESC" : "ASC";
             var pagingOffset = Math.Max(pagingSpec.Page - 1, 0) * pagingSpec.PageSize;
+
+            if (customSortExpression != null)
+            {
+                builder.OrderBy($"{customSortExpression} {sortDirection} LIMIT {pagingSpec.PageSize} OFFSET {pagingOffset}");
+
+                return queryFunc(builder).ToList();
+            }
+
+            var sortKey = TableMapping.Mapper.GetSortKey(pagingSpec.SortKey);
             builder.OrderBy($"\"{sortKey.Table ?? _table}\".\"{sortKey.Column}\" {sortDirection} LIMIT {pagingSpec.PageSize} OFFSET {pagingOffset}");
 
             return queryFunc(builder).ToList();

--- a/src/NzbDrone.Core/Datastore/Migration/233_quality_profile_quality_ranks.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/233_quality_profile_quality_ranks.cs
@@ -1,0 +1,38 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(233)]
+    public class quality_profile_quality_ranks : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Create.TableForModel("QualityProfileQualityRanks")
+                .WithColumn("ProfileId").AsInt32().NotNullable()
+                .WithColumn("QualityId").AsInt32().NotNullable()
+                .WithColumn("Score").AsDouble().NotNullable();
+
+            Create.Index()
+                .OnTable("QualityProfileQualityRanks")
+                .OnColumn("ProfileId").Ascending()
+                .OnColumn("QualityId").Ascending()
+                .WithOptions().Unique();
+
+            IfDatabase(ProcessorIdConstants.SQLite).Execute.Sql(
+                "CREATE INDEX \"IX_History_QualityId\" ON \"History\" (json_extract(\"Quality\", '$.quality'));");
+            IfDatabase(ProcessorIdConstants.PostgreSQL).Execute.Sql(
+                "CREATE INDEX \"IX_History_QualityId\" ON \"History\" (((\"Quality\"::jsonb ->> 'quality')::int));");
+
+            IfDatabase(ProcessorIdConstants.SQLite).Execute.Sql(
+                "CREATE INDEX \"IX_EpisodeFiles_QualityId\" ON \"EpisodeFiles\" (json_extract(\"Quality\", '$.quality'));");
+            IfDatabase(ProcessorIdConstants.PostgreSQL).Execute.Sql(
+                "CREATE INDEX \"IX_EpisodeFiles_QualityId\" ON \"EpisodeFiles\" (((\"Quality\"::jsonb ->> 'quality')::int));");
+
+            IfDatabase(ProcessorIdConstants.SQLite).Execute.Sql(
+                "CREATE INDEX \"IX_Blocklist_QualityId\" ON \"Blocklist\" (json_extract(\"Quality\", '$.quality'));");
+            IfDatabase(ProcessorIdConstants.PostgreSQL).Execute.Sql(
+                "CREATE INDEX \"IX_Blocklist_QualityId\" ON \"Blocklist\" (((\"Quality\"::jsonb ->> 'quality')::int));");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -142,6 +142,7 @@ namespace NzbDrone.Core.Datastore
             Mapper.Entity<CustomFormat>("CustomFormats").RegisterModel();
 
             Mapper.Entity<QualityProfile>("QualityProfiles").RegisterModel();
+            Mapper.Entity<QualityProfileQualityRank>("QualityProfileQualityRanks").RegisterModel();
             Mapper.Entity<Log>("Logs").RegisterModel();
             Mapper.Entity<NamingConfig>("NamingConfig").RegisterModel();
             Mapper.Entity<Blocklist>("Blocklist").RegisterModel();

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -140,19 +140,34 @@ namespace NzbDrone.Core.History
 
         public PagingSpec<EpisodeHistory> GetPaged(PagingSpec<EpisodeHistory> pagingSpec, int[] languages, int[] qualities)
         {
-            pagingSpec.Records = GetPagedRecords(PagedBuilder(languages, qualities), pagingSpec, PagedQuery);
+            var sortingByQuality = string.Equals(pagingSpec.SortKey, "quality", StringComparison.OrdinalIgnoreCase);
+            var customSortExpression = sortingByQuality ? "COALESCE(\"r\".\"Score\", -1)" : null;
+
+            pagingSpec.Records = GetPagedRecords(PagedBuilder(languages, qualities, sortingByQuality), pagingSpec, PagedQuery, customSortExpression);
 
             var countTemplate = $"SELECT COUNT(*) FROM (SELECT /**select**/ FROM \"{TableMapping.Mapper.TableNameMapping(typeof(EpisodeHistory))}\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/) AS \"Inner\"";
-            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder(languages, qualities).Select(typeof(EpisodeHistory)), pagingSpec, countTemplate);
+            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder(languages, qualities, sortingByQuality).Select(typeof(EpisodeHistory)), pagingSpec, countTemplate);
 
             return pagingSpec;
         }
 
-        private SqlBuilder PagedBuilder(int[] languages, int[] qualities)
+        private SqlBuilder PagedBuilder(int[] languages, int[] qualities, bool joinQualityRanks)
         {
             var builder = Builder()
                 .Join<EpisodeHistory, Series>((h, a) => h.SeriesId == a.Id)
                 .Join<EpisodeHistory, Episode>((h, a) => h.EpisodeId == a.Id);
+
+            if (joinQualityRanks)
+            {
+                var qualityIdExpr = _database.DatabaseType == DatabaseType.PostgreSQL
+                    ? "(\"History\".\"Quality\"::jsonb ->> 'quality')::int"
+                    : "json_extract(\"History\".\"Quality\", '$.quality')";
+
+                builder.LeftJoin(
+                    $"\"QualityProfileQualityRanks\" AS \"r\" " +
+                    $"ON \"r\".\"ProfileId\" = \"Series\".\"QualityProfileId\" " +
+                    $"AND \"r\".\"QualityId\" = {qualityIdExpr}");
+            }
 
             if (languages is { Length: > 0 })
             {

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileQualityRank.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileQualityRank.cs
@@ -1,0 +1,11 @@
+using NzbDrone.Core.Datastore;
+
+namespace NzbDrone.Core.Profiles.Qualities
+{
+    public class QualityProfileQualityRank : ModelBase
+    {
+        public int ProfileId { get; set; }
+        public int QualityId { get; set; }
+        public double Score { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRankRepository.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRankRepository.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Messaging.Events;
+
+namespace NzbDrone.Core.Profiles.Qualities
+{
+    public interface IQualityProfileRankRepository : IBasicRepository<QualityProfileQualityRank>
+    {
+        void ReplaceForProfile(int profileId, IEnumerable<QualityProfileQualityRank> ranks);
+        void DeleteForProfile(int profileId);
+    }
+
+    public class QualityProfileRankRepository : BasicRepository<QualityProfileQualityRank>, IQualityProfileRankRepository
+    {
+        public QualityProfileRankRepository(IMainDatabase database, IEventAggregator eventAggregator)
+            : base(database, eventAggregator)
+        {
+        }
+
+        public void ReplaceForProfile(int profileId, IEnumerable<QualityProfileQualityRank> ranks)
+        {
+            DeleteForProfile(profileId);
+
+            var toInsert = ranks.ToList();
+
+            if (toInsert.Count == 0)
+            {
+                return;
+            }
+
+            InsertMany(toInsert);
+        }
+
+        public void DeleteForProfile(int profileId)
+        {
+            Delete(r => r.ProfileId == profileId);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRankService.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileRankService.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Common.Cache;
+using NzbDrone.Core.Qualities;
+
+namespace NzbDrone.Core.Profiles.Qualities
+{
+    public interface IQualityProfileRankService
+    {
+        double GetRank(int? profileId, int? qualityId);
+        IEnumerable<QualityProfileQualityRank> ComputeRanks(QualityProfile profile);
+        void UpdateRanksForProfile(QualityProfile profile);
+        void DeleteRanksForProfile(int profileId);
+        void SeedAll(IEnumerable<QualityProfile> profiles);
+    }
+
+    public class QualityProfileRankService : IQualityProfileRankService
+    {
+        private readonly IQualityProfileRankRepository _repository;
+        private readonly Dictionary<int, double> _defaultRanks;
+        private readonly ICached<Dictionary<(int ProfileId, int QualityId), double>> _cache;
+
+        public QualityProfileRankService(IQualityProfileRankRepository repository, ICacheManager cacheManager)
+        {
+            _repository = repository;
+            _defaultRanks = ComputeRanks(BuildDefaultProfile())
+                .ToDictionary(r => r.QualityId, r => r.Score);
+            _cache = cacheManager.GetCache<Dictionary<(int ProfileId, int QualityId), double>>(typeof(QualityProfileQualityRank), "ranks");
+        }
+
+        public double GetRank(int? profileId, int? qualityId)
+        {
+            if (!qualityId.HasValue)
+            {
+                return -1.0;
+            }
+
+            if (profileId.HasValue)
+            {
+                return AllRanks().TryGetValue((profileId.Value, qualityId.Value), out var rank) ? rank : -1.0;
+            }
+
+            return _defaultRanks.TryGetValue(qualityId.Value, out var defaultRank) ? defaultRank : -1.0;
+        }
+
+        public IEnumerable<QualityProfileQualityRank> ComputeRanks(QualityProfile profile)
+        {
+            var items = profile.Items ?? new List<QualityProfileQualityItem>();
+            var singleItem = items.Count == 1;
+            var denominator = Math.Max(1, items.Count - 1);
+
+            for (var i = 0; i < items.Count; i++)
+            {
+                var score = singleItem ? 1.0 : (double)i / denominator;
+                var item = items[i];
+
+                if (item.Quality != null)
+                {
+                    yield return new QualityProfileQualityRank
+                    {
+                        ProfileId = profile.Id,
+                        QualityId = item.Quality.Id,
+                        Score = score
+                    };
+                    continue;
+                }
+
+                foreach (var member in item.Items ?? new List<QualityProfileQualityItem>())
+                {
+                    if (member.Quality == null)
+                    {
+                        continue;
+                    }
+
+                    yield return new QualityProfileQualityRank
+                    {
+                        ProfileId = profile.Id,
+                        QualityId = member.Quality.Id,
+                        Score = score
+                    };
+                }
+            }
+        }
+
+        public void UpdateRanksForProfile(QualityProfile profile)
+        {
+            _repository.ReplaceForProfile(profile.Id, ComputeRanks(profile));
+            _cache.Clear();
+        }
+
+        public void DeleteRanksForProfile(int profileId)
+        {
+            _repository.DeleteForProfile(profileId);
+            _cache.Clear();
+        }
+
+        public void SeedAll(IEnumerable<QualityProfile> profiles)
+        {
+            var existingProfileIds = AllRanks().Keys.Select(k => k.ProfileId).ToHashSet();
+            var seeded = false;
+
+            foreach (var profile in profiles)
+            {
+                if (existingProfileIds.Contains(profile.Id))
+                {
+                    continue;
+                }
+
+                _repository.ReplaceForProfile(profile.Id, ComputeRanks(profile));
+                seeded = true;
+            }
+
+            if (seeded)
+            {
+                _cache.Clear();
+            }
+        }
+
+        private Dictionary<(int ProfileId, int QualityId), double> AllRanks()
+        {
+            return _cache.Get("all", () => _repository.All()
+                .ToDictionary(r => (r.ProfileId, r.QualityId), r => r.Score));
+        }
+
+        private static QualityProfile BuildDefaultProfile()
+        {
+            var items = Quality.DefaultQualityDefinitions
+                .GroupBy(q => q.Weight)
+                .OrderBy(g => g.Key)
+                .Select(group => group.Count() == 1
+                    ? new QualityProfileQualityItem { Quality = group.First().Quality, Allowed = true }
+                    : new QualityProfileQualityItem
+                    {
+                        Items = group.Select(q => new QualityProfileQualityItem { Quality = q.Quality, Allowed = true }).ToList(),
+                        Allowed = true
+                    })
+                .ToList();
+
+            return new QualityProfile { Items = items };
+        }
+    }
+}

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfileService.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         private readonly IImportListFactory _importListFactory;
         private readonly ICustomFormatService _formatService;
         private readonly ISeriesService _seriesService;
+        private readonly IQualityProfileRankService _rankService;
         private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
 
@@ -40,6 +41,7 @@ namespace NzbDrone.Core.Profiles.Qualities
                                      IImportListFactory importListFactory,
                                      ICustomFormatService formatService,
                                      ISeriesService seriesService,
+                                     IQualityProfileRankService rankService,
                                      IEventAggregator eventAggregator,
                                      Logger logger)
         {
@@ -47,18 +49,22 @@ namespace NzbDrone.Core.Profiles.Qualities
             _importListFactory = importListFactory;
             _formatService = formatService;
             _seriesService = seriesService;
+            _rankService = rankService;
             _eventAggregator = eventAggregator;
             _logger = logger;
         }
 
         public QualityProfile Add(QualityProfile profile)
         {
-            return _qualityProfileRepository.Insert(profile);
+            var saved = _qualityProfileRepository.Insert(profile);
+            _rankService.UpdateRanksForProfile(saved);
+            return saved;
         }
 
         public void Update(QualityProfile profile)
         {
             _qualityProfileRepository.Update(profile);
+            _rankService.UpdateRanksForProfile(profile);
             _eventAggregator.PublishEvent(new QualityProfileUpdatedEvent(profile.Id));
         }
 
@@ -71,6 +77,7 @@ namespace NzbDrone.Core.Profiles.Qualities
             }
 
             _qualityProfileRepository.Delete(id);
+            _rankService.DeleteRanksForProfile(id);
         }
 
         public List<QualityProfile> All()
@@ -90,8 +97,12 @@ namespace NzbDrone.Core.Profiles.Qualities
 
         public void Handle(ApplicationStartedEvent message)
         {
-            if (All().Any())
+            var profiles = All();
+
+            if (profiles.Any())
             {
+                _rankService.SeedAll(profiles);
+
                 return;
             }
 

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -127,17 +127,14 @@ namespace NzbDrone.Core.Tv
 
         public PagingSpec<Episode> EpisodesWhereCutoffUnmet(PagingSpec<Episode> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff, bool includeSpecials, HashSet<int> seriesTags = null, List<int> quality = null)
         {
-            var startingSeasonNumber = 1;
+            var startingSeasonNumber = includeSpecials ? 0 : 1;
+            var sortingByQuality = string.Equals(pagingSpec.SortKey, "quality", StringComparison.OrdinalIgnoreCase);
+            var customSortExpression = sortingByQuality ? "MAX(COALESCE(\"r\".\"Score\", -1))" : null;
 
-            if (includeSpecials)
-            {
-                startingSeasonNumber = 0;
-            }
-
-            pagingSpec.Records = GetPagedRecords(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality), pagingSpec, PagedQuery);
+            pagingSpec.Records = GetPagedRecords(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality, sortingByQuality), pagingSpec, PagedQuery, customSortExpression);
 
             var countTemplate = $"SELECT COUNT(*) FROM (SELECT /**select**/ FROM \"{TableMapping.Mapper.TableNameMapping(typeof(Episode))}\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/) AS \"Inner\"";
-            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality).Select(typeof(Episode)), pagingSpec, countTemplate);
+            pagingSpec.TotalRecords = GetPagedRecordCount(EpisodesWhereCutoffUnmetBuilder(qualitiesBelowCutoff, startingSeasonNumber, seriesTags, quality, sortingByQuality).Select(typeof(Episode)), pagingSpec, countTemplate);
 
             return pagingSpec;
         }
@@ -318,7 +315,7 @@ namespace NzbDrone.Core.Tv
                                  currentTime.ToString("yyyy-MM-dd HH:mm:ss"));
         }
 
-        private SqlBuilder EpisodesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff, int startingSeasonNumber, HashSet<int> seriesTags, List<int> qualities)
+        private SqlBuilder EpisodesWhereCutoffUnmetBuilder(List<QualitiesBelowCutoff> qualitiesBelowCutoff, int startingSeasonNumber, HashSet<int> seriesTags, List<int> qualities, bool joinQualityRanks)
         {
             var builder = Builder()
                 .Join<Episode, Series>((e, s) => e.SeriesId == s.Id)
@@ -339,9 +336,23 @@ namespace NzbDrone.Core.Tv
                 builder = builder.Where(BuildQualityFilterWhereClause(qualities));
             }
 
-            return builder
+            builder = builder
                 .GroupBy<Episode>(e => e.Id)
                 .GroupBy<Series>(s => s.Id);
+
+            if (joinQualityRanks)
+            {
+                var qualityIdExpr = _database.DatabaseType == DatabaseType.PostgreSQL
+                    ? "(\"EpisodeFiles\".\"Quality\"::jsonb ->> 'quality')::int"
+                    : "json_extract(\"EpisodeFiles\".\"Quality\", '$.quality')";
+
+                builder.LeftJoin(
+                    $"\"QualityProfileQualityRanks\" AS \"r\" " +
+                    $"ON \"r\".\"ProfileId\" = \"Series\".\"QualityProfileId\" " +
+                    $"AND \"r\".\"QualityId\" = {qualityIdExpr}");
+            }
+
+            return builder;
         }
 
         private string BuildQualityCutoffWhereClause(List<QualitiesBelowCutoff> qualitiesBelowCutoff)

--- a/src/Sonarr.Api.V5/Blocklist/BlocklistController.cs
+++ b/src/Sonarr.Api.V5/Blocklist/BlocklistController.cs
@@ -34,6 +34,7 @@ public class BlocklistController : Controller
             {
                 "date",
                 "indexer",
+                "quality",
                 "series.sortTitle",
                 "sourceTitle"
             },

--- a/src/Sonarr.Api.V5/History/HistoryController.cs
+++ b/src/Sonarr.Api.V5/History/HistoryController.cs
@@ -71,7 +71,8 @@ public class HistoryController : Controller
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "date",
-                "series.sortTitle"
+                "series.sortTitle",
+                "quality"
             },
             "date",
             SortDirection.Descending);

--- a/src/Sonarr.Api.V5/Queue/QueueController.cs
+++ b/src/Sonarr.Api.V5/Queue/QueueController.cs
@@ -12,7 +12,6 @@ using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Profiles.Qualities;
-using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Queue;
 using NzbDrone.SignalR;
 using Sonarr.Http;
@@ -28,8 +27,7 @@ namespace Sonarr.Api.V5.Queue
     {
         private readonly IQueueService _queueService;
         private readonly IPendingReleaseService _pendingReleaseService;
-
-        private readonly QualityModelComparer _qualityComparer;
+        private readonly IQualityProfileRankService _rankService;
         private readonly ITrackedDownloadService _trackedDownloadService;
         private readonly IFailedDownloadService _failedDownloadService;
         private readonly IIgnoredDownloadService _ignoredDownloadService;
@@ -39,7 +37,7 @@ namespace Sonarr.Api.V5.Queue
         public QueueController(IBroadcastSignalRMessage broadcastSignalRMessage,
                            IQueueService queueService,
                            IPendingReleaseService pendingReleaseService,
-                           IQualityProfileService qualityProfileService,
+                           IQualityProfileRankService rankService,
                            ITrackedDownloadService trackedDownloadService,
                            IFailedDownloadService failedDownloadService,
                            IIgnoredDownloadService ignoredDownloadService,
@@ -49,13 +47,12 @@ namespace Sonarr.Api.V5.Queue
         {
             _queueService = queueService;
             _pendingReleaseService = pendingReleaseService;
+            _rankService = rankService;
             _trackedDownloadService = trackedDownloadService;
             _failedDownloadService = failedDownloadService;
             _ignoredDownloadService = ignoredDownloadService;
             _downloadClientProvider = downloadClientProvider;
             _blocklistService = blocklistService;
-
-            _qualityComparer = new QualityModelComparer(qualityProfileService.GetDefaultProfile(string.Empty));
         }
 
         [NonAction]
@@ -259,9 +256,12 @@ namespace Sonarr.Api.V5.Queue
             }
             else if (pagingSpec.SortKey == "quality")
             {
+                double rankOf(NzbDrone.Core.Queue.Queue q) =>
+                    _rankService.GetRank(q.Series?.QualityProfileId, q.Quality?.Quality?.Id);
+
                 ordered = ascending
-                    ? fullQueue.OrderBy(q => q.Quality, _qualityComparer)
-                    : fullQueue.OrderByDescending(q => q.Quality, _qualityComparer);
+                    ? fullQueue.OrderBy(rankOf)
+                    : fullQueue.OrderByDescending(rankOf);
             }
             else if (pagingSpec.SortKey == "languages")
             {

--- a/src/Sonarr.Api.V5/Wanted/CutoffController.cs
+++ b/src/Sonarr.Api.V5/Wanted/CutoffController.cs
@@ -46,7 +46,8 @@ public class CutoffController : EpisodeControllerWithSignalR
             {
                 "episodes.airDateUtc",
                 "episodes.lastSearchTime",
-                "series.sortTitle"
+                "series.sortTitle",
+                "quality"
             },
             "episodes.airDateUtc",
             SortDirection.Ascending);


### PR DESCRIPTION
#### Description

Adds a new table that stores the order of qualities in each profile to improve sorting by quality on Queue and uses the same table for Cutoff Unmet and Blocklist in the DB.

#### Screenshots for UI Changes

Cutoff Unmet, but applies to others

<img width="1688" height="527" alt="image" src="https://github.com/user-attachments/assets/794418d1-10a0-4331-9c6d-07e227b15d28" />

#### Database Migration

YES - 233

<!-- Remove if there is no database migration. If there is an database migration replace ### with the migration number -->

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #702
