### PR TITLE
New: Also search anime season titles without the season parameter

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -587,6 +587,40 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
+        public async Task season_search_for_anime_should_pass_search_mode_from_scene_mapping()
+        {
+            WithEpisodes();
+            _xemSeries.SeriesType = SeriesTypes.Anime;
+            _xemEpisodes.ForEach(e => e.EpisodeFileId = 0);
+
+            // Season 1 episodes map to scene season 2 (see WithEpisodes), so the scene
+            // mapping must target scene season 2 to survive the season filter.
+            Mocker.GetMock<ISceneMappingService>()
+                  .Setup(s => s.FindByTvdbId(It.IsAny<int>()))
+                  .Returns(new List<SceneMapping>
+                  {
+                      new SceneMapping
+                      {
+                          TvdbId = _xemSeries.TvdbId,
+                          SearchTerm = "Dr Stone Stone Wars",
+                          ParseTerm = "drstonestonewars",
+                          SeasonNumber = 2,
+                          SceneSeasonNumber = 2,
+                          SearchMode = SearchMode.SearchTitle
+                      }
+                  });
+
+            var allCriteria = WatchForSearchCriteria();
+
+            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
+
+            var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
+
+            criteria.Should().Contain(c => c.SearchMode == SearchMode.SearchTitle);
+            criteria.Should().Contain(c => c.SceneTitles.Contains("Dr Stone Stone Wars"));
+        }
+
+        [Test]
         public async Task season_search_for_daily_should_search_multiple_years()
         {
             WithEpisode(1, 1, null, null, "2005-12-30");

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -602,8 +602,8 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
                       new SceneMapping
                       {
                           TvdbId = _xemSeries.TvdbId,
-                          SearchTerm = "Dr Stone Stone Wars",
-                          ParseTerm = "drstonestonewars",
+                          SearchTerm = "Sonarrs Season Title",
+                          ParseTerm = "sonarrsseasontitle",
                           SeasonNumber = 2,
                           SceneSeasonNumber = 2,
                           SearchMode = SearchMode.SearchTitle
@@ -617,7 +617,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
             criteria.Should().Contain(c => c.SearchMode == SearchMode.SearchTitle);
-            criteria.Should().Contain(c => c.SceneTitles.Contains("Dr Stone Stone Wars"));
+            criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Season Title"));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -621,7 +621,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public async Task season_search_for_anime_should_not_group_a_series_wide_alias_with_a_season_title()
+        public async Task season_search_for_anime_should_search_a_series_wide_alias_and_a_season_title_together()
         {
             WithEpisodes();
             _xemSeries.SeriesType = SeriesTypes.Anime;
@@ -654,11 +654,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
 
-            criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Season Title") &&
-                                           !c.SceneTitles.Contains("Sonarrs Series Alias"));
-
-            criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Series Alias") &&
-                                           !c.SearchMode.HasFlag(SearchMode.SearchSeasonTitle));
+            criteria.Should().ContainSingle();
+            criteria.First().SceneTitles.Should().Contain("Sonarrs Season Title");
+            criteria.First().SceneTitles.Should().Contain("Sonarrs Series Alias");
+            criteria.First().SeasonSceneTitles.Should().BeEquivalentTo(new[] { "Sonarrs Season Title" });
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -621,6 +621,47 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
+        public async Task season_search_for_anime_should_not_group_a_series_wide_alias_with_a_season_title()
+        {
+            WithEpisodes();
+            _xemSeries.SeriesType = SeriesTypes.Anime;
+            _xemEpisodes.ForEach(e => e.EpisodeFileId = 0);
+
+            Mocker.GetMock<ISceneMappingService>()
+                  .Setup(s => s.FindByTvdbId(It.IsAny<int>()))
+                  .Returns(new List<SceneMapping>
+                  {
+                      new SceneMapping
+                      {
+                          TvdbId = _xemSeries.TvdbId,
+                          SearchTerm = "Sonarrs Season Title",
+                          ParseTerm = "sonarrsseasontitle",
+                          SeasonNumber = 2,
+                          SceneSeasonNumber = 2
+                      },
+                      new SceneMapping
+                      {
+                          TvdbId = _xemSeries.TvdbId,
+                          SearchTerm = "Sonarrs Series Alias",
+                          ParseTerm = "sonarrsseriesalias",
+                          SearchMode = SearchMode.SearchTitle
+                      }
+                  });
+
+            var allCriteria = WatchForSearchCriteria();
+
+            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
+
+            var criteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
+
+            criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Season Title") &&
+                                           !c.SceneTitles.Contains("Sonarrs Series Alias"));
+
+            criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Series Alias") &&
+                                           !c.SearchMode.HasFlag(SearchMode.SeasonSearchTitle));
+        }
+
+        [Test]
         public async Task season_search_for_daily_should_search_multiple_years()
         {
             WithEpisode(1, 1, null, null, "2005-12-30");

--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -658,7 +658,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
                                            !c.SceneTitles.Contains("Sonarrs Series Alias"));
 
             criteria.Should().Contain(c => c.SceneTitles.Contains("Sonarrs Series Alias") &&
-                                           !c.SearchMode.HasFlag(SearchMode.SeasonSearchTitle));
+                                           !c.SearchMode.HasFlag(SearchMode.SearchSeasonTitle));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -200,7 +200,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
 
             pages.Should().ContainSingle(p => p.Contains("q="));
