### PR TITLE
Close PRs without author activity in last 90 days

### DIFF
--- a/.github/workflows/close_stale_draft_prs.yml
+++ b/.github/workflows/close_stale_draft_prs.yml
@@ -18,9 +18,22 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           cutoff=$(date -u -d '90 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          gh pr list --draft --state open --limit 1000 \
-            --json number,updatedAt \
-            --jq ".[] | select(.updatedAt < \"$cutoff\") | .number" \
-          | while read -r pr; do
-              gh pr close "$pr" --comment ":wave: This draft pull request has been closed automatically because it has not had any activity in 90 days. If you are still working on this, please update it and let us know so we can reopen it."
-            done
+
+          for pr in $(gh pr list --draft --state open --limit 1000 --json number --jq '.[].number'); do
+            read -r author last <<< "$(gh pr view "$pr" --json author,commits,comments,reviews --jq '
+              .author.login as $author
+              | [ (.commits[].committedDate),
+                  (.comments[] | select(.author.login == $author) | .createdAt),
+                  (.reviews[] | select(.author.login == $author) | .submittedAt) ]
+              | "\($author) \(max // "")"')"
+
+            if [[ -n "$last" && "$last" < "$cutoff" ]]; then
+              echo "Closing #$pr (last author activity: $last)"
+              gh pr close "$pr" --comment ":wave: @${author}, this draft pull request has been closed automatically because it has not had any activity in 90 days.
+
+          **Please do not open a new PR for these changes**
+          If you are still working on this, please update it and let us know so we can reopen it."
+            else
+              echo "Skipping #$pr (last author activity: ${last:-unknown})"
+            fi
+          done


### PR DESCRIPTION
#### Description

PRs that haven't had any activity will be updated if there is a force push or something else applies a bulk update, instead of relying on that for stale PRs it will now look at the author's activity. Also tweaked the messaging a bit.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
