### PR TITLE
Fixed: IPv6 Addresses for Download Clients

### DIFF
--- a/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/UrlHostFixture.cs
+++ b/src/NzbDrone.Common.Test/ExtensionTests/StringExtensionTests/UrlHostFixture.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Common.Test.ExtensionTests.StringExtensionTests
+{
+    [TestFixture]
+    public class UrlHostFixture
+    {
+        [TestCase("::1", "[::1]")]
+        [TestCase("fd3a:9a29:b136:eeee:aaaa::6", "[fd3a:9a29:b136:eeee:aaaa::6]")]
+        [TestCase("[::1]", "[::1]")]
+        [TestCase("192.168.0.1", "192.168.0.1")]
+        [TestCase("sonarr.tv", "sonarr.tv")]
+        [TestCase("", "")]
+        [TestCase(null, null)]
+        public void should_bracket_ipv6_addresses(string input, string expected)
+        {
+            input.ToUrlHost().Should().Be(expected);
+        }
+
+        [TestCase("[::1]", "::1")]
+        [TestCase("[fd3a:9a29:b136:eeee:aaaa::6]", "fd3a:9a29:b136:eeee:aaaa::6")]
+        [TestCase("::1", "::1")]
+        [TestCase("192.168.0.1", "192.168.0.1")]
+        [TestCase("sonarr.tv", "sonarr.tv")]
+        [TestCase("", "")]
+        [TestCase(null, null)]
+        public void should_remove_brackets_from_ipv6_addresses(string input, string expected)
+        {
+            input.FromUrlHost().Should().Be(expected);
+        }
+
+        [TestCase("localhost")]
+        [TestCase("LocalHost")]
+        [TestCase("127.0.0.1")]
+        [TestCase("127.1.2.3")]
+        [TestCase("::1")]
+        [TestCase("[::1]")]
+        public void should_be_localhost_address(string input)
+        {
+            input.IsLocalhostAddress().Should().BeTrue();
+        }
+
+        [TestCase("192.168.0.1")]
+        [TestCase("[fd3a:9a29:b136:eeee:aaaa::6]")]
+        [TestCase("sonarr.tv")]
+        [TestCase("")]
+        [TestCase(null)]
+        public void should_not_be_localhost_address(string input)
+        {
+            input.IsLocalhostAddress().Should().BeFalse();
+        }
+    }
+}

--- a/src/NzbDrone.Common.Test/Http/HttpRequestBuilderFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpRequestBuilderFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Http;
@@ -25,6 +25,25 @@ namespace NzbDrone.Common.Test.Http
         {
             var requestBuilder = new HttpRequestBuilder("http://host/{seg}/some");
             Assert.Throws<InvalidOperationException>(() => requestBuilder.SetSegment("seg2", "dir"));
+        }
+
+        [TestCase("192.168.0.1", "http://192.168.0.1:8080/")]
+        [TestCase("localhost", "http://localhost:8080/")]
+        [TestCase("::1", "http://[::1]:8080/")]
+        [TestCase("[::1]", "http://[::1]:8080/")]
+        [TestCase("fd3a:9a29:b136:eeee:aaaa::6", "http://[fd3a:9a29:b136:eeee:aaaa::6]:8080/")]
+        public void should_build_base_url_for_host(string host, string expected)
+        {
+            HttpRequestBuilder.BuildBaseUrl(false, host, 8080, "/").Should().Be(expected);
+        }
+
+        [TestCase("::1", "http://[::1]:8080/api")]
+        [TestCase("[::1]", "http://[::1]:8080/api")]
+        public void should_build_request_for_ipv6_host(string host, string expected)
+        {
+            var builder = new HttpRequestBuilder(false, host, 8080);
+
+            builder.Resource("/api").Build().Url.FullUri.Should().Be(expected);
         }
 
         [Test]

--- a/src/NzbDrone.Common/Extensions/StringExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/StringExtensions.cs
@@ -235,9 +235,46 @@ namespace NzbDrone.Common.Extensions
             return parsedAddress.AddressFamily == AddressFamily.InterNetwork || parsedAddress.AddressFamily == AddressFamily.InterNetworkV6;
         }
 
