### PR TITLE
New: Match anime season packs named only by their season title

### DIFF
--- a/frontend/src/InteractiveSearch/ReleaseSceneIndicator.tsx
+++ b/frontend/src/InteractiveSearch/ReleaseSceneIndicator.tsx
@@ -34,7 +34,7 @@ function formatReleaseNumber(
     return absoluteEpisodeNumbers[0];
   }
 
-  if (seasonNumber !== undefined) {
+  if (seasonNumber !== undefined && seasonNumber >= 0) {
     return translate('SeasonNumberToken', { seasonNumber });
   }
 

--- a/frontend/src/InteractiveSearch/ReleaseSceneIndicator.tsx
+++ b/frontend/src/InteractiveSearch/ReleaseSceneIndicator.tsx
@@ -10,7 +10,7 @@ import translate from 'Utilities/String/translate';
 import styles from './ReleaseSceneIndicator.css';
 
 function formatReleaseNumber(
-  seasonNumber: number | undefined,
+  seasonNumber: number | null | undefined,
   episodeNumbers: number[] | undefined,
   absoluteEpisodeNumbers: number[] | undefined
 ) {
@@ -34,7 +34,7 @@ function formatReleaseNumber(
     return absoluteEpisodeNumbers[0];
   }
 
-  if (seasonNumber !== undefined && seasonNumber >= 0) {
+  if (seasonNumber != null) {
     return translate('SeasonNumberToken', { seasonNumber });
   }
 
@@ -46,7 +46,7 @@ interface ReleaseSceneIndicatorProps {
   seasonNumber?: number;
   episodeNumbers?: number[];
   absoluteEpisodeNumbers?: number[];
-  sceneSeasonNumber?: number;
+  sceneSeasonNumber?: number | null;
   sceneEpisodeNumbers?: number[];
   sceneAbsoluteEpisodeNumbers?: number[];
   sceneMapping?: {

--- a/frontend/src/InteractiveSearch/useReleases.ts
+++ b/frontend/src/InteractiveSearch/useReleases.ts
@@ -63,7 +63,7 @@ export interface ParsedInfo {
   releaseGroup: string;
   releaseHash: string;
   fullSeason: boolean;
-  seasonNumber: number;
+  seasonNumber: number | null;
   seriesTitle: string;
   episodeNumbers: number[];
   absoluteEpisodeNumbers?: number[];

--- a/frontend/src/Parse/ParseModel.ts
+++ b/frontend/src/Parse/ParseModel.ts
@@ -17,7 +17,7 @@ export interface ParsedEpisodeInfo {
   seriesTitle: string;
   seriesTitleInfo: SeriesTitleInfo;
   quality: QualityModel;
-  seasonNumber: number;
+  seasonNumber: number | null;
   episodeNumbers: number[];
   absoluteEpisodeNumbers: number[];
   specialAbsoluteEpisodeNumbers: number[];

--- a/frontend/src/Parse/ParseResult.tsx
+++ b/frontend/src/Parse/ParseResult.tsx
@@ -83,7 +83,7 @@ function ParseResult(props: ParseResultProps) {
             <ParseResultItem
               title={translate('SeasonNumber')}
               data={
-                seasonNumber < 0 ||
+                seasonNumber == null ||
                 (seasonNumber === 0 && absoluteEpisodeNumbers.length)
                   ? '-'
                   : seasonNumber

--- a/frontend/src/Parse/ParseResult.tsx
+++ b/frontend/src/Parse/ParseResult.tsx
@@ -83,7 +83,8 @@ function ParseResult(props: ParseResultProps) {
             <ParseResultItem
               title={translate('SeasonNumber')}
               data={
-                seasonNumber === 0 && absoluteEpisodeNumbers.length
+                seasonNumber < 0 ||
+                (seasonNumber === 0 && absoluteEpisodeNumbers.length)
                   ? '-'
                   : seasonNumber
               }

--- a/src/NzbDrone.Common/Extensions/NullableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/NullableExtensions.cs
@@ -2,11 +2,6 @@
 {
     public static class NullableExtensions
     {
-        public static int? NonNegative(this int source)
-        {
-            return NonNegative((int?)source);
-        }
-
         public static int? NonNegative(this int? source)
         {
             if (source.HasValue && source.Value != -1)

--- a/src/NzbDrone.Common/Extensions/NullableExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/NullableExtensions.cs
@@ -2,6 +2,11 @@
 {
     public static class NullableExtensions
     {
+        public static int? NonNegative(this int source)
+        {
+            return NonNegative((int?)source);
+        }
+
         public static int? NonNegative(this int? source)
         {
             if (source.HasValue && source.Value != -1)

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -150,7 +150,10 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         public void should_not_attempt_to_map_episode_if_not_parsable()
         {
             GivenSpecifications(_pass1, _pass2, _pass3);
-            _reports[0].Title = "Not parsable";
+
+            // Stripping the metadata leaves brackets rather than a title, so neither parser
+            // recovers anything to map.
+            _reports[0].Title = "[Not][parsable][1080p][x265(10bit)]";
 
             Subject.GetRssDecision(_reports).ToList();
 
@@ -159,6 +162,19 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _pass1.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
             _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
             _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<ReleaseDecisionInformation>()), Times.Never());
+        }
+
+        [Test]
+        public void should_map_a_title_the_regexes_cannot_parse()
+        {
+            GivenSpecifications(_pass1, _pass2, _pass3);
+            _reports[0].Title = "Not parsable";
+
+            Subject.GetRssDecision(_reports).ToList();
+
+            // A release carrying nothing but a title is still a title, so it is looked up
+            // rather than dropped. Without a matching series it is rejected as unknown.
+            Mocker.GetMock<IParsingService>().Verify(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()), Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -172,8 +172,6 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             Subject.GetRssDecision(_reports).ToList();
 
-            // A release carrying nothing but a title is still a title, so it is looked up
-            // rather than dropped. Without a matching series it is rejected as unknown.
             Mocker.GetMock<IParsingService>().Verify(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()), Times.Once());
         }
 

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Specifications/MatchesFolderSpecificationFixture.cs
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Specifications
 
         private void GivenEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, int[] episodeNumbers)
         {
-            var seasonNumber = parsedEpisodeInfo.SeasonNumber;
+            var seasonNumber = parsedEpisodeInfo.SeasonNumber.Value;
 
             var episodes = episodeNumbers.Select(n =>
                 Builder<Episode>.CreateNew()

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
@@ -405,7 +405,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
 
             Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Never());
+                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Never());
 
             Mocker.GetMock<IEpisodeService>()
                 .Verify(v => v.FindEpisode(_series.Id, tvdbSeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
@@ -426,7 +426,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 .Verify(v => v.FindEpisode(_series.Id, tvdbSeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Never());
 
             Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
+                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
         }
 
         [Test]
@@ -440,7 +440,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 .Verify(v => v.FindEpisode(_series.Id, tvdbSeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Never());
 
             Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
+                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
         }
 
         [Test]
@@ -458,7 +458,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
                 .Verify(v => v.FindEpisode(_series.Id, tvdbSeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Never());
 
             Mocker.GetMock<IEpisodeService>()
-                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
+                .Verify(v => v.FindEpisode(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
         }
 
         [Test]
@@ -467,7 +467,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenFullSeason();
 
             Mocker.GetMock<IEpisodeService>()
-                .Setup(s => s.GetEpisodesBySeason(_series.Id, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.GetEpisodesBySeason(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(_episodes);
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
@@ -486,7 +486,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenFullSeason();
 
             Mocker.GetMock<IEpisodeService>()
-                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(_episodes);
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
@@ -505,11 +505,11 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             GivenFullSeason();
 
             Mocker.GetMock<IEpisodeService>()
-                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(new List<Episode>());
 
             Mocker.GetMock<IEpisodeService>()
-                .Setup(s => s.GetEpisodesBySeason(_series.Id, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.GetEpisodesBySeason(_series.Id, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(_episodes);
 
             Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
@@ -558,7 +558,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             Subject.Map(_parsedEpisodeInfo, _series.TvdbId, _series.TvRageId, _series.ImdbId);
 
             Mocker.GetMock<IEpisodeService>()
-                  .Verify(v => v.FindEpisode(_series.TvdbId, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
+                  .Verify(v => v.FindEpisode(_series.TvdbId, _parsedEpisodeInfo.SeasonNumber.Value, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -266,7 +266,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             };
 
             Mocker.GetMock<ISceneMappingService>()
-                .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, _parsedEpisodeInfo.ReleaseTitle, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, _parsedEpisodeInfo.ReleaseTitle, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(sceneMapping);
 
             var result = Subject.Map(_parsedEpisodeInfo, _series);
@@ -286,7 +286,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
             };
 
             Mocker.GetMock<ISceneMappingService>()
-                .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, _parsedEpisodeInfo.ReleaseTitle, _parsedEpisodeInfo.SeasonNumber))
+                .Setup(s => s.FindSceneMapping(_parsedEpisodeInfo.SeriesTitle, _parsedEpisodeInfo.ReleaseTitle, _parsedEpisodeInfo.SeasonNumber.Value))
                 .Returns(sceneMapping);
 
             var result = Subject.Map(_parsedEpisodeInfo, _series);
@@ -393,7 +393,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         {
             GivenMatchBySeriesTitle();
 
-            _parsedEpisodeInfo.SeasonNumber = -1;
+            _parsedEpisodeInfo.SeasonNumber = null;
             _parsedEpisodeInfo.IsSeasonTitle = true;
             _parsedEpisodeInfo.EpisodeNumbers = [];
 

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -387,5 +387,23 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
 
             result.Series.Should().Be(_series);
         }
+
+        [Test]
+        public void should_keep_the_parsed_season_number_when_the_scene_mapping_has_no_season()
+        {
+            GivenMatchBySeriesTitle();
+
+            _parsedEpisodeInfo.SeasonNumber = -1;
+            _parsedEpisodeInfo.IsSeasonTitle = true;
+            _parsedEpisodeInfo.EpisodeNumbers = [];
+
+            Mocker.GetMock<ISceneMappingService>()
+                  .Setup(v => v.FindSceneMapping(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()))
+                  .Returns(new SceneMapping { TvdbId = _series.TvdbId });
+
+            var result = Subject.Map(_parsedEpisodeInfo, _series.TvdbId, _series.TvRageId, _series.ImdbId);
+
+            result.MappedSeasonNumber.Should().Be(-1);
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/MapFixture.cs
@@ -389,7 +389,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
         }
 
         [Test]
-        public void should_keep_the_parsed_season_number_when_the_scene_mapping_has_no_season()
+        public void should_not_have_a_mapped_season_number_when_the_scene_mapping_has_no_season()
         {
             GivenMatchBySeriesTitle();
 
@@ -403,7 +403,7 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
 
             var result = Subject.Map(_parsedEpisodeInfo, _series.TvdbId, _series.TvRageId, _series.ImdbId);
 
-            result.MappedSeasonNumber.Should().Be(-1);
+            result.MappedSeasonNumber.Should().BeNull();
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -20,17 +20,11 @@ namespace NzbDrone.Core.Test.ParserTests
             result.SeriesTitle.Should().Be(expectedTitle);
             result.FullSeason.Should().BeTrue();
             result.IsSeasonTitleOnly.Should().BeTrue();
-
-            // Which season the title refers to is held in the scene mappings, so it is left
-            // unset here and resolved by ParsingService. Not 0, that is the special season.
             result.SeasonNumber.Should().Be(-1);
             result.EpisodeNumbers.Should().BeEmpty();
             result.AbsoluteEpisodeNumbers.Should().BeEmpty();
         }
 
-        // DownloadDecisionComparer reads ParsedEpisodeInfo.Quality while sorting, so leaving it
-        // unset fails the whole search with "failed to compare two elements in the array"
-        // rather than skipping one release.
         [TestCase("[Group] Monkey Island Curse (BD 1280x720 x264 AAC)")]
         [TestCase("[Group] Monkey Island: Curse [Dual Audio 10bit 1080p][HEVC-x265]")]
         public void should_populate_the_fields_the_decision_engine_reads(string releaseTitle)
@@ -42,9 +36,6 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Languages.Should().NotBeNullOrEmpty();
         }
 
-        // Some groups bracket every part of the name including the title, and a bracketed group
-        // can contain another. Both leave metadata behind instead of a title, which is worse
-        // than returning nothing because it gets used as a lookup key.
         [TestCase("[Group][Monkey Island: Curse][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
         [TestCase("[Group][Monkey Island Curse][1080p][x264]")]
         public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
@@ -52,8 +43,6 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
         }
 
-        // Groups mark extras inside brackets, which is what stripping metadata removes, so an
-        // opening or an OVA would otherwise look exactly like a season pack.
         [TestCase("[Group] Monkey Island Curse (OVA)")]
         [TestCase("[Group] Monkey Island Curse [OVA]")]
         [TestCase("[Group] Monkey Island Curse (Special)")]
@@ -64,7 +53,6 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
         }
 
-        // ParsingService resolves the season off the flag, so only this parser may set it.
         [TestCase("Monkey Island S02E05 1080p WEB-DL")]
         [TestCase("[Group] Monkey Island - 05 (1080p)")]
         [TestCase("Monkey Island S02 1080p WEB-DL")]
@@ -73,9 +61,6 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitleOnly.Should().BeFalse();
         }
 
-        // The helper is not wired into ParseTitle, so anything ParseTitle rejects today it
-        // still rejects. Otherwise nothing would ever be unparsable and crap detection, daily
-        // date validation and the import path all lose their only signal.
         [TestCase("THIS SHOULD NEVER PARSE")]
         [TestCase("Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8")]
         [TestCase("[Group] Monkey Island Curse (BS11 1280x720 x264 AAC)")]

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().NotBeNull();
             result.SeriesTitle.Should().Be(expectedTitle);
             result.FullSeason.Should().BeTrue();
-            result.IsSeasonTitleOnly.Should().BeTrue();
+            result.IsSeasonTitle.Should().BeTrue();
             result.SeasonNumber.Should().Be(-1);
             result.EpisodeNumbers.Should().BeEmpty();
             result.AbsoluteEpisodeNumbers.Should().BeEmpty();
@@ -38,6 +38,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("[Group][Monkey Island: Curse][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
         [TestCase("[Group][Monkey Island Curse][1080p][x264]")]
+        [TestCase("[Group] Monkey Island Curse () (1080p)")]
         public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
         {
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
@@ -58,7 +59,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Monkey Island S02 1080p WEB-DL")]
         public void should_not_flag_a_release_the_regexes_can_parse(string releaseTitle)
         {
-            Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitleOnly.Should().BeFalse();
+            Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitle.Should().BeFalse();
         }
 
         [TestCase("THIS SHOULD NEVER PARSE")]

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class SeasonTitleParserFixture : CoreTest
+    {
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BS11 1280x720 x264 AAC)", "Dr. Stone Stone Wars")]
+        [TestCase("[S3rNx] Dr. Stone Stone Wars (BDRip 1920x1080 x264 FLAC)", "Dr. Stone Stone Wars")]
+        [TestCase("[DmonHiro] Dr.Stone - Stone Wars (BD, 720p)", "Dr.Stone - Stone Wars")]
+        [TestCase("Dr. Stone Stone Wars [Bluray.1080p.HEVC.AAC.ITA.FLAC.JAP.Sub.Ita]", "Dr. Stone Stone Wars")]
+        [TestCase("[Cleo] Dr. Stone: Stone Wars [Dual Audio 10bit 1080p][HEVC-x265]", "Dr. Stone: Stone Wars")]
+        public void should_return_the_title_when_there_is_no_season_or_episode(string releaseTitle, string expectedTitle)
+        {
+            var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
+
+            result.Should().NotBeNull();
+            result.SeriesTitle.Should().Be(expectedTitle);
+            result.FullSeason.Should().BeTrue();
+
+            // Which season the title refers to is held in the scene mappings, so it is left
+            // unset here and resolved by ParsingService.
+            result.SeasonNumber.Should().Be(0);
+            result.EpisodeNumbers.Should().BeEmpty();
+            result.AbsoluteEpisodeNumbers.Should().BeEmpty();
+        }
+
+        // DownloadDecisionComparer reads ParsedEpisodeInfo.Quality while sorting, so leaving it
+        // unset fails the whole search with "failed to compare two elements in the array"
+        // rather than skipping one release.
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BD 1280x720 x264 AAC)")]
+        [TestCase("[Cleo] Dr. Stone: Stone Wars [Dual Audio 10bit 1080p][HEVC-x265]")]
+        public void should_populate_the_fields_the_decision_engine_reads(string releaseTitle)
+        {
+            var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
+
+            result.Quality.Should().NotBeNull();
+            result.Quality.Quality.Should().NotBeNull();
+            result.Languages.Should().NotBeNullOrEmpty();
+        }
+
+        // Some groups bracket every part of the name including the title, and a bracketed group
+        // can contain another. Both leave metadata behind instead of a title, which is worse
+        // than returning nothing because it gets used as a lookup key.
+        [TestCase("[FY-Raws][Dr.STONE: Stone Wars][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
+        [TestCase("[Group][Some Title][1080p][x265(10bit)]")]
+        public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
+        {
+            Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
+        }
+
+        // Groups mark extras inside brackets, which is what stripping metadata removes, so an
+        // opening or an OVA would otherwise look exactly like a season pack.
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (OVA)")]
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars [OVA]")]
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (Special)")]
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (NCOP)")]
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (NCED)")]
+        public void should_not_return_a_title_for_an_extra(string releaseTitle)
+        {
+            Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
+        }
+
+        // The helper is not wired into ParseTitle, so anything ParseTitle rejects today it
+        // still rejects. Otherwise nothing would ever be unparsable and crap detection, daily
+        // date validation and the import path all lose their only signal.
+        [TestCase("THIS SHOULD NEVER PARSE")]
+        [TestCase("Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8")]
+        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BS11 1280x720 x264 AAC)")]
+        public void should_leave_parse_title_rejecting_what_it_rejects_today(string releaseTitle)
+        {
+            Parser.Parser.ParseTitle(releaseTitle).Should().BeNull();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().NotBeNull();
             result.SeriesTitle.Should().Be(expectedTitle);
             result.FullSeason.Should().BeTrue();
+            result.IsSeasonTitleOnly.Should().BeTrue();
 
             // Which season the title refers to is held in the scene mappings, so it is left
             // unset here and resolved by ParsingService. Not 0, that is the special season.
@@ -61,6 +62,15 @@ namespace NzbDrone.Core.Test.ParserTests
         public void should_not_return_a_title_for_an_extra(string releaseTitle)
         {
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
+        }
+
+        // ParsingService resolves the season off the flag, so only this parser may set it.
+        [TestCase("Monkey Island S02E05 1080p WEB-DL")]
+        [TestCase("[Group] Monkey Island - 05 (1080p)")]
+        [TestCase("Monkey Island S02 1080p WEB-DL")]
+        public void should_not_flag_a_release_the_regexes_can_parse(string releaseTitle)
+        {
+            Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitleOnly.Should().BeFalse();
         }
 
         // The helper is not wired into ParseTitle, so anything ParseTitle rejects today it

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -7,11 +7,11 @@ namespace NzbDrone.Core.Test.ParserTests
     [TestFixture]
     public class SeasonTitleParserFixture : CoreTest
     {
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BS11 1280x720 x264 AAC)", "Dr. Stone Stone Wars")]
-        [TestCase("[S3rNx] Dr. Stone Stone Wars (BDRip 1920x1080 x264 FLAC)", "Dr. Stone Stone Wars")]
-        [TestCase("[DmonHiro] Dr.Stone - Stone Wars (BD, 720p)", "Dr.Stone - Stone Wars")]
-        [TestCase("Dr. Stone Stone Wars [Bluray.1080p.HEVC.AAC.ITA.FLAC.JAP.Sub.Ita]", "Dr. Stone Stone Wars")]
-        [TestCase("[Cleo] Dr. Stone: Stone Wars [Dual Audio 10bit 1080p][HEVC-x265]", "Dr. Stone: Stone Wars")]
+        [TestCase("[Group] Monkey Island Curse (BS11 1280x720 x264 AAC)", "Monkey Island Curse")]
+        [TestCase("[Group] Monkey Island Curse (BDRip 1920x1080 x264 FLAC) [ABCD1234]", "Monkey Island Curse")]
+        [TestCase("[Group] Monkey.Island - Curse (BD, 720p)", "Monkey.Island - Curse")]
+        [TestCase("Monkey Island Curse [Bluray.1080p.HEVC.AAC.ITA.FLAC.JAP.Sub.Ita]", "Monkey Island Curse")]
+        [TestCase("[Group] Monkey Island: Curse [Dual Audio 10bit 1080p][HEVC-x265]", "Monkey Island: Curse")]
         public void should_return_the_title_when_there_is_no_season_or_episode(string releaseTitle, string expectedTitle)
         {
             var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
@@ -30,8 +30,8 @@ namespace NzbDrone.Core.Test.ParserTests
         // DownloadDecisionComparer reads ParsedEpisodeInfo.Quality while sorting, so leaving it
         // unset fails the whole search with "failed to compare two elements in the array"
         // rather than skipping one release.
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BD 1280x720 x264 AAC)")]
-        [TestCase("[Cleo] Dr. Stone: Stone Wars [Dual Audio 10bit 1080p][HEVC-x265]")]
+        [TestCase("[Group] Monkey Island Curse (BD 1280x720 x264 AAC)")]
+        [TestCase("[Group] Monkey Island: Curse [Dual Audio 10bit 1080p][HEVC-x265]")]
         public void should_populate_the_fields_the_decision_engine_reads(string releaseTitle)
         {
             var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
@@ -44,8 +44,8 @@ namespace NzbDrone.Core.Test.ParserTests
         // Some groups bracket every part of the name including the title, and a bracketed group
         // can contain another. Both leave metadata behind instead of a title, which is worse
         // than returning nothing because it gets used as a lookup key.
-        [TestCase("[FY-Raws][Dr.STONE: Stone Wars][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
-        [TestCase("[Group][Some Title][1080p][x265(10bit)]")]
+        [TestCase("[Group][Monkey Island: Curse][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
+        [TestCase("[Group][Monkey Island Curse][1080p][x264]")]
         public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
         {
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
@@ -53,11 +53,11 @@ namespace NzbDrone.Core.Test.ParserTests
 
         // Groups mark extras inside brackets, which is what stripping metadata removes, so an
         // opening or an OVA would otherwise look exactly like a season pack.
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (OVA)")]
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars [OVA]")]
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (Special)")]
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (NCOP)")]
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (NCED)")]
+        [TestCase("[Group] Monkey Island Curse (OVA)")]
+        [TestCase("[Group] Monkey Island Curse [OVA]")]
+        [TestCase("[Group] Monkey Island Curse (Special)")]
+        [TestCase("[Group] Monkey Island Curse (NCOP)")]
+        [TestCase("[Group] Monkey Island Curse (NCED)")]
         public void should_not_return_a_title_for_an_extra(string releaseTitle)
         {
             Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
@@ -68,7 +68,7 @@ namespace NzbDrone.Core.Test.ParserTests
         // date validation and the import path all lose their only signal.
         [TestCase("THIS SHOULD NEVER PARSE")]
         [TestCase("Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8")]
-        [TestCase("[Ohys-Raws] Dr. Stone Stone Wars (BS11 1280x720 x264 AAC)")]
+        [TestCase("[Group] Monkey Island Curse (BS11 1280x720 x264 AAC)")]
         public void should_leave_parse_title_rejecting_what_it_rejects_today(string releaseTitle)
         {
             Parser.Parser.ParseTitle(releaseTitle).Should().BeNull();

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -20,7 +20,7 @@ public class SeasonTitleParserFixture : CoreTest
         result.SeriesTitle.Should().Be(expectedTitle);
         result.FullSeason.Should().BeTrue();
         result.IsSeasonTitle.Should().BeTrue();
-        result.SeasonNumber.Should().Be(-1);
+        result.SeasonNumber.Should().BeNull();
         result.EpisodeNumbers.Should().BeEmpty();
         result.AbsoluteEpisodeNumbers.Should().BeEmpty();
     }

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeTrue();
 
             // Which season the title refers to is held in the scene mappings, so it is left
-            // unset here and resolved by ParsingService.
-            result.SeasonNumber.Should().Be(0);
+            // unset here and resolved by ParsingService. Not 0, that is the special season.
+            result.SeasonNumber.Should().Be(-1);
             result.EpisodeNumbers.Should().BeEmpty();
             result.AbsoluteEpisodeNumbers.Should().BeEmpty();
         }

--- a/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SeasonTitleParserFixture.cs
@@ -2,72 +2,71 @@ using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.Test.Framework;
 
-namespace NzbDrone.Core.Test.ParserTests
+namespace NzbDrone.Core.Test.ParserTests;
+
+[TestFixture]
+public class SeasonTitleParserFixture : CoreTest
 {
-    [TestFixture]
-    public class SeasonTitleParserFixture : CoreTest
+    [TestCase("[Group] Series Title Curse (BS11 1280x720 x264 AAC)", "Series Title Curse")]
+    [TestCase("[Group] Series Title Curse (BDRip 1920x1080 x264 FLAC) [ABCD1234]", "Series Title Curse")]
+    [TestCase("[Group] Series.Title - Curse (BD, 720p)", "Series.Title - Curse")]
+    [TestCase("Series Title Curse [Bluray.1080p.HEVC.AAC.ITA.FLAC.JAP.Sub.Ita]", "Series Title Curse")]
+    [TestCase("[Group] Series Title: Curse [Dual Audio 10bit 1080p][HEVC-x265]", "Series Title: Curse")]
+    public void should_return_the_title_when_there_is_no_season_or_episode(string releaseTitle, string expectedTitle)
     {
-        [TestCase("[Group] Monkey Island Curse (BS11 1280x720 x264 AAC)", "Monkey Island Curse")]
-        [TestCase("[Group] Monkey Island Curse (BDRip 1920x1080 x264 FLAC) [ABCD1234]", "Monkey Island Curse")]
-        [TestCase("[Group] Monkey.Island - Curse (BD, 720p)", "Monkey.Island - Curse")]
-        [TestCase("Monkey Island Curse [Bluray.1080p.HEVC.AAC.ITA.FLAC.JAP.Sub.Ita]", "Monkey Island Curse")]
-        [TestCase("[Group] Monkey Island: Curse [Dual Audio 10bit 1080p][HEVC-x265]", "Monkey Island: Curse")]
-        public void should_return_the_title_when_there_is_no_season_or_episode(string releaseTitle, string expectedTitle)
-        {
-            var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
+        var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
 
-            result.Should().NotBeNull();
-            result.SeriesTitle.Should().Be(expectedTitle);
-            result.FullSeason.Should().BeTrue();
-            result.IsSeasonTitle.Should().BeTrue();
-            result.SeasonNumber.Should().Be(-1);
-            result.EpisodeNumbers.Should().BeEmpty();
-            result.AbsoluteEpisodeNumbers.Should().BeEmpty();
-        }
+        result.Should().NotBeNull();
+        result.SeriesTitle.Should().Be(expectedTitle);
+        result.FullSeason.Should().BeTrue();
+        result.IsSeasonTitle.Should().BeTrue();
+        result.SeasonNumber.Should().Be(-1);
+        result.EpisodeNumbers.Should().BeEmpty();
+        result.AbsoluteEpisodeNumbers.Should().BeEmpty();
+    }
 
-        [TestCase("[Group] Monkey Island Curse (BD 1280x720 x264 AAC)")]
-        [TestCase("[Group] Monkey Island: Curse [Dual Audio 10bit 1080p][HEVC-x265]")]
-        public void should_populate_the_fields_the_decision_engine_reads(string releaseTitle)
-        {
-            var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
+    [TestCase("[Group] Series Title Curse (BD 1280x720 x264 AAC)")]
+    [TestCase("[Group] Series Title: Curse [Dual Audio 10bit 1080p][HEVC-x265]")]
+    public void should_populate_the_fields_the_decision_engine_reads(string releaseTitle)
+    {
+        var result = Parser.Parser.ParseSeasonTitle(releaseTitle);
 
-            result.Quality.Should().NotBeNull();
-            result.Quality.Quality.Should().NotBeNull();
-            result.Languages.Should().NotBeNullOrEmpty();
-        }
+        result.Quality.Should().NotBeNull();
+        result.Quality.Quality.Should().NotBeNull();
+        result.Languages.Should().NotBeNullOrEmpty();
+    }
 
-        [TestCase("[Group][Monkey Island: Curse][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
-        [TestCase("[Group][Monkey Island Curse][1080p][x264]")]
-        [TestCase("[Group] Monkey Island Curse () (1080p)")]
-        public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
-        {
-            Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
-        }
+    [TestCase("[Group][Series Title: Curse][BDRip][1080P_x265(10bit)-FLAC][ALL]")]
+    [TestCase("[Group][Series Title Curse][1080p][x264]")]
+    [TestCase("[Group] Series Title Curse () (1080p)")]
+    public void should_not_return_a_title_when_stripping_leaves_metadata(string releaseTitle)
+    {
+        Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
+    }
 
-        [TestCase("[Group] Monkey Island Curse (OVA)")]
-        [TestCase("[Group] Monkey Island Curse [OVA]")]
-        [TestCase("[Group] Monkey Island Curse (Special)")]
-        [TestCase("[Group] Monkey Island Curse (NCOP)")]
-        [TestCase("[Group] Monkey Island Curse (NCED)")]
-        public void should_not_return_a_title_for_an_extra(string releaseTitle)
-        {
-            Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
-        }
+    [TestCase("[Group] Series Title Curse (OVA)")]
+    [TestCase("[Group] Series Title Curse [OVA]")]
+    [TestCase("[Group] Series Title Curse (Special)")]
+    [TestCase("[Group] Series Title Curse (NCOP)")]
+    [TestCase("[Group] Series Title Curse (NCED)")]
+    public void should_not_return_a_title_for_an_extra(string releaseTitle)
+    {
+        Parser.Parser.ParseSeasonTitle(releaseTitle).Should().BeNull();
+    }
 
-        [TestCase("Monkey Island S02E05 1080p WEB-DL")]
-        [TestCase("[Group] Monkey Island - 05 (1080p)")]
-        [TestCase("Monkey Island S02 1080p WEB-DL")]
-        public void should_not_flag_a_release_the_regexes_can_parse(string releaseTitle)
-        {
-            Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitle.Should().BeFalse();
-        }
+    [TestCase("Series Title S02E05 1080p WEB-DL")]
+    [TestCase("[Group] Series Title - 05 (1080p)")]
+    [TestCase("Series Title S02 1080p WEB-DL")]
+    public void should_not_flag_a_release_the_regexes_can_parse(string releaseTitle)
+    {
+        Parser.Parser.ParseTitle(releaseTitle).IsSeasonTitle.Should().BeFalse();
+    }
 
-        [TestCase("THIS SHOULD NEVER PARSE")]
-        [TestCase("Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8")]
-        [TestCase("[Group] Monkey Island Curse (BS11 1280x720 x264 AAC)")]
-        public void should_leave_parse_title_rejecting_what_it_rejects_today(string releaseTitle)
-        {
-            Parser.Parser.ParseTitle(releaseTitle).Should().BeNull();
-        }
+    [TestCase("THIS SHOULD NEVER PARSE")]
+    [TestCase("Vrq6e1Aba3U amCjuEgV5R2QvdsLEGYF3YQAQkw8")]
+    [TestCase("[Group] Series Title Curse (BS11 1280x720 x264 AAC)")]
+    public void should_leave_parse_title_rejecting_what_it_rejects_today(string releaseTitle)
+    {
+        Parser.Parser.ParseTitle(releaseTitle).Should().BeNull();
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -88,6 +88,14 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                     }
 
+                    // Only for searches, where the season being looked for is already known and
+                    // a pack named by its season title is what was being asked for. RSS keeps
+                    // ignoring releases it cannot parse.
+                    if (searchCriteria != null)
+                    {
+                        parsedEpisodeInfo ??= Parser.Parser.ParseSeasonTitle(report.Title);
+                    }
+
                     if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
                     {
                         var remoteEpisode = _parsingService.Map(parsedEpisodeInfo, report.TvdbId, report.TvRageId, report.ImdbId, searchCriteria);

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -88,13 +88,7 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                     }
 
-                    // Only for searches, where the season being looked for is already known and
-                    // a pack named by its season title is what was being asked for. RSS keeps
-                    // ignoring releases it cannot parse.
-                    if (searchCriteria != null)
-                    {
-                        parsedEpisodeInfo ??= Parser.Parser.ParseSeasonTitle(report.Title);
-                    }
+                    parsedEpisodeInfo ??= Parser.Parser.ParseSeasonTitle(report.Title);
 
                     if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
                     {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -102,7 +102,7 @@ namespace NzbDrone.Core.DecisionEngine
 
                         if (remoteEpisode.Series == null)
                         {
-                            var matchingTvdbId = _sceneMappingService.FindTvdbId(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber);
+                            var matchingTvdbId = _sceneMappingService.FindTvdbId(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber ?? -1);
 
                             if (matchingTvdbId.HasValue)
                             {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -88,7 +88,11 @@ namespace NzbDrone.Core.DecisionEngine
                         }
                     }
 
-                    parsedEpisodeInfo ??= Parser.Parser.ParseSeasonTitle(report.Title);
+                    if (parsedEpisodeInfo == null)
+                    {
+                        // Attempt to parse as a release that includes the season title without a season number
+                        parsedEpisodeInfo = Parser.Parser.ParseSeasonTitle(report.Title);
+                    }
 
                     if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
                     {

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/Search/SeasonMatchSpecification.cs
@@ -33,7 +33,9 @@ namespace NzbDrone.Core.DecisionEngine.Specifications.Search
                 return DownloadSpecDecision.Accept();
             }
 
-            if (singleEpisodeSpec.SeasonNumber != remoteEpisode.ParsedEpisodeInfo.SeasonNumber)
+            var seasonNumber = remoteEpisode.ParsedEpisodeInfo.SeasonNumber ?? remoteEpisode.MappedSeasonNumber;
+
+            if (singleEpisodeSpec.SeasonNumber != seasonNumber)
             {
                 _logger.Debug("Season number does not match searched season number, skipping.");
                 return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeason, "Wrong season");

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -396,13 +396,13 @@ namespace NzbDrone.Core.Download.Pending
                     {
                         _logger.Debug(ex, ex.Message);
 
-                        release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber;
+                        release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber.NonNegative();
                         release.RemoteEpisode.Episodes = new List<Episode>();
                     }
                 }
                 else
                 {
-                    release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber;
+                    release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber.NonNegative();
                     release.RemoteEpisode.Episodes = new List<Episode>();
                 }
 

--- a/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
+++ b/src/NzbDrone.Core/Download/Pending/PendingReleaseService.cs
@@ -396,13 +396,13 @@ namespace NzbDrone.Core.Download.Pending
                     {
                         _logger.Debug(ex, ex.Message);
 
-                        release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber.NonNegative();
+                        release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber;
                         release.RemoteEpisode.Episodes = new List<Episode>();
                     }
                 }
                 else
                 {
-                    release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber.NonNegative();
+                    release.RemoteEpisode.MappedSeasonNumber = release.ParsedEpisodeInfo.SeasonNumber;
                     release.RemoteEpisode.Episodes = new List<Episode>();
                 }
 

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -13,7 +13,7 @@ namespace NzbDrone.Core.Parser.Model
         public string SeriesTitle { get; set; }
         public SeriesTitleInfo SeriesTitleInfo { get; set; }
         public QualityModel Quality { get; set; }
-        public int SeasonNumber { get; set; }
+        public int? SeasonNumber { get; set; }
         public int[] EpisodeNumbers { get; set; }
         public int[] AbsoluteEpisodeNumbers { get; set; }
         public decimal[] SpecialAbsoluteEpisodeNumbers { get; set; }
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Parser.Model
         {
             get
             {
-                return SeasonNumber != 0 && EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
+                return SeasonNumber.HasValue && SeasonNumber != 0 && EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
             }
 
             private set
@@ -125,7 +125,7 @@ namespace NzbDrone.Core.Parser.Model
             }
             else if (FullSeason)
             {
-                episodeString = string.Format("Season {0:00}", SeasonNumber);
+                episodeString = SeasonNumber.HasValue ? string.Format("Season {0:00}", SeasonNumber) : "[Unknown Season]";
             }
             else if (EpisodeNumbers != null && EpisodeNumbers.Any())
             {
@@ -137,7 +137,7 @@ namespace NzbDrone.Core.Parser.Model
             }
             else if (Special)
             {
-                if (SeasonNumber != 0)
+                if (SeasonNumber.HasValue && SeasonNumber != 0)
                 {
                     episodeString = string.Format("[Unknown Season {0:00} Special]", SeasonNumber);
                 }

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Parser.Model
         public bool IsPartialSeason { get; set; }
         public bool IsMultiSeason { get; set; }
         public bool IsSeasonExtra { get; set; }
+        public bool IsSeasonTitleOnly { get; set; }
         public bool IsSplitEpisode { get; set; }
         public bool IsMiniSeries { get; set; }
         public bool Special { get; set; }

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Parser.Model
         public bool IsPartialSeason { get; set; }
         public bool IsMultiSeason { get; set; }
         public bool IsSeasonExtra { get; set; }
-        public bool IsSeasonTitleOnly { get; set; }
+        public bool IsSeasonTitle { get; set; }
         public bool IsSplitEpisode { get; set; }
         public bool IsMiniSeries { get; set; }
         public bool Special { get; set; }

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -33,6 +33,7 @@ namespace NzbDrone.Core.Parser.Model
         public bool IsPartialSeason { get; set; }
         public bool IsMultiSeason => SeasonNumbers.Length > 1;
         public bool IsSeasonExtra { get; set; }
+        public bool IsSeasonTitleOnly { get; set; }
         public bool IsSplitEpisode { get; set; }
         public bool IsMiniSeries { get; set; }
         public bool Special { get; set; }

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -18,10 +18,10 @@ namespace NzbDrone.Core.Parser.Model
 
         // TODO: Remove this once `SeasonNumbers` replaces `SeasonNumber`
         [JsonPropertyOrder(-1)]
-        public int SeasonNumber
+        public int? SeasonNumber
         {
-            get => SeasonNumbers.FirstOrDefault(0);
-            set => SeasonNumbers = [value];
+            get => SeasonNumbers.Length > 0 ? SeasonNumbers[0] : null;
+            set => SeasonNumbers = value.HasValue ? [value.Value] : [];
         }
 
         public int[] EpisodeNumbers { get; set; }
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Parser.Model
         {
             get
             {
-                return SeasonNumber != 0 && EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
+                return SeasonNumber.HasValue && SeasonNumber != 0 && EpisodeNumbers.Length == 1 && EpisodeNumbers[0] == 0;
             }
 
             private set
@@ -135,9 +135,14 @@ namespace NzbDrone.Core.Parser.Model
             }
             else if (FullSeason)
             {
-                episodeString = IsMultiSeason
-                    ? string.Format("Season {0:00}-{1:00}", SeasonNumbers.First(), SeasonNumbers.Last())
-                    : string.Format("Season {0:00}", SeasonNumber);
+                if (IsMultiSeason)
+                {
+                    episodeString = string.Format("Season {0:00}-{1:00}", SeasonNumbers.First(), SeasonNumbers.Last());
+                }
+                else
+                {
+                    episodeString = SeasonNumber.HasValue ? string.Format("Season {0:00}", SeasonNumber) : "[Unknown Season]";
+                }
             }
             else if (EpisodeNumbers != null && EpisodeNumbers.Any())
             {
@@ -149,7 +154,7 @@ namespace NzbDrone.Core.Parser.Model
             }
             else if (Special)
             {
-                if (SeasonNumber != 0)
+                if (SeasonNumber.HasValue && SeasonNumber != 0)
                 {
                     episodeString = string.Format("[Unknown Season {0:00} Special]", SeasonNumber);
                 }

--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Parser.Model
         public bool IsPartialSeason { get; set; }
         public bool IsMultiSeason => SeasonNumbers.Length > 1;
         public bool IsSeasonExtra { get; set; }
-        public bool IsSeasonTitleOnly { get; set; }
+        public bool IsSeasonTitle { get; set; }
         public bool IsSplitEpisode { get; set; }
         public bool IsMiniSeries { get; set; }
         public bool Special { get; set; }

--- a/src/NzbDrone.Core/Parser/Model/RemoteEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/RemoteEpisode.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser.Model
         public ReleaseInfo Release { get; set; }
         public ParsedEpisodeInfo ParsedEpisodeInfo { get; set; }
         public SceneMapping SceneMapping { get; set; }
-        public int MappedSeasonNumber { get; set; }
+        public int? MappedSeasonNumber { get; set; }
         public Series Series { get; set; }
         public List<Episode> Episodes { get; set; }
         public bool EpisodeRequested { get; set; }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -844,6 +844,7 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
+                IsSeasonTitleOnly = true,
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -837,7 +837,7 @@ namespace NzbDrone.Core.Parser
                     Title = seriesTitle,
                     TitleWithoutYear = seriesTitle
                 },
-                SeasonNumber = -1,
+                SeasonNumber = null,
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
@@ -990,6 +990,7 @@ namespace NzbDrone.Core.Parser
                 result = new ParsedEpisodeInfo
                 {
                     ReleaseTitle = releaseTitle,
+                    SeasonNumber = 0,
                     EpisodeNumbers = Array.Empty<int>(),
                     AbsoluteEpisodeNumbers = Array.Empty<int>()
                 };
@@ -1204,6 +1205,7 @@ namespace NzbDrone.Core.Parser
                 result = new ParsedEpisodeInfo
                 {
                     ReleaseTitle = releaseTitle,
+                    SeasonNumber = 0,
                     AirDate = airDate.ToString(Episode.AIR_DATE_FORMAT),
                 };
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,6 +516,16 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
+        // Used to recover the series title from a release that carries no season, episode or
+        // date, where the title is all there is to go on.
+        private static readonly Regex ReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+
+        // Groups mark extras inside brackets, which is exactly what stripping metadata removes,
+        // so these have to be checked before the brackets are taken off. Same terms the anime
+        // regexes above treat as specials.
+        private static readonly Regex SpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
+                                                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -799,6 +809,54 @@ namespace NzbDrone.Core.Parser
 
             Logger.Debug("Unable to parse {0}", title);
             return null;
+        }
+
+        // Anime season packs are commonly named after the season's own title with no season or
+        // episode number anywhere, so none of the regexes above have anything to match on. The
+        // season title is the only identifier the release carries. Which season it refers to is
+        // held in the scene mappings, so that is resolved later by ParsingService.
+        public static ParsedEpisodeInfo ParseSeasonTitle(string title)
+        {
+            var releaseTitle = FileExtensions.RemoveFileExtension(title);
+
+            if (SpecialMarkerRegex.IsMatch(releaseTitle))
+            {
+                return null;
+            }
+
+            var seriesTitle = DuplicateSpacesRegex.Replace(ReleaseMetadataRegex.Replace(releaseTitle, " "), " ").Trim();
+
+            // Anything left in brackets means the title was not recovered. Either it was itself
+            // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
+            // another and could not be removed. Both leave metadata behind rather than a title.
+            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(new[] { '[', ']', '(', ')', '{', '}' }) >= 0)
+            {
+                return null;
+            }
+
+            var result = new ParsedEpisodeInfo
+            {
+                ReleaseTitle = releaseTitle,
+                SeriesTitle = seriesTitle,
+                SeriesTitleInfo = new SeriesTitleInfo
+                {
+                    Title = seriesTitle,
+                    TitleWithoutYear = seriesTitle
+                },
+                SeasonNumber = 0,
+                EpisodeNumbers = Array.Empty<int>(),
+                AbsoluteEpisodeNumbers = Array.Empty<int>(),
+                FullSeason = true,
+
+                // The decision engine reads these while sorting, so they cannot be left unset.
+                Languages = LanguageParser.ParseLanguages(releaseTitle),
+                Quality = QualityParser.ParseQuality(title),
+                ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)
+            };
+
+            Logger.Debug("Title only parse. {0}", result);
+
+            return result;
         }
 
         public static string ParseSeriesName(string title)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -806,10 +806,6 @@ namespace NzbDrone.Core.Parser
             return null;
         }
 
-        // Anime season packs are commonly named after the season's own title with no season or
-        // episode number anywhere, so none of the regexes above have anything to match on. The
-        // season title is the only identifier the release carries. Which season it refers to is
-        // held in the scene mappings, so that is resolved later by ParsingService.
         public static ParsedEpisodeInfo ParseSeasonTitle(string title)
         {
             var releaseTitle = FileExtensions.RemoveFileExtension(title);
@@ -819,6 +815,10 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
+            // Anime season packs are commonly named after the season's own title with no season or
+            // episode number anywhere, so none of the regexes above have anything to match on. The
+            // season title is the only identifier the release carries. Which season it refers to is
+            // held in the scene mappings, so that is resolved later by ParsingService.
             var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,15 +516,10 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        // Used to recover the series title from a release that carries no season, episode or
-        // date, where the title is all there is to go on.
-        private static readonly Regex ReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+        private static readonly Regex AnimeReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
 
-        // Groups mark extras inside brackets, which is exactly what stripping metadata removes,
-        // so these have to be checked before the brackets are taken off. Same terms the anime
-        // regexes above treat as specials.
-        private static readonly Regex SpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
-                                                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeSpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
+                                                                          RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
@@ -819,12 +814,12 @@ namespace NzbDrone.Core.Parser
         {
             var releaseTitle = FileExtensions.RemoveFileExtension(title);
 
-            if (SpecialMarkerRegex.IsMatch(releaseTitle))
+            if (AnimeSpecialMarkerRegex.IsMatch(releaseTitle))
             {
                 return null;
             }
 
-            var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
+            var seriesTitle = AnimeReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
@@ -849,8 +844,6 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
-
-                // The decision engine reads these while sorting, so they cannot be left unset.
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -816,9 +816,8 @@ namespace NzbDrone.Core.Parser
             }
 
             // Anime season packs are commonly named after the season's own title with no season or
-            // episode number anywhere, so none of the regexes above have anything to match on. The
-            // season title is the only identifier the release carries. Which season it refers to is
-            // held in the scene mappings, so that is resolved later by ParsingService.
+            // episode numbers. ParsingService will determine the correct series and season number
+            // from scene mappings.
             var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -823,9 +823,7 @@ namespace NzbDrone.Core.Parser
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
-            // Anything left in brackets means the title was not recovered. Either it was itself
-            // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
-            // another and could not be removed. Both leave metadata behind rather than a title.
+            // If any brackets remain we were unable to extract the season title correctly.
             if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(['[', ']', '(', ')', '{', '}']) >= 0)
             {
                 return null;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -844,8 +844,8 @@ namespace NzbDrone.Core.Parser
                     TitleWithoutYear = seriesTitle
                 },
                 SeasonNumber = 0,
-                EpisodeNumbers = Array.Empty<int>(),
-                AbsoluteEpisodeNumbers = Array.Empty<int>(),
+                EpisodeNumbers = [],
+                AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
 
                 // The decision engine reads these while sorting, so they cannot be left unset.

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -825,7 +825,7 @@ namespace NzbDrone.Core.Parser
             }
 
             var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
-            seriesTiltle = DuplicateSpacesRegex.Replace(seriesTiltle, " ");
+            seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
             // Anything left in brackets means the title was not recovered. Either it was itself

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,7 +516,7 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        private static readonly Regex AnimeReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+        private static readonly Regex AnimeSeasonReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]+[\])}]", RegexOptions.Compiled);
 
         private static readonly Regex AnimeSpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
                                                                           RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -819,7 +819,7 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
-            var seriesTitle = AnimeReleaseMetadataRegex.Replace(releaseTitle, " ");
+            var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
@@ -842,7 +842,7 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
-                IsSeasonTitleOnly = true,
+                IsSeasonTitle = true,
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -829,7 +829,7 @@ namespace NzbDrone.Core.Parser
             // Anything left in brackets means the title was not recovered. Either it was itself
             // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
             // another and could not be removed. Both leave metadata behind rather than a title.
-            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(new[] { '[', ']', '(', ')', '{', '}' }) >= 0)
+            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(['[', ']', '(', ')', '{', '}']) >= 0)
             {
                 return null;
             }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -824,7 +824,9 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
-            var seriesTitle = DuplicateSpacesRegex.Replace(ReleaseMetadataRegex.Replace(releaseTitle, " "), " ").Trim();
+            var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
+            seriesTiltle = DuplicateSpacesRegex.Replace(seriesTiltle, " ");
+            seriesTitle = seriesTitle.Trim();
 
             // Anything left in brackets means the title was not recovered. Either it was itself
             // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -843,7 +843,7 @@ namespace NzbDrone.Core.Parser
                     Title = seriesTitle,
                     TitleWithoutYear = seriesTitle
                 },
-                SeasonNumber = 0,
+                SeasonNumber = -1,
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -817,10 +817,6 @@ namespace NzbDrone.Core.Parser
             return null;
         }
 
-        // Anime season packs are commonly named after the season's own title with no season or
-        // episode number anywhere, so none of the regexes above have anything to match on. The
-        // season title is the only identifier the release carries. Which season it refers to is
-        // held in the scene mappings, so that is resolved later by ParsingService.
         public static ParsedEpisodeInfo ParseSeasonTitle(string title)
         {
             var releaseTitle = FileExtensions.RemoveFileExtension(title);
@@ -830,6 +826,10 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
+            // Anime season packs are commonly named after the season's own title with no season or
+            // episode number anywhere, so none of the regexes above have anything to match on. The
+            // season title is the only identifier the release carries. Which season it refers to is
+            // held in the scene mappings, so that is resolved later by ParsingService.
             var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,6 +516,16 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
+        // Used to recover the series title from a release that carries no season, episode or
+        // date, where the title is all there is to go on.
+        private static readonly Regex ReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+
+        // Groups mark extras inside brackets, which is exactly what stripping metadata removes,
+        // so these have to be checked before the brackets are taken off. Same terms the anime
+        // regexes above treat as specials.
+        private static readonly Regex SpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
+                                                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -810,6 +820,54 @@ namespace NzbDrone.Core.Parser
 
             Logger.Debug("Unable to parse {0}", title);
             return null;
+        }
+
+        // Anime season packs are commonly named after the season's own title with no season or
+        // episode number anywhere, so none of the regexes above have anything to match on. The
+        // season title is the only identifier the release carries. Which season it refers to is
+        // held in the scene mappings, so that is resolved later by ParsingService.
+        public static ParsedEpisodeInfo ParseSeasonTitle(string title)
+        {
+            var releaseTitle = FileExtensions.RemoveFileExtension(title);
+
+            if (SpecialMarkerRegex.IsMatch(releaseTitle))
+            {
+                return null;
+            }
+
+            var seriesTitle = DuplicateSpacesRegex.Replace(ReleaseMetadataRegex.Replace(releaseTitle, " "), " ").Trim();
+
+            // Anything left in brackets means the title was not recovered. Either it was itself
+            // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
+            // another and could not be removed. Both leave metadata behind rather than a title.
+            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(new[] { '[', ']', '(', ')', '{', '}' }) >= 0)
+            {
+                return null;
+            }
+
+            var result = new ParsedEpisodeInfo
+            {
+                ReleaseTitle = releaseTitle,
+                SeriesTitle = seriesTitle,
+                SeriesTitleInfo = new SeriesTitleInfo
+                {
+                    Title = seriesTitle,
+                    TitleWithoutYear = seriesTitle
+                },
+                SeasonNumber = 0,
+                EpisodeNumbers = Array.Empty<int>(),
+                AbsoluteEpisodeNumbers = Array.Empty<int>(),
+                FullSeason = true,
+
+                // The decision engine reads these while sorting, so they cannot be left unset.
+                Languages = LanguageParser.ParseLanguages(releaseTitle),
+                Quality = QualityParser.ParseQuality(title),
+                ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)
+            };
+
+            Logger.Debug("Title only parse. {0}", result);
+
+            return result;
         }
 
         public static string ParseSeriesName(string title)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,7 +516,7 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        private static readonly Regex AnimeReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+        private static readonly Regex AnimeSeasonReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]+[\])}]", RegexOptions.Compiled);
 
         private static readonly Regex AnimeSpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
                                                                           RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -830,7 +830,7 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
-            var seriesTitle = AnimeReleaseMetadataRegex.Replace(releaseTitle, " ");
+            var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
@@ -853,7 +853,7 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
-                IsSeasonTitleOnly = true,
+                IsSeasonTitle = true,
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -854,7 +854,7 @@ namespace NzbDrone.Core.Parser
                     Title = seriesTitle,
                     TitleWithoutYear = seriesTitle
                 },
-                SeasonNumber = 0,
+                SeasonNumber = -1,
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,15 +516,10 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        // Used to recover the series title from a release that carries no season, episode or
-        // date, where the title is all there is to go on.
-        private static readonly Regex ReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
+        private static readonly Regex AnimeReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]*[\])}]", RegexOptions.Compiled);
 
-        // Groups mark extras inside brackets, which is exactly what stripping metadata removes,
-        // so these have to be checked before the brackets are taken off. Same terms the anime
-        // regexes above treat as specials.
-        private static readonly Regex SpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
-                                                                    RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeSpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
+                                                                          RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
@@ -830,12 +825,12 @@ namespace NzbDrone.Core.Parser
         {
             var releaseTitle = FileExtensions.RemoveFileExtension(title);
 
-            if (SpecialMarkerRegex.IsMatch(releaseTitle))
+            if (AnimeSpecialMarkerRegex.IsMatch(releaseTitle))
             {
                 return null;
             }
 
-            var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
+            var seriesTitle = AnimeReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
@@ -860,8 +855,6 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
-
-                // The decision engine reads these while sorting, so they cannot be left unset.
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -835,7 +835,9 @@ namespace NzbDrone.Core.Parser
                 return null;
             }
 
-            var seriesTitle = DuplicateSpacesRegex.Replace(ReleaseMetadataRegex.Replace(releaseTitle, " "), " ").Trim();
+            var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
+            seriesTiltle = DuplicateSpacesRegex.Replace(seriesTiltle, " ");
+            seriesTitle = seriesTitle.Trim();
 
             // Anything left in brackets means the title was not recovered. Either it was itself
             // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -855,8 +855,8 @@ namespace NzbDrone.Core.Parser
                     TitleWithoutYear = seriesTitle
                 },
                 SeasonNumber = 0,
-                EpisodeNumbers = Array.Empty<int>(),
-                AbsoluteEpisodeNumbers = Array.Empty<int>(),
+                EpisodeNumbers = [],
+                AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
 
                 // The decision engine reads these while sorting, so they cannot be left unset.

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -836,7 +836,7 @@ namespace NzbDrone.Core.Parser
             }
 
             var seriesTitle = ReleaseMetadataRegex.Replace(releaseTitle, " ");
-            seriesTiltle = DuplicateSpacesRegex.Replace(seriesTiltle, " ");
+            seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
             // Anything left in brackets means the title was not recovered. Either it was itself

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -827,9 +827,8 @@ namespace NzbDrone.Core.Parser
             }
 
             // Anime season packs are commonly named after the season's own title with no season or
-            // episode number anywhere, so none of the regexes above have anything to match on. The
-            // season title is the only identifier the release carries. Which season it refers to is
-            // held in the scene mappings, so that is resolved later by ParsingService.
+            // episode numbers. ParsingService will determine the correct series and season number
+            // from scene mappings.
             var seriesTitle = AnimeSeasonReleaseMetadataRegex.Replace(releaseTitle, " ");
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -840,7 +840,7 @@ namespace NzbDrone.Core.Parser
             // Anything left in brackets means the title was not recovered. Either it was itself
             // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
             // another and could not be removed. Both leave metadata behind rather than a title.
-            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(new[] { '[', ']', '(', ')', '{', '}' }) >= 0)
+            if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(['[', ']', '(', ')', '{', '}']) >= 0)
             {
                 return null;
             }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -855,6 +855,7 @@ namespace NzbDrone.Core.Parser
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
+                IsSeasonTitleOnly = true,
                 Languages = LanguageParser.ParseLanguages(releaseTitle),
                 Quality = QualityParser.ParseQuality(title),
                 ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(releaseTitle)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -848,7 +848,7 @@ namespace NzbDrone.Core.Parser
                     Title = seriesTitle,
                     TitleWithoutYear = seriesTitle
                 },
-                SeasonNumber = -1,
+                SeasonNumber = null,
                 EpisodeNumbers = [],
                 AbsoluteEpisodeNumbers = [],
                 FullSeason = true,
@@ -1001,6 +1001,7 @@ namespace NzbDrone.Core.Parser
                 result = new ParsedEpisodeInfo
                 {
                     ReleaseTitle = releaseTitle,
+                    SeasonNumber = 0,
                     EpisodeNumbers = Array.Empty<int>(),
                     AbsoluteEpisodeNumbers = Array.Empty<int>()
                 };
@@ -1214,6 +1215,7 @@ namespace NzbDrone.Core.Parser
                 result = new ParsedEpisodeInfo
                 {
                     ReleaseTitle = releaseTitle,
+                    SeasonNumber = 0,
                     AirDate = airDate.ToString(Episode.AIR_DATE_FORMAT),
                 };
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -834,9 +834,7 @@ namespace NzbDrone.Core.Parser
             seriesTitle = DuplicateSpacesRegex.Replace(seriesTitle, " ");
             seriesTitle = seriesTitle.Trim();
 
-            // Anything left in brackets means the title was not recovered. Either it was itself
-            // bracketed, as in [Group][Title][Source][Codec], or a bracketed group contained
-            // another and could not be removed. Both leave metadata behind rather than a title.
+            // If any brackets remain we were unable to extract the season title correctly.
             if (seriesTitle.IsNullOrWhiteSpace() || seriesTitle.IndexOfAny(['[', ']', '(', ')', '{', '}']) >= 0)
             {
                 return null;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -516,7 +516,7 @@ namespace NzbDrone.Core.Parser
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
 
-        private static readonly Regex AnimeSeasonReleaseMetadataRegex = new Regex(@"[\[({][^\[\]{}()]+[\])}]", RegexOptions.Compiled);
+        private static readonly Regex AnimeSeasonReleaseMetadataRegex = new Regex(@"\[[^\[\]]+\]|\([^()]+\)|\{[^{}]+\}", RegexOptions.Compiled);
 
         private static readonly Regex AnimeSpecialMarkerRegex = new Regex(@"\b(special|ova|ovd|ncop|nced)\b",
                                                                           RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Parser
 
                 if (parsedEpisodeInfo.IsSeasonTitle)
                 {
-                    var mappedSeasonNumber = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber;
+                    var mappedSeasonNumber = sceneMapping.SceneSeasonNumber.NonNegative() ?? sceneMapping.SeasonNumber.NonNegative();
 
                     if (mappedSeasonNumber.HasValue)
                     {

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -194,12 +194,9 @@ namespace NzbDrone.Core.Parser
                     remoteEpisode.MappedSeasonNumber += sceneMapping.SeasonNumber.Value - sceneMapping.SceneSeasonNumber.Value;
                 }
 
-                // A release named only by a season title carries no season number for the regex
-                // parser to find, so the season it refers to comes from the mapping instead.
                 if (parsedEpisodeInfo.IsSeasonTitleOnly)
                 {
-                    // An alias with no season of its own leaves it unresolved, which matches no
-                    // episodes. Falling back to 0 would match the specials instead.
+                    // Assign the season number from the mapping so we have a valid season number
                     var mappedSeason = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
 
                     remoteEpisode.MappedSeasonNumber = mappedSeason;

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -196,7 +196,7 @@ namespace NzbDrone.Core.Parser
 
                 // A release named only by a season title carries no season number for the regex
                 // parser to find, so the season it refers to comes from the mapping instead.
-                if (parsedEpisodeInfo.FullSeason && parsedEpisodeInfo.SeasonNumber == -1)
+                if (parsedEpisodeInfo.IsSeasonTitleOnly)
                 {
                     // An alias with no season of its own leaves it unresolved, which matches no
                     // episodes. Falling back to 0 would match the specials instead.

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -194,13 +194,10 @@ namespace NzbDrone.Core.Parser
                     remoteEpisode.MappedSeasonNumber += sceneMapping.SeasonNumber.Value - sceneMapping.SceneSeasonNumber.Value;
                 }
 
-                if (parsedEpisodeInfo.IsSeasonTitleOnly)
+                if (parsedEpisodeInfo.IsSeasonTitle)
                 {
                     // Assign the season number from the mapping so we have a valid season number
-                    var mappedSeason = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
-
-                    remoteEpisode.MappedSeasonNumber = mappedSeason;
-                    parsedEpisodeInfo.SeasonNumber = mappedSeason;
+                    remoteEpisode.MappedSeasonNumber = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
                 }
 
                 if (sceneMapping.SceneOrigin == "tvdb")

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -194,6 +194,18 @@ namespace NzbDrone.Core.Parser
                     remoteEpisode.MappedSeasonNumber += sceneMapping.SeasonNumber.Value - sceneMapping.SceneSeasonNumber.Value;
                 }
 
+                // A release named only by a season title carries no season number for the regex
+                // parser to find, so the season it refers to comes from the mapping instead.
+                if (parsedEpisodeInfo.FullSeason && parsedEpisodeInfo.SeasonNumber == 0)
+                {
+                    // Leaving it unmapped would fall through to season 0 and match specials,
+                    // so an alias with no season resolves to nothing instead.
+                    var mappedSeason = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
+
+                    remoteEpisode.MappedSeasonNumber = mappedSeason;
+                    parsedEpisodeInfo.SeasonNumber = mappedSeason;
+                }
+
                 if (sceneMapping.SceneOrigin == "tvdb")
                 {
                     sceneSource = false;

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Core.Parser
                 return _seriesService.FindByTitle(title);
             }
 
-            var tvdbId = _sceneMappingService.FindTvdbId(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber);
+            var tvdbId = _sceneMappingService.FindTvdbId(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber ?? -1);
 
             if (tvdbId.HasValue)
             {
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Parser
 
                 if (series == null)
                 {
-                    tvdbId = _sceneMappingService.FindTvdbId(title, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber);
+                    tvdbId = _sceneMappingService.FindTvdbId(title, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber ?? -1);
                 }
 
                 if (!tvdbId.HasValue)
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Parser
         {
             var year = parsedEpisodeInfo.SeriesTitleInfo.Year;
             var titleWithoutyear = parsedEpisodeInfo.SeriesTitleInfo.TitleWithoutYear;
-            var tvdbId = _sceneMappingService.FindTvdbId(titleWithoutyear, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber);
+            var tvdbId = _sceneMappingService.FindTvdbId(titleWithoutyear, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber ?? -1);
 
             if (tvdbId.HasValue)
             {
@@ -175,13 +175,13 @@ namespace NzbDrone.Core.Parser
 
         private RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvdbId, int tvRageId, string imdbId, Series series, SearchCriteriaBase searchCriteria)
         {
-            var sceneMapping = _sceneMappingService.FindSceneMapping(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber);
+            var sceneMapping = _sceneMappingService.FindSceneMapping(parsedEpisodeInfo.SeriesTitle, parsedEpisodeInfo.ReleaseTitle, parsedEpisodeInfo.SeasonNumber ?? -1);
 
             var remoteEpisode = new RemoteEpisode
             {
                 ParsedEpisodeInfo = parsedEpisodeInfo,
                 SceneMapping = sceneMapping,
-                MappedSeasonNumber = parsedEpisodeInfo.SeasonNumber.NonNegative()
+                MappedSeasonNumber = parsedEpisodeInfo.SeasonNumber
             };
 
             // For now we just detect tvdb vs scene, but we can do multiple 'origins' in the future.
@@ -265,7 +265,12 @@ namespace NzbDrone.Core.Parser
                 return remoteEpisode.Episodes;
             }
 
-            return GetEpisodes(parsedEpisodeInfo, series, parsedEpisodeInfo.SeasonNumber, sceneSource, searchCriteria);
+            if (!parsedEpisodeInfo.SeasonNumber.HasValue)
+            {
+                return new List<Episode>();
+            }
+
+            return GetEpisodes(parsedEpisodeInfo, series, parsedEpisodeInfo.SeasonNumber.Value, sceneSource, searchCriteria);
         }
 
         private List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series series, int mappedSeasonNumber, bool sceneSource, SearchCriteriaBase searchCriteria)
@@ -310,7 +315,7 @@ namespace NzbDrone.Core.Parser
                 if (parsedSpecialEpisodeInfo != null)
                 {
                     // Use the season number and disable scene source since the season/episode numbers that were returned are not scene numbers
-                    return GetStandardEpisodes(series, parsedSpecialEpisodeInfo, parsedSpecialEpisodeInfo.SeasonNumber, false, searchCriteria);
+                    return GetStandardEpisodes(series, parsedSpecialEpisodeInfo, parsedSpecialEpisodeInfo.SeasonNumber.Value, false, searchCriteria);
                 }
             }
 
@@ -378,7 +383,7 @@ namespace NzbDrone.Core.Parser
             // SxxE00 episodes are sometimes mapped via TheXEM, don't use episode title parsing in that case.
             if (parsedEpisodeInfo != null && parsedEpisodeInfo.IsPossibleSceneSeasonSpecial && series.UseSceneNumbering)
             {
-                if (_episodeService.FindEpisodesBySceneNumbering(series.Id, parsedEpisodeInfo.SeasonNumber, 0).Any())
+                if (_episodeService.FindEpisodesBySceneNumbering(series.Id, parsedEpisodeInfo.SeasonNumber.Value, 0).Any())
                 {
                     return parsedEpisodeInfo;
                 }
@@ -616,11 +621,11 @@ namespace NzbDrone.Core.Parser
                     }
                     else if (parsedEpisodeInfo.SeasonNumber > 1 && parsedEpisodeInfo.EpisodeNumbers.Empty())
                     {
-                        episodes = _episodeService.FindEpisodesBySceneNumbering(series.Id, parsedEpisodeInfo.SeasonNumber, absoluteEpisodeNumber);
+                        episodes = _episodeService.FindEpisodesBySceneNumbering(series.Id, parsedEpisodeInfo.SeasonNumber.Value, absoluteEpisodeNumber);
 
                         if (episodes.Empty())
                         {
-                            var episode = _episodeService.FindEpisode(series.Id, parsedEpisodeInfo.SeasonNumber, absoluteEpisodeNumber);
+                            var episode = _episodeService.FindEpisode(series.Id, parsedEpisodeInfo.SeasonNumber.Value, absoluteEpisodeNumber);
                             episodes.AddIfNotNull(episode);
                         }
                     }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -196,8 +196,13 @@ namespace NzbDrone.Core.Parser
 
                 if (parsedEpisodeInfo.IsSeasonTitle)
                 {
-                    // Assign the season number from the mapping so we have a valid season number
-                    remoteEpisode.MappedSeasonNumber = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
+                    var mappedSeasonNumber = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber;
+
+                    if (mappedSeasonNumber.HasValue)
+                    {
+                        // Assign the season number from the mapping so we have a valid season number
+                        remoteEpisode.MappedSeasonNumber = mappedSeasonNumber.Value;
+                    }
                 }
 
                 if (sceneMapping.SceneOrigin == "tvdb")

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -181,7 +181,7 @@ namespace NzbDrone.Core.Parser
             {
                 ParsedEpisodeInfo = parsedEpisodeInfo,
                 SceneMapping = sceneMapping,
-                MappedSeasonNumber = parsedEpisodeInfo.SeasonNumber
+                MappedSeasonNumber = parsedEpisodeInfo.SeasonNumber.NonNegative()
             };
 
             // For now we just detect tvdb vs scene, but we can do multiple 'origins' in the future.
@@ -233,9 +233,10 @@ namespace NzbDrone.Core.Parser
             {
                 remoteEpisode.Series = series;
 
-                if (ValidateParsedEpisodeInfo.ValidateForSeriesType(parsedEpisodeInfo, series))
+                if (remoteEpisode.MappedSeasonNumber.HasValue &&
+                    ValidateParsedEpisodeInfo.ValidateForSeriesType(parsedEpisodeInfo, series))
                 {
-                    remoteEpisode.Episodes = GetEpisodes(parsedEpisodeInfo, series, remoteEpisode.MappedSeasonNumber, sceneSource, searchCriteria);
+                    remoteEpisode.Episodes = GetEpisodes(parsedEpisodeInfo, series, remoteEpisode.MappedSeasonNumber.Value, sceneSource, searchCriteria);
                 }
             }
 

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -196,10 +196,10 @@ namespace NzbDrone.Core.Parser
 
                 // A release named only by a season title carries no season number for the regex
                 // parser to find, so the season it refers to comes from the mapping instead.
-                if (parsedEpisodeInfo.FullSeason && parsedEpisodeInfo.SeasonNumber == 0)
+                if (parsedEpisodeInfo.FullSeason && parsedEpisodeInfo.SeasonNumber == -1)
                 {
-                    // Leaving it unmapped would fall through to season 0 and match specials,
-                    // so an alias with no season resolves to nothing instead.
+                    // An alias with no season of its own leaves it unresolved, which matches no
+                    // episodes. Falling back to 0 would match the specials instead.
                     var mappedSeason = sceneMapping.SceneSeasonNumber ?? sceneMapping.SeasonNumber ?? -1;
 
                     remoteEpisode.MappedSeasonNumber = mappedSeason;

--- a/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
+++ b/src/Sonarr.Api.V3/Indexers/ReleaseResource.cs
@@ -120,7 +120,7 @@ namespace Sonarr.Api.V3.Indexers
                 ReleaseHash = parsedEpisodeInfo.ReleaseHash,
                 Title = releaseInfo.Title,
                 FullSeason = parsedEpisodeInfo.FullSeason,
-                SeasonNumber = parsedEpisodeInfo.SeasonNumber,
+                SeasonNumber = parsedEpisodeInfo.SeasonNumber ?? -1,
                 Languages = remoteEpisode.Languages,
                 AirDate = parsedEpisodeInfo.AirDate,
                 SeriesTitle = parsedEpisodeInfo.SeriesTitle,

--- a/src/Sonarr.Api.V3/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V3/Parse/ParseController.cs
@@ -35,7 +35,11 @@ namespace Sonarr.Api.V3.Parse
                 return null;
             }
 
-            var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
+            // Only for a title, so this matches what a release goes through. Importing a file
+            // does not use the season title parser, so parsing a path should not either.
+            var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace()
+                ? Parser.ParsePath(path)
+                : Parser.ParseTitle(title) ?? Parser.ParseSeasonTitle(title);
 
             if (parsedEpisodeInfo == null)
             {

--- a/src/Sonarr.Api.V3/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V3/Parse/ParseController.cs
@@ -35,11 +35,13 @@ namespace Sonarr.Api.V3.Parse
                 return null;
             }
 
-            // Only for a title, so this matches what a release goes through. Importing a file
-            // does not use the season title parser, so parsing a path should not either.
-            var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace()
-                ? Parser.ParsePath(path)
-                : Parser.ParseTitle(title) ?? Parser.ParseSeasonTitle(title);
+            var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
+
+            // Only a title falls back to the season title parser, importing a file does not use it.
+            if (parsedEpisodeInfo == null && path.IsNullOrWhiteSpace())
+            {
+                parsedEpisodeInfo = Parser.ParseSeasonTitle(title);
+            }
 
             if (parsedEpisodeInfo == null)
             {

--- a/src/Sonarr.Api.V3/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V3/Parse/ParseController.cs
@@ -37,7 +37,7 @@ namespace Sonarr.Api.V3.Parse
 
             var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
 
-            // Only a title falls back to the season title parser, importing a file does not use it.
+            // Try to parse a season title if previous parsing failed and we're not dealing with a path.
             if (parsedEpisodeInfo == null && path.IsNullOrWhiteSpace())
             {
                 parsedEpisodeInfo = Parser.ParseSeasonTitle(title);

--- a/src/Sonarr.Api.V3/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V3/Parse/ParseController.cs
@@ -63,7 +63,7 @@ namespace Sonarr.Api.V3.Parse
                 return new ParseResource
                 {
                     Title = title,
-                    ParsedEpisodeInfo = remoteEpisode.ParsedEpisodeInfo,
+                    ParsedEpisodeInfo = remoteEpisode.ParsedEpisodeInfo.ToResource(),
                     Series = remoteEpisode.Series.ToResource(),
                     Episodes = remoteEpisode.Episodes.ToResource(),
                     Languages = remoteEpisode.Languages,
@@ -76,7 +76,7 @@ namespace Sonarr.Api.V3.Parse
                 return new ParseResource
                 {
                     Title = title,
-                    ParsedEpisodeInfo = parsedEpisodeInfo
+                    ParsedEpisodeInfo = parsedEpisodeInfo.ToResource()
                 };
             }
         }

--- a/src/Sonarr.Api.V3/Parse/ParseResource.cs
+++ b/src/Sonarr.Api.V3/Parse/ParseResource.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using NzbDrone.Core.Languages;
-using NzbDrone.Core.Parser.Model;
 using Sonarr.Api.V3.CustomFormats;
 using Sonarr.Api.V3.Episodes;
 using Sonarr.Api.V3.Series;
@@ -11,7 +10,7 @@ namespace Sonarr.Api.V3.Parse
     public class ParseResource : RestResource
     {
         public string Title { get; set; }
-        public ParsedEpisodeInfo ParsedEpisodeInfo { get; set; }
+        public ParsedEpisodeInfoResource ParsedEpisodeInfo { get; set; }
         public SeriesResource Series { get; set; }
         public List<EpisodeResource> Episodes { get; set; }
         public List<Language> Languages { get; set; }

--- a/src/Sonarr.Api.V3/Parse/ParsedEpisodeInfoResource.cs
+++ b/src/Sonarr.Api.V3/Parse/ParsedEpisodeInfoResource.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+
+namespace Sonarr.Api.V3.Parse
+{
+    public class ParsedEpisodeInfoResource
+    {
+        public string ReleaseTitle { get; set; }
+        public string SeriesTitle { get; set; }
+        public SeriesTitleInfo SeriesTitleInfo { get; set; }
+        public QualityModel Quality { get; set; }
+        public int[] SeasonNumbers { get; set; }
+        public int SeasonNumber { get; set; }
+        public int[] EpisodeNumbers { get; set; }
+        public int[] AbsoluteEpisodeNumbers { get; set; }
+        public decimal[] SpecialAbsoluteEpisodeNumbers { get; set; }
+        public string AirDate { get; set; }
+        public List<Language> Languages { get; set; }
+        public bool FullSeason { get; set; }
+        public bool IsPartialSeason { get; set; }
+        public bool IsMultiSeason { get; set; }
+        public bool IsSeasonExtra { get; set; }
+        public bool IsSplitEpisode { get; set; }
+        public bool IsMiniSeries { get; set; }
+        public bool Special { get; set; }
+        public string ReleaseGroup { get; set; }
+        public string ReleaseHash { get; set; }
+        public int SeasonPart { get; set; }
+        public string ReleaseTokens { get; set; }
+        public int? DailyPart { get; set; }
+        public bool IsDaily { get; set; }
+        public bool IsAbsoluteNumbering { get; set; }
+        public bool IsPossibleSpecialEpisode { get; set; }
+        public bool IsPossibleSceneSeasonSpecial { get; set; }
+        public ReleaseType ReleaseType { get; set; }
+    }
+
+    public static class ParsedEpisodeInfoResourceMapper
+    {
+        public static ParsedEpisodeInfoResource ToResource(this ParsedEpisodeInfo model)
+        {
+            if (model == null)
+            {
+                return null;
+            }
+
+            return new ParsedEpisodeInfoResource
+            {
+                ReleaseTitle = model.ReleaseTitle,
+                SeriesTitle = model.SeriesTitle,
+                SeriesTitleInfo = model.SeriesTitleInfo,
+                Quality = model.Quality,
+                SeasonNumbers = model.SeasonNumbers,
+                SeasonNumber = model.SeasonNumber ?? -1,
+                EpisodeNumbers = model.EpisodeNumbers,
+                AbsoluteEpisodeNumbers = model.AbsoluteEpisodeNumbers,
+                SpecialAbsoluteEpisodeNumbers = model.SpecialAbsoluteEpisodeNumbers,
+                AirDate = model.AirDate,
+                Languages = model.Languages,
+                FullSeason = model.FullSeason,
+                IsPartialSeason = model.IsPartialSeason,
+                IsMultiSeason = model.IsMultiSeason,
+                IsSeasonExtra = model.IsSeasonExtra,
+                IsSplitEpisode = model.IsSplitEpisode,
+                IsMiniSeries = model.IsMiniSeries,
+                Special = model.Special,
+                ReleaseGroup = model.ReleaseGroup,
+                ReleaseHash = model.ReleaseHash,
+                SeasonPart = model.SeasonPart,
+                ReleaseTokens = model.ReleaseTokens,
+                DailyPart = model.DailyPart,
+                IsDaily = model.IsDaily,
+                IsAbsoluteNumbering = model.IsAbsoluteNumbering,
+                IsPossibleSpecialEpisode = model.IsPossibleSpecialEpisode,
+                IsPossibleSceneSeasonSpecial = model.IsPossibleSceneSeasonSpecial,
+                ReleaseType = model.ReleaseType
+            };
+        }
+    }
+}

--- a/src/Sonarr.Api.V5/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V5/Parse/ParseController.cs
@@ -40,11 +40,13 @@ public class ParseController : Controller
             });
         }
 
-        // Only for a title, so this matches what a release goes through. Importing a file
-        // does not use the season title parser, so parsing a path should not either.
-        var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace()
-            ? Parser.ParsePath(path)
-            : Parser.ParseTitle(title) ?? Parser.ParseSeasonTitle(title);
+        var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
+
+        // Only a title falls back to the season title parser, importing a file does not use it.
+        if (parsedEpisodeInfo == null && path.IsNullOrWhiteSpace())
+        {
+            parsedEpisodeInfo = Parser.ParseSeasonTitle(title);
+        }
 
         if (parsedEpisodeInfo == null)
         {

--- a/src/Sonarr.Api.V5/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V5/Parse/ParseController.cs
@@ -42,7 +42,7 @@ public class ParseController : Controller
 
         var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
 
-        // Only a title falls back to the season title parser, importing a file does not use it.
+        // Try to parse a season title if previous parsing failed and we're not dealing with a path.
         if (parsedEpisodeInfo == null && path.IsNullOrWhiteSpace())
         {
             parsedEpisodeInfo = Parser.ParseSeasonTitle(title);

--- a/src/Sonarr.Api.V5/Parse/ParseController.cs
+++ b/src/Sonarr.Api.V5/Parse/ParseController.cs
@@ -40,7 +40,11 @@ public class ParseController : Controller
             });
         }
 
-        var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace() ? Parser.ParsePath(path) : Parser.ParseTitle(title);
+        // Only for a title, so this matches what a release goes through. Importing a file
+        // does not use the season title parser, so parsing a path should not either.
+        var parsedEpisodeInfo = path.IsNotNullOrWhiteSpace()
+            ? Parser.ParsePath(path)
+            : Parser.ParseTitle(title) ?? Parser.ParseSeasonTitle(title);
 
         if (parsedEpisodeInfo == null)
         {

--- a/src/Sonarr.Api.V5/Release/ParsedEpisodeInfoResource.cs
+++ b/src/Sonarr.Api.V5/Release/ParsedEpisodeInfoResource.cs
@@ -9,7 +9,7 @@ public class ParsedEpisodeInfoResource
     public string? ReleaseGroup { get; set; }
     public string? ReleaseHash { get; set; }
     public bool FullSeason { get; set; }
-    public int SeasonNumber { get; set; }
+    public int? SeasonNumber { get; set; }
     public string? AirDate { get; set; }
     public string? SeriesTitle { get; set; }
     public int[] EpisodeNumbers { get; set; } = [];


### PR DESCRIPTION
#### Description

Some anime releases for season packs don't include any season data such as S02 etc so they are discarded, sonarr already knows the scene mappings which include season aliases. This adds a separate method in parser outside of the regex that recovers the series title and then is able to match the season alias to the season using parsingservicing

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review