### PR TITLE
Don't show Open Browser setting on unsupported setups

### DIFF
--- a/frontend/src/Settings/General/HostSettings.tsx
+++ b/frontend/src/Settings/General/HostSettings.tsx
@@ -5,7 +5,7 @@ import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
 import { inputTypes, sizes } from 'Helpers/Props';
 import { useShowAdvancedSettings } from 'Settings/advancedSettingsStore';
-import { useIsWindowsService } from 'System/Status/useSystemStatus';
+import { useSystemStatusData } from 'System/Status/useSystemStatus';
 import { InputChanged } from 'typings/inputs';
 import { PendingSection } from 'typings/pending';
 import translate from 'Utilities/String/translate';
@@ -43,7 +43,7 @@ function HostSettings({
   onInputChange,
 }: HostSettingsProps) {
   const showAdvancedSettings = useShowAdvancedSettings();
-  const isWindowsService = useIsWindowsService();
+  const { isWindows, mode } = useSystemStatusData();
 
   return (
     <FieldSet legend={translate('Host')}>
@@ -202,7 +202,7 @@ function HostSettings({
         </>
       ) : null}
 
-      {isWindowsService ? null : (
+      {isWindows && mode !== 'service' ? (
         <FormGroup size={sizes.MEDIUM}>
           <FormLabel>{translate('OpenBrowserOnStart')}</FormLabel>
 
@@ -214,7 +214,7 @@ function HostSettings({
             {...launchBrowser}
           />
         </FormGroup>
-      )}
+      ) : null}
     </FieldSet>
   );
 }


### PR DESCRIPTION
#### Description

This was being shown on docker and other unsupported setups because it was gating on the wrong thing.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review
