### PR TITLE
Improve logging for 'Allowed Hosts' and 'Trusted Networks'

### DIFF
--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -215,6 +215,8 @@ namespace NzbDrone.Common.Instrumentation
             {
                 c.ForLogger("System.*").WriteToNil(LogLevel.Warn);
                 c.ForLogger("Microsoft.*").WriteToNil(LogLevel.Warn);
+                c.ForLogger("Microsoft.AspNetCore.HostFiltering*").WriteToNil(LogLevel.Info);
+                c.ForLogger("Microsoft.AspNetCore.HttpOverrides*").WriteToNil(LogLevel.Debug);
                 c.ForLogger("Microsoft.Hosting.Lifetime*").WriteToNil(LogLevel.Info);
                 c.ForLogger("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware").WriteToNil(LogLevel.Fatal);
                 c.ForLogger("Sonarr.Http.Authentication.ApiKeyAuthenticationHandler").WriteToNil(LogLevel.Info);

--- a/src/NzbDrone.Common/Network/IPNetworkParser.cs
+++ b/src/NzbDrone.Common/Network/IPNetworkParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -17,14 +18,14 @@ namespace NzbDrone.Common.Network
                 return false;
             }
 
-            var parts = value.Split('/');
+            var parts = value.Split('/', StringSplitOptions.TrimEntries);
 
             if (parts.Length > 2)
             {
                 return false;
             }
 
-            var addressPart = parts[0].Trim();
+            var addressPart = parts[0];
 
             if (!IPAddress.TryParse(addressPart, out var parsedAddress))
             {
@@ -46,7 +47,7 @@ namespace NzbDrone.Common.Network
                 return true;
             }
 
-            if (!int.TryParse(parts[1].Trim(), out var parsedPrefixLength) ||
+            if (!int.TryParse(parts[1], out var parsedPrefixLength) ||
                 parsedPrefixLength < 1 ||
                 parsedPrefixLength > maxPrefixLength)
             {
@@ -71,13 +72,8 @@ namespace NzbDrone.Common.Network
                 return true;
             }
 
-            foreach (var entry in value.Split(','))
+            foreach (var entry in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
-                if (entry.IsNullOrWhiteSpace())
-                {
-                    continue;
-                }
-
                 if (!TryParse(entry, out _, out _))
                 {
                     return false;
@@ -94,9 +90,7 @@ namespace NzbDrone.Common.Network
                 return string.Empty;
             }
 
-            return string.Join(", ", value.Split(',')
-                                          .Select(e => e.Trim())
-                                          .Where(e => e.IsNotNullOrWhiteSpace()));
+            return string.Join(", ", value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
         }
 
         private static bool HasHostBitsSet(IPAddress address, int prefixLength)

--- a/src/NzbDrone.Core/Configuration/AllowedHostsParser.cs
+++ b/src/NzbDrone.Core/Configuration/AllowedHostsParser.cs
@@ -16,9 +16,8 @@ namespace NzbDrone.Core.Configuration
                 return new List<string>();
             }
 
-            return value.Split(Separators)
-                        .Select(h => Normalize(h.Trim()))
-                        .Where(h => h.IsNotNullOrWhiteSpace())
+            return value.Split(Separators, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                        .Select(Normalize)
                         .Distinct()
                         .ToList();
         }

--- a/src/NzbDrone.Host/ForwardedHeadersConfigurator.cs
+++ b/src/NzbDrone.Host/ForwardedHeadersConfigurator.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
 using NLog;
@@ -25,13 +26,8 @@ namespace NzbDrone.Host
                 return;
             }
 
-            foreach (var entry in trustedNetworks.Split(','))
+            foreach (var entry in trustedNetworks.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
             {
-                if (entry.IsNullOrWhiteSpace())
-                {
-                    continue;
-                }
-
                 if (IPNetworkParser.TryParse(entry, out var address, out var prefixLength))
                 {
                     options.KnownIPNetworks.Add(new IPNetwork(address, prefixLength));
@@ -40,7 +36,7 @@ namespace NzbDrone.Host
                 }
                 else
                 {
-                    Logger.Warn("Invalid trusted network '{0}', forwarded headers from it will not be trusted", entry.Trim());
+                    Logger.Warn("Invalid trusted network '{0}', forwarded headers from it will not be trusted", entry);
                 }
             }
         }

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -7,13 +7,11 @@ using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi;
 using NLog.Extensions.Logging;
 using NzbDrone.Common.EnvironmentInfo;
@@ -57,6 +55,8 @@ namespace NzbDrone.Host
                 b.ClearProviders();
                 b.SetMinimumLevel(LogLevel.Trace);
                 b.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
+                b.AddFilter("Microsoft.AspNetCore.HostFiltering", LogLevel.Information);
+                b.AddFilter("Microsoft.AspNetCore.HttpOverrides", LogLevel.Debug);
                 b.AddFilter("Sonarr.Http.Authentication.ApiKeyAuthenticationHandler", LogLevel.Information);
                 b.AddFilter("Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager", LogLevel.Error);
                 b.AddNLog();
@@ -68,8 +68,6 @@ namespace NzbDrone.Host
             services.AddRouting(options => options.LowercaseUrls = true);
 
             services.AddResponseCompression();
-
-            services.AddSingleton<IConfigureOptions<HostFilteringOptions>, ConfigureHostFilteringOptions>();
 
             services.AddCors(options =>
             {


### PR DESCRIPTION
#### Description

Two changes here:

1. Better logging for  'Allowed Hosts' and 'Trusted Networks' rejections and also fixes double logging of `Allowed Hosts` on start up. Will cherry pick this to `develop`
2. Use options for string split to trim and drop empty items (not cherry picking back to `develop`)

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
