### PR TITLE
Allow retrying distinct Usenet NZBs with the same release title

### DIFF
--- a/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
+++ b/frontend/src/Settings/DownloadClients/Options/DownloadClientOptions.tsx
@@ -124,6 +124,24 @@ function DownloadClientOptions({
                 />
               </FormGroup>
             ) : null}
+
+            {settings.autoRedownloadFailed.value ? (
+              <FormGroup
+                advancedSettings={showAdvancedSettings}
+                isAdvanced={true}
+                size={sizes.MEDIUM}
+              >
+                <FormLabel>{translate('RetryUsenetReleasesByGuid')}</FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.CHECK}
+                  name="retryUsenetReleasesByGuid"
+                  helpText={translate('RetryUsenetReleasesByGuidHelpText')}
+                  onChange={handleInputChange}
+                  {...settings.retryUsenetReleasesByGuid}
+                />
+              </FormGroup>
+            ) : null}
           </Form>
         </FieldSet>
       ) : null}

--- a/frontend/src/Settings/DownloadClients/Options/useDownloadClientSettings.ts
+++ b/frontend/src/Settings/DownloadClients/Options/useDownloadClientSettings.ts
@@ -5,6 +5,7 @@ export interface DownloadClientSettingsModel {
   enableCompletedDownloadHandling: boolean;
   autoRedownloadFailed: boolean;
   autoRedownloadFailedFromInteractiveSearch: boolean;
+  retryUsenetReleasesByGuid: boolean;
 }
 
 const PATH = '/settings/downloadclient';

--- a/src/NzbDrone.Api.Test/v5/Settings/DownloadClientSettingsResourceMapperFixture.cs
+++ b/src/NzbDrone.Api.Test/v5/Settings/DownloadClientSettingsResourceMapperFixture.cs
@@ -1,0 +1,21 @@
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.Configuration;
+using Sonarr.Api.V5.Settings;
+
+namespace NzbDrone.Api.Test.v5.Settings;
+
+[TestFixture]
+public class DownloadClientSettingsResourceMapperFixture
+{
+    [Test]
+    public void should_map_retry_usenet_releases_by_guid()
+    {
+        var configService = new Mock<IConfigService>();
+        configService.SetupGet(s => s.RetryUsenetReleasesByGuid).Returns(true);
+
+        var resource = DownloadClientSettingsResourceMapper.ToResource(configService.Object);
+
+        Assert.That(resource.RetryUsenetReleasesByGuid, Is.True);
+    }
+}