-            pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
+            pages.Should().Contain(p => p.Contains("?t=search&") && p.Contains("q=Monkey%20Island") && !p.Contains("season="));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -194,7 +194,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_without_the_season_parameter()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -207,6 +207,20 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
+        public void should_search_season_title_alias_when_standard_format_search_is_disabled()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = false;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
+
+            pages.Should().ContainSingle();
+            pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
+        }
+
+        [Test]
         public void should_not_search_without_season_parameter_when_search_mode_is_default()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -191,18 +191,16 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_search_season_title_alias_with_and_without_season_parameter()
+        public void should_search_season_title_alias_without_the_season_parameter()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
             _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
-            results.Tiers.Should().Be(1);
-
             var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
 
-            pages.Should().Contain(p => p.Contains("q=Monkey%20Island&season=3"));
+            pages.Should().ContainSingle();
             pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
         }
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -198,8 +198,6 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
-            // Same tier, so both run. A fallback tier would only run when the season
-            // qualified search returned nothing at all.
             results.Tiers.Should().Be(1);
 
             var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
-using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Indexers.Newznab;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -194,13 +193,13 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_without_the_season_parameter()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Monkey Island" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
             var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
 
-            pages.Should().ContainSingle();
+            pages.Should().ContainSingle(p => p.Contains("q="));
             pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
         }
 
@@ -208,7 +207,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Monkey Island" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -219,31 +218,18 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         }
 
         [Test]
-        public void should_search_series_wide_alias_with_the_season_parameter()
+        public void should_only_search_the_season_title_without_the_season_parameter()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Monkey Island", "Monkey Island Revenge" };
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Monkey Island Revenge" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
             var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
 
             pages.Should().Contain(p => p.Contains("q=Monkey%20Island&season=3"));
-        }
-
-        [Test]
-        public void should_not_search_without_season_parameter_when_search_mode_is_default()
-        {
-            Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.Default;
-
-            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
-
-            results.Tiers.Should().Be(1);
-
-            var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
-
-            pages.Should().NotContain(p => p.Contains("q=") && !p.Contains("season="));
+            pages.Should().Contain(p => p.Contains("q=Monkey%20Island%20Revenge") && !p.Contains("season="));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -194,7 +194,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_without_the_season_parameter()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -216,6 +216,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             pages.Should().ContainSingle();
             pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
+        }
+
+        [Test]
+        public void should_search_series_wide_alias_with_the_season_parameter()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
+
+            pages.Should().Contain(p => p.Contains("q=Monkey%20Island&season=3"));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Indexers.Newznab;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -187,6 +188,39 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             pages[0].Url.FullUri.Should().Contain("rid=10&season=3");
             pages[1].Url.FullUri.Should().Contain("q=Monkey%20Island&season=3");
+        }
+
+        [Test]
+        public void should_search_season_title_alias_with_and_without_season_parameter()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            // Same tier, so both run. A fallback tier would only run when the season
+            // qualified search returned nothing at all.
+            results.Tiers.Should().Be(1);
+
+            var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
+
+            pages.Should().Contain(p => p.Contains("q=Monkey%20Island&season=3"));
+            pages.Should().Contain(p => p.Contains("q=Monkey%20Island") && !p.Contains("season="));
+        }
+
+        [Test]
+        public void should_not_search_without_season_parameter_when_search_mode_is_default()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.Default;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.Tiers.Should().Be(1);
+
+            var pages = results.GetAllTiers().Select(t => t.First().Url.FullUri).ToList();
+
+            pages.Should().NotContain(p => p.Contains("q=") && !p.Contains("season="));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -105,19 +105,16 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         }
 
         [Test]
-        public void should_search_season_title_alias_with_and_without_the_season_number()
+        public void should_search_season_title_alias_without_the_season_number()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
             _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
