### PR TITLE
Fix allowed hosts check check on config file changes

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/AllowedHostsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/AllowedHostsCheck.cs
@@ -8,7 +8,7 @@ using NzbDrone.Core.Localization;
 namespace NzbDrone.Core.HealthCheck.Checks
 {
     [CheckOn(typeof(ApplicationStartedEvent))]
-    [CheckOn(typeof(ConfigSavedEvent))]
+    [CheckOn(typeof(ConfigFileSavedEvent))]
     public class AllowedHostsCheck : HealthCheckBase
     {
         private readonly IConfigFileProvider _configFileProvider;


### PR DESCRIPTION
#### Description

`ConfigFileSavedEvent` is the event triggered by `ConfigFileProvider.SaveConfigDictionary`.