### PR TITLE
Fixed: Validate language existance for manual imports

### DIFF
--- a/src/NzbDrone.Core/Languages/Language.cs
+++ b/src/NzbDrone.Core/Languages/Language.cs
@@ -227,5 +227,15 @@ namespace NzbDrone.Core.Languages
 
             return language;
         }
+
+        public bool IsValid(bool throwOnMissing = true)
+        {
+            return Lookup.ContainsKey(Id) switch
+            {
+                false when throwOnMissing => throw new InvalidOperationException("ID does not match a known language"),
+                false => false,
+                _ => true
+            };
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportFile.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportFile.cs
@@ -12,10 +12,10 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         public string Path { get; set; }
         public string FolderName { get; set; }
         public int SeriesId { get; set; }
-        public List<int> EpisodeIds { get; set; }
+        public List<int> EpisodeIds { get; set; } = [];
         public int? EpisodeFileId { get; set; }
-        public QualityModel Quality { get; set; }
-        public List<Language> Languages { get; set; }
+        public QualityModel Quality { get; set; } = new();
+        public List<Language> Languages { get; set; } = [];
         public string ReleaseGroup { get; set; }
         public int IndexerFlags { get; set; }
         public ReleaseType ReleaseType { get; set; }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -542,9 +542,13 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                 localEpisode.Episodes = episodes;
                 localEpisode.ReleaseGroup = file.ReleaseGroup;
                 localEpisode.Quality = file.Quality;
-                localEpisode.Languages = file.Languages;
                 localEpisode.IndexerFlags = (IndexerFlags)file.IndexerFlags;
                 localEpisode.ReleaseType = file.ReleaseType;
+
+                if (file.Languages is { Count: > 0 } && file.Languages.All(l => l is not null && l.IsValid()))
+                {
+                    localEpisode.Languages = file.Languages;
+                }
 
                 _localEpisodeFormatCalculator.UpdateEpisodeCustomFormats(localEpisode);
 


### PR DESCRIPTION
#### Description

Adding validation for languages for user defined languages on manual imports.

Due to the fact that commands' body isn't validated on POST /command, any invalid language Id will be shown in the logs and not in the response of said endpoint.

This is also a change in behavior, as it's going to treat `[]` or `[null]` as not defined and won't override them thus allowing Sonarr to use the aggregate languages from media info instead.