### PR TITLE
Fixed: Preferred size compared against a single episode runtime for multi episode releases

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/PrioritizeDownloadDecisionFixture.cs
@@ -58,6 +58,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             return Builder<Episode>.CreateNew()
                             .With(e => e.Id = id)
                             .With(e => e.EpisodeNumber = id)
+                            .With(e => e.Runtime = 0)
                             .Build();
         }
 
@@ -216,6 +217,29 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
 
             var qualifiedReports = Subject.PrioritizeDecisions(decisions);
             qualifiedReports.First().RemoteEpisode.Should().Be(remoteEpisode3);
+        }
+
+        [Test]
+        public void should_order_by_closest_to_preferred_size_of_the_whole_release()
+        {
+            // 46 MB/Min * (10 episodes * 60 Min Runtime) = 27600 MB
+            GivenPreferredSize(_series.QualityProfile.Value, 46);
+
+            var episodes = Builder<Episode>.CreateListOfSize(10)
+                                           .All()
+                                           .With(e => e.Runtime = 60)
+                                           .Build()
+                                           .ToList();
+
+            var remoteEpisodeSmall = GivenRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p), Language.English, size: 12000.Megabytes(), age: 1);
+            var remoteEpisodeLarge = GivenRemoteEpisode(episodes, new QualityModel(Quality.HDTV720p), Language.English, size: 26000.Megabytes(), age: 1);
+
+            var decisions = new List<DownloadDecision>();
+            decisions.Add(new DownloadDecision(remoteEpisodeSmall));
+            decisions.Add(new DownloadDecision(remoteEpisodeLarge));
+
+            var qualifiedReports = Subject.PrioritizeDecisions(decisions);
+            qualifiedReports.First().RemoteEpisode.Should().Be(remoteEpisodeLarge);
         }
 
         [Test]

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -188,14 +188,15 @@ namespace NzbDrone.Core.DecisionEngine
                 var qualityOrGroup = qualityProfile.Items[qualityIndex.Index];
                 var item = qualityOrGroup.Quality == null ? qualityOrGroup.Items[qualityIndex.GroupIndex] : qualityOrGroup;
                 var preferredSize = item.PreferredSize;
+                var runtime = GetRuntime(remoteEpisode);
 
                 // If no value for preferred it means unlimited so fallback to sort largest is best
-                if (preferredSize.HasValue && remoteEpisode.Series.Runtime > 0)
+                if (preferredSize.HasValue && runtime > 0)
                 {
-                    var preferredEpisodeSize = remoteEpisode.Series.Runtime * preferredSize.Value.Megabytes();
+                    var preferredReleaseSize = runtime * preferredSize.Value.Megabytes();
 
                     // Calculate closest to the preferred size
-                    return Math.Abs((remoteEpisode.Release.Size - preferredEpisodeSize).Round(200.Megabytes())) * (-1);
+                    return Math.Abs((remoteEpisode.Release.Size - preferredReleaseSize).Round(200.Megabytes())) * (-1);
                 }
                 else
                 {
@@ -204,6 +205,16 @@ namespace NzbDrone.Core.DecisionEngine
             });
 
             return sizeCompare;
+        }
+
+        private static int GetRuntime(RemoteEpisode remoteEpisode)
+        {
+            if (remoteEpisode.Episodes is not { Count: not 0 })
+            {
+                return remoteEpisode.Series.Runtime;
+            }
+
+            return remoteEpisode.Episodes.Sum(episode => episode.Runtime > 0 ? episode.Runtime : remoteEpisode.Series.Runtime);
         }
     }
 }

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionComparer.cs
@@ -209,7 +209,7 @@ namespace NzbDrone.Core.DecisionEngine
 
         private static int GetRuntime(RemoteEpisode remoteEpisode)
         {
-            if (remoteEpisode.Episodes is not { Count: not 0 })
+            if (remoteEpisode.Episodes.Count == 0)
             {
                 return remoteEpisode.Series.Runtime;
             }


### PR DESCRIPTION
#### Description
`DownloadDecisionComparer.CompareSize` builds the preferred size target from `Series.Runtime` - the runtime of a *single* episode - and then compares it against the size of the whole release:

```csharp
var preferredEpisodeSize = remoteEpisode.Series.Runtime * preferredSize.Value.Megabytes();
```

For anything that isn't a single episode the target is too small by the number of episodes in the release. With a 10 episode season at 60 min and a preferred size of 46 MB/min the target works out as 2.7 GB instead of 27.6 GB, so every realistic season pack overshoots it and the sort collapses into "smallest wins" - whatever preferred size is configured, the smallest pack is picked once quality and custom format scores are tied.

`AcceptableSizeSpecification`, which runs on the same release, already measures it the other way and sums the runtime of every episode:

```csharp
foreach (var episode in subject.Episodes)
{
    runtime += episode.Runtime > 0 ? episode.Runtime : seriesRuntime;
}
```

So the min/max size limits and the preferred size sort currently disagree about what a release is. This makes the comparer use the same runtime as the specification. Single episode releases are unaffected.

The new test fails on `v5-develop` (the smaller pack wins) and passes with this change.

One note on the test change: `GivenEpisode` used to leave `Episode.Runtime` at whatever NBuilder generated, which never mattered because the comparer only looked at `Series.Runtime`. Now that episode runtimes are used, the helper sets it to 0 explicitly so those tests keep falling back to the series runtime they were written against.

This was reported in #8432 with the same analysis, but that issue was closed automatically by the bot for not using the issue template and was never looked at.

#### Database Migration
NO

#### Issues Fixed or Closed by this PR
* Closes #8432


#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
