### PR TITLE
Caching for the same series path in free space specification

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IO;
 using NLog;
+using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Configuration;
@@ -13,11 +15,15 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
 
-        public FreeSpaceSpecification(IConfigService configService, IDiskProvider diskProvider, Logger logger)
+        private readonly ICached<long?> _cache;
+
+        public FreeSpaceSpecification(IConfigService configService, IDiskProvider diskProvider, ICacheManager cacheManager, Logger logger)
         {
             _configService = configService;
             _diskProvider = diskProvider;
             _logger = logger;
+
+            _cache = cacheManager.GetCache<long?>(GetType());
         }
 
         public SpecificationPriority Priority => SpecificationPriority.Disk;
@@ -33,16 +39,7 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
 
             var size = subject.Release.Size;
             var path = subject.Series.Path;
-            long? freeSpace = null;
-
-            try
-            {
-                freeSpace = _diskProvider.GetAvailableSpace(path);
-            }
-            catch (DirectoryNotFoundException)
-            {
-                // Ignore so it'll be skipped in the following checks
-            }
+            var freeSpace = _cache.Get(path, () => GetFreeSpaceForPath(path), TimeSpan.FromSeconds(5));
 
             if (!freeSpace.HasValue)
             {
@@ -71,6 +68,20 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             }
 
             return DownloadSpecDecision.Accept();
+        }
+
+        private long? GetFreeSpaceForPath(string path)
+        {
+            try
+            {
+                return _diskProvider.GetAvailableSpace(path);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Ignore so it'll be skipped in the following checks
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
#### Description

Caching the disk space for the same series path for a small amount of time to avoid IO to the same remote mount, which might be slow when >1000 releases in search results.