### PR TITLE
Fixed: Expose pages as named main landmarks

### DIFF
--- a/frontend/src/Components/NotFound.tsx
+++ b/frontend/src/Components/NotFound.tsx
@@ -11,7 +11,7 @@ function NotFound(props: NotFoundProps) {
   const { message = translate('DefaultNotFoundMessage') } = props;
 
   return (
-    <PageContent title="MIA">
+    <PageContent title={translate('PageNotFound')}>
       <div className={styles.container}>
         <div className={styles.message}>{message}</div>
 

--- a/frontend/src/Components/Page/PageContent.tsx
+++ b/frontend/src/Components/Page/PageContent.tsx
@@ -6,7 +6,7 @@ import styles from './PageContent.css';
 
 interface PageContentProps {
   className?: string;
-  title?: string;
+  title: string;
   children: React.ReactNode;
 }
 
@@ -24,7 +24,9 @@ function PageContent({
             : window.Sonarr.instanceName
         }
       >
-        <div className={className}>{children}</div>
+        <main className={className} aria-label={title}>
+          {children}
+        </main>
       </DocumentTitle>
     </ErrorBoundary>
   );

--- a/frontend/src/Series/Index/SeriesIndex.tsx
+++ b/frontend/src/Series/Index/SeriesIndex.tsx
@@ -191,7 +191,7 @@ function SeriesIndex() {
   return (
     <QueueDetailsProvider all={true}>
       <SelectProvider items={data}>
-        <PageContent>
+        <PageContent title={translate('Series')}>
           <PageToolbar>
             <PageToolbarSection>
               <SeriesIndexRefreshSeriesButton

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1665,6 +1665,7 @@
   "OverviewOptions": "Overview Options",
   "PackageVersion": "Package Version",
   "PackageVersionInfo": "{packageVersion} by {packageAuthor}",
+  "PageNotFound": "Page not found",
   "PagerGoToFirstPage": "Go to first page",
   "PagerGoToLastPage": "Go to last page",
   "PagerGoToNextPage": "Go to next page",


### PR DESCRIPTION
#### Description

Sonarr pages currently use a div for the main page content, so screen reader landmark navigation does not identify the page.

This changes the shared PageContent component to use a named main landmark. It also adds the missing Series page title and replaces the Not Found page's MIA title with a localized Page not found label.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review