### PR TITLE
Fixed: HTTP Basic Auth credentials with non-ASCII characters

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -370,6 +371,28 @@ namespace NzbDrone.Common.Test.Http
             var response = await Subject.GetAsync<HttpBinResource>(request);
 
             response.Resource.Headers[header].ToString().Should().Be(value);
+        }
+
+        [Test]
+        public async Task should_send_basic_auth_header_as_utf8()
+        {
+            var username = "tèst";
+            var password = "pâsswörd_ș";
+
+            var request = new HttpRequest($"https://{_httpBinHost}/get")
+            {
+                Credentials = new BasicNetworkCredential(username, password)
+            };
+
+            var response = await Subject.GetAsync<HttpBinResource>(request);
+
+            response.Resource.Headers.Should().ContainKey("Authorization");
+
+            var authHeader = response.Resource.Headers["Authorization"].ToString();
+            var encodedPart = authHeader!.Split(' ', 2).Last();
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(encodedPart));
+
+            decoded.Should().Be($"{username}:{password}");
         }
 
         [Test]

--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -76,7 +76,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                 {
                     // Manually set header to avoid initial challenge response
                     var authInfo = bc.UserName + ":" + bc.Password;
-                    authInfo = Convert.ToBase64String(Encoding.GetEncoding("ISO-8859-1").GetBytes(authInfo));
+                    authInfo = Convert.ToBase64String(Encoding.UTF8.GetBytes(authInfo));
                     requestMessage.Headers.Add("Authorization", "Basic " + authInfo);
                 }
                 else if (request.Credentials is NetworkCredential nc)


### PR DESCRIPTION
#### Description

Pulled from Prowlarr, initial PR at https://github.com/Prowlarr/Prowlarr/pull/2749.