### PR TITLE
Fixed: Connecting to Jellyfin 12+

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Notifications.Emby
             var path = "/System/Configuration";
             var request = BuildRequest(path, settings);
             request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
+            request.Headers.Add("Authorization", $"MediaBrowser Token=\"{settings.ApiKey}\"");
 
             var response = _httpClient.Get(request);
             _logger.Trace("Response: {0}", response.Content);


### PR DESCRIPTION
#### Description

Adds support for sending the `Authorization` header for Jellyfin 12+. I've tested against Jellyfin 12.0 RC 3 and Emby 4.9.5.0, both are connecting correctly when sending both headers.

Once merged I'll backport both this and 8b7f9daab0b5461b14534e3c554d0756d0c9b757 to v4.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #8805
