### PR TITLE
Fixed: NRE when ManualImport command is sent without files

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Manual/ManualImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Manual/ManualImportServiceFixture.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles.EpisodeImport.Manual;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Manual
+{
+    [TestFixture]
+    public class ManualImportServiceFixture : CoreTest<ManualImportService>
+    {
+        [Test]
+        public void should_not_throw_if_files_is_null()
+        {
+            Assert.DoesNotThrow(() => Subject.Execute(new ManualImportCommand { Files = null }));
+        }
+
+        [Test]
+        public void should_not_throw_if_files_is_empty()
+        {
+            Assert.DoesNotThrow(() => Subject.Execute(new ManualImportCommand { Files = new List<ManualImportFile>() }));
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -488,6 +488,12 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
         public void Execute(ManualImportCommand message)
         {
+            if (message.Files == null || message.Files.Empty())
+            {
+                _logger.Debug("Manual import command received without files, skipping import");
+                return;
+            }
+
             _logger.ProgressTrace("Manually importing {0} files using mode {1}", message.Files.Count, message.ImportMode);
 
             var imported = new List<ImportResult>();


### PR DESCRIPTION
## Description

`ManualImportService.Execute` dereferences `message.Files` right at the top, but `ManualImportCommand.Files` doesn't have a default value. So if a client POSTs to `/api/v3/command` with just `{"name": "ManualImport"}` — no `files` array, or even an explicit `"files": null` — the property comes out of deserialization as null, and the command blows up every time with:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.MediaFiles.EpisodeImport.Manual.ManualImportService.Execute(ManualImportCommand message)
```

Easy to reproduce on a stock install (I tested on v4.0.19.2979):

```bash
curl -X POST 'http://localhost:8989/api/v3/command' \
  -H 'X-Api-Key: <key>' -H 'Content-Type: application/json' \
  -d '{"name": "ManualImport"}'
```

The command gets accepted and queued just fine, then dies in about 0.02s with the NRE, every single time.

Still happens on `v5-develop` — the same unguarded dereference is sitting at the top of `Execute` (it's on `develop` too, checked against `1a60641`). I added a fixture that reproduces it directly — `should_not_throw_if_files_is_null` fails with the same NullReferenceException at `ManualImportService.Execute` without the guard, and passes once the guard's in place.

I actually ran into this in the wild through decypharr (a third-party download client bridge) — it fires off bare `ManualImport` commands during its import handoff, so I was getting a failed command and a full stack trace in the logs every 20–60 seconds. Imports still went through fine via the completed-download handling path, so it's not breaking anything functionally — just failed commands and log spam. Still, the command executor shouldn't be crashing on a malformed request like this.

This PR adds a guard at the top of `Execute` that skips with a debug log if no files were supplied, and adds a small regression test suite for `ManualImportService` (there wasn't one before) covering both the null and empty-list cases. No behavior change for the normal case where files are actually passed in.

Related to but distinct from [#8648](https://github.com/Sonarr/Sonarr/pull/8648), which deals with a different NRE further down the same flow (`TrackedDownload.ImportItem`).

## Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
