### PR TITLE
Fixed: Parse spaced season and episode file names

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
@@ -33,6 +33,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase(@"C:\Test\Series\Season 2\01. Total Series Action - Episode 1 - Monster Cash.mkv", 2, 1)]
         [TestCase(@"C:\Test\Series\Season 1\02.04.24 - S01E01 - The Rabbit Hole", 1, 1)]
         [TestCase(@"C:\Test\Series\Season 1\8 Series Rules - S01E01 - Pilot", 1, 1)]
+        [TestCase(@"C:\Test\Breaking Bad\Breaking Bad S02 01.mkv", 2, 1)]
+        [TestCase(@"C:\Test\Breaking Bad\Breaking Bad S02 10.mkv", 2, 10)]
 
         // [TestCase(@"C:\series.state.S02E04.720p.WEB-DL.DD5.1.H.264\73696S02-04.mkv", 2, 4)] //Gets treated as S01E04 (because it gets parsed as anime); 2020-01 broken test case: Expected result.EpisodeNumbers to contain 1 item(s), but found 0
         public void should_parse_from_path(string path, int season, int episode)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -515,6 +515,7 @@ namespace NzbDrone.Core.Parser
 
         // Regex to detect whether the title was reversed.
         private static readonly Regex ReversedTitleRegex = new Regex(@"(?:^|[-._ ])(p027|p0801|\d{2,3}E-?\d{2}S)[-._ ]", RegexOptions.Compiled);
+        private static readonly Regex SpacedSeasonEpisodeFileRegex = new Regex(@"(?<season>S\d{1,4}) +(?<episode>\d{1,4})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly RegexReplace NormalizeRegex = new RegexReplace(@"((?:\b|_)(?<!^)([aà](?!$)|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 string.Empty,
@@ -693,6 +694,7 @@ namespace NzbDrone.Core.Parser
                 }
 
                 var releaseTitle = FileExtensions.RemoveFileExtension(title);
+                var isFileName = releaseTitle != title;
 
                 releaseTitle = releaseTitle.Replace("【", "[").Replace("】", "]");
 
@@ -706,6 +708,11 @@ namespace NzbDrone.Core.Parser
                 }
 
                 var simpleTitle = SimpleTitleRegex.Replace(releaseTitle);
+
+                if (isFileName)
+                {
+                    simpleTitle = SpacedSeasonEpisodeFileRegex.Replace(simpleTitle, "${season}E${episode}");
+                }
 
                 // TODO: Quick fix stripping [url] - prefixes and postfixes.
                 simpleTitle = ParserCommon.WebsitePrefixRegex.Replace(simpleTitle);


### PR DESCRIPTION
#### Description

Episode files named with a space between the season and episode numbers, such as `Breaking Bad S02 01.mkv`, were incorrectly matched as multi-season packs. Sonarr consequently treated each file as a full-season release and rejected automatic import.

This change normalizes the spaced `S## ##` format to `S##E##` when parsing media file names. The normalization is limited to file names, preserving the existing interpretation of ambiguous release titles such as `Series Title S01 04`.

Regression tests cover single-digit and double-digit episode numbers. The host-platform unit suite passed with 5,811 tests passing and 75 platform-specific tests skipped.

#### Screenshots for UI Changes

Not applicable.

#### Database Migration

No database migration.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended

#### Issues Fixed or Closed by this PR

- Closes #8878