### PR TITLE
Fixed: Pagination for Trakt import lists

### DIFF
--- a/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktListRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktListRequestGeneratorFixture.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.Trakt.List;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.Trakt;
+
+[TestFixture]
+public class TraktListRequestGeneratorFixture : CoreTest
+{
+    private const int PAGE_SIZE = 250;
+    private const int MAX_NUM_RESULTS = 1000;
+
+    private static TraktListSettings GivenSettings(int limit = 100)
+    {
+        return new TraktListSettings
+        {
+            Username = "testuser",
+            Listname = "my list",
+            AccessToken = "token",
+            Limit = limit,
+        };
+    }
+
+    [Test]
+    public void should_build_url_with_username_and_listname()
+    {
+        var generator = new TraktListRequestGenerator(GivenSettings(), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.Path.Should().Be("/users/testuser/lists/my-list/items/show,season,episode");
+    }
+
+    [Test]
+    public void should_request_single_page_when_limit_is_less_than_page_size()
+    {
+        var generator = new TraktListRequestGenerator(GivenSettings(limit: 100), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.FullUri.Should().Contain("limit=100&page=1");
+    }
+
+    [Test]
+    public void should_request_single_page_when_limit_is_same_as_page_size()
+    {
+        var generator = new TraktListRequestGenerator(GivenSettings(limit: 250), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.FullUri.Should().Contain("limit=250&page=1");
+    }
+
+    [Test]
+    public void should_request_multiple_pages_when_limit_exceeds_page_size()
+    {
+        var generator = new TraktListRequestGenerator(GivenSettings(limit: 435), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(2);
+        requests[0].Url.FullUri.Should().Contain("limit=250&page=1");
+        requests[1].Url.FullUri.Should().Contain("limit=250&page=2");
+    }
+
+    [Test]
+    public void should_request_maximum_pages_when_limit_exceeds_allowed_value()
+    {
+        var generator = new TraktListRequestGenerator(GivenSettings(limit: 2000), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(4);
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktUserRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/Trakt/TraktUserRequestGeneratorFixture.cs
@@ -1,0 +1,133 @@
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.Trakt.User;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.Trakt;
+
+[TestFixture]
+public class TraktUserRequestGeneratorFixture : CoreTest
+{
+    private const int PAGE_SIZE = 250;
+    private const int MAX_NUM_RESULTS = 1000;
+
+    private static TraktUserSettings GivenSettings(int limit = 100, TraktUserListType? listType = null, TraktUserWatchedListType? watchedListType = null, TraktUserWatchSorting? watchSorting = null)
+    {
+        var settings = new TraktUserSettings
+        {
+            Username = "testuser",
+            AccessToken = "token",
+            Limit = limit,
+        };
+
+        if (listType.HasValue)
+        {
+            settings.TraktListType = (int)listType.Value;
+        }
+
+        if (watchedListType.HasValue)
+        {
+            settings.TraktWatchedListType = (int)watchedListType.Value;
+        }
+
+        if (watchSorting.HasValue)
+        {
+            settings.TraktWatchSorting = (int)watchSorting.Value;
+        }
+
+        return settings;
+    }
+
+    [Test]
+    public void should_build_url_with_username_and_defaults()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.Path.Should().Be("/users/testuser/watchlist/shows/rank");
+        requests[0].Url.FullUri.Should().NotContain("extended=full");
+    }
+
+    [Test]
+    public void should_build_url_with_username_and_list_type_watch()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(listType: TraktUserListType.UserWatchList, watchSorting: TraktUserWatchSorting.Added), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.Path.Should().Be("/users/testuser/watchlist/shows/added");
+        requests[0].Url.FullUri.Should().NotContain("extended=full");
+    }
+
+    [Test]
+    public void should_build_url_with_username_and_list_type_watched()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(listType: TraktUserListType.UserWatchedList), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.Path.Should().Be("/users/testuser/watched/shows");
+        requests[0].Url.FullUri.Should().Contain("extended=full");
+    }
+
+    [Test]
+    public void should_build_url_with_username_and_list_type_collection()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(listType: TraktUserListType.UserCollectionList), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.Path.Should().Be("/users/testuser/collection/shows");
+        requests[0].Url.FullUri.Should().NotContain("extended=full");
+    }
+
+    [Test]
+    public void should_request_single_page_when_limit_is_less_than_page_size()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(limit: 100), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.FullUri.Should().Contain("limit=100&page=1");
+    }
+
+    [Test]
+    public void should_request_single_page_when_limit_is_same_as_page_size()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(limit: 250), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(1);
+        requests[0].Url.FullUri.Should().Contain("limit=250&page=1");
+    }
+
+    [Test]
+    public void should_request_multiple_pages_when_limit_exceeds_page_size()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(limit: 435), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(2);
+        requests[0].Url.FullUri.Should().Contain("limit=250&page=1");
+        requests[1].Url.FullUri.Should().Contain("limit=250&page=2");
+    }
+
+    [Test]
+    public void should_request_maximum_pages_when_limit_exceeds_allowed_value()
+    {
+        var generator = new TraktUserRequestGenerator(GivenSettings(limit: 2000), "12345", PAGE_SIZE, MAX_NUM_RESULTS);
+
+        var requests = generator.GetListItems().GetAllTiers().First().ToList();
+
+        requests.Should().HaveCount(4);
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListImport.cs
@@ -24,11 +24,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new TraktListRequestGenerator()
-            {
-                Settings = Settings,
-                ClientId = ClientId
-            };
+            return new TraktListRequestGenerator(Settings, ClientId, PageSize, MaxNumResultsPerQuery);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
@@ -6,8 +8,18 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
 {
     public class TraktListRequestGenerator : IImportListRequestGenerator
     {
-        public TraktListSettings Settings { get; set; }
-        public string ClientId { get; set; }
+        private readonly TraktListSettings _settings;
+        private readonly string _clientId;
+        private readonly int _pageSize;
+        private readonly int _maxNumResults;
+
+        public TraktListRequestGenerator(TraktListSettings settings, string clientId, int pageSize, int maxNumResults)
+        {
+            _settings = settings;
+            _clientId = clientId;
+            _pageSize = pageSize;
+            _maxNumResults = maxNumResults;
+        }
 
         public virtual ImportListPageableRequestChain GetListItems()
         {
@@ -20,31 +32,45 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl.Trim());
+            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
 
             requestBuilder
                 .Resource("/users/{userName}/lists/{listName}/items/show,season,episode")
-                .SetSegment("userName", Settings.Username.Trim())
-                .SetSegment("listName", Settings.Listname.ToUrlSlug())
+                .SetSegment("userName", _settings.Username.Trim())
+                .SetSegment("listName", _settings.Listname.ToUrlSlug())
                 .Accept(HttpAccept.Json);
 
-            var filterParams = TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Settings.Years, Settings.Limit, Settings.TraktAdditionalParameters);
+            requestBuilder
+                .SetHeader("trakt-api-version", "2")
+                .SetHeader("trakt-api-key", _clientId);
+
+            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
+            }
+
+            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
 
             foreach (var param in filterParams)
             {
                 requestBuilder.AddQueryParam(param.Key, param.Value);
             }
 
-            requestBuilder
-                .SetHeader("trakt-api-version", "2")
-                .SetHeader("trakt-api-key", ClientId);
+            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
+            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
+            var remainderLimit = limit % _pageSize;
 
-            if (Settings.AccessToken.IsNotNullOrWhiteSpace())
+            for (var page = 1; page <= maxPages; page++)
             {
-                requestBuilder.SetHeader("Authorization", $"Bearer {Settings.AccessToken}");
-            }
+                if (maxPages == 1 && remainderLimit > 0)
+                {
+                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
+                }
 
-            yield return new ImportListRequest(requestBuilder.Build());
+                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
+
+                yield return new ImportListRequest(requestBuilder.Build());
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
@@ -10,14 +11,17 @@ namespace NzbDrone.Core.ImportLists.Trakt.List
         {
         }
 
-        protected override string Years => Settings.Years;
-
         protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
             requestBuilder
                 .Resource("/users/{userName}/lists/{listName}/items/show,season,episode")
                 .SetSegment("userName", Settings.Username.Trim())
                 .SetSegment("listName", Settings.Listname.ToUrlSlug());
+        }
+
+        protected override Dictionary<string, string> GetFilterParameters()
+        {
+            return TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Settings.Years, _pageSize, Settings.TraktAdditionalParameters);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/List/TraktListRequestGenerator.cs
@@ -1,76 +1,23 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.Trakt.List
 {
-    public class TraktListRequestGenerator : IImportListRequestGenerator
+    public class TraktListRequestGenerator : TraktRequestGeneratorBase<TraktListSettings>
     {
-        private readonly TraktListSettings _settings;
-        private readonly string _clientId;
-        private readonly int _pageSize;
-        private readonly int _maxNumResults;
-
         public TraktListRequestGenerator(TraktListSettings settings, string clientId, int pageSize, int maxNumResults)
+            : base(settings, clientId, pageSize, maxNumResults)
         {
-            _settings = settings;
-            _clientId = clientId;
-            _pageSize = pageSize;
-            _maxNumResults = maxNumResults;
         }
 
-        public virtual ImportListPageableRequestChain GetListItems()
+        protected override string Years => Settings.Years;
+
+        protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
-            var pageableRequests = new ImportListPageableRequestChain();
-
-            pageableRequests.Add(GetSeriesRequest());
-
-            return pageableRequests;
-        }
-
-        private IEnumerable<ImportListRequest> GetSeriesRequest()
-        {
-            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
-
             requestBuilder
                 .Resource("/users/{userName}/lists/{listName}/items/show,season,episode")
-                .SetSegment("userName", _settings.Username.Trim())
-                .SetSegment("listName", _settings.Listname.ToUrlSlug())
-                .Accept(HttpAccept.Json);
-
-            requestBuilder
-                .SetHeader("trakt-api-version", "2")
-                .SetHeader("trakt-api-key", _clientId);
-
-            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
-            {
-                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
-            }
-
-            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
-
-            foreach (var param in filterParams)
-            {
-                requestBuilder.AddQueryParam(param.Key, param.Value);
-            }
-
-            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
-            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
-            var remainderLimit = limit % _pageSize;
-
-            for (var page = 1; page <= maxPages; page++)
-            {
-                if (maxPages == 1 && remainderLimit > 0)
-                {
-                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
-                }
-
-                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
-
-                yield return new ImportListRequest(requestBuilder.Build());
-            }
+                .SetSegment("userName", Settings.Username.Trim())
+                .SetSegment("listName", Settings.Listname.ToUrlSlug());
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularImport.cs
@@ -28,11 +28,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new TraktPopularRequestGenerator()
-            {
-                Settings = Settings,
-                ClientId = ClientId
-            };
+            return new TraktPopularRequestGenerator(Settings, ClientId, PageSize, MaxNumResultsPerQuery);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularParser.cs
@@ -8,7 +8,6 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
     public class TraktPopularParser : TraktParser
     {
         private readonly TraktPopularSettings _settings;
-        private ImportListResponse _importResponse;
 
         public TraktPopularParser(TraktPopularSettings settings)
         {
@@ -17,25 +16,18 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
         public override IList<ImportListItemInfo> ParseResponse(ImportListResponse importResponse)
         {
-            _importResponse = importResponse;
-
             var listItems = new List<ImportListItemInfo>();
 
-            if (!PreProcess(_importResponse))
+            if (!PreProcess(importResponse))
             {
                 return listItems;
             }
 
-            var traktSeries = new List<TraktSeriesResource>();
-
-            if (_settings.TraktListType == (int)TraktPopularListType.Popular)
+            var traktSeries = _settings.TraktListType switch
             {
-                traktSeries = STJson.Deserialize<List<TraktSeriesResource>>(_importResponse.Content);
-            }
-            else
-            {
-                traktSeries = STJson.Deserialize<List<TraktResponse>>(_importResponse.Content).SelectList(c => c.Show);
-            }
+                (int)TraktPopularListType.Popular => STJson.Deserialize<List<TraktSeriesResource>>(importResponse.Content),
+                _ => STJson.Deserialize<List<TraktResponse>>(importResponse.Content).SelectList(c => c.Show)
+            };
 
             // no series were returned
             if (traktSeries == null)
@@ -45,7 +37,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
             foreach (var series in traktSeries)
             {
-                listItems.AddIfNotNull(new ImportListItemInfo()
+                listItems.AddIfNotNull(new ImportListItemInfo
                 {
                     Title = series.Title,
                     TvdbId = series.Ids.Tvdb.GetValueOrDefault(),

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
@@ -1,42 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.Trakt.Popular
 {
-    public class TraktPopularRequestGenerator : IImportListRequestGenerator
+    public class TraktPopularRequestGenerator : TraktRequestGeneratorBase<TraktPopularSettings>
     {
-        private readonly TraktPopularSettings _settings;
-        private readonly string _clientId;
-        private readonly int _pageSize;
-        private readonly int _maxNumResults;
-
         public TraktPopularRequestGenerator(TraktPopularSettings settings, string clientId, int pageSize, int maxNumResults)
+            : base(settings, clientId, pageSize, maxNumResults)
         {
-            _settings = settings;
-            _clientId = clientId;
-            _pageSize = pageSize;
-            _maxNumResults = maxNumResults;
         }
 
-        public virtual ImportListPageableRequestChain GetListItems()
+        protected override string Years => Settings.Years;
+
+        protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
-            var pageableRequests = new ImportListPageableRequestChain();
-
-            pageableRequests.Add(GetSeriesRequest());
-
-            return pageableRequests;
-        }
-
-        private IEnumerable<ImportListRequest> GetSeriesRequest()
-        {
-            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
-
             var resource = "/shows";
 
-            switch (_settings.TraktListType)
+            switch (Settings.TraktListType)
             {
                 case (int)TraktPopularListType.Trending:
                     resource += "/trending";
@@ -77,39 +56,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
                     break;
             }
 
-            requestBuilder
-                .Resource(resource)
-                .Accept(HttpAccept.Json)
-                .SetHeader("trakt-api-version", "2")
-                .SetHeader("trakt-api-key", _clientId);
-
-            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
-            {
-                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
-            }
-
-            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
-
-            foreach (var param in filterParams)
-            {
-                requestBuilder.AddQueryParam(param.Key, param.Value);
-            }
-
-            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
-            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
-            var remainderLimit = limit % _pageSize;
-
-            for (var page = 1; page <= maxPages; page++)
-            {
-                if (maxPages == 1 && remainderLimit > 0)
-                {
-                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
-                }
-
-                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
-
-                yield return new ImportListRequest(requestBuilder.Build());
-            }
+            requestBuilder.Resource(resource);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
@@ -6,9 +8,18 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 {
     public class TraktPopularRequestGenerator : IImportListRequestGenerator
     {
-        public TraktPopularSettings Settings { get; set; }
+        private readonly TraktPopularSettings _settings;
+        private readonly string _clientId;
+        private readonly int _pageSize;
+        private readonly int _maxNumResults;
 
-        public string ClientId { get; set; }
+        public TraktPopularRequestGenerator(TraktPopularSettings settings, string clientId, int pageSize, int maxNumResults)
+        {
+            _settings = settings;
+            _clientId = clientId;
+            _pageSize = pageSize;
+            _maxNumResults = maxNumResults;
+        }
 
         public virtual ImportListPageableRequestChain GetListItems()
         {
@@ -21,11 +32,11 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl.Trim());
+            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
 
             var resource = "/shows";
 
-            switch (Settings.TraktListType)
+            switch (_settings.TraktListType)
             {
                 case (int)TraktPopularListType.Trending:
                     resource += "/trending";
@@ -68,25 +79,37 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
 
             requestBuilder
                 .Resource(resource)
-                .Accept(HttpAccept.Json);
+                .Accept(HttpAccept.Json)
+                .SetHeader("trakt-api-version", "2")
+                .SetHeader("trakt-api-key", _clientId);
 
-            var filterParams = TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Settings.Years, Settings.Limit, Settings.TraktAdditionalParameters);
+            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
+            }
+
+            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
 
             foreach (var param in filterParams)
             {
                 requestBuilder.AddQueryParam(param.Key, param.Value);
             }
 
-            requestBuilder
-                .SetHeader("trakt-api-version", "2")
-                .SetHeader("trakt-api-key", ClientId);
+            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
+            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
+            var remainderLimit = limit % _pageSize;
 
-            if (Settings.AccessToken.IsNotNullOrWhiteSpace())
+            for (var page = 1; page <= maxPages; page++)
             {
-                requestBuilder.SetHeader("Authorization", $"Bearer {Settings.AccessToken}");
-            }
+                if (maxPages == 1 && remainderLimit > 0)
+                {
+                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
+                }
 
-            yield return new ImportListRequest(requestBuilder.Build());
+                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
+
+                yield return new ImportListRequest(requestBuilder.Build());
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/Popular/TraktPopularRequestGenerator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.Trakt.Popular
@@ -8,8 +9,6 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
             : base(settings, clientId, pageSize, maxNumResults)
         {
         }
-
-        protected override string Years => Settings.Years;
 
         protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
@@ -57,6 +56,11 @@ namespace NzbDrone.Core.ImportLists.Trakt.Popular
             }
 
             requestBuilder.Resource(resource);
+        }
+
+        protected override Dictionary<string, string> GetFilterParameters()
+        {
+            return TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Settings.Years, _pageSize, Settings.TraktAdditionalParameters);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktImportBase.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.ImportLists.Trakt
@@ -15,6 +17,9 @@ namespace NzbDrone.Core.ImportLists.Trakt
     {
         public override ImportListType ListType => ImportListType.Trakt;
         public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
+
+        public override int PageSize => 250;
+        public override TimeSpan RateLimit => TimeSpan.FromSeconds(5);
 
         public const string OAuthUrl = "https://trakt.tv/oauth/authorize";
         public const string RedirectUri = "https://auth.servarr.com/v1/trakt_sonarr/auth";
@@ -45,14 +50,19 @@ namespace NzbDrone.Core.ImportLists.Trakt
                 RefreshToken();
             }
 
-            var generator = GetRequestGenerator();
-
             return FetchItems(g => g.GetListItems(), true);
         }
 
         public override IParseImportListResponse GetParser()
         {
             return new TraktParser();
+        }
+
+        protected override IList<ImportListItemInfo> CleanupListItems(IEnumerable<ImportListItemInfo> releases)
+        {
+            return base.CleanupListItems(releases)
+                .Take(Settings.Limit)
+                .ToList();
         }
 
         public override object RequestAction(string action, IDictionary<string, string> query)

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktQueryHelper.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktQueryHelper.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
 using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Core.ImportLists.Trakt
@@ -9,10 +9,12 @@ namespace NzbDrone.Core.ImportLists.Trakt
     {
         private static readonly HashSet<string> ReservedFilterParameters = new(StringComparer.OrdinalIgnoreCase)
         {
+            "extended",
             "genres",
             "ratings",
             "years",
-            "limit"
+            "limit",
+            "page",
         };
 
         public static Dictionary<string, string> BuildFilterParameters(string rating, string genres, string years, int limit, string additionalParameters)
@@ -43,7 +45,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
 
             if (genres.IsNotNullOrWhiteSpace())
             {
-                parameters["genres"] = genres.ToLower();
+                parameters["genres"] = genres.ToLowerInvariant();
             }
 
             if (rating.IsNotNullOrWhiteSpace())
@@ -56,7 +58,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
                 parameters["years"] = years;
             }
 
-            parameters["limit"] = limit.ToString();
+            parameters["limit"] = limit.ToString(CultureInfo.InvariantCulture);
 
             return parameters;
         }
@@ -81,11 +83,6 @@ namespace NzbDrone.Core.ImportLists.Trakt
             }
 
             return false;
-        }
-
-        public static string ToQueryString(this Dictionary<string, string> parameters)
-        {
-            return string.Join("&", parameters.Where(p => p.Value.IsNotNullOrWhiteSpace()).Select(p => $"{p.Key}={p.Value}"));
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktRequestGeneratorBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktRequestGeneratorBase.cs
@@ -9,9 +9,9 @@ namespace NzbDrone.Core.ImportLists.Trakt
     public abstract class TraktRequestGeneratorBase<TSettings> : IImportListRequestGenerator
         where TSettings : TraktSettingsBase<TSettings>
     {
-        private readonly string _clientId;
-        private readonly int _pageSize;
-        private readonly int _maxNumResults;
+        protected readonly string _clientId;
+        protected readonly int _pageSize;
+        protected readonly int _maxNumResults;
 
         protected TraktRequestGeneratorBase(TSettings settings, string clientId, int pageSize, int maxNumResults)
         {
@@ -22,8 +22,6 @@ namespace NzbDrone.Core.ImportLists.Trakt
         }
 
         protected TSettings Settings { get; }
-
-        protected abstract string Years { get; }
 
         public virtual ImportListPageableRequestChain GetListItems()
         {
@@ -36,9 +34,7 @@ namespace NzbDrone.Core.ImportLists.Trakt
 
         protected abstract void SetResource(HttpRequestBuilder requestBuilder);
 
-        protected virtual void SetFilterParameters(Dictionary<string, string> filterParams)
-        {
-        }
+        protected abstract Dictionary<string, string> GetFilterParameters();
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
@@ -56,13 +52,9 @@ namespace NzbDrone.Core.ImportLists.Trakt
 
             SetResource(requestBuilder);
 
-            var filterParams = TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Years, _pageSize, Settings.TraktAdditionalParameters);
-
-            SetFilterParameters(filterParams);
-
-            foreach (var param in filterParams)
+            foreach (var param in GetFilterParameters())
             {
-                requestBuilder.AddQueryParam(param.Key, param.Value);
+                requestBuilder.AddQueryParam(param.Key, param.Value, true);
             }
 
             var limit = Math.Clamp(Settings.Limit, 0, _maxNumResults);

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktRequestGeneratorBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktRequestGeneratorBase.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.ImportLists.Trakt
+{
+    public abstract class TraktRequestGeneratorBase<TSettings> : IImportListRequestGenerator
+        where TSettings : TraktSettingsBase<TSettings>
+    {
+        private readonly string _clientId;
+        private readonly int _pageSize;
+        private readonly int _maxNumResults;
+
+        protected TraktRequestGeneratorBase(TSettings settings, string clientId, int pageSize, int maxNumResults)
+        {
+            Settings = settings;
+            _clientId = clientId;
+            _pageSize = pageSize;
+            _maxNumResults = maxNumResults;
+        }
+
+        protected TSettings Settings { get; }
+
+        protected abstract string Years { get; }
+
+        public virtual ImportListPageableRequestChain GetListItems()
+        {
+            var pageableRequests = new ImportListPageableRequestChain();
+
+            pageableRequests.Add(GetSeriesRequest());
+
+            return pageableRequests;
+        }
+
+        protected abstract void SetResource(HttpRequestBuilder requestBuilder);
+
+        protected virtual void SetFilterParameters(Dictionary<string, string> filterParams)
+        {
+        }
+
+        private IEnumerable<ImportListRequest> GetSeriesRequest()
+        {
+            var requestBuilder = new HttpRequestBuilder(Settings.BaseUrl.Trim());
+
+            requestBuilder
+                .Accept(HttpAccept.Json)
+                .SetHeader("trakt-api-version", "2")
+                .SetHeader("trakt-api-key", _clientId);
+
+            if (Settings.AccessToken.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.SetHeader("Authorization", $"Bearer {Settings.AccessToken}");
+            }
+
+            SetResource(requestBuilder);
+
+            var filterParams = TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Years, _pageSize, Settings.TraktAdditionalParameters);
+
+            SetFilterParameters(filterParams);
+
+            foreach (var param in filterParams)
+            {
+                requestBuilder.AddQueryParam(param.Key, param.Value);
+            }
+
+            var limit = Math.Clamp(Settings.Limit, 0, _maxNumResults);
+            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
+            var remainderLimit = limit % _pageSize;
+
+            for (var page = 1; page <= maxPages; page++)
+            {
+                if (maxPages == 1 && remainderLimit > 0)
+                {
+                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
+                }
+
+                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
+
+                yield return new ImportListRequest(requestBuilder.Build());
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/TraktSettingsBase.cs
@@ -28,7 +28,6 @@ namespace NzbDrone.Core.ImportLists.Trakt
                                    .WithMessage("Must authenticate with Trakt")
                                    .When(c => c.AccessToken.IsNotNullOrWhiteSpace() && c.RefreshToken.IsNotNullOrWhiteSpace());
 
-            // Limit not smaller than 1 and not larger than 100
             RuleFor(c => c.Limit)
                 .GreaterThan(0)
                 .WithMessage("Must be integer greater than 0");

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserImport.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserImport.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new TraktUserRequestGenerator(Settings, ClientId);
+            return new TraktUserRequestGenerator(Settings, ClientId, PageSize, MaxNumResultsPerQuery);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
@@ -8,11 +10,15 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
     {
         private readonly TraktUserSettings _settings;
         private readonly string _clientId;
+        private readonly int _pageSize;
+        private readonly int _maxNumResults;
 
-        public TraktUserRequestGenerator(TraktUserSettings settings, string clientId)
+        public TraktUserRequestGenerator(TraktUserSettings settings, string clientId, int pageSize, int maxNumResults)
         {
             _settings = settings;
             _clientId = clientId;
+            _pageSize = pageSize;
+            _maxNumResults = maxNumResults;
         }
 
         public virtual ImportListPageableRequestChain GetListItems()
@@ -26,7 +32,17 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var link = _settings.BaseUrl.Trim();
+            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
+
+            requestBuilder
+                .Accept(HttpAccept.Json)
+                .SetHeader("trakt-api-version", "2")
+                .SetHeader("trakt-api-key", _clientId);
+
+            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
+            {
+                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
+            }
 
             var userName = _settings.Username.IsNotNullOrWhiteSpace() ? _settings.Username.Trim() : _settings.AuthUser.Trim();
 
@@ -41,36 +57,50 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
                         _ => "rank"
                     };
 
-                    link += $"/users/{userName}/watchlist/shows/{watchSorting}";
+                    requestBuilder
+                        .Resource("/users/{userName}/watchlist/shows/{watchSorting}")
+                        .SetSegment("userName", userName)
+                        .SetSegment("watchSorting", watchSorting);
                     break;
                 case (int)TraktUserListType.UserWatchedList:
-                    link += $"/users/{userName}/watched/shows";
+                    requestBuilder
+                        .Resource("/users/{userName}/watched/shows")
+                        .SetSegment("userName", userName);
                     break;
                 case (int)TraktUserListType.UserCollectionList:
-                    link += $"/users/{userName}/collection/shows";
+                    requestBuilder
+                        .Resource("/users/{userName}/collection/shows")
+                        .SetSegment("userName", userName);
                     break;
             }
 
-            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _settings.Limit, _settings.TraktAdditionalParameters);
+            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
 
             if (_settings.TraktListType == (int)TraktUserListType.UserWatchedList)
             {
                 filterParams["extended"] = "full";
             }
 
-            link += "?" + filterParams.ToQueryString();
-
-            var request = new ImportListRequest(link, HttpAccept.Json);
-
-            request.HttpRequest.Headers.Add("trakt-api-version", "2");
-            request.HttpRequest.Headers.Add("trakt-api-key", _clientId);
-
-            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
+            foreach (var param in filterParams)
             {
-                request.HttpRequest.Headers.Add("Authorization", $"Bearer {_settings.AccessToken}");
+                requestBuilder.AddQueryParam(param.Key, param.Value);
             }
 
-            yield return request;
+            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
+            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
+            var remainderLimit = limit % _pageSize;
+
+            for (var page = 1; page <= maxPages; page++)
+            {
+                if (maxPages == 1 && remainderLimit > 0)
+                {
+                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
+                }
+
+                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
+
+                yield return new ImportListRequest(requestBuilder.Build());
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
@@ -1,55 +1,26 @@
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.Trakt.User
 {
-    public class TraktUserRequestGenerator : IImportListRequestGenerator
+    public class TraktUserRequestGenerator : TraktRequestGeneratorBase<TraktUserSettings>
     {
-        private readonly TraktUserSettings _settings;
-        private readonly string _clientId;
-        private readonly int _pageSize;
-        private readonly int _maxNumResults;
-
         public TraktUserRequestGenerator(TraktUserSettings settings, string clientId, int pageSize, int maxNumResults)
+            : base(settings, clientId, pageSize, maxNumResults)
         {
-            _settings = settings;
-            _clientId = clientId;
-            _pageSize = pageSize;
-            _maxNumResults = maxNumResults;
         }
 
-        public virtual ImportListPageableRequestChain GetListItems()
+        protected override string Years => Settings.Years;
+
+        protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
-            var pageableRequests = new ImportListPageableRequestChain();
+            var userName = Settings.Username.IsNotNullOrWhiteSpace() ? Settings.Username.Trim() : Settings.AuthUser.Trim();
 
-            pageableRequests.Add(GetSeriesRequest());
-
-            return pageableRequests;
-        }
-
-        private IEnumerable<ImportListRequest> GetSeriesRequest()
-        {
-            var requestBuilder = new HttpRequestBuilder(_settings.BaseUrl.Trim());
-
-            requestBuilder
-                .Accept(HttpAccept.Json)
-                .SetHeader("trakt-api-version", "2")
-                .SetHeader("trakt-api-key", _clientId);
-
-            if (_settings.AccessToken.IsNotNullOrWhiteSpace())
-            {
-                requestBuilder.SetHeader("Authorization", $"Bearer {_settings.AccessToken}");
-            }
-
-            var userName = _settings.Username.IsNotNullOrWhiteSpace() ? _settings.Username.Trim() : _settings.AuthUser.Trim();
-
-            switch (_settings.TraktListType)
+            switch (Settings.TraktListType)
             {
                 case (int)TraktUserListType.UserWatchList:
-                    var watchSorting = _settings.TraktWatchSorting switch
+                    var watchSorting = Settings.TraktWatchSorting switch
                     {
                         (int)TraktUserWatchSorting.Added => "added",
                         (int)TraktUserWatchSorting.Title => "title",
@@ -73,33 +44,13 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
                         .SetSegment("userName", userName);
                     break;
             }
+        }
 
-            var filterParams = TraktQueryHelper.BuildFilterParameters(_settings.Rating, _settings.Genres, _settings.Years, _pageSize, _settings.TraktAdditionalParameters);
-
-            if (_settings.TraktListType == (int)TraktUserListType.UserWatchedList)
+        protected override void SetFilterParameters(Dictionary<string, string> filterParams)
+        {
+            if (Settings.TraktListType == (int)TraktUserListType.UserWatchedList)
             {
                 filterParams["extended"] = "full";
-            }
-
-            foreach (var param in filterParams)
-            {
-                requestBuilder.AddQueryParam(param.Key, param.Value);
-            }
-
-            var limit = Math.Clamp(_settings.Limit, 0, _maxNumResults);
-            var maxPages = (int)Math.Ceiling(decimal.Divide(limit, _pageSize));
-            var remainderLimit = limit % _pageSize;
-
-            for (var page = 1; page <= maxPages; page++)
-            {
-                if (maxPages == 1 && remainderLimit > 0)
-                {
-                    requestBuilder.AddQueryParam("limit", remainderLimit.ToString(CultureInfo.InvariantCulture), true);
-                }
-
-                requestBuilder.AddQueryParam("page", page.ToString(CultureInfo.InvariantCulture), true);
-
-                yield return new ImportListRequest(requestBuilder.Build());
             }
         }
     }

--- a/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Trakt/User/TraktUserRequestGenerator.cs
@@ -11,8 +11,6 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
         {
         }
 
-        protected override string Years => Settings.Years;
-
         protected override void SetResource(HttpRequestBuilder requestBuilder)
         {
             var userName = Settings.Username.IsNotNullOrWhiteSpace() ? Settings.Username.Trim() : Settings.AuthUser.Trim();
@@ -46,12 +44,16 @@ namespace NzbDrone.Core.ImportLists.Trakt.User
             }
         }
 
-        protected override void SetFilterParameters(Dictionary<string, string> filterParams)
+        protected override Dictionary<string, string> GetFilterParameters()
         {
+            var filterParams = TraktQueryHelper.BuildFilterParameters(Settings.Rating, Settings.Genres, Settings.Years, _pageSize, Settings.TraktAdditionalParameters);
+
             if (Settings.TraktListType == (int)TraktUserListType.UserWatchedList)
             {
                 filterParams["extended"] = "full";
             }
+
+            return filterParams;
         }
     }
 }


### PR DESCRIPTION
#### Description

Adding pagination support to Trakt lists, as now there's a hard limit of 250 for the query parameter `limit`. 

To maintain support for fetching exactly the number of items as per limit set in settings, an items.Take(limit) is needed in `CleanupListItems`. Needed as Trakt's pagination does not handle offset, just `page` + `limit`.

#### Issues Fixed or Closed by this PR

- Related https://github.com/Radarr/Radarr/issues/11538