### PR TITLE
Fixed: Improve cache busting for covers using a hash instead of file modification time

### DIFF
--- a/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/MediaCoverServiceFixture.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Test.MediaCoverTests
 
             _series = Builder<Series>.CreateNew()
                 .With(v => v.Id = 2)
-                .With(v => v.Images = new List<MediaCover.MediaCover> { new MediaCover.MediaCover(MediaCoverTypes.Poster, "") })
+                .With(v => v.Images = new List<MediaCover.MediaCover> { new(MediaCoverTypes.Poster, "") })
                 .Build();
         }
 
@@ -34,27 +34,21 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         public void should_convert_cover_urls_to_local()
         {
             var covers = new List<MediaCover.MediaCover>
-                {
-                    new MediaCover.MediaCover { CoverType = MediaCoverTypes.Banner }
-                };
-
-            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileGetLastWrite(It.IsAny<string>()))
-                  .Returns(new DateTime(1234));
-
-            Mocker.GetMock<IDiskProvider>().Setup(c => c.FileExists(It.IsAny<string>()))
-                  .Returns(true);
+            {
+                new() { CoverType = MediaCoverTypes.Banner, RemoteUrl = "https://artworks.examples.com/banners/1.jpg" }
+            };
 
             Subject.ConvertToLocalUrls(12, covers);
 
-            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg?lastWrite=1234");
+            covers.Single().Url.Should().Be("/MediaCover/12/banner.jpg?h=a6210a45e2b93963ad9e");
         }
 
         [Test]
-        public void should_convert_media_urls_to_local_without_time_if_file_doesnt_exist()
+        public void should_convert_media_urls_to_local_without_hash_if_remote_url_is_empty()
         {
             var covers = new List<MediaCover.MediaCover>
                 {
-                    new MediaCover.MediaCover { CoverType = MediaCoverTypes.Banner }
+                    new() { CoverType = MediaCoverTypes.Banner }
                 };
 
             Subject.ConvertToLocalUrls(12, covers);

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.MediaCover
 
         // ImageSharp is slow on ARM (no hardware acceleration on mono yet)
         // So limit the number of concurrent resizing tasks
-        private static SemaphoreSlim _semaphore = new SemaphoreSlim((int)Math.Ceiling(Environment.ProcessorCount / 2.0));
+        private static readonly SemaphoreSlim Semaphore = new((int)Math.Ceiling(Environment.ProcessorCount / 2.0));
 
         public MediaCoverService(IMediaCoverProxy mediaCoverProxy,
                                  IImageResizer resizer,
@@ -65,9 +65,9 @@ namespace NzbDrone.Core.MediaCover
 
         public string GetCoverPath(int seriesId, MediaCoverTypes coverType, int? height = null)
         {
-            var heightSuffix = height.HasValue ? "-" + height.ToString() : "";
+            var heightSuffix = height.HasValue ? $"-{height}" : "";
 
-            return Path.Combine(GetSeriesCoverPath(seriesId), coverType.ToString().ToLower() + heightSuffix + GetExtension(coverType));
+            return Path.Combine(GetSeriesCoverPath(seriesId), coverType.ToString().ToLowerInvariant() + heightSuffix + GetExtension(coverType));
         }
 
         public void ConvertToLocalUrls(int seriesId, IEnumerable<MediaCover> covers)
@@ -89,14 +89,11 @@ namespace NzbDrone.Core.MediaCover
                         continue;
                     }
 
-                    var filePath = GetCoverPath(seriesId, mediaCover.CoverType);
+                    mediaCover.Url = _configFileProvider.UrlBase + @"/MediaCover/" + seriesId + "/" + mediaCover.CoverType.ToString().ToLowerInvariant() + GetExtension(mediaCover.CoverType);
 
-                    mediaCover.Url = _configFileProvider.UrlBase + @"/MediaCover/" + seriesId + "/" + mediaCover.CoverType.ToString().ToLower() + GetExtension(mediaCover.CoverType);
-
-                    if (_diskProvider.FileExists(filePath))
+                    if (mediaCover.RemoteUrl.IsNotNullOrWhiteSpace())
                     {
-                        var lastWrite = _diskProvider.FileGetLastWrite(filePath);
-                        mediaCover.Url += "?lastWrite=" + lastWrite.Ticks;
+                        mediaCover.Url += "?h=" + mediaCover.RemoteUrl.SHA256Hash()[..20];
                     }
                 }
             }
@@ -150,7 +147,7 @@ namespace NzbDrone.Core.MediaCover
 
             try
             {
-                _semaphore.Wait();
+                Semaphore.Wait();
 
                 foreach (var tuple in toResize)
                 {
@@ -159,7 +156,7 @@ namespace NzbDrone.Core.MediaCover
             }
             finally
             {
-                _semaphore.Release();
+                Semaphore.Release();
             }
 
             return updated;
@@ -218,16 +215,13 @@ namespace NzbDrone.Core.MediaCover
             }
         }
 
-        private string GetExtension(MediaCoverTypes coverType)
+        private static string GetExtension(MediaCoverTypes coverType)
         {
-            switch (coverType)
+            return coverType switch
             {
-                default:
-                    return ".jpg";
-
-                case MediaCoverTypes.Clearlogo:
-                    return ".png";
-            }
+                MediaCoverTypes.Clearlogo => ".png",
+                _ => ".jpg"
+            };
         }
 
         public void HandleAsync(SeriesUpdatedEvent message)

--- a/src/Sonarr.Api.V3/Series/SeriesController.cs
+++ b/src/Sonarr.Api.V3/Series/SeriesController.cs
@@ -228,7 +228,7 @@ namespace Sonarr.Api.V3.Series
             return resource;
         }
 
-        private void MapCoversToLocal(params SeriesResource[] series)
+        private void MapCoversToLocal(params IEnumerable<SeriesResource> series)
         {
             foreach (var seriesResource in series)
             {


### PR DESCRIPTION
#### Description

Improve loading times for series endpoint by skipping the last modification time fetching for covers to be used as argument for cache busting. Instead switching to generating a hash based on `RemoteUrl`.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes https://github.com/Radarr/Radarr/issues/11558
