### PR TITLE
Bump Mono.Unix to 7.1.0

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -122,8 +122,8 @@ runs:
 
             echo "Adding Sonarr.Mono to UpdatePackage"
             cp $folder/Sonarr.Mono.* $folder/Sonarr.Update
-            cp $folder/Mono.Posix.NETStandard.* $folder/Sonarr.Update
-            cp $folder/libMonoPosixHelper.* $folder/Sonarr.Update
+            cp $folder/Openur.Mono.Unix.* $folder/Sonarr.Update
+            cp $folder/libMono.Unix.* $folder/Sonarr.Update
             ;;
           win)
             folder=_artifacts/$runtime/$framework/Sonarr
@@ -138,8 +138,8 @@ runs:
 
             echo "Removing Sonarr.Mono"
             rm -f $folder/Sonarr.Mono.*
-            rm -f $folder/Mono.Posix.NETStandard.*
-            rm -f $folder/libMonoPosixHelper.*
+            rm -f $folder/Openur.Mono.Unix.*
+            rm -f $folder/libMono.Unix.*
 
             echo "Adding Sonarr.Windows to UpdatePackage"
             cp $folder/Sonarr.Windows.* $folder/Sonarr.Update
@@ -164,8 +164,8 @@ runs:
 
             echo "Adding Sonarr.Mono to UpdatePackage"
             cp $folder/Sonarr.Mono.* $folder/Sonarr.Update
-            cp $folder/Mono.Posix.NETStandard.* $folder/Sonarr.Update
-            cp $folder/libMonoPosixHelper.* $folder/Sonarr.Update
+            cp $folder/Openur.Mono.Unix.* $folder/Sonarr.Update
+            cp $folder/libMono.Unix.* $folder/Sonarr.Update
             ;;
         esac
 

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="SourceGear.sqlite3" Version="3.53.3" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.3" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj
@@ -2,13 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
-  <!--
-       The netstandard version here doesn't work in net framework
-       See https://github.com/xamarin/XamarinComponents/issues/282
-  -->
-  <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Sonarr.Common.Test.csproj" />
     <ProjectReference Include="..\NzbDrone.Mono\Sonarr.Mono.csproj" />

--- a/src/NzbDrone.Mono/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Mono/Disk/DiskProvider.cs
@@ -8,15 +8,13 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
-using NzbDrone.Common.Extensions;
 
 namespace NzbDrone.Mono.Disk
 {
     public class DiskProvider : DiskProviderBase
     {
-        // Mono supports sending -1 for a uint to indicate that the owner or group should not be set
-        // `unchecked((uint)-1)` and `uint.MaxValue` are the same thing.
-        private const uint UNCHANGED_ID = uint.MaxValue;
+        // Mono supports sending -1 for an int to indicate that the owner or group should not be set
+        private const int UnchangedId = -1;
 
         private readonly Logger _logger;
         private readonly IProcMountProvider _procMountProvider;
@@ -105,7 +103,7 @@ namespace NzbDrone.Mono.Disk
 
             var groupId = GetGroupId(group);
 
-            if (Syscall.chown(path, unchecked((uint)-1), groupId) < 0)
+            if (Syscall.chown(path, -1, groupId) < 0)
             {
                 var error = Stdlib.GetLastError();
 
@@ -321,8 +319,8 @@ namespace NzbDrone.Mono.Disk
             // Mono 6.x till 6.10 doesn't properly try use rename first.
             if (move)
             {
-                if (Syscall.lstat(source, out var sourcestat) == 0 &&
-                    Syscall.lstat(destination, out var deststat) != 0 &&
+                if (Syscall.lstat(source, out _) == 0 &&
+                    Syscall.lstat(destination, out _) != 0 &&
                     Syscall.rename(source, destination) == 0)
                 {
                     _logger.Trace("Moved '{0}' -> '{1}' using Syscall.rename", source, destination);
@@ -449,14 +447,14 @@ namespace NzbDrone.Mono.Disk
             }
         }
 
-        private uint GetUserId(string user)
+        private static int GetUserId(string user)
         {
-            if (user.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(user))
             {
-                return UNCHANGED_ID;
+                return UnchangedId;
             }
 
-            if (uint.TryParse(user, out var userId))
+            if (int.TryParse(user, out var userId))
             {
                 return userId;
             }
@@ -468,17 +466,17 @@ namespace NzbDrone.Mono.Disk
                 throw new LinuxPermissionsException("Unknown user: {0}", user);
             }
 
-            return u.pw_uid;
+            return checked((int)u.pw_uid);
         }
 
-        private uint GetGroupId(string group)
+        private static int GetGroupId(string group)
         {
-            if (group.IsNullOrWhiteSpace())
+            if (string.IsNullOrWhiteSpace(group))
             {
-                return UNCHANGED_ID;
+                return UnchangedId;
             }
 
-            if (uint.TryParse(group, out var groupId))
+            if (int.TryParse(group, out var groupId))
             {
                 return groupId;
             }
@@ -490,7 +488,7 @@ namespace NzbDrone.Mono.Disk
                 throw new LinuxPermissionsException("Unknown group: {0}", group);
             }
 
-            return g.gr_gid;
+            return checked((int)g.gr_gid);
         }
     }
 }

--- a/src/NzbDrone.Mono/Sonarr.Mono.csproj
+++ b/src/NzbDrone.Mono/Sonarr.Mono.csproj
@@ -3,12 +3,8 @@
     <TargetFrameworks>net10.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  <!--
-       The netstandard version here doesn't work in net framework
-       See https://github.com/xamarin/XamarinComponents/issues/282
-  -->
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
+    <PackageReference Include="Openur.Mono.Unix" Version="7.1.0.256" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Mono/Sonarr.Mono.csproj
+++ b/src/NzbDrone.Mono/Sonarr.Mono.csproj
@@ -9,7 +9,7 @@
   -->
   <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Sonarr.Common.csproj" />

--- a/src/NzbDrone.Windows/Sonarr.Windows.csproj
+++ b/src/NzbDrone.Windows/Sonarr.Windows.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Sonarr.Common.csproj" />


### PR DESCRIPTION
#### Description

Bumping the old mono library released in [2019](https://github.com/mono/mono/releases/tag/mono-5.20.1.34) to the replacement [mono.posix](https://github.com/mono/mono.posix).

Downgraded System.IO.FileSystem.AccessControl to 5.0.0

```
   [net10.0]:
   Top-level Package                         Requested                 Resolved                  Reason(s)   Alternative
   > System.IO.FileSystem.AccessControl      6.0.0-preview.5.21301.5   6.0.0-preview.5.21301.5   Legacy      System.IO.FileSystem.AccessControl >= 5.0.0
```