### PR TITLE
Update color impaired calendar gradient color

### DIFF
--- a/frontend/src/Styles/Themes/dark.js
+++ b/frontend/src/Styles/Themes/dark.js
@@ -82,7 +82,7 @@ module.exports = {
   inputErrorBoxShadowColor: 'rgba(240, 80, 80, 0.6)',
   inputWarningBorderColor: '#ffa500',
   inputWarningBoxShadowColor: 'rgba(255, 165, 0, 0.6)',
-  colorImpairedGradient: '#707070',
+  colorImpairedGradient: '#202020',
   colorImpairedGradientDark: '#424242',
   colorImpairedDangerGradient: '#d84848',
   colorImpairedWarningGradient: '#e59400',


### PR DESCRIPTION
#### Description

This PR proposes a change to the color impaired mode, specifically the background of the calendar bars.

<details><summary>TL;DR:</summary>Change the color impaired calendar items in the dark skin:

<img width="461" height="268" alt="Screenshot of upcoming episodes in dark skin" src="https://github.com/user-attachments/assets/81cb79a1-e8b0-4d2b-ac7e-d0c2fca9f0cc" /> ➡️ <img width="461" height="267" alt="Screenshot of upcoming episodes in dark skin with this pull request's changes applied" src="https://github.com/user-attachments/assets/1bbbac6e-4185-4fe2-9ce1-503b746d10b9" />

---
</details>


Color impaired mode is implemented for the series progress bars, and looks like this in light/dark skins:

<img width="333" height="123" alt="Screenshot of progress bar key colors in color impaired mode" src="https://github.com/user-attachments/assets/83ede998-1e95-4b7c-8061-cdb36ed70387" />

While I can only speak for my own color impairment, I find the combination of colors and striping to be easily distinguished amongst each other.  In addition, the only colors that are striped are the missing episodes bars, so this means the striped bars draw attention to an abnormal state, and this is fantastic.

But this PR is about the calendar; the screenshots below show the agenda view.

In the light skin, the contrast between the text and the background is quite good:

<img width="461" height="278" alt="Screenshot of upcoming episodes in Calendar view" src="https://github.com/user-attachments/assets/296c7bff-85c0-4402-8bf0-d75ff646b4e9" />

But in dark skin, we have three different shades of gray which makes text hard to read:

<img width="461" height="268" alt="Screenshot of upcoming episodes in dark skin" src="https://github.com/user-attachments/assets/81cb79a1-e8b0-4d2b-ac7e-d0c2fca9f0cc" />

**This is the proposed change for the PR:**

<img width="461" height="267" alt="Screenshot of upcoming episodes in dark skin with this pull request's changes applied" src="https://github.com/user-attachments/assets/1bbbac6e-4185-4fe2-9ce1-503b746d10b9" />


#### Alternate solution

Personally I think removing the stripes would be much better since Unaired is not an abnormal state and does not need attention drawn to it:

<img width="461" height="254" alt="Screenshot of alternate solution for readability of upcoming episodes on Calendar view" src="https://github.com/user-attachments/assets/4af0147e-deab-496d-8e70-acebe0c03adb" />

I am not proposing changing any of the calendar stripes because [every change breaks someone's workflow](https://xkcd.com/1172/) and I'm sure somebody is counting on seeing them.

For reference, here are the existing colors for color-impaired mode with the dark skin:

<img width="461" height="77" alt="Screenshot showing key of episode colors in dark color-impaired mode" src="https://github.com/user-attachments/assets/ad49e261-39ab-415e-b294-31a4c38e2ed9" />



#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
