### PR TITLE
Fixed: BroadcasTheNet searches for three digit episode numbers

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/BroadcastheNetTests/BroadcastheNetRequestGeneratorFixture.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Indexers;
+using NzbDrone.Core.Indexers.BroadcastheNet;
+using NzbDrone.Core.IndexerSearch.Definitions;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.IndexerTests.BroadcastheNetTests
+{
+    public class BroadcastheNetRequestGeneratorFixture : CoreTest<BroadcastheNetRequestGenerator>
+    {
+        private Series _series;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Subject.Settings = new BroadcastheNetSettings
+            {
+                BaseUrl = "https://api.broadcasthe.net/",
+                ApiKey = "abc"
+            };
+
+            Subject.PageSize = 100;
+
+            _series = new Series { TvdbId = 433335 };
+        }
+
+        private SingleEpisodeSearchCriteria SingleEpisode(int seasonNumber, params int[] episodeNumbers)
+        {
+            return new SingleEpisodeSearchCriteria
+            {
+                Series = _series,
+                SceneTitles = new List<string> { "Series Title" },
+                SeasonNumber = seasonNumber,
+                EpisodeNumber = episodeNumbers.First(),
+                Episodes = episodeNumbers
+                    .Select(e => new Episode { SeasonNumber = seasonNumber, EpisodeNumber = e })
+                    .ToList()
+            };
+        }
+
+        private static List<string> QueriedNames(IndexerPageableRequestChain chain, int tier)
+        {
+            return chain.GetTier(tier)
+                .Select(pageable => pageable.First().HttpRequest.ContentSummary)
+                .ToList();
+        }
+
+        [Test]
+        public void should_search_for_three_digit_episode_number_in_the_same_request()
+        {
+            var results = Subject.GetSearchRequests(SingleEpisode(1, 99));
+
+            results.Tiers.Should().Be(1);
+            QueriedNames(results, 0).Should().HaveCount(1);
+            QueriedNames(results, 0).First().Should().Contain(@"""Name"":""S01%E%99%""");
+        }
+
+        [TestCase(1, "S01%E%01%")]
+        [TestCase(9, "S01%E%09%")]
+        [TestCase(97, "S01%E%97%")]
+        [TestCase(99, "S01%E%99%")]
+        public void should_wildcard_episode_numbers_below_one_hundred(int episodeNumber, string expected)
+        {
+            var results = Subject.GetSearchRequests(SingleEpisode(1, episodeNumber));
+
+            results.Tiers.Should().Be(1);
+            QueriedNames(results, 0).Should().HaveCount(1);
+            QueriedNames(results, 0).First().Should().Contain($@"""Name"":""{expected}""");
+        }
+
+        [TestCase(100, "S01%E100%")]
+        [TestCase(101, "S01%E101%")]
+        [TestCase(999, "S01%E999%")]
+        public void should_not_wildcard_episode_numbers_over_ninety_nine(int episodeNumber, string expected)
+        {
+            var results = Subject.GetSearchRequests(SingleEpisode(1, episodeNumber));
+
+            results.Tiers.Should().Be(1);
+            QueriedNames(results, 0).Should().HaveCount(1);
+            QueriedNames(results, 0).First().Should().Contain($@"""Name"":""{expected}""");
+        }
+
+        [Test]
+        public void should_only_wildcard_the_episodes_below_one_hundred_of_a_multi_episode_search()
+        {
+            var results = Subject.GetSearchRequests(SingleEpisode(1, 99, 100));
+
+            results.Tiers.Should().Be(1);
+            QueriedNames(results, 0).Should().HaveCount(2);
+            QueriedNames(results, 0)[0].Should().Contain(@"""Name"":""S01%E%99%""");
+            QueriedNames(results, 0)[1].Should().Contain(@"""Name"":""S01%E100%""");
+        }
+
+        [Test]
+        public void should_not_search_without_a_tvdb_or_tvrage_id()
+        {
+            _series.TvdbId = 0;
+
+            var results = Subject.GetSearchRequests(SingleEpisode(1, 99));
+
+            results.GetAllTiers().Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_change_season_search()
+        {
+            var criteria = new SeasonSearchCriteria
+            {
+                Series = _series,
+                SceneTitles = new List<string> { "Series Title" },
+                SeasonNumber = 1,
+                Episodes = new List<Episode> { new Episode { SeasonNumber = 1, EpisodeNumber = 99 } }
+            };
+
+            var results = Subject.GetSearchRequests(criteria);
+
+            results.Tiers.Should().Be(1);
+            var names = QueriedNames(results, 0);
+            names.Should().HaveCount(2);
+            names[0].Should().Contain(@"""Name"":""Season 1%""");
+
+            // the season wildcard already matches three digit episode numbers
+            names[1].Should().Contain(@"""Name"":""S01E%""");
+        }
+
+        [TestCase(99, "S01E%99")]
+        [TestCase(100, "S01E100")]
+        public void should_search_for_three_digit_episode_number_for_anime(int episodeNumber, string expected)
+        {
+            var criteria = new AnimeEpisodeSearchCriteria
+            {
+                Series = _series,
+                SceneTitles = new List<string> { "Series Title" },
+                SeasonNumber = 1,
+                EpisodeNumber = episodeNumber,
+                AbsoluteEpisodeNumber = episodeNumber,
+                Episodes = new List<Episode> { new Episode { SeasonNumber = 1, EpisodeNumber = episodeNumber } }
+            };
+
+            var results = Subject.GetSearchRequests(criteria);
+
+            results.Tiers.Should().Be(1);
+            QueriedNames(results, 0)[0].Should().Contain($@"""Name"":""{expected}""");
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -249,17 +249,5 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeFalse();
             result.IsSplitEpisode.Should().BeTrue();
         }
-
-        [TestCase("Series.Title.S01E099.1080p.WEB-DL.AAC2.0.H.264-VARYG", "Series Title", 1, 99)]
-        [TestCase("Series.Title.S01E100.1080p.WEB-DL.AAC2.0.H.264-GROUP", "Series Title", 1, 100)]
-        [TestCase("Series.Title.S01E009.1080p.WEB-DL.AAC2.0.H.264-GROUP", "Series Title", 1, 9)]
-        public void should_parse_three_digit_padded_episode_numbers(string postTitle, string title, int seasonNumber, int episodeNumber)
-        {
-            var result = Parser.Parser.ParseTitle(postTitle);
-            result.Should().NotBeNull();
-            result.SeasonNumber.Should().Be(seasonNumber);
-            result.EpisodeNumbers.Should().BeEquivalentTo(new[] { episodeNumber });
-            result.SeriesTitle.Should().Be(title);
-        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
@@ -249,5 +249,17 @@ namespace NzbDrone.Core.Test.ParserTests
             result.FullSeason.Should().BeFalse();
             result.IsSplitEpisode.Should().BeTrue();
         }
+
+        [TestCase("Series.Title.S01E099.1080p.WEB-DL.AAC2.0.H.264-VARYG", "Series Title", 1, 99)]
+        [TestCase("Series.Title.S01E100.1080p.WEB-DL.AAC2.0.H.264-GROUP", "Series Title", 1, 100)]
+        [TestCase("Series.Title.S01E009.1080p.WEB-DL.AAC2.0.H.264-GROUP", "Series Title", 1, 9)]
+        public void should_parse_three_digit_padded_episode_numbers(string postTitle, string title, int seasonNumber, int episodeNumber)
+        {
+            var result = Parser.Parser.ParseTitle(postTitle);
+            result.Should().NotBeNull();
+            result.SeasonNumber.Should().Be(seasonNumber);
+            result.EpisodeNumbers.Should().BeEquivalentTo(new[] { episodeNumber });
+            result.SeriesTitle.Should().Be(title);
+        }
     }
 }

