### PR TITLE
Fix TrackedDownloadAlreadyImported matching an unrelated download's import history by episode ID alone

### DIFF
--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadAlreadyImportedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadAlreadyImportedFixture.cs
@@ -1,19 +1,24 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using FizzWare.NBuilder;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Common.Disk;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.Download.TrackedDownloads
 {
     [TestFixture]
     public class TrackedDownloadAlreadyImportedFixture : CoreTest<TrackedDownloadAlreadyImported>
     {
+        private readonly OsPath _outputPath = new OsPath(@"C:\DropFolder\MyDownload".AsOsAgnostic());
+        private readonly OsPath _otherDownloadOutputPath = new OsPath(@"C:\DropFolder\SomeOtherDownload".AsOsAgnostic());
         private List<Episode> _episodes;
         private TrackedDownload _trackedDownload;
         private List<EpisodeHistory> _historyItems;
@@ -28,11 +33,13 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
                                                       .Build();
 
             var downloadItem = Builder<DownloadClientItem>.CreateNew()
+                                                         .With(d => d.OutputPath = _outputPath)
                                                          .Build();
 
             _trackedDownload = Builder<TrackedDownload>.CreateNew()
                                                        .With(t => t.RemoteEpisode = remoteEpisode)
                                                        .With(t => t.DownloadItem = downloadItem)
+                                                       .With(t => t.ImportItem = downloadItem)
                                                        .Build();
 
             _historyItems = new List<EpisodeHistory>();
@@ -46,13 +53,24 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
 
         public void GivenHistoryForEpisode(Episode episode, params EpisodeHistoryEventType[] eventTypes)
         {
+            GivenHistoryForEpisode(episode, _outputPath, eventTypes);
+        }
+
+        public void GivenHistoryForEpisode(Episode episode, OsPath droppedFromPath, params EpisodeHistoryEventType[] eventTypes)
+        {
             foreach (var eventType in eventTypes)
             {
-                _historyItems.Add(
-                    Builder<EpisodeHistory>.CreateNew()
+                var history = Builder<EpisodeHistory>.CreateNew()
                                             .With(h => h.EpisodeId = episode.Id)
                                             .With(h => h.EventType = eventType)
-                                            .Build());
+                                            .Build();
+
+                if (eventType == EpisodeHistoryEventType.DownloadFolderImported)
+                {
+                    history.Data["DroppedPath"] = Path.Combine(droppedFromPath.FullPath, "episode.mkv");
+                }
+
+                _historyItems.Add(history);
             }
         }
 
@@ -127,6 +145,40 @@ namespace NzbDrone.Core.Test.Download.TrackedDownloads
             Subject.IsImported(_trackedDownload, _historyItems)
                    .Should()
                    .BeTrue();
+        }
+
+        [Test]
+        public void should_return_false_if_download_folder_imported_history_came_from_a_different_download()
+        {
+            // Reproduces a data-loss scenario: a download client's own duplicate
+            // detection (e.g. NZBGet recognizing repeat grabs of the same
+            // release) can cause DownloadItem.DownloadId to be reused across
+            // genuinely distinct download attempts. HistoryService.FindByDownloadId
+            // then surfaces an OLDER, unrelated attempt's DownloadFolderImported
+            // event for this episode, even though the CURRENT download's own
+            // files (at _outputPath) were never imported. Matching by EpisodeId
+            // alone falsely reports this download as complete - which, combined
+            // with removeCompletedDownloads, deletes its never-imported files.
+            GivenEpisodes(1);
+
+            GivenHistoryForEpisode(_episodes[0], _otherDownloadOutputPath, EpisodeHistoryEventType.DownloadFolderImported, EpisodeHistoryEventType.Grabbed);
+
+            Subject.IsImported(_trackedDownload, _historyItems)
+                   .Should()
+                   .BeFalse();
+        }
+
+        [Test]
+        public void should_return_false_if_only_one_episode_in_multi_episode_download_has_matching_import_path()
+        {
+            GivenEpisodes(2);
+
+            GivenHistoryForEpisode(_episodes[0], _outputPath, EpisodeHistoryEventType.DownloadFolderImported, EpisodeHistoryEventType.Grabbed);
+            GivenHistoryForEpisode(_episodes[1], _otherDownloadOutputPath, EpisodeHistoryEventType.DownloadFolderImported, EpisodeHistoryEventType.Grabbed);
+
+            Subject.IsImported(_trackedDownload, _historyItems)
+                   .Should()
+                   .BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadAlreadyImported.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadAlreadyImported.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.History;
 
@@ -30,6 +31,22 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                 return false;
             }
 
+            // trackedDownload.DownloadItem.DownloadId can be reused/matched by
+            // the download client's own duplicate handling across genuinely
+            // distinct grab attempts (observed with NZBGet's "found in history
+            // with exactly same content" duplicate detection). When that
+            // happens, historyItems can contain an OLDER attempt's
+            // DownloadFolderImported event for an episode ID that THIS
+            // download's files were never actually imported from. Matching by
+            // EpisodeId alone then falsely reports the current, un-imported
+            // download as already complete - which, combined with
+            // removeCompletedDownloads, deletes its files before Sonarr ever
+            // attempts to import them. Requiring the history event's own
+            // recorded source path to fall under this download's current
+            // output path closes that gap: a stale/unrelated import can never
+            // satisfy it.
+            var outputPath = trackedDownload.ImportItem.OutputPath;
+
             var allEpisodesImportedInHistory = trackedDownload.RemoteEpisode.Episodes.All(e =>
             {
                 var lastHistoryItem = historyItems.FirstOrDefault(h => h.EpisodeId == e.Id);
@@ -42,7 +59,22 @@ namespace NzbDrone.Core.Download.TrackedDownloads
 
                 _logger.Trace("Last event for episode: S{0:00}E{1:00} [{2}] is: {3}", e.SeasonNumber, e.EpisodeNumber, e.Id, lastHistoryItem.EventType);
 
-                return lastHistoryItem.EventType == EpisodeHistoryEventType.DownloadFolderImported;
+                if (lastHistoryItem.EventType != EpisodeHistoryEventType.DownloadFolderImported)
+                {
+                    return false;
+                }
+
+                var droppedPath = lastHistoryItem.Data.GetValueOrDefault("DroppedPath");
+
+                if (droppedPath.IsNullOrWhiteSpace() || !outputPath.Contains(new OsPath(droppedPath)))
+                {
+                    _logger.Trace(
+                        "Import history for episode: S{0:00}E{1:00} [{2}] does not match this download's current output path '{3}' (history source: '{4}') - treating as not imported",
+                        e.SeasonNumber, e.EpisodeNumber, e.Id, outputPath, droppedPath);
+                    return false;
+                }
+
+                return true;
             });
 
             _logger.Trace("All episodes for '{0}' have been imported: {1}", trackedDownload.DownloadItem.Title, allEpisodesImportedInHistory);


### PR DESCRIPTION
Fixes #8864

## Problem

`TrackedDownloadAlreadyImported.IsImported()` treats a download as fully imported whenever the most recent history event for each episode ID is `DownloadFolderImported` - without checking whether that import actually came from *this* download's current output path. When a download client's own duplicate detection causes `DownloadId` to be reused/matched across genuinely distinct grab attempts (observed with NZBGet's "found in history with exactly same content" handling), this surfaces an older, unrelated attempt's import history for a new, not-yet-imported download of the same episode. Combined with `removeCompletedDownloads`, Sonarr then deletes the new download's files via `RemoveItem(deleteData: true)` before ever attempting to import them.

Full root cause writeup and production log evidence (11 episodes deleted in one sweep, folder deletion followed 1-2 seconds later by "Import failed, path does not exist" for the same path) in #8864.

## Fix

Require the matched history item's own recorded `DroppedPath` to fall under the download's current `ImportItem.OutputPath` before trusting it as evidence the download is complete. A stale import from a different download's directory can no longer satisfy the check, regardless of episode ID or `DownloadId` matching.

## Test plan

- Updated the existing `TrackedDownloadAlreadyImportedFixture` tests to supply a matching `DroppedPath` (they previously didn't set `Data` at all, which would have broken under the fix).
- Added two new regression tests:
  - `should_return_false_if_download_folder_imported_history_came_from_a_different_download` - single-episode case, history import path doesn't match current download.
  - `should_return_false_if_only_one_episode_in_multi_episode_download_has_matching_import_path` - multi-episode case, one episode's history matches, the other's doesn't.
- Confirmed both new tests fail against the pre-fix code (reproducing the bug) and pass with the fix.
- Full `dotnet test src/Sonarr.sln --filter "FullyQualifiedName~TrackedDownloadAlreadyImportedFixture"` run: 8/8 passing, no build warnings under `TreatWarningsAsErrors`.
