### PR TITLE
fix: Properly resolve file renaming conflicts

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/RenameEpisodeFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/RenameEpisodeFileServiceFixture.cs
@@ -1,14 +1,19 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FizzWare.NBuilder;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Disk;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Commands;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.MediaFiles
 {
@@ -21,6 +26,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         public void Setup()
         {
             _series = Builder<Series>.CreateNew()
+                                     .With(s => s.Path = @"C:\Test\TV\Series Title".AsOsAgnostic())
                                      .Build();
 
             _episodeFiles = Builder<EpisodeFile>.CreateListOfSize(2)
@@ -33,6 +39,16 @@ namespace NzbDrone.Core.Test.MediaFiles
             Mocker.GetMock<ISeriesService>()
                   .Setup(s => s.GetSeries(_series.Id))
                   .Returns(_series);
+
+            Mocker.GetMock<IEpisodeService>()
+                  .Setup(s => s.GetEpisodesByFileId(It.IsAny<int>()))
+                  .Returns(new List<Episode>());
+
+            // By default every file renames to a unique, uncontested path so tests that don't care about
+            // naming conflicts don't need to stub the builder themselves.
+            Mocker.GetMock<IBuildFileNames>()
+                  .Setup(f => f.BuildFilePath(It.IsAny<List<Episode>>(), It.IsAny<Series>(), It.IsAny<EpisodeFile>(), It.IsAny<string>(), It.IsAny<NamingConfig>(), It.IsAny<List<CustomFormat>>()))
+                  .Returns<List<Episode>, Series, EpisodeFile, string, NamingConfig, List<CustomFormat>>((episodes, series, file, ext, namingConfig, customFormats) => Path.Combine(series.Path, "Renamed-" + file.RelativePath));
         }
 
         private void GivenNoEpisodeFiles()
@@ -55,6 +71,15 @@ namespace NzbDrone.Core.Test.MediaFiles
                   .Setup(s => s.MoveEpisodeFile(It.IsAny<EpisodeFile>(), _series));
         }
 
+        // Points a specific file's computed destination at the given (series-relative) path, so tests can
+        // construct swaps, rotations, and blocked conflicts without touching the real naming logic or disk.
+        private void GivenTargetPath(EpisodeFile episodeFile, string targetRelativePath)
+        {
+            Mocker.GetMock<IBuildFileNames>()
+                  .Setup(f => f.BuildFilePath(It.IsAny<List<Episode>>(), _series, episodeFile, It.IsAny<string>(), It.IsAny<NamingConfig>(), It.IsAny<List<CustomFormat>>()))
+                  .Returns(Path.Combine(_series.Path, targetRelativePath));
+        }
+
         [Test]
         public void should_not_publish_event_if_no_files_to_rename()
         {
@@ -71,11 +96,14 @@ namespace NzbDrone.Core.Test.MediaFiles
         {
             GivenEpisodeFiles();
 
-            Mocker.GetMock<IMoveEpisodeFiles>()
-                  .Setup(s => s.MoveEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<Series>()))
-                  .Throws(new SameFilenameException("Same file name", "Filename"));
+            // Both files already sit at their correctly-computed path - nothing to do.
+            GivenTargetPath(_episodeFiles[0], _episodeFiles[0].RelativePath);
+            GivenTargetPath(_episodeFiles[1], _episodeFiles[1].RelativePath);
 
-            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1 }));
+            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1, 2 }));
+
+            Mocker.GetMock<IMoveEpisodeFiles>()
+                  .Verify(v => v.MoveEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<Series>()), Times.Never());
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(v => v.PublishEvent(It.IsAny<SeriesRenamedEvent>()), Times.Never());
@@ -117,6 +145,134 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IMediaFileService>()
                   .Verify(v => v.Get(files), Times.Once());
