### PR TITLE
Fixed: Allow keyboard activation for check inputs

### DIFF
--- a/frontend/src/Components/Form/CheckInput.tsx
+++ b/frontend/src/Components/Form/CheckInput.tsx
@@ -69,6 +69,10 @@ function CheckInput(props: CheckInputProps) {
         return;
       }
 
+      if (event.target === inputRef.current) {
+        return;
+      }
+
       const shiftKey = event.nativeEvent.shiftKey;
       const checked = !(inputRef.current?.checked ?? false);
 


### PR DESCRIPTION
#### Description

Checkboxes render a native input inside a clickable wrapper. When the native input was activated with Space, its click bubbled to the wrapper and was prevented before the browser could complete the native checkbox action.

This change leaves events originating from the native input to its existing change handler. Mouse clicks on the custom checkbox and its label continue to use the wrapper behavior, including Shift-click.

Tested with the "Start search for missing episodes" checkbox in the Add Series dialog using NVDA and keyboard navigation. Also tested normal pointer clicks, label clicks, repeated clicks, and Shift-click in a browser harness matching the rendered structure. The focused frontend lint and full frontend build pass.

A source audit confirmed that React checkboxes throughout Sonarr use this shared control. The static login page's native "Remember Me" checkbox is the only exception and already supports native keyboard and pointer interaction.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review