### PR TITLE
Fixed: Announce sidebar messages to screen readers

### DIFF
--- a/frontend/src/Components/Page/Sidebar/Messages/Message.tsx
+++ b/frontend/src/Components/Page/Sidebar/Messages/Message.tsx
@@ -15,6 +15,7 @@ interface MessageProps {
 
 function Message({ id, hideAfter, name, message, type }: MessageProps) {
   const dismissTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const isError = type === 'error';
 
   const icon: IconName = useMemo(() => {
     switch (name) {
@@ -60,9 +61,13 @@ function Message({ id, hideAfter, name, message, type }: MessageProps) {
   }, [id, hideAfter, message, type]);
 
   return (
-    <div className={classNames(styles.message, styles[type])}>
+    <div
+      className={classNames(styles.message, styles[type])}
+      role={isError ? 'alert' : 'status'}
+      aria-atomic={true}
+    >
       <div className={styles.iconContainer}>
-        <Icon name={icon} title={name} />
+        <Icon name={icon} aria-hidden={true} />
       </div>
 
       <div className={styles.text}>{message}</div>


### PR DESCRIPTION
#### Description

Sonarr displays command results and other application messages in the sidebar, but these updates are not currently announced by screen readers unless the user finds them manually.

This updates the shared sidebar message component so errors are exposed as alerts, while informational, success, and warning messages are exposed as status updates. The complete message is announced when it appears, and the decorative icon is hidden from assistive technology so internal command names are not read alongside the useful message.

This applies anywhere Sonarr uses the shared sidebar message system, including command completion and failure notifications.

ESLint, the frontend Webpack build, and `git diff --check` pass.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