-            results.GetTier(0).Should().HaveCount(2);
-
-            var pages = results.GetTier(0).Select(t => t.First().Url.FullUri).ToList();
-
-            pages.Should().Contain(p => p.Contains("term=Naruto+Shippuuden+s03"));
-            pages.Should().Contain(p => p.Contains("term=Naruto+Shippuuden") && !p.Contains("s03"));
+            results.GetTier(0).Should().HaveCount(1);
+            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
+            results.GetTier(0).First().First().Url.FullUri.Should().NotContain("s03");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.Indexers.Nyaa;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Test.Framework;
@@ -101,6 +102,34 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
             var page = results.GetAllTiers().First().First();
 
             page.Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
+        }
+
+        [Test]
+        public void should_search_season_title_alias_with_and_without_the_season_number()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetTier(0).Should().HaveCount(2);
+
+            var pages = results.GetTier(0).Select(t => t.First().Url.FullUri).ToList();
+
+            pages.Should().Contain(p => p.Contains("term=Naruto+Shippuuden+s03"));
+            pages.Should().Contain(p => p.Contains("term=Naruto+Shippuuden") && !p.Contains("s03"));
+        }
+
+        [Test]
+        public void should_not_search_without_the_season_number_when_search_mode_is_default()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.Default;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetTier(0).Should().HaveCount(1);
+            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -108,7 +108,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_without_the_season_number()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -121,7 +121,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -108,7 +108,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_without_the_season_number()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -121,13 +121,25 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SeasonSearchTitle;
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
             results.GetTier(0).Should().HaveCount(1);
             results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
             results.GetTier(0).First().First().Url.FullUri.Should().NotContain("s03");
+        }
+
+        [Test]
+        public void should_search_series_wide_alias_with_the_season_number()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = true;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetTier(0).Should().HaveCount(1);
+            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
-using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.Indexers.Nyaa;
 using NzbDrone.Core.IndexerSearch.Definitions;
 using NzbDrone.Core.Test.Framework;
@@ -108,7 +107,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_without_the_season_number()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Naruto Shippuuden" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -121,7 +120,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         public void should_search_season_title_alias_when_standard_format_search_is_disabled()
         {
             Subject.Settings.AnimeStandardFormatSearch = false;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchSeasonTitle;
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Naruto Shippuuden" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
@@ -131,27 +130,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         }
 
         [Test]
-        public void should_search_series_wide_alias_with_the_season_number()
+        public void should_only_search_the_season_title_without_the_season_number()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Naruto", "Naruto Shippuuden" };
+            _animeSeasonSearchCriteria.SeasonSceneTitles = new List<string> { "Naruto Shippuuden" };
 
             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
 
-            results.GetTier(0).Should().HaveCount(1);
-            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
-        }
+            var pages = results.GetTier(0).Select(t => t.First().Url.FullUri).ToList();
 
-        [Test]
-        public void should_not_search_without_the_season_number_when_search_mode_is_default()
-        {
-            Subject.Settings.AnimeStandardFormatSearch = true;
-            _animeSeasonSearchCriteria.SearchMode = SearchMode.Default;
-
-            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
-
-            results.GetTier(0).Should().HaveCount(1);
-            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
+            pages.Should().HaveCount(2);
+            pages.Should().Contain(p => p.Contains("term=Naruto+s03"));
+            pages.Should().Contain(p => p.Contains("term=Naruto+Shippuuden") && !p.Contains("s03"));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
@@ -121,6 +121,19 @@ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
         }
 
         [Test]
+        public void should_search_season_title_alias_when_standard_format_search_is_disabled()
+        {
+            Subject.Settings.AnimeStandardFormatSearch = false;
+            _animeSeasonSearchCriteria.SearchMode = SearchMode.SearchTitle;
+
+            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+
+            results.GetTier(0).Should().HaveCount(1);
+            results.GetTier(0).First().First().Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
+            results.GetTier(0).First().First().Url.FullUri.Should().NotContain("s03");
+        }
+
+        [Test]
         public void should_not_search_without_the_season_number_when_search_mode_is_default()
         {
             Subject.Settings.AnimeStandardFormatSearch = true;

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
@@ -8,10 +8,6 @@ namespace NzbDrone.Core.DataAugmentation.Scene
         Default = 0,
         SearchID = 1,
         SearchTitle = 2,
-        SeasonTitle = 4,
-
-        // Includes SearchTitle so a season title is still a title search everywhere that only
-        // looks for one, the season searches check for this to drop the season number.
-        SearchSeasonTitle = SearchTitle | SeasonTitle
+        SearchSeasonTitle = 4
     }
 }

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
@@ -7,7 +7,6 @@ namespace NzbDrone.Core.DataAugmentation.Scene
     {
         Default = 0,
         SearchID = 1,
-        SearchTitle = 2,
-        SearchSeasonTitle = 4
+        SearchTitle = 2
     }
 }

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
@@ -10,8 +10,8 @@ namespace NzbDrone.Core.DataAugmentation.Scene
         SearchTitle = 2,
         SeasonTitle = 4,
 
