### PR TITLE
Fixed: existing episode file deleted before the new file name is built

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FizzWare.NBuilder;
@@ -5,9 +7,11 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
+using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
@@ -91,6 +95,32 @@ namespace NzbDrone.Core.Test.MediaFiles
                                                                                 })
                                                      .Build()
                                                      .ToList();
+        }
+
+        [Test]
+        public void should_not_delete_the_existing_file_when_the_new_file_name_cannot_be_built()
+        {
+            GivenSingleEpisodeWithSingleEpisodeFile();
+
+            // The real MoveEpisodeFile builds the file name as its first statement, so a name that
+            // can't be built surfaces from either of these two, depending on where the build happens.
+            Mocker.GetMock<IBuildFileNames>()
+                  .Setup(s => s.BuildFilePath(It.IsAny<List<Episode>>(),
+                                              It.IsAny<Series>(),
+                                              It.IsAny<EpisodeFile>(),
+                                              It.IsAny<string>(),
+                                              It.IsAny<NamingConfig>(),
+                                              It.IsAny<List<CustomFormat>>()))
+                  .Throws(new NullReferenceException());
+
+            Mocker.GetMock<IMoveEpisodeFiles>()
+                  .Setup(s => s.MoveEpisodeFile(It.IsAny<EpisodeFile>(), It.IsAny<LocalEpisode>()))
+                  .Throws(new NullReferenceException());
+
+            Assert.Throws<NullReferenceException>(() => Subject.UpgradeEpisodeFile(_episodeFile, _localEpisode));
+
+            Mocker.GetMock<IRecycleBinProvider>().Verify(v => v.DeleteFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+            Mocker.GetMock<IMediaFileService>().Verify(v => v.Delete(It.IsAny<EpisodeFile>(), DeleteMediaFileReason.Upgrade), Times.Never());
         }
 
         [Test]

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -4,6 +4,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.MediaFiles.EpisodeImport;
+using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles
@@ -18,18 +19,21 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IRecycleBinProvider _recycleBinProvider;
         private readonly IMediaFileService _mediaFileService;
         private readonly IMoveEpisodeFiles _episodeFileMover;
+        private readonly IBuildFileNames _buildFileNames;
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
 
         public UpgradeMediaFileService(IRecycleBinProvider recycleBinProvider,
                                        IMediaFileService mediaFileService,
                                        IMoveEpisodeFiles episodeFileMover,
+                                       IBuildFileNames buildFileNames,
                                        IDiskProvider diskProvider,
                                        Logger logger)
         {
             _recycleBinProvider = recycleBinProvider;
             _mediaFileService = mediaFileService;
             _episodeFileMover = episodeFileMover;
+            _buildFileNames = buildFileNames;
             _diskProvider = diskProvider;
             _logger = logger;
         }
@@ -50,6 +54,19 @@ namespace NzbDrone.Core.MediaFiles
             if (existingFiles.Any() && !_diskProvider.FolderExists(rootFolder))
             {
                 throw new RootFolderNotFoundException($"Root folder '{rootFolder}' was not found.");
+            }
+
+            // Build the destination path before deleting anything, for the same reason: if the name can't be
+            // built the existing file must stay where it is instead of ending up in the recycle bin with no
+            // replacement imported.
+            if (existingFiles.Any())
+            {
+                _buildFileNames.BuildFilePath(localEpisode.Episodes,
+                                              localEpisode.Series,
+                                              episodeFile,
+                                              Path.GetExtension(localEpisode.Path),
+                                              null,
+                                              localEpisode.CustomFormats);
             }
 
             foreach (var existingFile in existingFiles)


### PR DESCRIPTION
#### Description

`UpgradeEpisodeFile` deletes the existing episode file - recycle bin at line 65, database at line 73 - and only then calls `MoveEpisodeFile` at line 84, where the very first statement (`EpisodeFileMovingService.cs:85`) builds the new file name. Anything that throws while building that name throws after the old file is already gone, and `ImportApprovedEpisodes.cs:193` swallows it in `catch (Exception)` with a single Warn. The episode is left with no file, the download stays in the queue, and the next pass does the same thing again. On my setup one release produced 928 failed imports in 24 hours, binning the existing file every time.

The method already guards against exactly this shape of problem a few lines earlier, with the comment spelling out why:

```
// If there are existing episode files and the root folder is missing, throw, so the old file isn't left behind during the import process.
```

That covers a missing root folder. It does not cover a name that cannot be built. This PR adds the same kind of guard: when there are existing files, build the destination path before the delete loop, so a failure there leaves the existing file where it is.

Test: `should_not_delete_the_existing_file_when_the_new_file_name_cannot_be_built` in `UpgradeMediaFileServiceFixture`. On a clean `v5-develop` it fails with `Moq.MockException: Expected invocation on the mock should never have been performed, but was 1 times: DeleteFile(...)` - the file is in the recycle bin although the move threw. With this change the fixture is 11/11. Full `Sonarr.Core.Test` run: 5155 passed, 28 skipped, 6 failures, all in the network-dependent scene mapping tests, which fail the same way on a clean checkout in the same container.

Known trade-off: the path is built twice, once for the check and once inside `MoveEpisodeFile`. The cheaper alternative is to pass the built path down, which changes the `IMoveEpisodeFiles` signature - happy to do it that way instead if you prefer, or to move the guard elsewhere.

This came out of #8900. My original report there blamed `AddQualityTokens` based on a line number from an optimised build, and that part did not hold up - I have said so in the issue. The ordering problem above is what is left, and it does not depend on which exception was thrown.

#### Submission Checklist

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

- Related to #8900
