### PR TITLE
Fallback to name tag in media info stream titles for mp4

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -105,6 +105,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                         {
                             model.Title = audioTitle.Trim();
                         }
+                        else if ((stream.Tags?.TryGetValue("name", out var audioName) ?? false) && audioName.IsNotNullOrWhiteSpace())
+                        {
+                            model.Title = audioName.Trim();
+                        }
 
                         return  model;
                     })
@@ -124,6 +128,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                         if ((stream.Tags?.TryGetValue("title", out var subtitleTitle) ?? false) && subtitleTitle.IsNotNullOrWhiteSpace())
                         {
                             model.Title = subtitleTitle.Trim();
+                        }
+                        else if ((stream.Tags?.TryGetValue("name", out var subtitleName) ?? false) && subtitleName.IsNotNullOrWhiteSpace())
+                        {
+                            model.Title = subtitleName.Trim();
                         }
 
                         if (stream.Disposition?.TryGetValue("forced", out var forcedSubtitle) ?? false)


### PR DESCRIPTION
#### Description

Fallback to the tag name for stream titles, which is supported by ffprobe 8.x for mp4 files.



#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