-        // Carries the SearchTitle bit so the generators that only care about a title search
-        // are unaffected, the season searches check for this one to drop the season number.
-        SeasonSearchTitle = SearchTitle | SeasonTitle
+        // Includes SearchTitle so a season title is still a title search everywhere that only
+        // looks for one, the season searches check for this to drop the season number.
+        SearchSeasonTitle = SearchTitle | SeasonTitle
     }
 }

--- a/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
+++ b/src/NzbDrone.Core/DataAugmentation/Scene/SearchMode.cs
@@ -7,6 +7,11 @@ namespace NzbDrone.Core.DataAugmentation.Scene
     {
         Default = 0,
         SearchID = 1,
-        SearchTitle = 2
+        SearchTitle = 2,
+        SeasonTitle = 4,
+
+        // Carries the SearchTitle bit so the generators that only care about a title search
+        // are unaffected, the season searches check for this one to drop the season number.
+        SeasonSearchTitle = SearchTitle | SeasonTitle
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,10 +7,10 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
     public class AnimeSeasonSearchCriteria : SearchCriteriaBase
     {
         public int SeasonNumber { get; set; }
-        public List<string> SeasonSceneTitles { get; set; } = new List<string>();
+        public List<string> SeasonSceneTitles { get; set; } = [];
 
-        public List<string> AllSeasonSceneTitles => SeasonSceneTitles.Concat(CleanSeasonSceneTitles).Distinct().ToList();
-        public List<string> CleanSeasonSceneTitles => SeasonSceneTitles.Select(GetCleanSceneTitle).Distinct().ToList();
+        public List<string> AllSeasonSceneTitles => SeasonSceneTitles.Concat(CleanSeasonSceneTitles).Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+        public List<string> CleanSeasonSceneTitles => SeasonSceneTitles.Select(GetCleanSceneTitle).Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
@@ -1,8 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public class AnimeSeasonSearchCriteria : SearchCriteriaBase
     {
         public int SeasonNumber { get; set; }
+        public List<string> SeasonSceneTitles { get; set; } = new List<string>();
+
+        public List<string> AllSeasonSceneTitles => SeasonSceneTitles.Concat(CleanSeasonSceneTitles).Distinct().ToList();
+        public List<string> CleanSeasonSceneTitles => SeasonSceneTitles.Select(GetCleanSceneTitle).Distinct().ToList();
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SceneEpisodeMapping.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SceneEpisodeMapping.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public Episode Episode { get; set; }
         public SearchMode SearchMode { get; set; }
         public List<string> SceneTitles { get; set; }
+        public List<string> SeasonSceneTitles { get; set; }
         public int SeasonNumber { get; set; }
         public int EpisodeNumber { get; set; }
         public int? AbsoluteEpisodeNumber { get; set; }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SceneSeasonMapping.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SceneSeasonMapping.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public SceneEpisodeMapping EpisodeMapping { get; set; }
         public SearchMode SearchMode { get; set; }
         public List<string> SceneTitles { get; set; }
+        public List<string> SeasonSceneTitles { get; set; }
         public int SeasonNumber { get; set; }
 
         public override int GetHashCode()

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -278,7 +278,7 @@ namespace NzbDrone.Core.IndexerSearch
                 }
 
                 // By default we do a alt title search in case indexers don't have the release properly indexed.  Services can override this behavior.
-                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SearchSeasonTitle : SearchMode.Default);
+                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SearchTitle | SearchMode.SearchSeasonTitle : SearchMode.Default);
 
                 if (ignoreSceneNumbering)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -427,8 +427,8 @@ namespace NzbDrone.Core.IndexerSearch
             var seasonMappings = GetSceneSeasonMappings(series, episodesToSearch);
 
             var seasonsToSearch = seasonMappings
-                .GroupBy(m => m.SeasonNumber)
-                .Select(g => g.First())
+                .GroupBy(ep => ep.SeasonNumber)
+                .Select(epList => epList.First())
                 .ToList();
 
             foreach (var season in seasonsToSearch)

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -278,7 +278,7 @@ namespace NzbDrone.Core.IndexerSearch
                 }
 
                 // By default we do a alt title search in case indexers don't have the release properly indexed.  Services can override this behavior.
