### PR TITLE
Bump node.js to 24 LTS

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:2": {
       "nodeGypDependencies": true,
-      "version": "20",
+      "version": "24",
       "nvmVersion": "latest"
     }
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@microsoft/signalr": "10.0.0",
     "@sentry/browser": "7.119.1",
     "@tanstack/react-query": "5.61.0",
-    "@types/node": "20.16.11",
+    "@types/node": "24.13.3",
     "@types/react": "18.3.28",
     "@types/react-dom": "18.3.1",
     "chart.js": "4.5.1",
@@ -148,8 +148,8 @@
     "@types/react-dom": "18.3.1"
   },
   "volta": {
-    "node": "20.11.1",
-    "yarn": "1.22.19"
+    "node": "24.19.0",
+    "yarn": "1.22.22"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,12 +1475,12 @@
   dependencies:
     undici-types "~7.21.0"
 
-"@types/node@20.16.11":
-  version "20.16.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.11.tgz#9b544c3e716b1577ac12e70f9145193f32750b33"
-  integrity sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==
+"@types/node@24.13.3":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~7.18.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -6709,10 +6709,10 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 undici-types@~7.21.0:
   version "7.21.0"


### PR DESCRIPTION
#### Description

20 it's EOL for some time, switching to current latest LTS.