--- a/src/NzbDrone.Core.Test/Blocklisting/BlocklistServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Blocklisting/BlocklistServiceFixture.cs
@@ -3,9 +3,13 @@ using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Blocklisting;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Test.Blocklisting
 {
@@ -53,6 +57,144 @@ namespace NzbDrone.Core.Test.Blocklisting
 
             Mocker.GetMock<IBlocklistRepository>()
                 .Verify(v => v.Insert(It.Is<Blocklist>(b => b.EpisodeIds == _event.EpisodeIds)), Times.Once());
+        }
+
+        [Test]
+        public void should_store_indexer_guid_from_failed_download_history()
+        {
+            const string indexerGuid = "nzb-guid-123";
+            _event.Data.Add("guid", indexerGuid);
+
+            Subject.Handle(_event);
+
+            Mocker.GetMock<IBlocklistRepository>()
+                .Verify(v => v.Insert(It.Is<Blocklist>(b => b.IndexerGuid == indexerGuid)), Times.Once());
+        }
+
+        [Test]
+        public void should_store_indexer_guid_when_release_is_blocked_directly()
+        {
+            const string indexerGuid = "nzb-guid-456";
+            var remoteEpisode = new RemoteEpisode
+            {
+                Series = new Series { Id = _event.SeriesId },
+                Episodes = new List<Episode> { new() { Id = 1 } },
+                ParsedEpisodeInfo = new ParsedEpisodeInfo { Quality = _event.Quality },
+                Release = GivenUsenetRelease("Indexer A", indexerGuid)
+            };
+
+            Subject.Block(remoteEpisode, "Failed", "Test");
+
+            Mocker.GetMock<IBlocklistRepository>()
+                .Verify(v => v.Insert(It.Is<Blocklist>(b => b.IndexerGuid == indexerGuid)), Times.Once());
+        }
+
+        [Test]
+        public void should_block_exact_same_indexer_and_guid_when_guid_retry_is_enabled()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer A", "nzb-guid-123");
+            GivenBlocklistedRelease(release, "Indexer A", "nzb-guid-123");
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.True);
+        }
+
+        [Test]
+        public void should_allow_different_guid_from_same_indexer_when_guid_retry_is_enabled()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer A", "working-guid");
+            GivenBlocklistedRelease(release, "Indexer A", "failed-guid");
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.False);
+        }
+
+        [Test]
+        public void should_allow_same_guid_from_different_indexer_when_guid_retry_is_enabled()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer B", "shared-guid");
+            GivenBlocklistedRelease(release, "Indexer A", "shared-guid");
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.False);
+        }
+
+        [Test]
+        public void should_allow_release_with_guid_when_blocklist_guid_is_missing()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer B", "nzb-guid-123");
+            GivenBlocklistedRelease(release, "Indexer A", null);
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.False);
+        }
+
+        [Test]
+        public void should_allow_release_without_guid_when_blocklist_guid_is_present()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer B", null);
+            GivenBlocklistedRelease(release, "Indexer A", "nzb-guid-123");
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.False);
+        }
+
+        [Test]
+        public void should_fall_back_to_standard_matching_when_both_guids_are_missing()
+        {
+            GivenGuidRetryEnabled();
+            var release = GivenUsenetRelease("Indexer B", null);
+            GivenBlocklistedRelease(release, "Indexer A", null);
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.True);
+        }
+
+        [Test]
+        public void should_preserve_cross_indexer_usenet_blocking_when_guid_retry_is_disabled()
+        {
+            var release = GivenUsenetRelease("Indexer B", "working-guid");
+            GivenBlocklistedRelease(release, "Indexer A", "failed-guid");
+
+            Assert.That(Subject.Blocklisted(_event.SeriesId, release), Is.True);
+        }
+
+        private void GivenGuidRetryEnabled()
+        {
+            Mocker.GetMock<IConfigService>()
+                .SetupGet(s => s.RetryUsenetReleasesByGuid)
+                .Returns(true);
+        }
+
+        private ReleaseInfo GivenUsenetRelease(string indexer, string indexerGuid)
+        {
+            return new ReleaseInfo
+            {
+                Title = _event.SourceTitle,
+                Indexer = indexer,
+                Guid = indexerGuid,
+                DownloadProtocol = DownloadProtocol.Usenet,
+                PublishDate = DateTime.UtcNow,
+                Size = 1000
+            };
+        }
+
+        private void GivenBlocklistedRelease(ReleaseInfo release, string indexer, string indexerGuid)
+        {
+            Mocker.GetMock<IBlocklistRepository>()
+                .Setup(s => s.BlocklistedByTitle(_event.SeriesId, release.Title))
+                .Returns(new List<Blocklist>
+                {
+                    new()
+                    {
+                        SeriesId = _event.SeriesId,
+                        SourceTitle = release.Title,
+                        Indexer = indexer,
+                        IndexerGuid = indexerGuid,
+                        Protocol = DownloadProtocol.Usenet,
+                        PublishedDate = release.PublishDate,
+                        Size = release.Size
+                    }
+                });
         }
     }
 }

