### PR TITLE
Don't start miniprofiler if it's disabled

### DIFF
--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -358,7 +358,11 @@ namespace NzbDrone.Host
             app.UseMiddleware<BufferingMiddleware>(new List<string> { "/api/v3/command", "/api/v5/command" });
 
             app.UseWebSockets();
-            app.UseMiniProfiler();
+
+            if (configFileProvider.ProfilerEnabled)
+            {
+                app.UseMiniProfiler();
+            }
 
             // Enable middleware to serve generated Swagger as a JSON endpoint.
             if (BuildInfo.IsDebug)
@@ -372,7 +376,12 @@ namespace NzbDrone.Host
             app.UseEndpoints(x =>
             {
                 x.MapHub<MessageHub>("/signalr/messages").RequireAuthorization("SignalR");
-                x.MapPost("/profiler/results", context => Task.CompletedTask).RequireAuthorization("UI");
+
+                if (configFileProvider.ProfilerEnabled)
+                {
+                    x.MapPost("/profiler/results", context => Task.CompletedTask).RequireAuthorization("UI");
+                }
+
                 x.MapControllers();
             });
         }


### PR DESCRIPTION
#### Description

Prevents the miniprofiler from running (and disables it's API endpoint) when it's not enabled, since it's a config-file (or Environment Variable) only setting it'll only run if enabled at startup.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review