### PR TITLE
New: Preserve original episode file date during upgrades

### DIFF
--- a/frontend/src/Settings/MediaManagement/MediaManagement.tsx
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.tsx
@@ -106,6 +106,12 @@ const fileDateOptions: EnhancedSelectInputValue<string>[] = [
       return translate('UtcAirDate');
     },
   },
+  {
+    key: 'preserveOriginal',
+    get value() {
+      return translate('PreserveOriginal');
+    },
+  },
 ];
 
 const seasonPackUpgradeOptions: EnhancedSelectInputValue<string>[] = [

--- a/src/NzbDrone.Core.Test/MediaFiles/UpdateEpisodeFileServiceTests/ChangeFileDateForFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpdateEpisodeFileServiceTests/ChangeFileDateForFileFixture.cs
@@ -114,5 +114,57 @@ namespace NzbDrone.Core.Test.MediaFiles.UpdateEpisodeFileServiceTests
             var actualWriteTime = Mocker.GetMock<IDiskProvider>().Object.FileGetLastWrite(_episodeFile.Path).ToLocalTime();
             actualWriteTime.Should().Be(_episodes[0].AirDateUtc.Value.ToLocalTime().WithTicksFrom(previousWrite));
         }
+
+        [Test]
+        public void should_preserve_original_file_date_when_mode_is_preserve_original()
+        {
+            var originalFileDate = new DateTime(2020, 01, 01, 12, 0, 0, 512, 512, DateTimeKind.Utc);
+            var previousWrite = new DateTime(_lastWrite.Ticks, _lastWrite.Kind);
+
+            Mocker.GetMock<IConfigService>()
+                .Setup(x => x.FileDate)
+                .Returns(FileDateType.PreserveOriginal);
+
+            Subject.ChangeFileDateForFile(_episodeFile, _series, _episodes, originalFileDate);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(_episodeFile.Path, It.IsAny<DateTime>()), Times.Once());
+
+            var actualWriteTime = Mocker.GetMock<IDiskProvider>().Object.FileGetLastWrite(_episodeFile.Path).ToLocalTime();
+            actualWriteTime.Should().Be(originalFileDate.ToLocalTime().WithTicksFrom(previousWrite));
+        }
+
+        [Test]
+        public void should_return_false_when_preserve_original_mode_but_no_preserved_date()
+        {
+            Mocker.GetMock<IConfigService>()
+                .Setup(x => x.FileDate)
+                .Returns(FileDateType.PreserveOriginal);
+
+            var result = Subject.ChangeFileDateForFile(_episodeFile, _series, _episodes, preservedFileDate: null);
+
+            result.Should().BeFalse();
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(_episodeFile.Path, It.IsAny<DateTime>()), Times.Never());
+        }
+
+        [Test]
+        public void should_not_change_behavior_for_existing_modes()
+        {
+            var previousWrite = new DateTime(_lastWrite.Ticks, _lastWrite.Kind);
+
+            // Test LocalAirDate mode
+            Mocker.GetMock<IConfigService>()
+                .Setup(x => x.FileDate)
+                .Returns(FileDateType.LocalAirDate);
+
+            Subject.ChangeFileDateForFile(_episodeFile, _series, _episodes, preservedFileDate: null);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Verify(v => v.FileSetLastWriteTime(_episodeFile.Path, It.IsAny<DateTime>()), Times.Once());
+
+            var actualWriteTime = Mocker.GetMock<IDiskProvider>().Object.FileGetLastWrite(_episodeFile.Path).ToLocalTime();
+            actualWriteTime.Should().Be(_episodes[0].AirDateUtc.Value.ToLocalTime().WithTicksFrom(previousWrite));
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -209,5 +209,22 @@ namespace NzbDrone.Core.Test.MediaFiles
 
             Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(_localEpisode.Episodes.Single().EpisodeFile, It.IsAny<DeleteMediaFileReason>()), Times.Never());
         }
+
+        [Test]
+        public void should_capture_original_file_date_before_deletion()
+        {
+            GivenSingleEpisodeWithSingleEpisodeFile();
+
+            var originalDate = System.DateTime.UtcNow.AddDays(-5);
+            var episodeFilePath = System.IO.Path.Combine(_localEpisode.Series.Path, _localEpisode.Episodes.First().EpisodeFile.RelativePath);
+
+            Mocker.GetMock<IDiskProvider>()
+                .Setup(x => x.FileGetLastWrite(episodeFilePath))
+                .Returns(originalDate);
+
+            Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode);
+
+            _localEpisode.PreservedFileDate.Should().Be(originalDate);
+        }
     }
 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1701,6 +1701,7 @@
   "PrefixedRange": "Prefixed Range",
   "Premiere": "Premiere",
   "Presets": "Presets",
