### PR TITLE
New: Reject releases with different external Ids

### DIFF
--- a/src/NzbDrone.Core/DecisionEngine/Specifications/ExternalIdsSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/ExternalIdsSpecification.cs
@@ -1,0 +1,35 @@
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.DecisionEngine.Specifications;
+
+public class ExternalIdsSpecification : IDownloadDecisionEngineSpecification
+{
+    private readonly Logger _logger;
+
+    public SpecificationPriority Priority => SpecificationPriority.Default;
+    public RejectionType Type => RejectionType.Permanent;
+
+    public ExternalIdsSpecification(Logger logger)
+    {
+        _logger = logger;
+    }
+
+    public DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, ReleaseDecisionInformation information)
+    {
+        if (subject.Release.TvdbId != 0 && subject.Release.TvdbId != subject.Series.TvdbId)
+        {
+            _logger.Debug("Wrong series. TVDb Id {0} wanted, but found {1}.", subject.Series.TvdbId, subject.Release.TvdbId);
+            return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeries, "Wrong series. TVDb Id {0} wanted, but found {1}.", subject.Series.TvdbId, subject.Release.TvdbId);
+        }
+
+        if (subject.Release.ImdbId.IsNotNullOrWhiteSpace() && subject.Release.ImdbId != "0" && subject.Release.ImdbId != subject.Series.ImdbId)
+        {
+            _logger.Debug("Wrong series. IMDb ID {0} wanted, but found {1}.", subject.Series.ImdbId, subject.Release.ImdbId);
+            return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeries, "Wrong series. IMDb ID {0} wanted, but found {1}.", subject.Series.ImdbId, subject.Release.ImdbId);
+        }
+
+        return DownloadSpecDecision.Accept();
+    }
+}


### PR DESCRIPTION
#### Description
Minor specification to reject releases based on external Ids like tvdbid and imdbid, which comes in handy when you have the same exact release title without years for different series, example series like Dark Matter.

Caveat, it requires the indexers to provide the ids and be the right correct one. Mismatches for wrong tt titles or tt for episodes will be rejected since it's just checking at series level.

We could make it opt-out via a configuration setting.

#### Screenshot

<img width="700"  alt="Screenshot" src="https://github.com/user-attachments/assets/04eebf54-bc7b-4407-8062-934deecce302" />
