### PR TITLE
Don't skip health check if Allowed Hosts is set to *

### DIFF
--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/AllowedHostsCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/AllowedHostsCheckFixture.cs
@@ -62,6 +62,19 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
             Subject.Check().ShouldBeOk();
         }
 
+        [TestCase("*")]
+        [TestCase("*, sonarr.local")]
+        [TestCase("sonarr.local; *")]
+        public void should_return_warning_when_allowed_hosts_contains_wildcard(string allowedHosts)
+        {
+            GivenAllowedHosts(allowedHosts);
+            GivenAuthenticationRequired(AuthenticationRequiredType.DisabledForLocalAddresses);
+
+            Subject.Check().ShouldBeWarning();
+
+            ExceptionVerification.ExpectedWarns(1);
+        }
+
         [Test]
         public void should_return_warning_when_allowed_hosts_is_whitespace()
         {

--- a/src/NzbDrone.Core/HealthCheck/Checks/AllowedHostsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/AllowedHostsCheck.cs
@@ -23,7 +23,9 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
-            if (AllowedHostsParser.Parse(_configFileProvider.AllowedHosts).Count > 0)
+            var allowedHosts = AllowedHostsParser.Parse(_configFileProvider.AllowedHosts);
+
+            if (allowedHosts.Count > 0 && !allowedHosts.Contains("*"))
             {
                 return new HealthCheck(GetType());
             }


### PR DESCRIPTION
#### Description

While you can't set it to `*` in the UI, you could in the config file and because it's valid it won't fail the helath check and show the appropriate warning. Will backport to v4.

#### Submission Checklist

<!-- You must put an X in appropriate checkboxes before submitting -->

- [x] I have read [CONTRIBUTING.md](/Sonarr/Sonarr/blob/v5-develop/CONTRIBUTING.md) and this PR follows the guidelines
- [x] I have fully reviewed all code in this PR and confirm it works as intended
- [ ] This PR was authored and submitted by an AI agent without human review