### PR TITLE
Set PooledConnectionLifetime to 30 minutes

### DIFF
--- a/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
+++ b/src/NzbDrone.Common/Http/Dispatchers/ManagedHttpDispatcher.cs
@@ -155,6 +155,7 @@ namespace NzbDrone.Common.Http.Dispatchers
                 Credentials = GetCredentialCache(),
                 PreAuthenticate = true,
                 MaxConnectionsPerServer = 12,
+                PooledConnectionLifetime = TimeSpan.FromMinutes(30),
                 ConnectCallback = Socket.OSSupportsIPv6 ? _httpHappyEyeballs.OnConnect : null,
                 SslOptions = new SslClientAuthenticationOptions
                 {


### PR DESCRIPTION
#### Description

I don't fully trust the LLM's diagnosis on the issue, but I did some digging into it and of the options setting `PooledConnectionLifetime` to 10m has a minimal impact, but should allow Sonarr to reflect IP changes without restarting as well as avoiding requests failing until the container is restarted. Other options would result in additional requests to ping that I don't feel are necessary, but does mean that it can take up to 10m for things to self correct if they start failing.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #8912