+        public static bool IsLocalhostAddress(this string input)
+        {
+            if (input.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            var host = input.FromUrlHost();
+
+            if (host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            return IPAddress.TryParse(host, out var parsedAddress) && IPAddress.IsLoopback(parsedAddress);
+        }
+
         public static string ToUrlHost(this string input)
         {
-            return input.Contains(':') ? $"[{input}]" : input;
+            if (input.IsNullOrWhiteSpace() || !input.Contains(':') || IsBracketed(input))
+            {
+                return input;
+            }
+
+            return $"[{input}]";
+        }
+
+        public static string FromUrlHost(this string input)
+        {
+            if (input.IsNullOrWhiteSpace() || !IsBracketed(input))
+            {
+                return input;
+            }
+
+            return input[1..^1];
+        }
+
+        private static bool IsBracketed(string input)
+        {
+            return input.StartsWith('[') && input.EndsWith(']');
         }
 
         public static string Reverse(this string text)

--- a/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
+++ b/src/NzbDrone.Common/Http/HttpRequestBuilder.cs
@@ -62,7 +62,7 @@ namespace NzbDrone.Common.Http
                 urlBase = "/" + urlBase;
             }
 
-            return string.Format("{0}://{1}:{2}{3}", protocol, host, port, urlBase);
+            return string.Format("{0}://{1}:{2}{3}", protocol, host.ToUrlHost(), port, urlBase);
         }
 
         public virtual HttpRequestBuilder Clone()

--- a/src/NzbDrone.Common/Http/HttpUri.cs
+++ b/src/NzbDrone.Common/Http/HttpUri.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Common.Http
         private readonly string _uri;
         public string FullUri => _uri;
 
-        [GeneratedRegex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[[A-F0-9:]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+        [GeneratedRegex(@"^(?:(?<scheme>[a-z]+):)?(?://(?<host>[-_A-Z0-9.]+|\[[A-F0-9:.]+\])(?::(?<port>[0-9]{1,5}))?)?(?<path>(?:(?:(?<=^)|/+)[^/?#\r\n]+)+/*|/+)?(?:\?(?<query>[^#\r\n]*))?(?:\#(?<fragment>.*))?$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
         private static partial Regex UriRegex();
 
         public HttpUri(string uri)

--- a/src/NzbDrone.Core.Test/ValidationTests/ValidHostFixture.cs
+++ b/src/NzbDrone.Core.Test/ValidationTests/ValidHostFixture.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using FluentValidation;
+using NUnit.Framework;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Test.ValidationTests
+{
+    [TestFixture]
+    public class ValidHostFixture
+    {
+        private HostValidator _validator;
+
+        [SetUp]
+        public void Setup()
+        {
+            _validator = new HostValidator();
+        }
+
+        [TestCase("localhost")]
+        [TestCase("qbittorrent.lan")]
+        [TestCase("192.168.0.1")]
+        [TestCase("::1")]
+        [TestCase("[::1]")]
+        [TestCase("fd3a:9a29:b136:eeee:aaaa::6")]
+        [TestCase("[fd3a:9a29:b136:eeee:aaaa::6]")]
+        public void should_be_valid_host(string host)
+        {
+            _validator.Validate(new HostSettings { Host = host }).IsValid.Should().BeTrue();
+        }
+
+        [TestCase("")]
+        [TestCase("http://localhost")]
+        [TestCase("localhost:8080")]
+        [TestCase("[localhost]")]
+        [TestCase("[192.168.0.1]")]
+        public void should_not_be_valid_host(string host)
+        {
+            _validator.Validate(new HostSettings { Host = host }).IsValid.Should().BeFalse();
+        }
+
+        private class HostSettings
+        {
+            public string Host { get; set; }
+        }
+
+        private class HostValidator : AbstractValidator<HostSettings>
+        {
+            public HostValidator()
+            {
+                RuleFor(c => c.Host).ValidHost();
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Configuration/AllowedHostsParser.cs
+++ b/src/NzbDrone.Core/Configuration/AllowedHostsParser.cs
@@ -40,17 +40,7 @@ namespace NzbDrone.Core.Configuration
 
         private static string Normalize(string host)
         {
-            if (!IsBracketed(host) && host.Contains(':') && host.IsValidIpAddress())
-            {
-                return $"[{host}]";
-            }
-
-            return host;
-        }
-
-        private static bool IsBracketed(string host)
-        {
-            return host.StartsWith("[") && host.EndsWith("]");
+            return host.IsValidIpAddress() ? host.ToUrlHost() : host;
         }
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
@@ -194,7 +194,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host.Contains("127.0.0.1") || Settings.Host.Contains("localhost"),
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir["dir"])) }
             };
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -250,7 +250,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host is "127.0.0.1" or "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             if (!destDir.IsEmpty)

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -129,7 +129,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 return new DownloadClientInfo
                 {
-                    IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                    IsLocalhost = Settings.Host.IsLocalhostAddress(),
                     OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, fullPath) }
                 };
             }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/UsenetDownloadStation.cs
@@ -151,7 +151,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
                 return new DownloadClientInfo
                 {
-                    IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                    IsLocalhost = Settings.Host.IsLocalhostAddress(),
                     OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, fullPath) }
                 };
             }