--- a/src/NzbDrone.Core.Test/Datastore/Migration/234_add_indexer_guid_to_blocklistFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/Migration/234_add_indexer_guid_to_blocklistFixture.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Dapper;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Datastore.Migration;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.Datastore.Migration
+{
+    [TestFixture]
+    public class add_indexer_guid_to_blocklistFixture : MigrationTest<add_indexer_guid_to_blocklist>
+    {
+        [Test]
+        public void should_add_nullable_indexer_guid_column_to_blocklist()
+        {
+            using var db = WithDapperMigrationTestDb();
+
+            var columns = db.Query<ColumnDefinition234>("PRAGMA table_info(\"Blocklist\")").ToList();
+            var indexerGuid = columns.Single(c => c.Name == "IndexerGuid");
+
+            indexerGuid.NotNull.Should().Be(0);
+        }
+    }
+
+    public class ColumnDefinition234
+    {
+        public string Name { get; set; }
+        public int NotNull { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/Blocklisting/Blocklist.cs
+++ b/src/NzbDrone.Core/Blocklisting/Blocklist.cs
@@ -21,6 +21,7 @@ namespace NzbDrone.Core.Blocklisting
         public long? Size { get; set; }
         public DownloadProtocol Protocol { get; set; }
         public string Indexer { get; set; }
+        public string IndexerGuid { get; set; }
         public IndexerFlags IndexerFlags { get; set; }
         public ReleaseType ReleaseType { get; set; }
         public string Message { get; set; }

--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Indexers;
@@ -29,10 +30,13 @@ namespace NzbDrone.Core.Blocklisting
                                     IHandleAsync<SeriesDeletedEvent>
     {
         private readonly IBlocklistRepository _blocklistRepository;
+        private readonly IConfigService _configService;
 
-        public BlocklistService(IBlocklistRepository blocklistRepository)
+        public BlocklistService(IBlocklistRepository blocklistRepository,
+                                IConfigService configService)
         {
             _blocklistRepository = blocklistRepository;
+            _configService = configService;
         }
 
         public bool Blocklisted(int seriesId, ReleaseInfo release)
@@ -84,6 +88,7 @@ namespace NzbDrone.Core.Blocklisting
                                 PublishedDate = remoteEpisode.Release.PublishDate,
                                 Size = remoteEpisode.Release.Size,
                                 Indexer = remoteEpisode.Release.Indexer,
+                                IndexerGuid = remoteEpisode.Release.Guid,
                                 Protocol = remoteEpisode.Release.DownloadProtocol,
                                 Message = message,
                                 Source = source,
@@ -110,6 +115,28 @@ namespace NzbDrone.Core.Blocklisting
 
         private bool SameNzb(Blocklist item, ReleaseInfo release)
         {
+            if (_configService.RetryUsenetReleasesByGuid)
+            {
+                var blocklistHasGuid = item.IndexerGuid.IsNotNullOrWhiteSpace();
+                var releaseHasGuid = release.Guid.IsNotNullOrWhiteSpace();
+
+                if (blocklistHasGuid != releaseHasGuid)
+                {
+                    return false;
+                }
+
+                if (blocklistHasGuid)
+                {
+                    if (item.Indexer.IsNullOrWhiteSpace() || release.Indexer.IsNullOrWhiteSpace())
+                    {
+                        return item.IndexerGuid.Equals(release.Guid, StringComparison.InvariantCultureIgnoreCase);
+                    }
+
+                    return item.Indexer.Equals(release.Indexer, StringComparison.InvariantCultureIgnoreCase) &&
+                           item.IndexerGuid.Equals(release.Guid, StringComparison.InvariantCultureIgnoreCase);
+                }
+            }
+
             return ReleaseComparer.SameNzb(new ReleaseComparerModel(item), release);
         }
 
@@ -135,6 +162,7 @@ namespace NzbDrone.Core.Blocklisting
                 PublishedDate = DateTime.Parse(message.Data.GetValueOrDefault("publishedDate")),
                 Size = long.Parse(message.Data.GetValueOrDefault("size", "0")),
                 Indexer = message.Data.GetValueOrDefault("indexer"),
+                IndexerGuid = message.Data.GetValueOrDefault("guid"),
                 Protocol = (DownloadProtocol)Convert.ToInt32(message.Data.GetValueOrDefault("protocol")),
                 Message = message.Message,
                 Source = message.Source,

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -157,6 +157,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("AutoRedownloadFailedFromInteractiveSearch", value); }
         }
 
+        public bool RetryUsenetReleasesByGuid
+        {
+            get { return GetValueBoolean("RetryUsenetReleasesByGuid", false); }
+
+            set { SetValue("RetryUsenetReleasesByGuid", value); }
+        }
+
         public bool CreateEmptySeriesFolders
         {
             get { return GetValueBoolean("CreateEmptySeriesFolders", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Configuration
         bool EnableCompletedDownloadHandling { get; set; }
         bool AutoRedownloadFailed { get; set; }
         bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        bool RetryUsenetReleasesByGuid { get; set; }
 
         // Media Management
         bool AutoUnmonitorPreviouslyDownloadedEpisodes { get; set; }

--- a/src/NzbDrone.Core/Datastore/Migration/234_add_indexer_guid_to_blocklist.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/234_add_indexer_guid_to_blocklist.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(234)]
+    public class add_indexer_guid_to_blocklist : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Blocklist").AddColumn("IndexerGuid").AsString().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1900,6 +1900,8 @@
   "Retention": "Retention",
   "RetentionHelpText": "Usenet only: Set to zero to set for unlimited retention",
   "RetryingDownloadOn": "Retrying download on {date} at {time}",
+  "RetryUsenetReleasesByGuid": "Retry Distinct Usenet NZBs",
+  "RetryUsenetReleasesByGuidHelpText": "When a Usenet download fails, block only the exact indexer and NZB GUID combination so other NZB entries with the same title may be tried. Standard matching is used only when both entries lack GUID data",
   "RootFolder": "Root Folder",
   "RootFolderEmptyHealthCheckMessage": "Empty root folder: {rootFolderPath}",
   "RootFolderMissingHealthCheckMessage": "Missing root folder: {rootFolderPath}",

--- a/src/Sonarr.Api.V3/Config/DownloadClientConfigResource.cs
+++ b/src/Sonarr.Api.V3/Config/DownloadClientConfigResource.cs
@@ -10,6 +10,7 @@ namespace Sonarr.Api.V3.Config
         public bool EnableCompletedDownloadHandling { get; set; }
         public bool AutoRedownloadFailed { get; set; }
         public bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+        public bool RetryUsenetReleasesByGuid { get; set; }
     }
 
     public static class DownloadClientConfigResourceMapper
@@ -22,7 +23,8 @@ namespace Sonarr.Api.V3.Config
 
                 EnableCompletedDownloadHandling = model.EnableCompletedDownloadHandling,
                 AutoRedownloadFailed = model.AutoRedownloadFailed,
-                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch
+                AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch,
+                RetryUsenetReleasesByGuid = model.RetryUsenetReleasesByGuid
             };
         }
     }