-                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SearchTitle : SearchMode.Default);
+                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SeasonSearchTitle : SearchMode.Default);
 
                 if (ignoreSceneNumbering)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -399,8 +399,6 @@ namespace NzbDrone.Core.IndexerSearch
         {
             var downloadDecisions = new List<DownloadDecision>();
 
-            var searchSpec = Get<AnimeSeasonSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
-
             // Episode needs to be monitored if it's not an interactive search
             // and Ensure episode has an airdate and has already aired
             var episodesToSearch = episodes
@@ -414,13 +412,11 @@ namespace NzbDrone.Core.IndexerSearch
 
             var allEpisodesAiredOrAiringSoon = seasonEpisodes.All(ep => ep.AirDateUtc.HasValue && !ep.AirDateUtc.Value.After(DateTime.UtcNow.AddHours(24)));
 
-            var seasonsToSearch = GetSceneSeasonMappings(series, episodesToSearch)
-                .GroupBy(ep => ep.SeasonNumber)
-                .Select(epList => epList.First())
-                .ToList();
+            var seasonsToSearch = GetSceneSeasonMappings(series, episodesToSearch);
 
             foreach (var season in seasonsToSearch)
             {
+                var searchSpec = Get<AnimeSeasonSearchCriteria>(series, season, monitoredOnly, userInvokedSearch, interactiveSearch);
                 searchSpec.SeasonNumber = season.SeasonNumber;
 
                 var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -278,7 +278,7 @@ namespace NzbDrone.Core.IndexerSearch
                 }
 
                 // By default we do a alt title search in case indexers don't have the release properly indexed.  Services can override this behavior.
-                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SeasonSearchTitle : SearchMode.Default);
+                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SearchSeasonTitle : SearchMode.Default);
 
                 if (ignoreSceneNumbering)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -180,6 +180,7 @@ namespace NzbDrone.Core.IndexerSearch
                         Episodes = groupedEpisode.ToList(),
                         EpisodeMapping = episodeMapping,
                         SceneTitles = episodeMapping.SceneTitles,
+                        SeasonSceneTitles = episodeMapping.SeasonSceneTitles,
                         SearchMode = episodeMapping.SearchMode,
                         SeasonNumber = episodeMapping.SeasonNumber
                     };