--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -252,7 +252,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "::1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir)) }
             };
         }

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodProxy.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using NLog;
 using NzbDrone.Common.Cache;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
 using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Download.Clients.Flood.Types;
@@ -37,7 +38,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
 
         private string BuildUrl(FloodSettings settings)
         {
-            return $"{(settings.UseSsl ? "https://" : "http://")}{settings.Host}:{settings.Port}/{settings.UrlBase}";
+            return $"{(settings.UseSsl ? "https://" : "http://")}{settings.Host.ToUrlHost()}:{settings.Port}/{settings.UrlBase}";
         }
 
         private string BuildCachedCookieKey(FloodSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
@@ -160,7 +160,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "::1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir)) }
             };
         }

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             if (!destDir.IsEmpty)

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortex.cs
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         {
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             return status;

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/Nzbget.cs
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             if (category != null)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -446,7 +446,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, destDir) },
                 RemovesCompletedDownloads = RemovesCompletedDownloads(config)
             };

--- a/src/NzbDrone.Core/Download/Clients/RQBit/RQBit.cs
+++ b/src/NzbDrone.Core/Download/Clients/RQBit/RQBit.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Core.Download.Clients.RQBit
         {
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
             };
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -257,7 +257,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             if (category != null)

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -208,7 +208,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir)) }
             };
         }

--- a/src/NzbDrone.Core/Download/Clients/Tribler/TriblerDownloadClient.cs
+++ b/src/NzbDrone.Core/Download/Clients/Tribler/TriblerDownloadClient.cs
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.Download.Clients.Tribler
 
             return new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost",
+                IsLocalhost = Settings.Host.IsLocalhostAddress(),
                 OutputRootFolders = new List<OsPath> { _remotePathMappingService.RemapRemoteToLocal(Settings.Host, new OsPath(destDir)) }
             };
         }

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             return status;

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host.IsLocalhostAddress()
             };
 
             if (!destDir.IsEmpty)

--- a/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
+++ b/src/NzbDrone.Core/Validation/RuleBuilderExtensions.cs
@@ -31,7 +31,29 @@ namespace NzbDrone.Core.Validation
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
 
-            return ruleBuilder.Must(x => HostRegex.IsMatch(x) || x.IsValidIpAddress()).WithMessage("must be valid Host without http://");
+            return ruleBuilder.Must(IsValidHost).WithMessage("must be valid Host without http://");
+        }
+
+        private static bool IsValidHost(string host)
+        {
+            if (host.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            if (HostRegex.IsMatch(host))
+            {
+                return true;
+            }
+
+            var address = host.FromUrlHost();
+
+            if (!address.IsValidIpAddress())
+            {
+                return false;
+            }
+
+            return address == host || address.Contains(':');
         }
 
         public static IRuleBuilderOptions<T, string> ValidHosts<T>(this IRuleBuilder<T, string> ruleBuilder)


### PR DESCRIPTION
#### Description

IPv6 support for download clients was iffy and didn't support `::1`, just `[::1]` and also didn't correctly map that as local host.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review

#### Issues Fixed or Closed by this PR

<!-- Remove if there is no issue -->

- Closes #7534
