### PR TITLE
Fixed: Identify Queue download progress to screen readers

### DIFF
--- a/frontend/src/Activity/Queue/QueueRow.tsx
+++ b/frontend/src/Activity/Queue/QueueRow.tsx
@@ -375,6 +375,7 @@ function QueueRow(props: QueueRowProps) {
             <TableRowCell key={name} className={styles.progress}>
               {!!progress && (
                 <ProgressBar
+                  ariaLabel={translate('DownloadProgressForTitle', { title })}
                   progress={progress}
                   title={`${progress.toFixed(1)}%`}
                 />

--- a/frontend/src/Components/ProgressBar.tsx
+++ b/frontend/src/Components/ProgressBar.tsx
@@ -7,6 +7,7 @@ import translate from 'Utilities/String/translate';
 import styles from './ProgressBar.css';
 
 interface ProgressBarProps {
+  ariaLabel?: string;
   className?: string;
   containerClassName?: string;
   title?: string;
@@ -20,6 +21,7 @@ interface ProgressBarProps {
 }
 
 function ProgressBar({
+  ariaLabel,
   className = styles.progressBar,
   containerClassName = styles.container,
   title,
@@ -62,9 +64,12 @@ function ProgressBar({
                 enableColorImpairedMode && 'colorImpaired'
               )}
               role="meter"
-              aria-label={translate('ProgressBarProgress', {
-                progress: progress.toFixed(0),
-              })}
+              aria-label={
+                ariaLabel ??
+                translate('ProgressBarProgress', {
+                  progress: progress.toFixed(0),
+                })
+              }
               aria-valuenow={Math.floor(progress)}
               aria-valuemin={0}
               aria-valuemax={100}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -607,6 +607,7 @@
   "DownloadFailedEpisodeTooltip": "Episode download failed",
   "DownloadIgnored": "Download Ignored",
   "DownloadIgnoredEpisodeTooltip": "Episode Download Ignored",
+  "DownloadProgressForTitle": "Download progress for {title}",
   "DownloadPropersAndRepacks": "Propers and Repacks",
   "DownloadPropersAndRepacksHelpText": "Whether or not to automatically upgrade to Propers/Repacks",
   "DownloadPropersAndRepacksHelpTextCustomFormat": "Use 'Do not Prefer' to sort by custom format  score over Propers/Repacks",


### PR DESCRIPTION
#### Description

Queue progress bars currently announce a generic percentage, so it can be difficult to tell which download the value belongs to with a screen reader.

This lets the shared ProgressBar accept a specific accessible label, then uses the download title for Queue rows. Other progress bars keep their existing label.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review