### PR TITLE
rqbit: fix out path mapping

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/RQBit/RQbitProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/RQBit/RQbitProxy.cs
@@ -100,7 +100,12 @@ namespace NzbDrone.Core.Download.Clients.RQBit
                         torrent.Name = torrentWithStats.Name;
                         torrent.Hash = torrentWithStats.InfoHash;
                         torrent.TotalSize = torrentWithStats.Stats.TotalBytes;
-                        torrent.Path = torrentWithStats.OutputFolder + torrentWithStats.Name;
+                        torrent.Path = torrentWithStats.OutputFolder;
+
+                        if (!torrentWithStats.OutputFolder.EndsWith(torrentWithStats.Name))
+                        {
+                            torrent.Path += torrentWithStats.Name;
+                        }
 
                         var statsLive = torrentWithStats.Stats.Live;
                         if (statsLive?.DownloadSpeed != null)

--- a/src/NzbDrone.Core/Download/Clients/RQBit/ResponseModels/ListTorrentsWithStatsResponse.cs
+++ b/src/NzbDrone.Core/Download/Clients/RQBit/ResponseModels/ListTorrentsWithStatsResponse.cs
@@ -16,7 +16,10 @@ namespace NzbDrone.Core.Download.Clients.RQBit.ResponseModels
         public string InfoHash { get; set; }
 
         public string Name { get; set; }
+
+        [JsonProperty("output_folder")]
         public string OutputFolder { get; set; }
+
         public TorrentStatsResponse Stats { get; set; }
     }
 


### PR DESCRIPTION
#### Description

Fix how paths form the rqbit api are interpreted.

Torrents with a single file have a path of the folder containing the file (And other Torrents). Torrents with multiple files get a separate folder created which then gets referenced in the path by rqbit. 



#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