--- a/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/BroadcastheNet/BroadcastheNetRequestGenerator.cs
@@ -51,7 +51,9 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                     parameters = parameters.Clone();
 
                     parameters.Category = "Episode";
-                    parameters.Name = $"S{episode.SeasonNumber:00}%E{episode.EpisodeNumber:00}%";
+                    parameters.Name = episode.EpisodeNumber is > 0 and < 100
+                        ? $"S{episode.SeasonNumber:00}%E%{episode.EpisodeNumber:00}%"
+                        : $"S{episode.SeasonNumber:00}%E{episode.EpisodeNumber:00}%";
 
                     pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
                 }
@@ -154,7 +156,9 @@ namespace NzbDrone.Core.Indexers.BroadcastheNet
                     parameters = parameters.Clone();
 
                     parameters.Category = "Episode";
-                    parameters.Name = $"S{episode.SeasonNumber:00}E{episode.EpisodeNumber:00}";
+                    parameters.Name = episode.EpisodeNumber is > 0 and < 100
+                        ? $"S{episode.SeasonNumber:00}E%{episode.EpisodeNumber:00}"
+                        : $"S{episode.SeasonNumber:00}E{episode.EpisodeNumber:00}";
 
                     pageableRequests.Add(GetPagedRequests(MaxPages, parameters));
                 }