+        }
+
+        [Test]
+        public void should_rename_swapped_episode_files()
+        {
+            GivenEpisodeFiles();
+            GivenMovedFiles();
+
+            // Episode 1 and episode 2 trade filenames - a closed, two-file rotation.
+            GivenTargetPath(_episodeFiles[0], _episodeFiles[1].RelativePath);
+            GivenTargetPath(_episodeFiles[1], _episodeFiles[0].RelativePath);
+
+            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1, 2 }));
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Verify(v => v.Update(It.IsAny<EpisodeFile>()), Times.Exactly(2));
+
+            Mocker.GetMock<IEventAggregator>()
+                  .Verify(v => v.PublishEvent(It.IsAny<SeriesRenamedEvent>()), Times.Once());
+
+            // Exactly one file needs to be displaced to a temporary name to break the rotation.
+            Mocker.GetMock<IDiskProvider>()
+                  .Verify(v => v.MoveFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once());
+        }
+
+        [Test]
+        public void should_rename_episode_files_in_a_three_way_rotation()
+        {
+            var episodeFiles = Builder<EpisodeFile>.CreateListOfSize(3)
+                                                    .All()
+                                                    .With(e => e.SeriesId = _series.Id)
+                                                    .With(e => e.SeasonNumber = 1)
+                                                    .Build()
+                                                    .ToList();
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Setup(s => s.Get(It.IsAny<IEnumerable<int>>()))
+                  .Returns(episodeFiles);
+
+            GivenMovedFiles();
+
+            // 1 -> 2's spot, 2 -> 3's spot, 3 -> 1's spot: episodes renumbered E1->E2->E3->E1.
+            GivenTargetPath(episodeFiles[0], episodeFiles[1].RelativePath);
+            GivenTargetPath(episodeFiles[1], episodeFiles[2].RelativePath);
+            GivenTargetPath(episodeFiles[2], episodeFiles[0].RelativePath);
+
+            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1, 2, 3 }));
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Verify(v => v.Update(It.IsAny<EpisodeFile>()), Times.Exactly(3));
+
+            Mocker.GetMock<IEventAggregator>()
+                  .Verify(v => v.PublishEvent(It.IsAny<SeriesRenamedEvent>()), Times.Once());
+
+            // Exactly one file needs to be displaced to a temporary name to break the rotation.
+            Mocker.GetMock<IDiskProvider>()
+                  .Verify(v => v.MoveFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once());
+        }
+
+        [Test]
+        public void should_still_rename_files_unaffected_by_a_blocked_conflict()
+        {
+            GivenEpisodeFiles();
+            GivenMovedFiles();
+
+            const string blockedTargetRelativePath = "Blocked/Target.mkv";
+
+            // File 0's target is permanently occupied by something outside this batch.
+            GivenTargetPath(_episodeFiles[0], blockedTargetRelativePath);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(d => d.FileExists(Path.Combine(_series.Path, blockedTargetRelativePath)))
+                  .Returns(true);
+
+            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1, 2 }));
+
+            // The blocked file is never even attempted...
+            Mocker.GetMock<IMoveEpisodeFiles>()
+                  .Verify(v => v.MoveEpisodeFile(_episodeFiles[0], _series), Times.Never());
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Verify(v => v.Update(_episodeFiles[0]), Times.Never());
+
+            // ...but the unrelated, independent file still renames normally.
+            Mocker.GetMock<IMoveEpisodeFiles>()
+                  .Verify(v => v.MoveEpisodeFile(_episodeFiles[1], _series), Times.Once());
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Verify(v => v.Update(_episodeFiles[1]), Times.Once());
+
+            ExceptionVerification.ExpectedWarns(1);
+        }
+
+        [Test]
+        public void should_not_move_any_file_in_a_chain_that_depends_on_a_blocked_file()
+        {
+            GivenEpisodeFiles();
+            GivenMovedFiles();
+
+            const string blockedTargetRelativePath = "Blocked/Target.mkv";
+
+            // File 0 can only move once file 1 vacates its current location...
+            GivenTargetPath(_episodeFiles[0], _episodeFiles[1].RelativePath);
+
+            // ...but file 1's own target is permanently occupied by something outside this batch, so it can
+            // never vacate its spot - meaning file 0 can never safely move into it either.
+            GivenTargetPath(_episodeFiles[1], blockedTargetRelativePath);
+
+            Mocker.GetMock<IDiskProvider>()
+                  .Setup(d => d.FileExists(Path.Combine(_series.Path, blockedTargetRelativePath)))
+                  .Returns(true);
+
+            Subject.Execute(new RenameFilesCommand(_series.Id, new List<int> { 1, 2 }));
+
+            Mocker.GetMock<IMoveEpisodeFiles>()
+                  .Verify(v => v.MoveEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<Series>()), Times.Never());
+
+            Mocker.GetMock<IMediaFileService>()
+                  .Verify(v => v.Update(It.IsAny<EpisodeFile>()), Times.Never());
+
+            Mocker.GetMock<IEventAggregator>()
+                  .Verify(v => v.PublishEvent(It.IsAny<SeriesRenamedEvent>()), Times.Never());
+
+            // Nothing was ever moved, so there is no temporary state to create in the first place.
+            Mocker.GetMock<IDiskProvider>()
+                  .Verify(v => v.MoveFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never());
+
+            ExceptionVerification.ExpectedWarns(2);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/RenameEpisodeFileService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
+using NzbDrone.Common;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -34,6 +35,28 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IBuildFileNames _filenameBuilder;
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
+
+        private enum RenameState
+        {
+            InProgress,
+            Resolvable,
+            Blocked
+        }
+
+        private class EpisodeFileRename
+        {
+            public EpisodeFile EpisodeFile { get; set; }
+            public string PreviousRelativePath { get; set; }
+            public string CurrentPath { get; set; }
+            public string TargetPath { get; set; }
+        }
+
+        private class RenamePlan
+        {
+            public List<EpisodeFileRename> Moves { get; } = new List<EpisodeFileRename>();
+            public List<List<EpisodeFileRename>> Cycles { get; } = new List<List<EpisodeFileRename>>();
+            public List<EpisodeFileRename> Blocked { get; } = new List<EpisodeFileRename>();
+        }
 
         public RenameEpisodeFileService(ISeriesService seriesService,
                                         IMediaFileService mediaFileService,
@@ -130,42 +153,22 @@ namespace NzbDrone.Core.MediaFiles
         private List<RenamedEpisodeFile> RenameFiles(List<EpisodeFile> episodeFiles, Series series)
         {
             var renamed = new List<RenamedEpisodeFile>();
+            var pending = BuildPendingRenames(episodeFiles, series);
+            var plan = BuildRenamePlan(pending);
 
-            foreach (var episodeFile in episodeFiles)
+            foreach (var blocked in plan.Blocked)
             {
-                var previousRelativePath = episodeFile.RelativePath;
-                var previousPath = Path.Combine(series.Path, episodeFile.RelativePath);
+                _logger.Warn("File not renamed, there is already a file at the destination: {0}", blocked.TargetPath);
+            }
 
-                try
-                {
-                    _logger.Debug("Renaming episode file: {0}", episodeFile);
-                    _episodeFileMover.MoveEpisodeFile(episodeFile, series);
+            foreach (var move in plan.Moves)
+            {
+                ExecuteMove(move, series, renamed);
+            }
 
-                    _mediaFileService.Update(episodeFile);
-
-                    renamed.Add(new RenamedEpisodeFile
-                                {
-                                    EpisodeFile = episodeFile,
-                                    PreviousRelativePath = previousRelativePath,
-                                    PreviousPath = previousPath
-                                });
-
-                    _logger.Debug("Renamed episode file: {0}", episodeFile);
-
-                    _eventAggregator.PublishEvent(new EpisodeFileRenamedEvent(series, episodeFile, previousPath));
-                }
-                catch (FileAlreadyExistsException ex)
-                {
-                    _logger.Warn("File not renamed, there is already a file at the destination: {0}", ex.Filename);
-                }
-                catch (SameFilenameException ex)
-                {
-                    _logger.Debug("File not renamed, source and destination are the same: {0}", ex.Filename);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error(ex, "Failed to rename file {0}", previousPath);
-                }
+            foreach (var cycle in plan.Cycles)
+            {
+                ExecuteCycle(cycle, series, renamed);
             }
 
             if (renamed.Any())
@@ -176,6 +179,252 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             return renamed;
+        }
+
+        // Computes every file's current and target path up front so conflicts can be planned around
+        // instead of discovered mid-move.
+        private List<EpisodeFileRename> BuildPendingRenames(List<EpisodeFile> episodeFiles, Series series)
+        {
+            var pending = new List<EpisodeFileRename>();
+
+            foreach (var episodeFile in episodeFiles)
+            {
+                var currentPath = Path.Combine(series.Path, episodeFile.RelativePath);
+                var episodes = _episodeService.GetEpisodesByFileId(episodeFile.Id);
+                var targetPath = _filenameBuilder.BuildFilePath(episodes, series, episodeFile, Path.GetExtension(episodeFile.RelativePath));
+
+                if (currentPath.PathEquals(targetPath))
+                {
+                    _logger.Debug("File not renamed, source and destination are the same: {0}", currentPath);
+                    continue;
+                }
+
+                pending.Add(new EpisodeFileRename
+                            {
+                                EpisodeFile = episodeFile,
+                                PreviousRelativePath = episodeFile.RelativePath,
+                                CurrentPath = currentPath,
+                                TargetPath = targetPath
+                            });
+            }
+
+            return pending;
+        }
+
+        // Follows each file's target to whoever currently occupies it (if anyone) to determine, before any
+        // file is touched, whether the whole chain of dependent moves can ultimately complete. A file whose
+        // target is occupied by another file in this batch can only move once that file has moved; a chain
+        // that bottoms out at a free path can all be moved (last-to-first); a chain that bottoms out at a
+        // path occupied by a file outside this batch can never complete and is left untouched entirely; a
+        // chain that loops back on itself (e.g. episodes swapping numbers) is a closed rotation that can
+        // always be completed using one temporary displacement.
+        private RenamePlan BuildRenamePlan(List<EpisodeFileRename> pending)
+        {
+            var plan = new RenamePlan();
+            var byCurrentPath = new Dictionary<string, EpisodeFileRename>(PathEqualityComparer.Instance);
+
+            foreach (var rename in pending)
+            {
+                byCurrentPath[rename.CurrentPath] = rename;
+            }
+
+            EpisodeFileRename NextInBatch(EpisodeFileRename rename)
+            {
+                return byCurrentPath.TryGetValue(rename.TargetPath, out var occupant) && occupant != rename ? occupant : null;
+            }
+
+            var state = new Dictionary<EpisodeFileRename, RenameState>();
+
+            foreach (var start in pending)
+            {
+                if (state.ContainsKey(start))
+                {
+                    continue;
+                }
+
+                var stack = new List<EpisodeFileRename>();
+                var current = start;
+                var settled = false;
+
+                // Each step either breaks immediately or consumes one file that was not yet in 'state',
+                // and 'state' can hold at most pending.Count distinct files - so the walk cannot take more
+                // than pending.Count + 1 steps to either reach a terminal or loop back on itself.
+                for (var step = 0; step <= pending.Count; step++)
+                {
+                    if (state.TryGetValue(current, out var currentState))
+                    {
+                        if (currentState == RenameState.InProgress)
+                        {
+                            // Looped back into our own stack: a closed rotation.
+                            var cycleStart = stack.IndexOf(current);
+                            var cycle = stack.GetRange(cycleStart, stack.Count - cycleStart);
+                            var prefix = stack.GetRange(0, cycleStart);
+
+                            MarkResolvable(cycle, state);
+                            plan.Cycles.Add(cycle);
+
+                            // A tail leading into a rotation from outside it can't be freed by the rotation alone.
+                            MarkBlocked(prefix, state);
+                            plan.Blocked.AddRange(prefix);
+                        }
+                        else if (currentState == RenameState.Resolvable)
+                        {
+                            MarkResolvableInOrder(stack, state, plan.Moves);
+                        }
+                        else
+                        {
+                            MarkBlocked(stack, state);
+                            plan.Blocked.AddRange(stack);
+                        }
+
+                        settled = true;
+                        break;
+                    }
+
+                    stack.Add(current);
+                    state[current] = RenameState.InProgress;
+
+                    var next = NextInBatch(current);
+
+                    if (next == null)
+                    {
+                        if (_diskProvider.FileExists(current.TargetPath))
+                        {
+                            MarkBlocked(stack, state);
+                            plan.Blocked.AddRange(stack);
+                        }
+                        else
+                        {
+                            MarkResolvableInOrder(stack, state, plan.Moves);
+                        }
+
+                        settled = true;
+                        break;
+                    }
+
+                    current = next;
+                }
+
+                if (!settled)
+                {
+                    // Unreachable unless the traversal above no longer satisfies the bound described
+                    // above - fail loudly rather than silently dropping files from the plan.
+                    throw new InvalidOperationException("Unable to resolve episode rename dependency chain");
+                }
+            }
+
+            return plan;
+        }
+
+        private static void MarkResolvableInOrder(List<EpisodeFileRename> chain, Dictionary<EpisodeFileRename, RenameState> state, List<EpisodeFileRename> moves)
+        {
+            // The file at the end of the chain has a free target and must move first, freeing the path
+            // needed by the file before it, and so on back to the start of the chain.
+            for (var i = chain.Count - 1; i >= 0; i--)
+            {
+                state[chain[i]] = RenameState.Resolvable;
+                moves.Add(chain[i]);
+            }
+        }
+
+        private static void MarkResolvable(List<EpisodeFileRename> renames, Dictionary<EpisodeFileRename, RenameState> state)
+        {
+            foreach (var rename in renames)
+            {
+                state[rename] = RenameState.Resolvable;
+            }
+        }
+
+        private static void MarkBlocked(List<EpisodeFileRename> renames, Dictionary<EpisodeFileRename, RenameState> state)
+        {
+            foreach (var rename in renames)
+            {
+                state[rename] = RenameState.Blocked;
+            }
+        }
+
+        private void ExecuteMove(EpisodeFileRename move, Series series, List<RenamedEpisodeFile> renamed)
+        {
+            try
+            {
+                _logger.Debug("Renaming episode file: {0}", move.EpisodeFile);
+                _episodeFileMover.MoveEpisodeFile(move.EpisodeFile, series);
+
+                // Clear the temporary source path override (if any) now that the file lives at its real destination.
+                move.EpisodeFile.Path = null;
+
+                _mediaFileService.Update(move.EpisodeFile);
+
+                renamed.Add(new RenamedEpisodeFile
+                            {
+                                EpisodeFile = move.EpisodeFile,
+                                PreviousRelativePath = move.PreviousRelativePath,
+                                PreviousPath = move.CurrentPath
+                            });
+
+                _logger.Debug("Renamed episode file: {0}", move.EpisodeFile);
+
+                _eventAggregator.PublishEvent(new EpisodeFileRenamedEvent(series, move.EpisodeFile, move.CurrentPath));
+            }
+            catch (SameFilenameException ex)
+            {
+                _logger.Debug("File not renamed, source and destination are the same: {0}", ex.Filename);
+            }
+            catch (FileAlreadyExistsException ex)
+            {
+                _logger.Warn("File not renamed, there is already a file at the destination: {0}", ex.Filename);
+            }
+            catch (DestinationAlreadyExistsException)
+            {
+                _logger.Warn("File not renamed, there is already a file at the destination: {0}", move.TargetPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to rename file {0}", move.CurrentPath);
+            }
+        }
+
+        // A closed rotation (e.g. episode 1 and 2 swapping numbers) has no free slot to start from - every
+        // target in the loop is occupied by another member of the loop. One member is displaced to a
+        // temporary name just long enough to free up the loop, then moved into its real, final target once
+        // the rest of the loop has vacated it; the temporary name is never persisted.
+        private void ExecuteCycle(List<EpisodeFileRename> cycle, Series series, List<RenamedEpisodeFile> renamed)
+        {
+            var displaced = cycle[0];
+            var tempPath = GenerateTempPath(displaced.CurrentPath);
+
+            try
+            {
+                _diskProvider.MoveFile(displaced.CurrentPath, tempPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to rename file {0}", displaced.CurrentPath);
+                return;
+            }
+
+            displaced.EpisodeFile.Path = tempPath;
+
+            for (var i = cycle.Count - 1; i >= 1; i--)
+            {
+                ExecuteMove(cycle[i], series, renamed);
+            }
+
+            ExecuteMove(displaced, series, renamed);
+        }
+
+        private string GenerateTempPath(string path)
+        {
+            var tempPath = path + ".swap~";
+            var attempt = 1;
+
+            while (_diskProvider.FileExists(tempPath))
+            {
+                tempPath = $"{path}.swap{attempt}~";
+                attempt++;
+            }
+
+            return tempPath;
         }
 
         public void Execute(RenameFilesCommand message)


### PR DESCRIPTION
~I apologize if new PRs are supposed to target the v5-develop branch, I didn't see anywhere that made it clear which branch to target, however I do believe this fix is worthy of making it into v4/stable. Please let me know if I should instead target the v5 branch.~

#### Description

When trying to move episode files that result in a loop or conflict, the moves currently fails.

Example: moving files `A.mkv` -> `B.mkv`, `B.mkv` -> `A.mkv` results in the move not taking place.

This is the same for longer chains or cycles: `A.mkv` -> `B.mkv`, `B.mkv` -> `C.mkv`, `C.mkv` -> `D.mkv`, ..., `Z.mkv` -> `A.mkv`

These fixes pre-build a list of moves that are immediately available without conflicts as well as a list of "cycles", where moves are dependent on moving a file to a temporary location in order to properly resolve all moves.

Renames get marked as "blocked" if:

* There exists a file at the target location already that is not part of this rename process, or
* Two or more files in this rename process map to the same target

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Closes #5610
