### PR TITLE
New: Parsing file names with ambiguous episode numbering

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/PathParserFixture.cs
@@ -33,6 +33,12 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase(@"C:\Test\Series\Season 2\01. Total Series Action - Episode 1 - Monster Cash.mkv", 2, 1)]
         [TestCase(@"C:\Test\Series\Season 1\02.04.24 - S01E01 - The Rabbit Hole", 1, 1)]
         [TestCase(@"C:\Test\Series\Season 1\8 Series Rules - S01E01 - Pilot", 1, 1)]
+        [TestCase(@"C:\Test\Series Title\Series Title S02 01.mkv", 2, 1)]
+        [TestCase(@"C:\Test\Series Title\Series Title S2 1.mkv", 2, 1)]
+        [TestCase(@"C:\Test\Series Title\Series Title S2 10.mkv", 2, 10)]
+        [TestCase(@"C:\Test\Series Title\S02 01.mkv", 2, 1)]
+        [TestCase(@"C:\Test\Series Title\Series Title S02 10.mkv", 2, 10)]
+        [TestCase(@"C:\Test\Series Title S01 02\Series Title S02 01 1080p WEB-DL.mkv", 2, 1)]
 
         // [TestCase(@"C:\series.state.S02E04.720p.WEB-DL.DD5.1.H.264\73696S02-04.mkv", 2, 4)] //Gets treated as S01E04 (because it gets parsed as anime); 2020-01 broken test case: Expected result.EpisodeNumbers to contain 1 item(s), but found 0
         public void should_parse_from_path(string path, int season, int episode)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -573,10 +573,21 @@ namespace NzbDrone.Core.Parser
         public static ParsedEpisodeInfo ParsePath(string path)
         {
             var fileInfo = new FileInfo(path);
-            var result = ParseTitle(fileInfo.Name);
+            var fileName = fileInfo.Name;
+
+            foreach (var replace in ParserCommon.PathPreSubstitutionRegex)
+            {
+                if (replace.TryReplace(ref fileName))
+                {
+                    Logger.Trace($"Replace regex: {replace}");
+                    Logger.Debug("Substituted with " + fileName);
+                }
+            }
+
+            var result = ParseTitle(fileName);
 
             // Parse using the folder and file separately, but combine if they both parse correctly.
-            var episodeNumberMatch = SimpleEpisodeNumberRegex.Match(fileInfo.Name);
+            var episodeNumberMatch = SimpleEpisodeNumberRegex.Match(fileName);
 
             if (episodeNumberMatch.Success && fileInfo.Directory?.Name != null && (result == null || result.IsMiniSeries || result.AbsoluteEpisodeNumbers.Any()))
             {
@@ -607,7 +618,7 @@ namespace NzbDrone.Core.Parser
                 }
             }
 
-            if (result == null && int.TryParse(Path.GetFileNameWithoutExtension(fileInfo.Name), out var number))
+            if (result == null && int.TryParse(Path.GetFileNameWithoutExtension(fileName), out var number))
             {
                 Logger.Debug("Attempting to parse episode info using directory and file names. {0}", fileInfo.Directory.Name);
                 result = ParseTitle(fileInfo.Directory.Name);
@@ -631,7 +642,7 @@ namespace NzbDrone.Core.Parser
             if (result == null)
             {
                 Logger.Debug("Attempting to parse episode info using combined directory and file names. {0}", fileInfo.Directory.Name);
-                result = ParseTitle(fileInfo.Directory.Name + " " + fileInfo.Name);
+                result = ParseTitle(fileInfo.Directory.Name + " " + fileName);
             }
 
             if (result == null)

--- a/src/NzbDrone.Core/Parser/ParserCommon.cs
+++ b/src/NzbDrone.Core/Parser/ParserCommon.cs
@@ -51,6 +51,12 @@ internal static class ParserCommon
         new RegexReplace(@"^(?<title>.+?(?=[ ._-]\()).+?\((?<year>\d{4})\/(?<info>S[^\/]+)", "${title} (${year}) - ${info} ", RegexOptions.Compiled),
     };
 
+    internal static readonly RegexReplace[] PathPreSubstitutionRegex = new[]
+    {
+        // Season and episode number separated by a space (S02 01)
+        new RegexReplace(@"(?<separator>^|[-_. ])S(?<season>(?<!\d+)\d{1,2}(?!\d+)) (?<episode>(?<!\d+)\d{1,2}(?!\d+))(?!\d+)", "${separator}S${season}E${episode}", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    };
+
     internal static readonly RegexReplace WebsitePrefixRegex = new(@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
         string.Empty,
         RegexOptions.IgnoreCase | RegexOptions.Compiled);


### PR DESCRIPTION
#### Description

Moves some of the logic from #8877 up and around so it's a better fit for pre-processing file paths before parsing.

<!-- Remove if there is no database migration. If there is an database migration replace ### with the migration number -->

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #8878
