### PR TITLE
New: Treat stalled torrents as failed after a configurable timeout

### DIFF
--- a/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
+++ b/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
@@ -124,6 +124,22 @@ function DownloadClientOptions({
                 />
               </FormGroup>
             ) : null}
+
+            <FormGroup
+              advancedSettings={showAdvancedSettings}
+              isAdvanced={true}
+              size={sizes.MEDIUM}
+            >
+              <FormLabel>{translate('StalledTorrentTimeout')}</FormLabel>
+
+              <FormInputGroup
+                type={inputTypes.NUMBER}
+                name="stalledTorrentTimeout"
+                helpText={translate('StalledTorrentTimeoutHelpText')}
+                onChange={handleInputChange}
+                {...settings.stalledTorrentTimeout}
+              />
+            </FormGroup>
           </Form>
         </FieldSet>
       ) : null}

--- a/frontend/src/Settings/DownloadClients/Options/useDownloadClientSettings.ts
+++ b/frontend/src/Settings/DownloadClients/Options/useDownloadClientSettings.ts
@@ -5,6 +5,7 @@ export interface DownloadClientSettingsModel {
   enableCompletedDownloadHandling: boolean;
   autoRedownloadFailed: boolean;
   autoRedownloadFailedFromInteractiveSearch: boolean;
+  stalledTorrentTimeout: number;
 }
 
 const PATH = '/settings/downloadclient';

--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Cache;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.History;
 using NzbDrone.Core.Download.TrackedDownloads;
@@ -528,6 +530,54 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             trackedDownload.RemoteEpisode.Episodes.First().Id.Should().Be(4);
             trackedDownload.RemoteEpisode.ParsedEpisodeInfo.SeasonNumber.Should().Be(1);
             trackedDownload.RemoteEpisode.MappedSeasonNumber.Should().Be(1);
+        }
+
+        [Test]
+        public void should_only_reset_last_progress_date_when_download_progresses()
+        {
+            Mocker.GetMock<ICacheManager>()
+                  .Setup(s => s.GetCache<TrackedDownload>(It.IsAny<Type>()))
+                  .Returns(new Cached<TrackedDownload>());
+
+            GivenDownloadHistory();
+
+            var client = new DownloadClientDefinition()
+            {
+                Id = 1,
+                Protocol = DownloadProtocol.Torrent
+            };
+
+            DownloadClientItem BuildItem(long remainingSize)
+            {
+                return new DownloadClientItem()
+                {
+                    Title = "The Series Title!: Season 01",
+                    DownloadId = "35238",
+                    Status = DownloadItemStatus.Downloading,
+                    RemainingSize = remainingSize,
+                    DownloadClientInfo = new DownloadClientItemClientInfo
+                    {
+                        Protocol = client.Protocol,
+                        Id = client.Id,
+                        Name = client.Name
+                    }
+                };
+            }
+
+            var trackedDownload = Subject.TrackDownload(client, BuildItem(100));
+
+            trackedDownload.LastProgressDate.Should().HaveValue();
+
+            var lastProgressDate = DateTime.UtcNow.AddHours(-1);
+            trackedDownload.LastProgressDate = lastProgressDate;
+
+            var stalledDownload = Subject.TrackDownload(client, BuildItem(100));
+
+            stalledDownload.LastProgressDate.Should().Be(lastProgressDate);
+
+            var progressedDownload = Subject.TrackDownload(client, BuildItem(50));
+
+            progressedDownload.LastProgressDate.Should().NotBe(lastProgressDate);
         }
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -157,6 +157,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("AutoRedownloadFailedFromInteractiveSearch", value); }
         }
 
