### PR TITLE
Fixed: Run missing episode searches from Calendar

### DIFF
--- a/frontend/src/Calendar/CalendarMissingEpisodeSearchButton.tsx
+++ b/frontend/src/Calendar/CalendarMissingEpisodeSearchButton.tsx
@@ -1,43 +1,27 @@
 import moment from 'moment';
 import React, { useCallback } from 'react';
 import { useQueueDetails } from 'Activity/Queue/Details/QueueDetailsProvider';
-import { useCommands } from 'Commands/useCommands';
+import CommandNames from 'Commands/CommandNames';
+import { useCommandExecuting, useExecuteCommand } from 'Commands/useCommands';
 import PageToolbarButton from 'Components/Page/Toolbar/PageToolbarButton';
 import { icons } from 'Helpers/Props';
-import { isCommandExecuting } from 'Utilities/Command';
 import isBefore from 'Utilities/Date/isBefore';
 import translate from 'Utilities/String/translate';
-import useCalendar, {
-  useCalendarRange,
-  useCalendarSearchMissingCommandId,
-} from './useCalendar';
-
-function useIsSearching(searchMissingCommandId: number | undefined) {
-  const { data: commands } = useCommands();
-
-  if (searchMissingCommandId == null) {
-    return false;
-  }
-
-  return isCommandExecuting(
-    commands.find((command) => {
-      return command.id === searchMissingCommandId;
-    })
-  );
-}
+import useCalendar, { useCalendarRange } from './useCalendar';
 
 const useMissingEpisodeIdsSelector = () => {
   const { start, end } = useCalendarRange();
   const { data } = useCalendar();
   const queueDetails = useQueueDetails();
+  const rangeStart = moment(start).startOf('day');
+  const rangeEnd = moment(end).endOf('day');
 
   return data.reduce<number[]>((acc, episode) => {
     const airDateUtc = episode.airDateUtc;
 
     if (
       !episode.episodeFileId &&
-      moment(airDateUtc).isAfter(start) &&
-      moment(airDateUtc).isBefore(end) &&
+      moment(airDateUtc).isBetween(rangeStart, rangeEnd, undefined, '[]') &&
       isBefore(episode.airDateUtc) &&
       !queueDetails.some((details) => details.episodeIds?.includes(episode.id))
     ) {
@@ -49,11 +33,21 @@ const useMissingEpisodeIdsSelector = () => {
 };
 
 export default function CalendarMissingEpisodeSearchButton() {
-  const searchMissingCommandId = useCalendarSearchMissingCommandId();
+  const executeCommand = useExecuteCommand();
   const missingEpisodeIds = useMissingEpisodeIdsSelector();
-  const isSearchingForMissing = useIsSearching(searchMissingCommandId);
+  const isSearchingForMissing = useCommandExecuting(
+    CommandNames.EpisodeSearch,
+    {
+      episodeIds: missingEpisodeIds,
+    }
+  );
 
-  const handlePress = useCallback(() => {}, []);
+  const handlePress = useCallback(() => {
+    executeCommand({
+      name: CommandNames.EpisodeSearch,
+      episodeIds: missingEpisodeIds,
+    });
+  }, [executeCommand, missingEpisodeIds]);
 
   return (
     <PageToolbarButton

--- a/frontend/src/Calendar/useCalendar.ts
+++ b/frontend/src/Calendar/useCalendar.ts
@@ -58,7 +58,6 @@ interface CalendarStore {
   time: moment.Moment;
   dates: string[];
   dayCount: number;
-  searchMissingCommandId?: number;
 }
 
 const calendarStore = create<CalendarStore>(() => ({
@@ -183,10 +182,6 @@ export const useCalendarRange = () => {
     start: dates[0],
     end: dates[dates.length - 1],
   };
-};
-
-export const useCalendarSearchMissingCommandId = () => {
-  return calendarStore((state) => state.searchMissingCommandId);
 };
 
 export const setCalendarDayCount = (dayCount: number) => {


### PR DESCRIPTION
#### Description

The Calendar's Search for Missing button currently has an empty click handler, so pressing it never starts a search.

This change sends an episode search command for eligible episodes in the displayed Calendar range and uses the shared command state to show when that search is running. Eligible episodes must have aired, have no episode file, and not already be queued. The complete first and final displayed days are included.

ESLint, the frontend Webpack build, and `git diff --check` pass.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