### PR DESCRIPTION
#### Description

BTN records long running series with three digit episode numbers in the group name, for example `S01E099`. The `Name` filter is matched against that group name, and `BroadcastheNetRequestGenerator` built it with the `:00` format specifier, which pads to a minimum of two digits, so an episode search for episode 99 sent `S01%E99%`.

That never matches. The literal text `E99` does not occur anywhere inside `S01E099` — the characters after the `E` are `0`, `9`, `9`. The same applies to every episode from 1 to 99: a search for episode 9 sends `S01%E09%`, and `S01E009` contains `E00` and `009` but never `E09`.

Episode 100 and above have always worked, because at three digits the two forms converge on the same string. That produces a sharp boundary on an affected series: every episode below 100 returns no results, everything from 100 onwards is found.

This adds a wildcard after the `E` for episode numbers below 100, so one request matches both the two digit and the zero padded form. Numbers of 100 and above keep the existing string, where a wildcard would only broaden the match for no gain. Both the standard and the anime episode paths are affected and both are fixed. The anime path matters in practice because series long enough to pass episode 99 are frequently set to Series Type: Anime. Each keeps the `Name` format it already used — the standard path keeps its wildcards, the anime path does not gain any.

Season searches are deliberately left alone. They already send `S01E%`, which matches three digit numbering fine, which is why season packs were never affected.

Verified against a live BTN indexer. Result counts are the API's own `results` value for the given `Name` filter:

| `Name` filter | results |
| --- | --- |
| `S01%E99%` (previous behaviour, episode 99) | 0 |
| `S01%E%99%` (this change) | 1, group `S01E099` |
| `S01E99` (previous anime behaviour) | 0 |
| `S01E%99` (this change, anime) | 1, group `S01E099` |
| `S01%E01%` on a normally numbered series | 11 |
| `S01%E%01%` on the same series | 11, unchanged |

One trade-off worth naming: on a three digit series a low episode number can also match its neighbours, because the trailing wildcard admits a further digit — searching episode 9 returns `S01E009` plus `S01E090` to `S01E099`. Those are discarded when the release name is parsed, and the count stays far inside one page, so it remains a single request. The trailing wildcard cannot be dropped to avoid this: it is what matches multi episode groups such as `S01E01E02` and variant groups such as `S01E01 - Extended`.

An earlier revision of this PR used a second request tier holding the zero padded form. The wildcard replaces it on @mynameisbogdan's suggestion, which avoids the extra request and also removes a limitation that version had: in the anime path the fallback tier sat behind the season query, so a matching season pack would stop the chain before the padded query ran.

#### Tests

New `BroadcastheNetRequestGeneratorFixture` with 13 tests:

- the wildcarded query is the only request issued, for episodes 1, 9, 97 and 99
- no wildcard and no extra request for 100, 101 and 999
- a multi episode search wildcards only the members below 100
- season search is unchanged
- the anime path, wildcarded below 100 and untouched at 100
- no requests at all when the series has neither a TVDB nor a TVRage id


Note that `BroadcastheNetFixture.should_back_off_and_report_api_key_invalid` fails on `v5-develop` before this change as well when the fixture is run on its own, so it is unrelated to this PR.

#### Database Migration

None.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

None open that I could find.