@@ -188,6 +189,7 @@ namespace NzbDrone.Core.IndexerSearch
                     {
                         existing.Episodes.AddRange(seasonMapping.Episodes);
                         existing.SceneTitles.AddRange(seasonMapping.SceneTitles);
+                        existing.SeasonSceneTitles.AddRange(seasonMapping.SeasonSceneTitles);
                     }
                     else
                     {
@@ -200,6 +202,7 @@ namespace NzbDrone.Core.IndexerSearch
             {
                 item.Value.Episodes = item.Value.Episodes.Distinct().ToList();
                 item.Value.SceneTitles = item.Value.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+                item.Value.SeasonSceneTitles = item.Value.SeasonSceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             }
 
             return dict.Values.ToList();
@@ -218,6 +221,7 @@ namespace NzbDrone.Core.IndexerSearch
                 if (dict.TryGetValue(episodeMapping, out var existing))
                 {
                     existing.SceneTitles.AddRange(episodeMapping.SceneTitles);
+                    existing.SeasonSceneTitles.AddRange(episodeMapping.SeasonSceneTitles);
                 }
                 else
                 {
@@ -228,6 +232,7 @@ namespace NzbDrone.Core.IndexerSearch
             foreach (var item in dict)
             {
                 item.Value.SceneTitles = item.Value.SceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
+                item.Value.SeasonSceneTitles = item.Value.SeasonSceneTitles.Distinct(StringComparer.InvariantCultureIgnoreCase).ToList();
             }
 
             return dict.Values.ToList();
@@ -277,8 +282,12 @@ namespace NzbDrone.Core.IndexerSearch
                     includeGlobal = false;
                 }
 
+                var isSeasonTitle = mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle();
+
                 // By default we do a alt title search in case indexers don't have the release properly indexed.  Services can override this behavior.
-                var searchMode = sceneMapping.SearchMode ?? ((mappingSceneSeasonNumber.HasValue && series.CleanTitle != sceneMapping.SearchTerm.CleanSeriesTitle()) ? SearchMode.SearchTitle | SearchMode.SearchSeasonTitle : SearchMode.Default);
+                var searchMode = sceneMapping.SearchMode ?? (isSeasonTitle ? SearchMode.SearchTitle : SearchMode.Default);
+
+                var seasonSceneTitles = isSeasonTitle ? new List<string> { sceneMapping.SearchTerm } : new List<string>();
 
                 if (ignoreSceneNumbering)
                 {
@@ -287,6 +296,7 @@ namespace NzbDrone.Core.IndexerSearch
                         Episode = episode,
                         SearchMode = searchMode,
                         SceneTitles = new List<string> { sceneMapping.SearchTerm },
+                        SeasonSceneTitles = seasonSceneTitles,
                         SeasonNumber = releaseSeasonNumber,
                         EpisodeNumber = episode.EpisodeNumber,
                         AbsoluteEpisodeNumber = episode.AbsoluteEpisodeNumber
@@ -299,6 +309,7 @@ namespace NzbDrone.Core.IndexerSearch
                         Episode = episode,
                         SearchMode = searchMode,
                         SceneTitles = new List<string> { sceneMapping.SearchTerm },
+                        SeasonSceneTitles = seasonSceneTitles,
                         SeasonNumber = releaseSeasonNumber,
                         EpisodeNumber = episode.SceneEpisodeNumber ?? episode.EpisodeNumber,
                         AbsoluteEpisodeNumber = episode.SceneAbsoluteEpisodeNumber ?? episode.AbsoluteEpisodeNumber
@@ -313,6 +324,7 @@ namespace NzbDrone.Core.IndexerSearch
                     Episode = episode,
                     SearchMode = SearchMode.Default,
                     SceneTitles = new List<string> { series.Title },
+                    SeasonSceneTitles = new List<string>(),
                     SeasonNumber = episode.SceneSeasonNumber ?? episode.SeasonNumber,
                     EpisodeNumber = episode.SceneEpisodeNumber ?? episode.EpisodeNumber,
                     AbsoluteEpisodeNumber = episode.SceneSeasonNumber ?? episode.AbsoluteEpisodeNumber
@@ -412,12 +424,29 @@ namespace NzbDrone.Core.IndexerSearch
 
             var allEpisodesAiredOrAiringSoon = seasonEpisodes.All(ep => ep.AirDateUtc.HasValue && !ep.AirDateUtc.Value.After(DateTime.UtcNow.AddHours(24)));
 
-            var seasonsToSearch = GetSceneSeasonMappings(series, episodesToSearch);
+            var seasonMappings = GetSceneSeasonMappings(series, episodesToSearch);
+
+            var seasonsToSearch = seasonMappings
+                .GroupBy(m => m.SeasonNumber)
+                .Select(g => g.First())
+                .ToList();
 
             foreach (var season in seasonsToSearch)
             {
                 var searchSpec = Get<AnimeSeasonSearchCriteria>(series, season, monitoredOnly, userInvokedSearch, interactiveSearch);
                 searchSpec.SeasonNumber = season.SeasonNumber;
+
+                searchSpec.SceneTitles = seasonMappings
+                    .Where(m => m.SeasonNumber == season.SeasonNumber)
+                    .SelectMany(m => m.SceneTitles)
+                    .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                    .ToList();
+
+                searchSpec.SeasonSceneTitles = seasonMappings
+                    .Where(m => m.SeasonNumber == season.SeasonNumber)
+                    .SelectMany(m => m.SeasonSceneTitles)
+                    .Distinct(StringComparer.InvariantCultureIgnoreCase)
+                    .ToList();
 
                 var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
                 downloadDecisions.AddRange(decisions);

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -466,6 +466,24 @@ namespace NzbDrone.Core.Indexers.Newznab
                         "tvsearch",
                         $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
                 }
+
+                // A season title alias already identifies the season, so sending the season
+                // parameter as well excludes the pack on trackers that match it as text.
+                // Dr. Stone: Stone Wars is season 2, but the pack is not named S02.
+                //
+                // Searched in the same tier rather than as a fallback, because the season
+                // qualified search usually does return something, just not the pack. A
+                // fallback tier would only run when it returned nothing at all.
+                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+                {
+                    foreach (var queryTitle in queryTitles)
+                    {
+                        pageableRequests.Add(GetPagedRequests(MaxPages,
+                            Settings.AnimeCategories,
+                            "tvsearch",
+                            $"&q={NewsnabifyTitle(queryTitle)}"));
+                    }
+                }
             }
 
             return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -467,13 +467,8 @@ namespace NzbDrone.Core.Indexers.Newznab
                         $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
                 }
 