+        public int StalledTorrentTimeout
+        {
+            get { return GetValueInt("StalledTorrentTimeout", 0); }
+
+            set { SetValue("StalledTorrentTimeout", value); }
+        }
+
         public bool CreateEmptySeriesFolders
         {
             get { return GetValueBoolean("CreateEmptySeriesFolders", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Configuration
         bool EnableCompletedDownloadHandling { get; set; }
         bool AutoRedownloadFailed { get; set; }
         bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        int StalledTorrentTimeout { get; set; }
 
         // Media Management
         bool AutoUnmonitorPreviouslyDownloadedEpisodes { get; set; }

--- a/src/NzbDrone.Core/Download/FailedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/FailedDownloadService.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Parser.Model;
 
@@ -22,13 +24,16 @@ namespace NzbDrone.Core.Download
     {
         private readonly IHistoryService _historyService;
         private readonly IEventAggregator _eventAggregator;
+        private readonly IConfigService _configService;
 
         public FailedDownloadService(IHistoryService historyService,
                                      ITrackedDownloadService trackedDownloadService,
-                                     IEventAggregator eventAggregator)
+                                     IEventAggregator eventAggregator,
+                                     IConfigService configService)
         {
             _historyService = historyService;
             _eventAggregator = eventAggregator;
+            _configService = configService;
         }
 
         public void MarkAsFailed(int historyId, string message, string source = null, bool skipRedownload = false)
@@ -103,7 +108,11 @@ namespace NzbDrone.Core.Download
                 }
 
                 trackedDownload.State = TrackedDownloadState.FailedPending;
+
+                return;
             }
+
+            CheckStalled(trackedDownload);
         }
 
         public void ProcessFailed(TrackedDownload trackedDownload)
@@ -126,6 +135,10 @@ namespace NzbDrone.Core.Download
             {
                 failure = "Encrypted download detected";
             }
+            else if (trackedDownload.IsStalled)
+            {
+                failure = "Download stalled with no progress";
+            }
             else if (trackedDownload.DownloadItem.Status == DownloadItemStatus.Failed && trackedDownload.DownloadItem.Message.IsNotNullOrWhiteSpace())
             {
                 failure = trackedDownload.DownloadItem.Message;
@@ -133,6 +146,41 @@ namespace NzbDrone.Core.Download
 
             trackedDownload.State = TrackedDownloadState.Failed;
             PublishDownloadFailedEvent(grabbedItems.First(), GetEpisodeIds(grabbedItems), failure, $"{BuildInfo.AppName} Failed Download Handling", trackedDownload);
+        }
+
+        private void CheckStalled(TrackedDownload trackedDownload)
+        {
+            var stalledTorrentTimeout = _configService.StalledTorrentTimeout;
+
+            if (stalledTorrentTimeout == 0 || trackedDownload.Protocol != DownloadProtocol.Torrent)
+            {
+                return;
+            }
+
+            // Paused and queued downloads aren't making progress by design, only consider
+            // downloads the client is actively trying to get data for.
+            if (trackedDownload.DownloadItem.Status != DownloadItemStatus.Downloading &&
+                trackedDownload.DownloadItem.Status != DownloadItemStatus.Warning)
+            {
+                return;
+            }
+
+            if (!trackedDownload.LastProgressDate.HasValue ||
+                trackedDownload.LastProgressDate.Value.AddMinutes(stalledTorrentTimeout) > DateTime.UtcNow)
+            {
+                return;
+            }
+
+            var grabbedItems = GetGrabbedHistory(trackedDownload.DownloadItem.DownloadId);
+
+            if (grabbedItems.Empty())
+            {
+                trackedDownload.Warn("Download is stalled and wasn't grabbed by Sonarr, skipping automatic download handling");
+                return;
+            }
+
+            trackedDownload.IsStalled = true;
+            trackedDownload.State = TrackedDownloadState.FailedPending;
         }
 
         private void PublishDownloadFailedEvent(EpisodeHistory historyItem, List<int> episodeIds, string message, string source, TrackedDownload trackedDownload = null, bool skipRedownload = false)

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownload.cs
@@ -18,6 +18,8 @@ namespace NzbDrone.Core.Download.TrackedDownloads
         public DateTime? Added { get; set; }
         public bool IsTrackable { get; set; }
         public bool HasNotifiedManualInteractionRequired { get; set; }
+        public DateTime? LastProgressDate { get; set; }
+        public bool IsStalled { get; set; }
 
         public TrackedDownload()
         {

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -117,6 +117,17 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 HasNotifiedManualInteractionRequired = existingItem?.HasNotifiedManualInteractionRequired ?? false
             };
 
