### PR TITLE
Use same request builder for all Emby/Jellyfin requests

### DIFF
--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -22,9 +22,7 @@ namespace NzbDrone.Core.Notifications.Emby
         public void TestConnection(MediaBrowserSettings settings)
         {
             var path = "/System/Configuration";
-            var request = BuildRequest(path, settings);
-            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
-            request.Headers.Add("Authorization", $"MediaBrowser Token=\"{settings.ApiKey}\"");
+            var request = BuildRequest(path, settings).Build();
 
             var response = _httpClient.Get(request);
             _logger.Trace("Response: {0}", response.Content);
@@ -33,7 +31,7 @@ namespace NzbDrone.Core.Notifications.Emby
         public void Notify(MediaBrowserSettings settings, string title, string message)
         {
             var path = "/Notifications/Admin";
-            var request = BuildRequest(path, settings);
+            var request = BuildRequest(path, settings).Build();
             request.Headers.ContentType = "application/json";
             request.LogHttpError = false;
 
@@ -44,17 +42,14 @@ namespace NzbDrone.Core.Notifications.Emby
                                ImageUrl = "https://raw.github.com/Sonarr/Sonarr/develop/Logo/64.png"
                            }.ToJson());
 
-            ProcessRequest(request, settings);
+            ProcessRequest(request);
         }
 
         public HashSet<string> GetPaths(MediaBrowserSettings settings, Series series)
         {
             var path = "/Items";
-            var url = GetUrl(settings);
 
-            // NameStartsWith uses the sort title, which is not the series title
-            var request = new HttpRequestBuilder(url)
-                .Resource(path)
+            var request = BuildRequest(path, settings)
                 .AddQueryParam("recursive", "true")
                 .AddQueryParam("includeItemTypes", "Series")
                 .AddQueryParam("fields", "Path,ProviderIds")
@@ -63,7 +58,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
             try
             {
-                var paths = ProcessGetRequest<MediaBrowserItems>(request, settings).Items.GroupBy(item =>
+                var paths = ProcessGetRequest<MediaBrowserItems>(request).Items.GroupBy(item =>
                 {
                     if (item is { ProviderIds.Tvdb: int tvdbid } && tvdbid != 0 && tvdbid == series.TvdbId)
                     {
@@ -121,7 +116,7 @@ namespace NzbDrone.Core.Notifications.Emby
         public void Update(MediaBrowserSettings settings, string seriesPath, string updateType)
         {
             var path = "/Library/Media/Updated";
-            var request = BuildRequest(path, settings);
+            var request = BuildRequest(path, settings).Build();
             request.Headers.ContentType = "application/json";
 
             request.SetContent(new
@@ -136,14 +131,12 @@ namespace NzbDrone.Core.Notifications.Emby
                 }
             }.ToJson());
 
-            ProcessRequest(request, settings);
+            ProcessRequest(request);
         }
 
-        private T ProcessGetRequest<T>(HttpRequest request, MediaBrowserSettings settings)
+        private T ProcessGetRequest<T>(HttpRequest request)
             where T : new()
         {
-            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
-
             var response = _httpClient.Get<T>(request);
             _logger.Trace("Response: {0}", response.Content);
 
@@ -152,10 +145,8 @@ namespace NzbDrone.Core.Notifications.Emby
             return response.Resource;
         }
 
-        private string ProcessRequest(HttpRequest request, MediaBrowserSettings settings)
+        private string ProcessRequest(HttpRequest request)
         {
-            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
-
             var response = _httpClient.Post(request);
             _logger.Trace("Response: {0}", response.Content);
 
@@ -170,11 +161,15 @@ namespace NzbDrone.Core.Notifications.Emby
             return $@"{scheme}://{settings.Address}";
         }
 
-        private HttpRequest BuildRequest(string path, MediaBrowserSettings settings)
+        private HttpRequestBuilder BuildRequest(string path, MediaBrowserSettings settings)
         {
             var url = GetUrl(settings);
+            var request = new HttpRequestBuilder(url).Resource(path);
 
-            return new HttpRequestBuilder(url).Resource(path).Build();
+            request.Headers.Add("X-MediaBrowser-Token", settings.ApiKey);
+            request.Headers.Add("Authorization", $"MediaBrowser Token=\"{settings.ApiKey}\"");
+
+            return request;
         }
 
         private void CheckForError(HttpResponse response)


### PR DESCRIPTION
#### Description

Uses the same request builder for all requests and applies authentication in a single place instead of multiple.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #8842