-                // A season title alias already identifies the season, so sending the season
-                // parameter as well excludes the pack on trackers that match it as text.
-                // Dr. Stone: Stone Wars is season 2, but the pack is not named S02.
-                //
-                // Searched in the same tier rather than as a fallback, because the season
-                // qualified search usually does return something, just not the pack. A
-                // fallback tier would only run when it returned nothing at all.
+                // A season title alias already identifies the season, so trackers that match
+                // the season parameter as text will exclude the pack it names.
                 if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
                 {
                     foreach (var queryTitle in queryTitles)

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -457,11 +457,9 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
 
-            // A season title alias already identifies the season, so the season number is not
-            // added to it. Doing so excludes the pack the alias names on trackers that match
-            // the season parameter as text.
-            if (searchCriteria.SearchMode.HasFlag(SearchMode.SeasonSearchTitle))
+            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchSeasonTitle))
             {
+                // A season title alias already identifies the season, no need to add a season number.
                 foreach (var queryTitle in queryTitles)
                 {
                     pageableRequests.Add(GetPagedRequests(MaxPages,

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -473,7 +473,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                     // A season title alias already identifies the season, no need to add a season number.
                     pageableRequests.Add(GetPagedRequests(MaxPages,
                         Settings.AnimeCategories,
-                        "tvsearch",
+                        "search",
                         $"&q={NewsnabifyTitle(queryTitle)}"));
                 }
                 else if (Settings.AnimeStandardFormatSearch)

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -450,14 +450,19 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            if (SupportsSearch && Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+            if (!SupportsSearch || searchCriteria.SeasonNumber <= 0)
+            {
+                return pageableRequests;
+            }
+
+            var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
+
+            if (Settings.AnimeStandardFormatSearch)
             {
                 AddTvIdPageableRequests(pageableRequests,
                     Settings.AnimeCategories,
                     searchCriteria,
                     $"&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}");
-
-                var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
 
                 foreach (var queryTitle in queryTitles)
                 {
@@ -466,18 +471,19 @@ namespace NzbDrone.Core.Indexers.Newznab
                         "tvsearch",
                         $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
                 }
+            }
 
-                // A season title alias already identifies the season, so trackers that match
-                // the season parameter as text will exclude the pack it names.
-                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+            // A season title alias already identifies the season, so trackers that match
+            // the season parameter as text will exclude the pack it names. This is neither
+            // an absolute nor a standard format search, so it is not gated with them.
+            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+            {
+                foreach (var queryTitle in queryTitles)
                 {
-                    foreach (var queryTitle in queryTitles)
-                    {
-                        pageableRequests.Add(GetPagedRequests(MaxPages,
-                            Settings.AnimeCategories,
-                            "tvsearch",
-                            $"&q={NewsnabifyTitle(queryTitle)}"));
-                    }
+                    pageableRequests.Add(GetPagedRequests(MaxPages,
+                        Settings.AnimeCategories,
+                        "tvsearch",
+                        $"&q={NewsnabifyTitle(queryTitle)}"));
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -456,26 +456,27 @@ namespace NzbDrone.Core.Indexers.Newznab
             }
 
             var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
+            var seasonQueryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSeasonSceneTitles : searchCriteria.CleanSeasonSceneTitles;
 
-            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchSeasonTitle))
-            {
-                // A season title alias already identifies the season, no need to add a season number.
-                foreach (var queryTitle in queryTitles)
-                {
-                    pageableRequests.Add(GetPagedRequests(MaxPages,
-                        Settings.AnimeCategories,
-                        "tvsearch",
-                        $"&q={NewsnabifyTitle(queryTitle)}"));
-                }
-            }
-            else if (Settings.AnimeStandardFormatSearch)
+            if (Settings.AnimeStandardFormatSearch)
             {
                 AddTvIdPageableRequests(pageableRequests,
                     Settings.AnimeCategories,
                     searchCriteria,
                     $"&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}");
+            }
 
-                foreach (var queryTitle in queryTitles)
+            foreach (var queryTitle in queryTitles)
+            {
+                if (seasonQueryTitles.Contains(queryTitle, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    // A season title alias already identifies the season, no need to add a season number.
+                    pageableRequests.Add(GetPagedRequests(MaxPages,
+                        Settings.AnimeCategories,
+                        "tvsearch",
+                        $"&q={NewsnabifyTitle(queryTitle)}"));
+                }
+                else if (Settings.AnimeStandardFormatSearch)
                 {
                     pageableRequests.Add(GetPagedRequests(MaxPages,
                         Settings.AnimeCategories,

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -457,7 +457,20 @@ namespace NzbDrone.Core.Indexers.Newznab
 
             var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
 
-            if (Settings.AnimeStandardFormatSearch)
+            // A season title alias already identifies the season, so the season number is not
+            // added to it. Doing so excludes the pack the alias names on trackers that match
+            // the season parameter as text.
+            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+            {
+                foreach (var queryTitle in queryTitles)
+                {
+                    pageableRequests.Add(GetPagedRequests(MaxPages,
+                        Settings.AnimeCategories,
+                        "tvsearch",
+                        $"&q={NewsnabifyTitle(queryTitle)}"));
+                }
+            }
+            else if (Settings.AnimeStandardFormatSearch)
             {
                 AddTvIdPageableRequests(pageableRequests,
                     Settings.AnimeCategories,
@@ -470,20 +483,6 @@ namespace NzbDrone.Core.Indexers.Newznab
                         Settings.AnimeCategories,
                         "tvsearch",
                         $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
-                }
-            }
-
-            // A season title alias already identifies the season, so trackers that match
-            // the season parameter as text will exclude the pack it names. This is neither
-            // an absolute nor a standard format search, so it is not gated with them.
-            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
-            {
-                foreach (var queryTitle in queryTitles)
-                {
-                    pageableRequests.Add(GetPagedRequests(MaxPages,
-                        Settings.AnimeCategories,
-                        "tvsearch",
-                        $"&q={NewsnabifyTitle(queryTitle)}"));
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -460,7 +460,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             // A season title alias already identifies the season, so the season number is not
             // added to it. Doing so excludes the pack the alias names on trackers that match
             // the season parameter as text.
-            if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+            if (searchCriteria.SearchMode.HasFlag(SearchMode.SeasonSearchTitle))
             {
                 foreach (var queryTitle in queryTitles)
                 {

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.IndexerSearch.Definitions;
 
 namespace NzbDrone.Core.Indexers.Nyaa
@@ -92,6 +93,13 @@ namespace NzbDrone.Core.Indexers.Nyaa
                 if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
                 {
                     pageableRequests.Add(GetPagedRequests($"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
+                }
+
+                // There is no season parameter, so the season number is part of the query text
+                // and excludes a pack that is named only by its season title.
+                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+                {
+                    pageableRequests.Add(GetPagedRequests(searchTitle));
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -1,7 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Http;
-using NzbDrone.Core.DataAugmentation.Scene;
 using NzbDrone.Core.IndexerSearch.Definitions;
 
 namespace NzbDrone.Core.Indexers.Nyaa
@@ -88,9 +88,11 @@ namespace NzbDrone.Core.Indexers.Nyaa
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
+            foreach (var sceneTitle in searchCriteria.SceneTitles)
             {
-                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchSeasonTitle))
+                var searchTitle = PrepareQuery(sceneTitle);
+
+                if (searchCriteria.SeasonSceneTitles.Contains(sceneTitle, StringComparer.InvariantCultureIgnoreCase))
                 {
                     // A season title alias already identifies the season, no need to add a season number.
                     pageableRequests.Add(GetPagedRequests(searchTitle));

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -90,16 +90,16 @@ namespace NzbDrone.Core.Indexers.Nyaa
 
             foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
             {
-                if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
-                {
-                    pageableRequests.Add(GetPagedRequests($"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
-                }
-
-                // There is no season parameter, so the season number is part of the query text
-                // and excludes a pack that is named only by its season title.
+                // A season title alias already identifies the season, so the season number is
+                // not added to it. There is no season parameter here, so it would become part
+                // of the query text and exclude the pack the alias names.
                 if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
                 {
                     pageableRequests.Add(GetPagedRequests(searchTitle));
+                }
+                else if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+                {
+                    pageableRequests.Add(GetPagedRequests($"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -90,11 +90,9 @@ namespace NzbDrone.Core.Indexers.Nyaa
 
             foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
             {
-                // A season title alias already identifies the season, so the season number is
-                // not added to it. There is no season parameter here, so it would become part
-                // of the query text and exclude the pack the alias names.
-                if (searchCriteria.SearchMode.HasFlag(SearchMode.SeasonSearchTitle))
+                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchSeasonTitle))
                 {
+                    // A season title alias already identifies the season, no need to add a season number.
                     pageableRequests.Add(GetPagedRequests(searchTitle));
                 }
                 else if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)

--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
@@ -93,7 +93,7 @@ namespace NzbDrone.Core.Indexers.Nyaa
                 // A season title alias already identifies the season, so the season number is
                 // not added to it. There is no season parameter here, so it would become part
                 // of the query text and exclude the pack the alias names.
-                if (searchCriteria.SearchMode.HasFlag(SearchMode.SearchTitle))
+                if (searchCriteria.SearchMode.HasFlag(SearchMode.SeasonSearchTitle))
                 {
                     pageableRequests.Add(GetPagedRequests(searchTitle));
                 }


### PR DESCRIPTION
#### Description

When searching for anime, sonarr will add the season parameter causing some results to be blank.
This will search the season aliases without that parameter, meaning more results when using some trackers that use string only searching and helps avoid no results in some senarios such as searching for Dr Stone S2 with the season parameter will search for Dr Stone S2 S02 which returns no results.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