--- a/src/Sonarr.Api.V5/Settings/DownloadClientSettingsResource.cs
+++ b/src/Sonarr.Api.V5/Settings/DownloadClientSettingsResource.cs
@@ -9,6 +9,7 @@ public class DownloadClientSettingsResource : RestResource
     public bool EnableCompletedDownloadHandling { get; set; }
     public bool AutoRedownloadFailed { get; set; }
     public bool AutoRedownloadFailedFromInteractiveSearch { get; set; }
+    public bool RetryUsenetReleasesByGuid { get; set; }
 }
 
 public static class DownloadClientSettingsResourceMapper
@@ -20,7 +21,8 @@ public static class DownloadClientSettingsResourceMapper
             DownloadClientWorkingFolders = model.DownloadClientWorkingFolders,
             EnableCompletedDownloadHandling = model.EnableCompletedDownloadHandling,
             AutoRedownloadFailed = model.AutoRedownloadFailed,
-            AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch
+            AutoRedownloadFailedFromInteractiveSearch = model.AutoRedownloadFailedFromInteractiveSearch,
+            RetryUsenetReleasesByGuid = model.RetryUsenetReleasesByGuid
         };
     }
 }


### PR DESCRIPTION
#### Description

PROBLEM

I noticed that after a NZB failed, Sonarr would block other search results with the same release name. The same release name can be listed by several indexers. From experience manually downloading episodes and movies, I have seen that different indexers can provide a working NZB while still using the same name. I have also seen the same release name posted multiple times on a single indexer. One NZB can be incomplete while another one works. I confirmed this by manually downloading the same named release from different indexers and eventually getting a complete file. I currently use seven different indexers with both Sonarr and manual downloading.


CURRENT BEHAVIOR

When a download fails, Sonarr adds it to the blocklist. During another search of the same episode, Sonarr checks the results with the same title and compares the information of the NZB, such as the indexer, posted date and file size. This can cause a different NZB to be considered the same failed download because the NZB GUID is not used to identify it. An otherwise available NZB, from the same indexer or another, can then be rejected by Sonarr before it is sent to SABnzbd. Thus, SABnzbd never gets the chance to try downloading it.


