### PR TITLE
New: Do not blocklist similar NZBs from a different indexer

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseComparerFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseComparerFixture.cs
@@ -1,0 +1,103 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Blocklisting;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class ReleaseComparerFixture
+    {
+        private const string Title = "Series.Title.S01E05.1080p.x265-ELiTE";
+        private const long Size = 1352581934;
+
+        private static readonly DateTime PublishedDate = new DateTime(2026, 2, 6, 15, 39, 0, DateTimeKind.Utc);
+
+        private static ReleaseComparerModel Blocklisted(string indexer, DateTime? publishedDate)
+        {
+            return new ReleaseComparerModel(new Blocklist
+            {
+                SourceTitle = Title,
+                Indexer = indexer,
+                PublishedDate = publishedDate,
+                Size = Size
+            });
+        }
+
+        private static ReleaseInfo Release(string indexer, DateTime publishDate)
+        {
+            return new ReleaseInfo
+            {
+                Title = Title,
+                Indexer = indexer,
+                PublishDate = publishDate,
+                Size = Size
+            };
+        }
+
+        [Test]
+        public void should_not_match_release_from_another_indexer_with_near_published_date()
+        {
+            var item = Blocklisted("NZBgeek", PublishedDate);
+            var release = Release("NZBFinder", PublishedDate.AddSeconds(-10));
+
+            ReleaseComparer.SameNzb(item, release).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_release_from_another_indexer_with_identical_published_date()
+        {
+            var item = Blocklisted("NZBgeek", PublishedDate);
+            var release = Release("NZBFinder", PublishedDate);
+
+            ReleaseComparer.SameNzb(item, release).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_match_same_indexer_with_identical_published_date()
+        {
+            var item = Blocklisted("NZBgeek", PublishedDate);
+            var release = Release("NZBgeek", PublishedDate);
+
+            ReleaseComparer.SameNzb(item, release).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_same_indexer_when_published_date_differs()
+        {
+            var item = Blocklisted("NZBgeek", PublishedDate);
+            var release = Release("NZBgeek", PublishedDate.AddSeconds(-10));
+
+            ReleaseComparer.SameNzb(item, release).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_same_indexer_when_item_has_no_published_date()
+        {
+            var item = Blocklisted("NZBgeek", null);
+            var release = Release("NZBgeek", PublishedDate);
+
+            ReleaseComparer.SameNzb(item, release).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_match_item_without_indexer_with_identical_published_date()
+        {
+            var item = Blocklisted(null, PublishedDate);
+            var release = Release("NZBFinder", PublishedDate);
+
+            ReleaseComparer.SameNzb(item, release).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_item_without_indexer_when_published_date_differs()
+        {
+            var item = Blocklisted(null, PublishedDate);
+            var release = Release("NZBFinder", PublishedDate.AddSeconds(-10));
+
+            ReleaseComparer.SameNzb(item, release).Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/ReleaseComparer.cs
+++ b/src/NzbDrone.Core/Parser/ReleaseComparer.cs
@@ -8,19 +8,12 @@ public static class ReleaseComparer
 {
     public static bool SameNzb(ReleaseComparerModel item, ReleaseInfo release)
     {
-        if (item.PublishedDate == release.PublishDate)
+        if (!HasSameIndexer(item, release.Indexer))
         {
-            return true;
+            return false;
         }
 
-        if (!HasSameIndexer(item, release.Indexer) &&
-            HasSamePublishedDate(item, release.PublishDate) &&
-            HasSameSize(item, release.Size))
-        {
-            return true;
-        }
-
-        return false;
+        return item.PublishedDate == release.PublishDate;
     }
 
     public static bool SameTorrent(ReleaseComparerModel item, TorrentInfo release)
@@ -41,28 +34,5 @@ public static class ReleaseComparer
         }
 
         return item.Indexer.Equals(indexer, StringComparison.InvariantCultureIgnoreCase);
-    }
-
-    private static bool HasSamePublishedDate(ReleaseComparerModel item, DateTime publishedDate)
-    {
-        if (!item.PublishedDate.HasValue)
-        {
-            return true;
-        }
-
-        return item.PublishedDate.Value.AddMinutes(-2) <= publishedDate &&
-               item.PublishedDate.Value.AddMinutes(2) >= publishedDate;
-    }
-
-    private static bool HasSameSize(ReleaseComparerModel item, long size)
-    {
-        if (item.Size == 0)
-        {
-            return true;
-        }
-
-        var difference = Math.Abs(item.Size - size);
-
-        return difference <= 2.Megabytes();
     }
 }


### PR DESCRIPTION
#### Description

This change drops the fuzzy date/size comparison for NZBs from other indexers and limits the exact date check to the same indexer (Indexer + Title + Date becomes our unique identifier). This results in a similar outcome to https://github.com/Sonarr/Sonarr/pull/8880 was doing without the need for storing extra information or a setting. Also added some tests to validate the behaviour.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #8881
