### PR TITLE
Remove unused package references

### DIFF
--- a/src/NzbDrone.Common/Sonarr.Common.csproj
+++ b/src/NzbDrone.Common/Sonarr.Common.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SourceGear.sqlite3" Version="3.53.4" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.4" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.11" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.11" />
   </ItemGroup>

--- a/src/NzbDrone.Core/Sonarr.Core.csproj
+++ b/src/NzbDrone.Core/Sonarr.Core.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Equ" Version="2.3.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="MiniProfiler.AspNetCore" Version="4.5.4" />
     <PackageReference Include="Openur.FFMpegCore" Version="5.4.0.37" />
     <PackageReference Include="Openur.FFprobeStatic" Version="9.0.1.461" />


### PR DESCRIPTION
#### Description

`Microsoft.Data.SqlClient` and `System.Configuration.ConfigurationManager` are not referenced anywhere. Sonarr talks to SQLite and PostgreSQL only (the FluentMigrator SQLite and Postgres runners are the ones referenced), and there is no `using Microsoft.Data` or any use of `ConfigurationManager` in the tree.

`System.Configuration.ConfigurationManager` is also pulled in transitively by `Microsoft.Data.SqlClient`, so once the latter is gone, there is nothing else requiring it.

Dropping both removes **27 files** from the build output: the `Microsoft.Data.SqlClient` assemblies (plus `Microsoft.Bcl.Cryptography`, `Microsoft.SqlServer.Server` and the SqlClient extension/logging assemblies), the whole `Microsoft.IdentityModel` stack, `System.IdentityModel.Tokens.Jwt`, `System.Security.Cryptography.ProtectedData` and 13 localized resource directories.

`dotnet msbuild -restore src/Sonarr.sln -p:Configuration=Release -p:Platform=Posix` builds everything, including `Sonarr.Windows`, `Sonarr.Windows.Test`, `Sonarr.Mono.Test` and all other test projects with 0 errors.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review