+  "PreserveOriginal": "Preserve Original File Date",
   "PreviewRename": "Preview Rename",
   "PreviewRenameSeason": "Preview Rename for this season",
   "PreviousAiring": "Previous Airing",

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.MediaFiles
                 _diskTransferService.TransferFile(episodeFilePath, destinationFilePath, mode);
             }
 
-            _updateEpisodeFileService.ChangeFileDateForFile(episodeFile, series, episodes);
+            _updateEpisodeFileService.ChangeFileDateForFile(episodeFile, series, episodes, localEpisode?.PreservedFileDate);
 
             try
             {

--- a/src/NzbDrone.Core/MediaFiles/FileDateType.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileDateType.cs
@@ -4,6 +4,7 @@
     {
         None = 0,
         LocalAirDate = 1,
-        UtcAirDate = 2
+        UtcAirDate = 2,
+        PreserveOriginal = 3
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpdateEpisodeFileService.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.MediaFiles
 {
     public interface IUpdateEpisodeFileService
     {
-        void ChangeFileDateForFile(EpisodeFile episodeFile, Series series, List<Episode> episodes);
+        void ChangeFileDateForFile(EpisodeFile episodeFile, Series series, List<Episode> episodes, DateTime? preservedFileDate = null);
     }
 
     public class UpdateEpisodeFileService : IUpdateEpisodeFileService,
@@ -38,12 +38,12 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        public void ChangeFileDateForFile(EpisodeFile episodeFile, Series series, List<Episode> episodes)
+        public void ChangeFileDateForFile(EpisodeFile episodeFile, Series series, List<Episode> episodes, DateTime? preservedFileDate = null)
         {
-            ChangeFileDate(episodeFile, series, episodes);
+            ChangeFileDate(episodeFile, series, episodes, preservedFileDate);
         }
 
-        private bool ChangeFileDate(EpisodeFile episodeFile, Series series, List<Episode> episodes)
+        private bool ChangeFileDate(EpisodeFile episodeFile, Series series, List<Episode> episodes, DateTime? preservedFileDate = null)
         {
             var episodeFilePath = Path.Combine(series.Path, episodeFile.RelativePath);
             var airDateUtc = episodes.First().AirDateUtc;
@@ -63,6 +63,10 @@ namespace NzbDrone.Core.MediaFiles
                     ChangeFileDateToLocalDate(
                         episodeFilePath,
                         DateTime.SpecifyKind(airDateUtc.Value, DateTimeKind.Local)),
+                        
+                FileDateType.PreserveOriginal when preservedFileDate.HasValue =>
+                    ChangeFileDateToLocalDate(episodeFilePath, preservedFileDate.Value.ToLocalTime()),
+
 
                 _ => false,
             };

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using NLog;
@@ -61,6 +62,17 @@ namespace NzbDrone.Core.MediaFiles
 
                 if (_diskProvider.FileExists(episodeFilePath))
                 {
+                    // Capture original file date before deletion for potential preservation
+                    try
+                    {
+                        localEpisode.PreservedFileDate = _diskProvider.FileGetLastWrite(episodeFilePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug(ex, "Failed to read file date for preservation: {0}", episodeFilePath);
+                        localEpisode.PreservedFileDate = null;
+                    }
+
                     _logger.Debug("Removing existing episode file: {0}", file);
                     recycleBinPath = _recycleBinProvider.DeleteFile(episodeFilePath, subfolder);
                 }

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Parser.Model
         public Series Series { get; set; }
         public List<Episode> Episodes { get; set; } = [];
         public List<DeletedEpisodeFile> OldFiles { get; set; }
+        public DateTime? PreservedFileDate { get; set; }
         public QualityModel Quality { get; set; }
         public List<Language> Languages { get; set; } = [];
         public IndexerFlags IndexerFlags { get; set; }


### PR DESCRIPTION
#### Description

This PR adds a new media management behavior that preserves the original file modification date when an episode file is upgraded.
This can make external players detect the movie as recently added, even if it was already in the library.

#### What changed :

- Added a new file date mode: PreserveOriginal.
- Added UI option for the new mode in media management settings.
- Added localization entry for the new setting label.
- Captured the existing episode file last write date before deleting/replacing it.
- Propagated the preserved date through the file transfer/update flow.
- Updated file date update logic to support the new mode while keeping existing modes intact.
- Added tests covering:
- preserve original mode applies preserved timestamp
- preserve mode with missing timestamp does not modify file date
- existing modes keep their current behavior
- upgrade flow captures original timestamp before deletion


#### Screenshots for UI Changes

<img width="728" height="145" alt="Capture d’écran 2026-07-31 à 12 58 28" src="https://github.com/user-attachments/assets/aff9eade-2586-48c7-bc5b-aff80ab8e98c" />

#### Database Migration

No
#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review