NEW OPTIONAL BEHAVIOR

This change adds an advanced setting called “Retry Distinct Usenet NZBs” under Settings | Download Clients | Completed Download Handling. This setting is only shown when 'redownloading failed' downloads is enabled and it is turned off by default, preserving the default functionality of Sonarr. When enabled, Sonarr stores the NZB GUID with the failed blocklist entry and uses the indexer and GUID together to identify the exact failed NZB. Other NZBs with the same release name can then remain available for Sonarr to try. When the setting is disabled, Sonarr continues to use its current default blocklist behavior.


IDENTITY RULES

When the option is enabled, Sonarr uses the following rules:

- The same indexer and same GUID is considered the exact same NZB and remains blocked.
- A different GUID from the same indexer is considered another NZB and can be tried.
- An NZB from a different indexer can be tried, even if the GUID is the same.
- If only one of the two entries has a GUID, they are considered different and the other NZB can be tried.
- If neither entry has a GUID, Sonarr falls back to its standard blocklist matching.
- If the indexer information is missing, matching GUIDs are considered the same NZB.


WHY THIS IS OPTIONAL

The original blocklist behavior, as I understand it, was created for a reason. It helps prevent Sonarr from repeatedly downloading what it thinks is the same failed release. Changing this behavior for every user could create unwanted retries or download loops. Making the new behavior optional and leaving it disabled by default preserves the existing Sonarr behavior, while allowing users to enable GUID-based matching for distinct NZBs from the same or different indexers if they want it.


TESTING PERFORMED

I tested this change on my Asustor NAS using an isolated copy of Sonarr-HD 4.0.19.2979 on port 8990. My production configuration was copied for testing, but the production database and container were not modified.

The test setup used SABnzbd, Prowlarr and seven enabled Usenet indexers.

Manual testing included:

- I used episodes from Star Trek Starfleet Academy that had several NZB files with the same release name.
- Episode 5 had a release from the group 'elite' fail in SABnzbd. Sonarr then selected another distinct 'elite' NZB with the same release name. The second NZB completed successfully and Sonarr imported the episode.
- Episode 6 failed on the first NZB and completed successfully after Sonarr tried a second NZB.
- Episode 7 completed successfully on its first attempt, confirming that normal downloading and importing still worked.
- The failed NZB files remained blocklisted after the successful alternate NZB was imported.
- After testing, the isolated container was removed and production Sonarr remained operational.

Automated tests cover:

- The same indexer and GUID remaining blocked.
- A different GUID from the same indexer being allowed.
- Results from different indexers being allowed.
- Results where only one entry has a GUID.
- Standard matching when neither entry has a GUID.
- Existing behavior when the new setting is disabled.
- Saving the NZB GUID in the blocklist.
- The database migration used to add the GUID field.
- Mapping the new setting through the Sonarr API.

FINAL RESULT:

The Sonarr v5 development patch applied cleanly and passed all nine local Linux validation stages. This included frontend dependency restore, frontend linting, stylesheet linting, the production frontend build, the complete backend compile, targeted regression, settings API and migration tests, the full unit-test suite and the integration-test suite.

Total validation time: 1 hour, 8 minutes and 16 seconds.


#### Screenshots for UI Changes

<img width="1078" height="876" alt="Github - sonarr indexer download fix" src="https://github.com/user-attachments/assets/dcf1168f-8706-47f2-80f2-2c4a217714a4" />


#### Database Migration

YES - 234

This migration adds a nullable IndexerGuid field to the blocklist so Sonarr can store the GUID of a failed NZB.


#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review


AI ASSISTANCE NOTE

I used ChatGPT to help me solve the problem of failed downloads where the first NZB of the same name failed and Sonarr would not retry a distinct NZB with the same name.

I guided ChatGPT through my problem and explained the outcome I preferred. ChatGPT came up with the code design and regression tests while I tested everything myself on my NAS.

As this is only my second attempted contribution to GitHub, I asked ChatGPT to guide me step by step on how I could provide this contribution to GitHub.

I confirm that all testing, confirmation of downloads, and general behaviour of Sonarr has been done by me. I also reviewed how the code works and confirm that I understand this submitted change.


#### Issues Fixed or Closed by this PR