+            if (existingItem != null &&
+                existingItem.DownloadItem.Status == downloadItem.Status &&
+                existingItem.DownloadItem.RemainingSize == downloadItem.RemainingSize)
+            {
+                trackedDownload.LastProgressDate = existingItem.LastProgressDate;
+            }
+            else
+            {
+                trackedDownload.LastProgressDate = DateTime.UtcNow;
+            }
+
             try
             {
                 var downloadHistory = _downloadHistoryService.GetLatestDownloadHistoryItem(downloadItem.DownloadId);

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -2096,6 +2096,8 @@
   "SslKeyPath": "SSL Key Path",
   "SslKeyPathHelpText": "Path to key file used with pem file",
   "SslPort": "SSL Port",
+  "StalledTorrentTimeout": "Stalled Torrent Timeout",
+  "StalledTorrentTimeoutHelpText": "How long a torrent can make no progress before it is treated as failed and blocklisted, in minutes. 0 to disable. The timer is held in memory, so it restarts when Sonarr restarts.",
   "Standard": "Standard",
   "StandardEpisodeFormat": "Standard Episode Format",
   "StandardEpisodeTypeDescription": "Episodes released with SxxEyy pattern",

--- a/src/Sonarr.Api.V3/Config/DownloadClientConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/DownloadClientConfigResource.cs
@@ -10,6 +10,7 @@ namespace Sonarr.Api.V3.Config
         public bool EnableCompletedDownloadHandling { get; set; }
         public bool AutoRedownloadFailed { get; set; }
         public bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        public int StalledTorrentTimeout { get; set; }
     }
 
     public static class DownloadClientConfigResourceMapper
@@ -22,7 +23,8 @@ namespace Sonarr.Api.V3.Config
 
                 EnableCompletedDownloadHandling = model.EnableCompletedDownloadHandling,
                 AutoRedownloadFailed = model.AutoRedownloadFailed,
-                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch
+                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch,
+                StalledTorrentTimeout = model.StalledTorrentTimeout
             };
         }
     }


### PR DESCRIPTION
IMPORTANT -->

This text was generated by an AI so it is better written than by me, I could rewrite things, but it would just make it worse... but all facts and tests and real life usage are mine.

Also it would take me a lot more time than an AI to write all this, and in the end... I use it and it's helping me a lot to get rid of the 'dead' torrents... So why not share ?

Please consider reviewing this, and throw it away if this seems to you not 'enterprise-grade' enough (which your software is)... Or help me get it to your standard ! Any comment and suggestions are welcome and will be processed !

Here are some facts why I needed this, and now this is solved -->
- 36 of 37 incomplete torrents with availability < 1.0 — no complete copy ever = they could never complete !
- Because of them, and my config of qBit etc... they were holding all active slots... so no room for real torrents !
- one was spotted at 94.1% for 38 days !

--------



#### Database Migration



NO



#### Description

This is not 'mine' it is a port from Radarr/Radarr#11555 by @Hzoid. The commit is authored to them.



WHAT IT ADDS
Optional "Stalled Torrent Timeout" (advanced, under Failed Download Handling, default 0 = off).
When a torrent the client is actively downloading has made no progress for longer than the timeout, it is treated as failed through the existing pipeline: blocklisted, with removal and redownload following the current Failed Download Handling settings. Progress is tracked from a change in remaining size or client status, on the existing once-a-minute tracked-download refresh.



SCOPE
- torrent protocol only
- only downloads grabbed by Sonarr
- paused and queued torrents are not counted
- disabled by default



DIFFERENCES FROM THE RADARR PR
- warn message says Sonarr
- `return;` added after the existing encrypted/failed branch in Check()
- help text notes the timer is held in memory and restarts with Sonarr
- settings control ported to the v5 TypeScript UI (DownloadClientOptions.tsx, useDownloadClientSettings.ts); the .js file the Radarr PR edits does not exist on v5-develop



VALIDATION on v5-develop (.NET 10)
- dotnet build src/Sonarr.sln -- 0 warnings, 0 errors
- Sonarr.Core.Test, TrackedDownloadService fixtures -- 9/9
- eslint -- clean on both frontend files
- mutation test: reverting ONLY TrackedDownloadService.cs still builds 0 warnings / 0 errors, and the new test then fails with "Expected nullable date and time to have a value, but found <null>"; restored -> 9/9 again. The test is therefore not tautological.



UPSTREAM
Radarr/Radarr#11555 has open review feedback (setting validation; gating the stall check on download progress) that is not reflected here. Draft until that settles.



#### Issues Fixed or Closed by this PR



* Closes #958

