### PR TITLE
Fixed: Avoid checking for free space if other specifications fail first

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             _logger = logger;
         }
 
-        public SpecificationPriority Priority => SpecificationPriority.Default;
+        public SpecificationPriority Priority => SpecificationPriority.Disk;
         public RejectionType Type => RejectionType.Permanent;
 
         public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchCriteriaBase searchCriteria)


### PR DESCRIPTION
#### Description
Backporting this minor fix to v4 since it has a great impact with remote mounts and >1000 releases in the search results.